### PR TITLE
no optimization for Fortran in programs/Simulation/HDGeant

### DIFF
--- a/src/programs/Simulation/HDGeant/SConscript
+++ b/src/programs/Simulation/HDGeant/SConscript
@@ -15,6 +15,9 @@ else:
 
 	# get env object and clone it
 	env = env.Clone()
+	print "FORTRANFLAGS before:", env['FORTRANFLAGS']
+	env['FORTRANFLAGS'] = ['-g', '-O0', '-fPIC', '-Wall']
+	print "FORTRANFLAGS after:", env['FORTRANFLAGS']
 
 	SConscript(dirs=['gelhad', 'hitutil', 'utilities'], exports='env osname', duplicate=0)
 


### PR DESCRIPTION
Kludge to fix hdgeant on GCC 4.8.3 (RHEL7). Forces all Fortran files to be compiled without optimization (-O0). Otherwise hdgeant complains about unknown shapes in ginme and goes into an infinite loop. This behavior has been present for some time (many weeks); we have never been able to run the b1pi test on RHEL7 as a result.

The fix here is not elegant. There are two ways it might be improved:
1) Do a better modification of the SConscript in HDGeant. The way it is done here will defeat some user options, but I don't have the expertise to do better at this writing. @faustus123 would have done a better job.
2) Fix the underlying problem with optimization breaking something in the Fortran. I suspect that it has to do with using CERNLIB on a 64-bit machine. If so it the fix may not be obvious. @rjones30 might know something about this problem.
