### PR TITLE
Ignore backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Darwin_*
 SunOS_*
 src/.*
 src/SBMS/*.pyc
+*~

--- a/src/plugins/Calibration/README
+++ b/src/plugins/Calibration/README
@@ -1,0 +1,1 @@
+This directory is for plugins whose primary purpose is detector calibrations.

--- a/src/plugins/Calibration/SConscript
+++ b/src/plugins/Calibration/SConscript
@@ -1,0 +1,9 @@
+
+import sbms
+
+Import('*')
+
+# update this when plugins are added
+subdirs = []
+SConscript(dirs=subdirs, exports='env osname', duplicate=0)
+


### PR DESCRIPTION
Ignore files ending in "~", which is a common suffix used for backup or otherwise extraneous files.
