### PR TITLE
Apply time cut when adding a hit to a cluster. 

### DIFF
--- a/src/libraries/FCAL/DFCALCluster.h
+++ b/src/libraries/FCAL/DFCALCluster.h
@@ -9,7 +9,7 @@
 #define _DFCALCluster_
 
 #include <DVector3.h>
-//#include "DFCALHit.h"
+#include "DFCALHit.h"
 using namespace std;
 
 #include <JANA/JObject.h>

--- a/src/libraries/FCAL/DFCALCluster_factory.h
+++ b/src/libraries/FCAL/DFCALCluster_factory.h
@@ -29,6 +29,7 @@ class DFCALCluster_factory:public JFactory<DFCALCluster>{
 
 		unsigned int MIN_CLUSTER_BLOCK_COUNT;
 		float MIN_CLUSTER_SEED_ENERGY;
+		float TIME_CUT;
 
 		// this is the location of the front 
 		// of the FCAL in a coordinate system 


### PR DESCRIPTION
This cut is needed to avoid adding hits with late times (with respect to the hit with the most energy) to a cluster.    For real FCAL data these bad hits can come more than 100 ns later than the good hits.   The default setting of the cut is +-15 ns, but can be changed on the command line by setting -PFCAL:TIME_CUT=<number> .
