### PR TITLE
Add -fno-aggressive-loop-optimizations for Fortran in HDGeant directory

### DIFF
--- a/src/programs/Simulation/HDGeant/SConscript
+++ b/src/programs/Simulation/HDGeant/SConscript
@@ -1,6 +1,7 @@
 
 import os
 import sbms
+import subprocess
 
 Import('*')
 
@@ -15,11 +16,11 @@ else:
 
 	# get env object and clone it
 	env = env.Clone()
-	flags = env['FORTRANFLAGS']
-	print "FORTRANFLAGS before:", flags
-	for (i,flag) in enumerate(flags):
-		if '-O' in flag: flags[i] = '-O0'
-	print "FORTRANFLAGS after:", flags
+
+	vstring = subprocess.check_output(["gcc", "-dumpversion"]).rstrip()
+	versions = vstring.split('.')
+	if int(versions[0]) >= 4 and int(versions[1]) >= 8:
+		env.PrependUnique(FORTRANFLAGS = ['-fno-aggressive-loop-optimizations'])
 	
 	SConscript(dirs=['gelhad', 'hitutil', 'utilities'], exports='env osname', duplicate=0)
 


### PR DESCRIPTION
For programs/Simulation/HDGeant only, and only for Fortran code, and only if the gcc compiler version is greater than or equal to 4.8, throw the -fno_aggressive-loop-optimizations flag. This fixes the infinite loop problem of hdgeant on RHEL7 even if optimization level 2 is chosen.

See the ["changes" page for GCC 4.8](https://gcc.gnu.org/gcc-4.8/changes.html) for a caution about using the new optimization scheme for this version.

I'm not sure how this affects other compilers (non-GCC compilers). If there are implications for them, we may have to revise this fix.

This is a less drastic fix than the one Nathan and I previously pushed. See pull request #41. That one turns off optimization completely for all Fortran code in HDGeant.
