### PR TITLE
Make CCDB calls in GetObjects() only print information the first time…

### DIFF
--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -155,6 +155,7 @@ jerror_t DEventSourceHDDM::GetObjects(JEvent &event, JFactory_base *factory)
    /// JEventSource base class. It creates the objects of the type
    /// on which factory is based. It uses the hddm_s::HDDM* object
    /// kept in the ref field of the JEvent object passed.
+   static bool print_calib_info = true;
 
    // We must have a factory to hold the data
    if (!factory)
@@ -191,15 +192,19 @@ jerror_t DEventSourceHDDM::GetObjects(JEvent &event, JFactory_base *factory)
             return VALUE_OUT_OF_RANGE;
          }
          // Notify user
-         jout << "Read " << tvals.size()
-              << " values from FDC/strip_calib in calibDB"
-              << endl;
-         jout << "   strip_calib columns (alphabetical): ";
          map<string,float>::iterator iter;
+         if(print_calib_info) {
+             print_calib_info = false;           // only print once
+             jout << "Read " << tvals.size()
+                  << " values from FDC/strip_calib in calibDB"
+                  << endl;
+             jout << "   strip_calib columns (alphabetical): ";
+             for (iter=tvals[0].begin(); iter!=tvals[0].end(); iter++) {
+                 jout << iter->first << " ";
+                 jout << endl;
+             }
+         }
          for (iter=tvals[0].begin(); iter!=tvals[0].end(); iter++) {
-            jout << iter->first << " ";
-            jout << endl;
-
             // Copy values into tables. We preserve the order since
             // that is how it was originally done in hitFDC.c
             for (unsigned int i=0; i<tvals.size(); i++) {

--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -155,7 +155,7 @@ jerror_t DEventSourceHDDM::GetObjects(JEvent &event, JFactory_base *factory)
    /// JEventSource base class. It creates the objects of the type
    /// on which factory is based. It uses the hddm_s::HDDM* object
    /// kept in the ref field of the JEvent object passed.
-   static bool print_calib_info = true;
+   static bool print_calib_info = true;  
 
    // We must have a factory to hold the data
    if (!factory)
@@ -194,7 +194,10 @@ jerror_t DEventSourceHDDM::GetObjects(JEvent &event, JFactory_base *factory)
          // Notify user
          map<string,float>::iterator iter;
          if(print_calib_info) {
-             print_calib_info = false;           // only print once
+             // print out some diagnostic info, but only once per execution
+             // warning:  this is not technically thread safe, but since this 
+             // is just a diagnostic print out, we are going to hold our noses for now...
+             print_calib_info = false;           
              jout << "Read " << tvals.size()
                   << " values from FDC/strip_calib in calibDB"
                   << endl;
@@ -217,7 +220,7 @@ jerror_t DEventSourceHDDM::GetObjects(JEvent &event, JFactory_base *factory)
    }
 
    //Get target center
-      //multiple reader threads can access this object: need lock
+   //multiple reader threads can access this object: need lock
    bool locNewRunNumber = false;
    unsigned int locRunNumber = event.GetRunNumber();
    LockRead();

--- a/src/libraries/HDDM/DEventSourceHDDM.h
+++ b/src/libraries/HDDM/DEventSourceHDDM.h
@@ -150,7 +150,8 @@ class DEventSourceHDDM:public JEventSource
 
    private:
       bool initialized;
-   
+      int dRunNumber;
+
       pthread_mutex_t rt_mutex;
       map<hddm_s::HDDM*, vector<DReferenceTrajectory*> > rt_by_event;
       list<DReferenceTrajectory*> rt_pool;


### PR DESCRIPTION
… they are called.

This only affects running over simulated HDDM files.  As requested by Justin.
