### PR TITLE
Ignore by-products of Makefile_sim-recon.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ src/SBMS/*.pyc
 *.so
 *.root
 *.dblite
+.clone_done
+.getarg_patches_done
+.sconstruct_done
+sim-recon_prereqs_version.xml


### PR DESCRIPTION
This identifies a few files that get produced by the make but should not be version controlled.
