### PR TITLE
Filter out extra debug flags

### DIFF
--- a/src/SBMS/sbms.py
+++ b/src/SBMS/sbms.py
@@ -284,6 +284,7 @@ def AddCompileFlags(env, allflags):
 		if f.startswith('-I'):
 			cpppath.append(f[2:])
 		else:
+			if f == '-g': continue
 			if f.startswith('-std=c++'):
 				cxxflags.append(f)
 			else:


### PR DESCRIPTION
Skip debug flags ("-g") in AddCompileFlags(). On CentOS6, an extra
debug flag was identified as coming from a cflag from "jana-config",
and it from a cflag from "mysql_config". This was preventing the
command-line option DEBUG=0 from taking effect on CentOS6. CentOS7
was not affected because on it, mysql is not configured with "-g".
The debug flag which is added when DEBUG=1 (in the SConstruct) is not
affected by this commit. This commit prevents extra debug flags.
