### PR TITLE
Fix issues with deletion of tracks that were falsely considered to be…

### DIFF
--- a/src/libraries/TRACKING/DTrackTimeBased_factory.h
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.h
@@ -108,7 +108,7 @@ class DTrackTimeBased_factory:public jana::JFactory<DTrackTimeBased>{
   vector<DVector3>sc_pos;
   vector<DVector3>sc_norm;
 
- 
+  int myevt;
 };
 
 #endif // _DTrackTimeBased_factory_


### PR DESCRIPTION
… clones of other tracks.  Change code such that if a clone is found for two different candidates for any of the mass hypotheses, keep results for all mass hypotheses for only one of these candidates.
