### PR TITLE
Moved definition of static consts within DTPOLHit_factory

### DIFF
--- a/src/libraries/TPOL/DTPOLHit_factory.cc
+++ b/src/libraries/TPOL/DTPOLHit_factory.cc
@@ -14,6 +14,12 @@ using namespace std;
 
 using namespace jana;
 
+// static consts need initialization
+const double DTPOLHit_factory::SECTOR_DIVISION = 360. / DTPOLHit_factory::NSECTORS;
+const double DTPOLHit_factory::INNER_RADIUS = 22. / 2;       // From "ACTIVE INNER DIAMETER" in catalog
+const double DTPOLHit_factory::OUTER_RADIUS = 70. / 2;       // From "ACTIVE OUTER DIAMETER" in catalog
+const double DTPOLHit_factory::RING_DIVISION   = (OUTER_RADIUS - INNER_RADIUS ) / DTPOLHit_factory::NRINGS;
+
 // Order hits by sector/ring. If same sector/ring, use ADC time to order hits.
 bool DTPOLSectorHit_fadc_cmp(const DTPOLSectorDigiHit *a,const DTPOLSectorDigiHit *b){
   if (a->sector==b->sector) return (a->pulse_time<b->pulse_time);
@@ -37,16 +43,6 @@ jerror_t DTPOLHit_factory::init(void)
     /// set the base conversion scales
     a_scale    = 0.0001; 
     t_scale    = 0.0625;   // 62.5 ps/count
-    
-    NSECTORS = 32;
-    NRINGS   = 24;
-    
-    INNER_RADIUS = 22 / 2;       // From "ACTIVE INNER DIAMETER" in catalog
-    OUTER_RADIUS = 70 / 2;       // From "ACTIVE OUTER DIAMETER" in catalog
-    SECTOR_DIVISION = 360. / 32; // 360. / NSECTORS
-    RING_DIVISION   = (35. - 11. ) / 24;
-
-
 
     return NOERROR;
 }
@@ -139,9 +135,9 @@ jerror_t DTPOLHit_factory::evnt(JEventLoop *loop, int eventnumber)
 	}
 
         // Make sure sector is in valid range
-        if( sectordigihit->sector <= 0 || sectordigihit->sector > NSECTORS){
+        if( sectordigihit->sector <= 0 || sectordigihit->sector > DTPOLHit_factory::NSECTORS){
 	  sprintf(str, "DTPOLSectorDigiHit sector out of range! sector=%d (should be 1-%d)", 
-		  sectordigihit->sector, NSECTORS);
+		  sectordigihit->sector, DTPOLHit_factory::NSECTORS);
 	  throw JException(str);
 	}
 
@@ -349,9 +345,9 @@ const double DTPOLHit_factory::GetConstant(const vector<double> &the_table,
         const int in_sector) const{
     char str[256];
 
-    if ( (in_sector < 0) || (in_sector >= NSECTORS)){
+    if ( (in_sector < 0) || (in_sector >= DTPOLHit_factory::NSECTORS)){
       sprintf(str, "Bad sector # requested in DTPOLHit_factory::GetConstant()!"
-	      " requested=%d , should be %ud", in_sector, NSECTORS);
+	      " requested=%d , should be %ud", in_sector, DTPOLHit_factory::NSECTORS);
       cerr << str << endl;
       throw JException(str);
     }
@@ -363,10 +359,10 @@ const double DTPOLHit_factory::GetConstant(const vector<double> &the_table,
         const DSCDigiHit *in_digihit) const{
     char str[256];
 
-    if ( (in_digihit->sector < 0) || (in_digihit->sector >= NSECTORS)){
+    if ( (in_digihit->sector < 0) || (in_digihit->sector >= DTPOLHit_factory::NSECTORS)){
       sprintf(str, "Bad sector # requested in DTPOLHit_factory::GetConstant()!"
 	      " requested=%d , should be %ud", 
-	      in_digihit->sector, NSECTORS);
+	      in_digihit->sector, DTPOLHit_factory::NSECTORS);
       cerr << str << endl;
       throw JException(str);
     }
@@ -378,10 +374,10 @@ const double DTPOLHit_factory::GetConstant(const vector<double> &the_table,
 					   const DTPOLHit *in_hit) const {
   char str[256];
   
-  if ( (in_hit->sector < 0) || (in_hit->sector >= NSECTORS)){
+  if ( (in_hit->sector < 0) || (in_hit->sector >= DTPOLHit_factory::NSECTORS)){
     sprintf(str, "Bad sector # requested in DTPOLHit_factory::GetConstant()!"
 	    " requested=%d , should be %ud",
-	    in_hit->sector, NSECTORS);
+	    in_hit->sector, DTPOLHit_factory::NSECTORS);
     cerr << str << endl;
     throw JException(str);
   }

--- a/src/libraries/TPOL/DTPOLHit_factory.h
+++ b/src/libraries/TPOL/DTPOLHit_factory.h
@@ -11,6 +11,18 @@ class DTPOLHit_factory:public jana::JFactory<DTPOLHit>{
 		DTPOLHit_factory(){};
 		~DTPOLHit_factory(){};
 
+		// Geometric information		
+		static const int NSECTORS   = 32;
+		static const int NRINGS     = 24;
+
+		static const double SECTOR_DIVISION;  
+		static const double INNER_RADIUS;      // From "ACTIVE INNER DIAMETER" in catalog
+		static const double OUTER_RADIUS ;     // From "ACTIVE OUTER DIAMETER" in catalog
+		static const double RING_DIVISION ;    
+		// (OUTER_RADIUS - INNER_RADIUS) / DTPOLRingDigiHit::NRINGS;
+		// 1mm, agrees with "JUNCTION ELEMENT SEPARATION" in catalog
+
+
 		// overall scale factors
 		double a_scale;
 		double t_scale;
@@ -23,18 +35,6 @@ class DTPOLHit_factory:public jana::JFactory<DTPOLHit>{
 
 		double HIT_TIME_WINDOW;
 		double ADC_THRESHOLD;
-
-		// detector geometry (mm, degrees)
-		// "JUNCTION" refers to ring side, "OHMIC" refers to sector side
-		int NSECTORS ;
-		int NRINGS   ;
-
-		double INNER_RADIUS;       // From "ACTIVE INNER DIAMETER" in catalog
-		double OUTER_RADIUS ;       // From "ACTIVE OUTER DIAMETER" in catalog
-		double SECTOR_DIVISION ; // 360. / NSECTORS
-		double RING_DIVISION ;
-		// (OUTER_RADIUS - INNER_RADIUS) / DTPOLRingDigiHit::NRINGS;
-		// 1mm, agrees with "JUNCTION ELEMENT SEPARATION" in catalog
 
 		DTPOLHit* FindMatch(int sector, double T);
 

--- a/src/libraries/TPOL/DTPOLRingDigiHit.h
+++ b/src/libraries/TPOL/DTPOLRingDigiHit.h
@@ -8,7 +8,6 @@ class DTPOLRingDigiHit:public jana::JObject{
 	public:
 		JOBJECT_PUBLIC(DTPOLRingDigiHit);
 		
-		static const int NRINGS   = 24;
 
 		int      ring;                 // ring number 1-24
 		uint32_t pulse_integral;       // identified pulse integral as returned by FPGA algorithm

--- a/src/libraries/TPOL/DTPOLSectorDigiHit.h
+++ b/src/libraries/TPOL/DTPOLSectorDigiHit.h
@@ -7,8 +7,6 @@
 class DTPOLSectorDigiHit:public jana::JObject{
 	public:
 		JOBJECT_PUBLIC(DTPOLSectorDigiHit);
-		
-		static const int NSECTORS   = 32;
 
 		int      sector;             // sector number 1-32
 		uint32_t pulse_integral;    // identified pulse integral as returned by FPGA algorithm

--- a/src/plugins/monitoring/TPOL_online/JEventProcessor_TPOL_online.cc
+++ b/src/plugins/monitoring/TPOL_online/JEventProcessor_TPOL_online.cc
@@ -12,6 +12,7 @@ using namespace jana;
 #include "DAQ/Df250WindowRawData.h"
 #include <TPOL/DTPOLSectorDigiHit.h>
 #include <TPOL/DTPOLHit.h>
+#include <TPOL/DTPOLHit_factory.h>
 
 #include <TDirectory.h>
 #include <TH1.h>
@@ -62,9 +63,9 @@ jerror_t JEventProcessor_TPOL_online::init(void) {
 
   // book hists
   tpol_num_events = new TH1I("tpol_num_events","TPOL number of events",1, 0.5, 1.5);
-  tpol_hitMultiplicity = new TH1I("tpol_hitMultiplicity",";multiplicity of TPOL hits/event;",DTPOLSectorDigiHit::NSECTORS,0.5,DTPOLSectorDigiHit::NSECTORS+0.5);
+  tpol_hitMultiplicity = new TH1I("tpol_hitMultiplicity",";multiplicity of TPOL hits/event;",DTPOLHit_factory::NSECTORS,0.5,DTPOLHit_factory::NSECTORS+0.5);
 
-  // hnHitBySector = new TH2F("hnHitBySector","TPOL hit multiplicity by sector;sector;# hits",DTPOLSectorDigiHit::NSECTORS,-0.5,DTPOLSectorDigiHit::NSECTORS-0.5,10,-0.5,9.5);
+  // hnHitBySector = new TH2F("hnHitBySector","TPOL hit multiplicity by sector;sector;# hits",DTPOLHit_factory::NSECTORS,-0.5,DTPOLHit_factory::NSECTORS-0.5,10,-0.5,9.5);
   // back to main dir
   mainDir->cd();
 
@@ -97,7 +98,7 @@ jerror_t JEventProcessor_TPOL_online::evnt(JEventLoop *eventLoop, int eventnumbe
   // polarity of the detector. 
   // vector<const DTPOLHit*> hits;
   // eventLoop->Get(hits);
-  // vector<const DTPOLSectorDigiHit*> sectordigihits;
+  // vector<const DTPOLHit_factory*> sectordigihits;
   // eventLoop->Get(sectordigihits);
 
   // For the spring 2015 data, we need to grab the Df250WindowRawData objects
@@ -141,9 +142,9 @@ jerror_t JEventProcessor_TPOL_online::evnt(JEventLoop *eventLoop, int eventnumbe
     // if((sectordigihits.size()>0))
     //   tpol_num_events->Fill(1);
 
-    // UInt_t hits[DTPOLSectorDigiHit::NSECTORS];
+    // UInt_t hits[DTPOLHit_factory::NSECTORS];
     // // initialize counts for each sector
-    // for(Int_t sector=0;sector<DTPOLSectorDigiHit::NSECTORS;sector++){
+    // for(Int_t sector=0;sector<DTPOLHit_factory::NSECTORS;sector++){
     //   hits[sector] = 0;
     // }
 
@@ -154,7 +155,7 @@ jerror_t JEventProcessor_TPOL_online::evnt(JEventLoop *eventLoop, int eventnumbe
     // }
 
     // // fill hit numbers for each sector
-    // for(Int_t sector=1;sector<=DTPOLSectorDigiHit::NSECTORS;sector++){
+    // for(Int_t sector=1;sector<=DTPOLHit_factory::NSECTORS;sector++){
     //   hnHitBySector->Fill(sector,hits[sector-1]);
     // }
 


### PR DESCRIPTION
Make detector info such as # of sectors, rings, and their divisions static const members of DTPOLHit_factory, move declaration out of constructor so that the values are available anywhere
