### PR TITLE
Revert " looping over the charged tracks instead of time based tracks…

### DIFF
--- a/src/plugins/monitoring/ST_online_tracking/JEventProcessor_ST_online_tracking.cc
+++ b/src/plugins/monitoring/ST_online_tracking/JEventProcessor_ST_online_tracking.cc
@@ -8,25 +8,26 @@
 #include "JEventProcessor_ST_online_tracking.h"
 using namespace jana;
 using namespace std;
+
 // Routine used to create our JEventProcessor
 #include <JANA/JApplication.h>
 #include <JANA/JFactory.h>
+#include <stdint.h>
+#include <vector>
+
 // ROOT header files
 #include <TDirectory.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <TEfficiency.h>
 // ST header files
 #include "START_COUNTER/DSCHit.h"
 #include "START_COUNTER/DSCDigiHit.h"
-// C++ header files
-#include <stdint.h>
-#include <vector>
-#include <stdio.h>
+
 // Include some JANA libraries
 // PID libraries
 #include "PID/DDetectorMatches.h"
 #include "PID/DParticleID.h"
-#include "PID/DChargedTrack.h"
 // Tracking libraries
 #include "TRACKING/DTrackTimeBased.h"
 
@@ -47,10 +48,8 @@ static TH2I *h2_dedx_P_mag_negtv;
 static TH1D *h_phi_sec_hit_cntr;
 static TH1D *h_phi_sec_pred_hit_cntr;
 static TH1D *pEff;
-static TH1D *MacropEff;
 static TH1D *h_phi_sec_adc_cntr;
 static TH1D *pEff_adc;
-static TH1D *MacropEff_adc;
 // Declare detection efficency counters
 uint32_t phi_sec_cntr[NCHANNELS];
 uint32_t phi_sec_pred_hit_cntr[NCHANNELS];
@@ -115,10 +114,9 @@ jerror_t JEventProcessor_ST_online_tracking::init(void)
   h_phi_sec_pred_hit_cntr = new TH1D("h_phi_sec_pred_hit_cntr", "phi_sec_pred_hit_cntr; Sector; Predicted Hit Counts", 31, -0.5, 30.5);
   h_phi_sec_hit_cntr      = new TH1D("h_phi_sec_hit_cntr", "phi_sec_hit_cntr; Sector; Hit Counts", 31, -0.5, 30.5);
   pEff= new TH1D("pEff", "Hit Efficiency; Sector; N_{HIT}/N_{TRK}", 31, -0.5, 30.5);
-  MacropEff= new TH1D("MacropEff", "Hit Efficiency; Sector; N_{HIT}/N_{TRK}", 31, -0.5, 30.5);
+
   h_phi_sec_adc_cntr = new TH1D("h_phi_sec_adc_cntr", "phi_sec_adc_cntr; Sector; adc Counts", 31, -0.5, 30.5);
   pEff_adc = new TH1D("pEff_adc", "ADC Efficiency; Sector; N_{ADC}/N_{TRK}", 31, -0.5, 30.5);
-  MacropEff_adc = new TH1D("MacropEff_adc", "ADC Efficiency; Sector; N_{ADC}/N_{TRK}", 31, -0.5, 30.5);
   // cd back to main directory
   gDirectory->cd("../");
   main->cd();
@@ -139,17 +137,8 @@ jerror_t JEventProcessor_ST_online_tracking::init(void)
 //------------------
 jerror_t JEventProcessor_ST_online_tracking::brun(JEventLoop *eventLoop, int runnumber)
 {
-  // This is called whenever the run number changes
-  // Get the particleID object for each run
-  vector<const DParticleID *> dParticleID_algos;
-  eventLoop->Get(dParticleID_algos);
-  if(dParticleID_algos.size() < 1)
-    {
-      _DBG_<<"Unable to get a DParticleID object! NO PID will be done!"<<endl;
-      return RESOURCE_UNAVAILABLE;
-    }
-  dParticleID = dParticleID_algos[0];
-  return NOERROR;
+	// This is called whenever the run number changes
+	return NOERROR;
 }
 
 //------------------
@@ -171,96 +160,73 @@ jerror_t JEventProcessor_ST_online_tracking::evnt(JEventLoop *eventLoop, int eve
 	//  ... fill historgrams or trees ...
 	// japp->RootUnLock();
   vector<const DSCDigiHit*>       st_adc_digi_hits;
+  vector<const DDetectorMatches*> glx_matches;
+  vector<const DTrackTimeBased*>  tb_tracks;
   vector<const DParticleID*>      pid_algorithm;
   vector<const DSCHit*>           st_hits;
   eventLoop->Get(st_adc_digi_hits);
+  eventLoop->Get(glx_matches);
+  eventLoop->Get(tb_tracks);
   eventLoop->Get(pid_algorithm);
   eventLoop->Get(st_hits);
   vector<DVector3> sc_track_position;
-  vector<const DChargedTrack*> chargedTrackVector;
-  eventLoop->Get(chargedTrackVector);
-  // Grab the associated detector matches object
-  const DDetectorMatches* locDetectorMatches = NULL;
-  eventLoop->GetSingle(locDetectorMatches);
+ 
   // Lock ROOT mutex so other threads won't interfere 
   japp->RootWriteLock();
 
   sc_track_position.clear();
- 
-// Loop over charged tracks
-  for (uint32_t i = 0; i < chargedTrackVector.size(); i++)
+  // Loop over time based tracks only, no matching
+  for (uint32_t i = 0; i < tb_tracks.size(); i++)
     {
-      // Grab the charged track
-      const DChargedTrack *thisChargedTrack = chargedTrackVector[i];
+      // Reset hit counters since there are multiple time based tracks 
+      //   per track per event
       
-      // Declare the time based track object
-      const DTrackTimeBased *timeBasedTrack;
-
-      // Grab associated time based track object by selecting charged track with best FOM
-      thisChargedTrack->Get_BestTrackingFOM()->GetSingle(timeBasedTrack);
-      // Implement quality cuts for the time based tracks 
-      float trackingFOMCut = 0.0027;  // 3 sigma cut
-      if(timeBasedTrack->FOM  < trackingFOMCut)  continue;
+      memset(phi_sec_cntr, 0, sizeof(phi_sec_cntr));
+      
       // Get the charge of the track and cut on charged tracks
-      int q = timeBasedTrack->charge();
-      // Grab the ST hit match params object and cut on only tracks matched to the ST
-      DSCHitMatchParams locSCHitMatchParams;
-      bool foundSC = dParticleID->Get_BestSCMatchParams(timeBasedTrack, locDetectorMatches, locSCHitMatchParams);
-      if (!foundSC) continue;
-      // Define vertex vector
-      DVector3 vertex;
-      // Vertex info
-      vertex = timeBasedTrack->position();
-      // Cartesian Coordinates
-      double z_v = vertex.z();
-      double r_v = vertex.Perp();
-      // Liquid hydrogen target cuts 
-      // Target length 30 cm, centered at z = 65.0 cm
-      // Upstream Diameter of target cell = 2.42 cm
-      // ID of scattering chamber = 7.49 cm
-      bool z_vertex_cut = 50.0 <= z_v && z_v <= 80.0; 
-      bool r_vertex_cut = r_v < 3.745;
-      // applied vertex cut
-      if (!z_vertex_cut) continue;
-      if (!r_vertex_cut) continue;
-      // Declare a vector which quantizes the point of the intersection of a charged particle 
-      //   with a plane in the middle of the scintillator 
-      DVector3 IntersectionPoint;
-      // Declare a vector which quantizes the unit vector of the charged particle track traversing
-      //   through the scintillator with its origin at the intersection point
-      DVector3 IntersectionDir;
-      // Grab the paramteres associated to a track matched to the ST
-      vector<DSCHitMatchParams> st_params;
-      bool st_match = locDetectorMatches->Get_SCMatchParams(timeBasedTrack, st_params); 
-      // If st_match = true, there is a match between this track and the ST
-      if (!st_match) continue;
-
-      bool st_match_pid = dParticleID->MatchToSC(timeBasedTrack, 
-						 timeBasedTrack->rt, 
-						 st_params[0].dSCHit, 
-						 st_params[0].dSCHit->t, 
-						 locSCHitMatchParams, 
-						 true,
-						 &IntersectionPoint, &IntersectionDir);      
-      if(!st_match_pid) continue;  
-
-      DVector3 momentum_vec;
-      momentum_vec = timeBasedTrack->momentum();
-      // applied vertex cut
-      DLorentzVector Lor_Mom = timeBasedTrack->lorentzMomentum();
-      double P_mag = Lor_Mom.P(); 
-      double phi_mom = momentum_vec.Phi()*RAD2DEG;
-      if (phi_mom < 0.0) phi_mom += 360.0;
-      for (uint32_t j = 0; j < NCHANNELS; j++)
+      int q = tb_tracks[i]->charge();
+      //      h_q->Fill(q);      
+      if (q != 0) // This includes any charged track (pi/p or k) It can be determined from the mass hypothesis on hd_root command 
 	{
-	  if (phi_mom >= phi_sec[j][0] && phi_mom <= phi_sec[j][1])
+	  // Acquire the tracking FOM
+          float  chisq      = tb_tracks[i]->chisq;
+	  int    ndof       = tb_tracks[i]->Ndof;
+	  double track_prob = TMath::Prob(chisq, ndof);
+	  // Cut on tracks with "good" FOM
+	  if (track_prob > 0.001)
 	    {
-	      phi_sec_cntr[j] += 1;
-	    }
-	}
+	      // Define vertex vector
+	      DVector3 vertex;
+	      
+	      // Vertex info
+	      vertex = tb_tracks[i]->position();
+	      // Cartesian Coordinates
+	      double z_v = vertex.z();
+	      double r_v = vertex.Perp();
+	      DVector3 momentum_vec;
+	      momentum_vec = tb_tracks[i]->momentum();
+	      // Cut on vertex (target 30 mm LH2 centered at z = 65 cm 
+ 	      //   with scattering chamber diameter = 5 cm
+	      Bool_t z_vertex_cut = ((50.0 <= z_v) && (z_v <= 80.0)); 
+	      Bool_t r_vertex_cut = (r_v < 2.5);
+	      // applied vertex cut
+	      if (z_vertex_cut && r_vertex_cut)
+		{
+		  DLorentzVector Lor_Mom = tb_tracks[i]->lorentzMomentum();
+		  double P_mag = Lor_Mom.P(); 
+		  double phi_mom = momentum_vec.Phi()*RAD2DEG;
+		  if (phi_mom < 0.0) phi_mom += 360.0;
+		  for (uint32_t j = 0; j < NCHANNELS; j++)
+		    {
+		      if (phi_mom >= phi_sec[j][0] && phi_mom <= phi_sec[j][1])
+			{
+			  phi_sec_cntr[j] += 1;
+			}
+		    }
+
 		  // Grab the ST sector predicted to be hit by the charged time based track
 		  // 0.069 rad = 4 deg, 0.087 rad = 5 deg, 0.105 rad = 6 deg
-		  uint32_t st_pred_id = pid_algorithm[0]->PredictSCSector(timeBasedTrack->rt, 0.069);
+		  uint32_t st_pred_id = pid_algorithm[0]->PredictSCSector(tb_tracks[i]->rt, 0.069);
 		  uint32_t st_pred_id_index = st_pred_id - 1;
 		  
 		  if (st_pred_id != 0) 
@@ -283,37 +249,63 @@ jerror_t JEventProcessor_ST_online_tracking::evnt(JEventLoop *eventLoop, int eve
 			    phi_sec_adc_hit_cntr[phi_sec_adc_hit_sector_index] += 1;
 			}
 		    } // end if (st_pred_id != 0) 	
-		  
-		  if (st_match_pid)  // Get the intersection point which can not be obtained from st_match
+		  // Declare the ST hit match paramters object
+		  DSCHitMatchParams st_matches;
+		  // Declare a vector which quantizes the point of the intersection of a charged particle 
+		  //   with a plane in the middle of the scintillator 
+		  DVector3 IntersectionPoint;
+		  // Declare a vector which quantizes the unit vector of the charged particle track traversing
+		  //   through the scintillator with its origin at the intersection point
+		  DVector3 IntersectionDir;
+		  vector<DSCHitMatchParams> st_params;
+		  bool st_match = glx_matches[0]->Get_SCMatchParams(tb_tracks[i], st_params);
+		  // st_match true = there is a match between this track and ST
+
+		  if (st_match)
 		    {
-		      // Grab the sector
-		      Int_t sector_m = st_params[0].dSCHit->sector;
-		      //Acquire the energy loss per unit length in the ST (arbitrary units)
-		      double dEdx = st_params[0].dEdx;
-		      double dphi = st_params[0].dDeltaPhiToHit*RAD2DEG;
-		      // Fill dEdx vs Momentum 
-		      h2_dedx_P_mag->Fill(P_mag,dEdx);
-		      // Fill dEdx vs Momentum with cut on positive charges  
-		      if (q > 0)
+		      
+		      // This boolian is needed to acess the intersection point information of a match and all st_params variables	    
+		      bool st_match_pid = pid_algorithm[0]->MatchToSC(tb_tracks[i], 
+								      tb_tracks[i]->rt, 
+								      st_params[0].dSCHit, 
+								      st_params[0].dSCHit->t, 
+								      st_matches, 
+								      true,
+								      &IntersectionPoint, &IntersectionDir);
+		      if (st_match_pid)  // Get the intersection point which can not be obtained from st_match
 			{
-			  h2_dedx_P_mag_postv->Fill(P_mag,dEdx);
-			}
-		      // Fill dEdx vs Momentum with cut on negative charges  
-		      if (q < 0)
-			{
-			  h2_dedx_P_mag_negtv->Fill(P_mag,dEdx);
-			}
-		      // Obtain the intersection point with the ST		  
-		      double phi_ip   = IntersectionPoint.Phi()*RAD2DEG;
-		      // Correct phi calculation
-		      if (phi_ip < 0.0) phi_ip += 360.0;
-		      // Acquire the intersection point
-		      sc_track_position.push_back(IntersectionPoint);
-		      //Fill 2D histos
-		      h2_phi_vs_sector->Fill(sector_m,phi_ip);
-		      h2_dphi_sector->Fill(sector_m,dphi);
-		    }  // PID match cut
-    }                  // Charged track loop
+			  // Grab the sector
+			  Int_t sector_m = st_params[0].dSCHit->sector;
+			  //Acquire the energy loss per unit length in the ST (arbitrary units)
+			  double dEdx = st_params[0].dEdx;
+			  double dphi = st_params[0].dDeltaPhiToHit*RAD2DEG;
+			  // Fill dEdx vs Momentum 
+			  h2_dedx_P_mag->Fill(P_mag,dEdx);
+			  // Fill dEdx vs Momentum with cut on positive charges  
+			  if (q > 0)
+			    {
+			      h2_dedx_P_mag_postv->Fill(P_mag,dEdx);
+			    }
+			  // Fill dEdx vs Momentum with cut on negative charges  
+			  if (q < 0)
+			    {
+			      h2_dedx_P_mag_negtv->Fill(P_mag,dEdx);
+			    }
+			  // Obtain the intersection point with the ST		  
+			  double phi_ip   = IntersectionPoint.Phi()*RAD2DEG;
+			  // Correct phi calculation
+			  if (phi_ip < 0.0) phi_ip += 360.0;
+			  // Acquire the intersection point
+			  sc_track_position.push_back(IntersectionPoint);
+			  //Fill 2D histos
+			  h2_phi_vs_sector->Fill(sector_m,phi_ip);
+			  h2_dphi_sector->Fill(sector_m,dphi);
+			}  // PID match cut
+		    }      // Detector match cut
+		}          // Vertex cut
+	    }              // Tracking FOM cut
+	}                  // Charged track cut
+    }                      // Time based track loop 
   // Fill 2D histo
   for (uint32_t i = 0; i < sc_track_position.size(); i++)
     {
@@ -351,16 +343,16 @@ jerror_t JEventProcessor_ST_online_tracking::fini(void)
      
 
     }
-  // //How to get Binomial errors in an efficiency plot
-  // // hit object efficiency
-  // h_phi_sec_hit_cntr->Sumw2();
-  // h_phi_sec_pred_hit_cntr->Sumw2();
-  // pEff->Sumw2();
-  // pEff->Divide(h_phi_sec_hit_cntr,h_phi_sec_pred_hit_cntr,1,1,"B");
-  // // adc efficiency
-  // h_phi_sec_adc_cntr->Sumw2();
-  // pEff_adc->Sumw2();
-  // pEff_adc->Divide(h_phi_sec_adc_cntr,h_phi_sec_pred_hit_cntr,1,1,"B");
+  //How to get Binomial errors in an efficiency plot
+  // hit object efficiency
+  h_phi_sec_hit_cntr->Sumw2();
+  h_phi_sec_pred_hit_cntr->Sumw2();
+  pEff->Sumw2();
+  pEff->Divide(h_phi_sec_hit_cntr,h_phi_sec_pred_hit_cntr,1,1,"B");
+  // adc efficiency
+  h_phi_sec_adc_cntr->Sumw2();
+  pEff_adc->Sumw2();
+  pEff_adc->Divide(h_phi_sec_adc_cntr,h_phi_sec_pred_hit_cntr,1,1,"B");
   return NOERROR;
 }
 

--- a/src/plugins/monitoring/ST_online_tracking/ST_Monitoring_Eff.C
+++ b/src/plugins/monitoring/ST_online_tracking/ST_Monitoring_Eff.C
@@ -5,25 +5,13 @@
 {
   // Define the directory that contains the histograms
   TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("st_tracking");
+  //gDirectory->ls();
   if(dir) dir->cd();
+
   // Grab 1D histograms 
-  TH1D *MacropEff     = (TH1D*)dir->FindObjectAny("MacropEff");
-  TH1D *MacropEff_adc     = (TH1D*)dir->FindObjectAny("MacropEff_adc");
-  TH1D *h_phi_sec_pred_hit_cntr = (TH1D*)dir->FindObjectAny("h_phi_sec_pred_hit_cntr");
-  TH1D *h_phi_sec_hit_cntr  = (TH1D*)dir->FindObjectAny("h_phi_sec_hit_cntr");
-  TH1D *h_phi_sec_adc_cntr = (TH1D*)dir->FindObjectAny("h_phi_sec_adc_cntr");
-
-  // get Binomial errors in an efficiency plot
-  // hit object efficiency
-  h_phi_sec_hit_cntr->Sumw2();
-  h_phi_sec_pred_hit_cntr->Sumw2();
-  MacropEff->Sumw2();
-  MacropEff->Divide(h_phi_sec_hit_cntr,h_phi_sec_pred_hit_cntr,1,1,"B");
-
-  // adc efficiency
-  h_phi_sec_adc_cntr->Sumw2();
-  MacropEff_adc->Sumw2();
-  MacropEff_adc->Divide(h_phi_sec_adc_cntr,h_phi_sec_pred_hit_cntr,1,1,"B");
+  TH1D *pEff     = (TH1D*)dir->FindObjectAny("pEff");
+  TH1D *pEff_adc     = (TH1D*)dir->FindObjectAny("pEff_adc");
+  
 
   //Create the canvas
   if(gPad == NULL)
@@ -33,90 +21,43 @@
       c1->Draw();
       c1->Update();
     }
+  
   if(!gPad) return;
   TCanvas *c1 = gPad->GetCanvas();
   c1->Divide(2,1);
   // ST ADC Efficiency histogram
   c1->cd(1);
-  gStyle->SetOptStat(0);
+
+  gStyle->SetStatW(0.13);
+  gStyle->SetStatH(0.05);
+  gStyle->SetStatY(0.97);
+  gStyle->SetStatX(0.9);
+  gStyle->SetOptStat(10);
+  gStyle->SetOptFit(0100); 
   gStyle->SetErrorX(0); 
   gPad->SetTicks();
   gPad->SetGrid();
-  if (MacropEff_adc) {
-   MacropEff_adc->Draw("E1");
-   MacropEff_adc->SetMarkerStyle(21);
-   MacropEff_adc->SetMarkerSize(1.5);
-   MacropEff_adc->SetMarkerColor(4.0);
-   MacropEff_adc->SetAxisRange(0., 1.,"Y");
-   MacropEff_adc->GetYaxis()->SetTitleOffset(1.26);
-   Double_t TWA_adc=0;
-   Double_t sumE_adc=0;
-   Double_t Final_adc=0;
-   for (int i = 0; i < 30; i++)
-     {
-       Double_t error_adc =   MacropEff_adc->GetBinError(i+2);
-       sumE_adc = sumE_adc + error_adc;
-       Double_t BC_adc =   MacropEff_adc->GetBinContent(i+2);
-       Double_t WA_adc = BC_adc*error_adc;
-       TWA_adc = TWA_adc + WA_adc ;
-       Double_t Final_adc = TWA_adc/sumE_adc;
-       // cout << "error_adc =  "<< error_adc << endl;
-       // cout << "BC_adc =  "<< BC_adc << endl;
-       // cout << "Final_adc =  "<< Final_adc << endl;
-     } 
-   TLine *line = new TLine(1,Final_adc,30,Final_adc);
-   line->SetLineWidth(3);
-   line->SetLineColor(2);
-   //Write the eff value on the histogram 
-   char tFinal_adc[40];
-   char terror_adc[40];
-   sprintf(tFinal_adc,"ADC Efficiency (%) = %g",Final_adc*100);
-   sprintf(terror_adc,"ADC Efficiency error (%) = %g",error_adc*100);
-   line->Draw();
-   TPaveLabel *p = new TPaveLabel(0.3,0.6,0.7,0.7,tFinal_adc,"brNDC");
-   p->Draw();
-   TPaveLabel *p1 = new TPaveLabel(0.3,0.5,0.7,0.6,terror_adc,"brNDC");
-   p1->Draw();
+  if (pEff_adc) {
+    pEff_adc->Draw("E1");
+    pEff_adc->SetMarkerStyle(4);
+    pEff_adc->SetMarkerSize(0.7);
+    pEff_adc->SetAxisRange(0.7, 1.,"Y");
+    pEff_adc->GetYaxis()->SetTitleOffset(1.26);
+    pEff_adc->Fit("pol0");
   }
+   
   // ST Hit Efficiency histogram
   c1->cd(2);
+  gStyle->SetOptStat(10);
   gPad->SetTicks();
   gPad->SetGrid();
-  if (MacropEff) {
-    MacropEff->Draw("E1");
-    MacropEff->SetMarkerStyle(21);
-    MacropEff->SetMarkerSize(1.5);
-    MacropEff->SetMarkerColor(4.0);
-    MacropEff->SetAxisRange(0., 1.,"Y");
-    MacropEff->GetYaxis()->SetTitleOffset(1.26);
-    Double_t TWA=0;
-    Double_t sumE=0;
-    Double_t Final=0; 
-    for (int i = 0; i < 30; i++)
-      {
-	Double_t error =   MacropEff->GetBinError(i+2);
-	sumE = sumE+error;
-	Double_t BC =   MacropEff->GetBinContent(i+2);
-	Double_t WA = BC*error;
-	TWA = TWA + WA ;
-	Double_t Final = TWA/sumE;
-	//	cout << "error =  "<< error << endl;
-	//	cout << "BC =  "<< BC << endl;
-	//	cout << "Final =  "<< Final << endl;
-      } 
-    TLine *line = new TLine(1,Final,30,Final);
-    line->SetLineWidth(3);
-    line->SetLineColor(2);
-    //Write the eff value on the histogram 
-   char tFinal[40];
-   char terror[40];
-   sprintf(tFinal,"Hit Efficiency (%) = %g",Final*100);
-   sprintf(terror,"Hit Efficiency error (%) = %g",error*100);
-   line->Draw();
-   TPaveLabel *p = new TPaveLabel(0.3,0.6,0.7,0.7,tFinal,"brNDC");
-   p->Draw();
-   TPaveLabel *p1 = new TPaveLabel(0.3,0.5,0.7,0.6,terror,"brNDC");
-   p1->Draw();
+  if (pEff) {
+    pEff->Draw("E1");
+    pEff->SetMarkerStyle(4);
+    pEff->SetMarkerSize(0.7);
+    pEff->SetAxisRange(0.7, 1.,"Y");
+    pEff->GetYaxis()->SetTitleOffset(1.26);
+    pEff->Fit("pol0");
   }
-  
+
 }


### PR DESCRIPTION
Reverts JeffersonLab/sim-recon#12
These changes seem to have broken the nightly builds for August 1 and August 2. This pull request backs them out. One of the log files showing the errors is /u/scratch/gluex/nightly/2015-08-02/halld_ifarm1401.log, but the error is present on all five platforms.
