### PR TITLE
Use c++ and cc instead of g++ and gcc

### DIFF
--- a/src/SConstruct
+++ b/src/SConstruct
@@ -29,7 +29,8 @@ include = "%s/include" % (installdir)
 bin = "%s/bin" % (installdir)
 lib = "%s/lib" % (installdir)
 plugins = "%s/plugins" % (installdir)
-env = Environment(    CPPPATH = [include],
+env = Environment(        ENV = os.environ,  # Bring in full environement, including PATH
+                      CPPPATH = [include],
                       LIBPATH = [lib],
                   variant_dir = ".%s" % (osname))
 
@@ -64,8 +65,8 @@ if SHOWBUILD==0:
 
 
 # Get compiler from environment variables (if set)
-env.Replace( CXX = os.getenv('CXX', 'g++'),
-             CC  = os.getenv('CC' , 'gcc'),
+env.Replace( CXX = os.getenv('CXX', 'c++'),
+             CC  = os.getenv('CC' , 'cc'),
              FC  = os.getenv('FC' , 'gfortran') )
 
 # Add libraries and libraries/include to include search path


### PR DESCRIPTION
Similar to recent change to HDDS: Use c++ and cc when compiling instead of g++ and gcc so that we can more easily use alternative compilers. The default for gcc seems to have links for c++ and cc installed so this should not affect anyone unless they already have another c++ and cc in their PATH.

This change also adds the complete shell environment to the scons build environment. This was done specifically to bring in the PATH and LD_LIBRARY_PATH environments which may contain non-standard locations for c++ and cc
