### PR TITLE
Add single-ended hit energies to cluster energy without using single-…

### DIFF
--- a/src/libraries/BCAL/DBCALCluster.h
+++ b/src/libraries/BCAL/DBCALCluster.h
@@ -29,6 +29,10 @@ public:
   DBCALCluster(const DBCALPoint* point, double z_target_center);
 
   vector< const DBCALPoint* > points() const { return m_points; }
+  // Returns a vector of the single-ended hits used in the cluster.
+  // This returns a pair because we need to store the attenuated-corrected energy
+  // and the DBCALUnifiedHit cannot hold this information.
+  vector< pair<const DBCALUnifiedHit*,double> > hits() const { return m_single_ended_hits; }
 
   int nCells() const { return m_points.size(); }
   
@@ -58,6 +62,7 @@ public:
   
   // these functions modify the cluster
   void addPoint( const DBCALPoint* point );
+  void addHit ( const DBCALUnifiedHit* hit, double hit_E_unattenuated );
   void mergeClust( const DBCALCluster& clust );
   
   // this prints out info
@@ -69,7 +74,10 @@ private:
   void clear();
   
   vector< const DBCALPoint* > m_points;
-  
+  vector< pair<const DBCALUnifiedHit*,double> > m_single_ended_hits; //Store single-ended hits together with their unattenuated energies
+
+  float m_hit_E_unattenuated_sum; //attenuation-corrected sum of energies from single-ended hits
+  float m_E_points;
   float m_E;
   
   float m_t;

--- a/src/libraries/BCAL/DBCALCluster_factory.h
+++ b/src/libraries/BCAL/DBCALCluster_factory.h
@@ -15,6 +15,7 @@ using namespace jana;
 
 #include "BCAL/DBCALHit.h"
 #include "BCAL/DBCALCluster.h"
+#include "BCAL/DBCALUnifiedHit.h"
 
 #include "TTree.h"
 #include "TFile.h"
@@ -37,7 +38,7 @@ private:
   
   // these routines combine points and clusters together
 
-  vector<DBCALCluster*> clusterize( vector< const DBCALPoint* > points ) const;
+  vector<DBCALCluster*> clusterize( vector< const DBCALPoint* > points, vector< const DBCALUnifiedHit* > hits ) const;
   void merge( vector<DBCALCluster*>& clusters ) const;
   
   // these are the routines used for testing whether things should be
@@ -50,19 +51,16 @@ private:
                 const DBCALPoint* point ) const;
   
   bool overlap( const DBCALCluster& clust, 
-                const DBCALHit* hit ) const; 
+                const DBCALUnifiedHit* hit ) const; 
   
   float m_mergeSig;
   float m_moliereRadius;
+  float m_clust_hit_timecut;
   float m_timeCut;
-
   double m_z_target_center;
-  
-  // we may consider a separate factory to provide the BCAL points at
-  // a future stage; for now have this factory own and maintain them
-  
-  vector< DBCALPoint* > m_bcalPoints;
-    
+  vector<double> effective_velocities;
+  vector< vector<double > > attenuation_parameters;
+
 #ifdef BCAL_CLUSTER_DIAGNOSTIC
   
 #define MAX_POINT 1000

--- a/src/libraries/BCAL/DBCALHit_factory.cc
+++ b/src/libraries/BCAL/DBCALHit_factory.cc
@@ -150,7 +150,7 @@ jerror_t DBCALHit_factory::evnt(JEventLoop *loop, int eventnumber)
       double gain              = GetConstant(gains,digihit);
       double hit_E = 0;
       if (integral > 0) hit_E  = gain * (integral - totalpedestal);
-
+      if ( hit_E < 0 ) continue;  // Throw away negative energy hits  
       // Calculate time for channel
       double pulse_time        = (double)digihit->pulse_time;
       double hit_t             = t_scale * pulse_time - GetConstant(time_offsets,digihit) + t_base;

--- a/src/libraries/BCAL/DBCALPoint.cc
+++ b/src/libraries/BCAL/DBCALPoint.cc
@@ -114,48 +114,6 @@ DBCALPoint::DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2,
   convertCylindricalToSpherical();
 }
 
-DBCALPoint::DBCALPoint( const DBCALHit& hit, float z, float z_target_center )
-{
-  
-  int cellId = DBCALGeometry::cellId( hit.module, hit.layer, hit.sector );
-  
-  // a boolean true if upstream hit false if downstream hit
-  bool isUp = ( hit.end == DBCALGeometry::kUpstream );
-  
-  // save typing
-  float fibLen = DBCALGeometry::BCALFIBERLENGTH;
-  float cEff = DBCALGeometry::C_EFFECTIVE;
-  
-  // set the z position relative to the center of the target
-  m_z = z;
-  m_zLocal = m_z + z_target_center - DBCALGeometry::GLOBAL_CENTER;
-  
-  float d = ( isUp ? 0.5 * fibLen + m_zLocal : 0.5 * fibLen - m_zLocal );
-  float att = exp( -d / DBCALGeometry::ATTEN_LENGTH );
-  
-  m_t = hit.t - d / cEff;
-  m_E =  hit.E / att;
-  
-  m_r = DBCALGeometry::r( cellId );
-  m_sig_r = DBCALGeometry::rSize( cellId );
-  
-  m_phi = DBCALGeometry::phi( cellId );
-  m_sig_phi = DBCALGeometry::phiSize( cellId );
-  
-  // this needs more careful examination.. especially for single end
-  // hits like this one
-  
-  m_sig_z = cEff * 400 * k_psec;
-
-  m_module = hit.module;
-  m_layer = hit.layer;
-  m_sector = hit.sector;
-  
-  // recast in terms of spherical coordinates
-  convertCylindricalToSpherical();
-}
-
-
 float
 DBCALPoint::tInnerRadius() const {
  

--- a/src/libraries/BCAL/DBCALPoint.h
+++ b/src/libraries/BCAL/DBCALPoint.h
@@ -32,10 +32,6 @@ public:
   // this constructor uses two hits to obtain a local z position
   DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2, double z_target_center, double attenutation_length);
   
-  // this constructor is helpful for single-ended hits when
-  // z is known -- z measured with respect to target
-  DBCALPoint( const DBCALHit& hit, float z, float z_target_center );
-
   float E() const { return m_E; }
   float E_US() const { return m_E_US; }  ///< Return the attenuation corrected Energy of US Hit
   float E_DS() const { return m_E_DS; }  ///< Return the attenuation corrected Energy of DS Hit


### PR DESCRIPTION
…ended hits to calculated cluster centroid or time. Added a safeguard in the Hit Factory to throw away hits with negative energy. Removed obsolete code from when the BCALPoints were being reconstructed in the Cluster factory.
