### PR TITLE
Re-add directory for calibration plugins 

### DIFF
--- a/src/plugins/Calibration/README
+++ b/src/plugins/Calibration/README
@@ -1,0 +1,1 @@
+This directory is for plugins whose primary purpose is detector calibrations.

--- a/src/plugins/Calibration/SConscript
+++ b/src/plugins/Calibration/SConscript
@@ -1,0 +1,9 @@
+
+import sbms
+
+Import('*')
+
+# update this when plugins are added
+subdirs = []
+SConscript(dirs=subdirs, exports='env osname', duplicate=0)
+


### PR DESCRIPTION
Re-add directory for calibration plugins and make corresponding changes to SConscript files.

This directory got lost in the move to git, since it was empty at the time causing git to ignore it, apparently.
