### PR TITLE
Git, ignore install and build product directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+Linux_*
+Darwin_*
+SunOS_*
+src/.*
+src/SBMS/*.pyc


### PR DESCRIPTION
Tell git to ignore directories and files which are not intended to be committed.
