### PR TITLE
Also add fortran flag for gcc-5 and higher

### DIFF
--- a/src/programs/Simulation/HDGeant/SConscript
+++ b/src/programs/Simulation/HDGeant/SConscript
@@ -20,9 +20,9 @@ else:
 	sout,serr = subprocess.Popen(["gcc", "-dumpversion"], stdout = subprocess.PIPE, stderr= subprocess.PIPE).communicate()
 	vstring = sout.rstrip()
 	versions = vstring.split('.')
-	if int(versions[0]) >= 4 and int(versions[1]) >= 8:
+	if int(versions[0]) >= 4 and int(versions[1]) >= 8 or int(versions[0]) >= 5:
 		env.PrependUnique(FORTRANFLAGS = ['-fno-aggressive-loop-optimizations'])
-	
+
 	SConscript(dirs=['gelhad', 'hitutil', 'utilities'], exports='env osname', duplicate=0)
 
 	env.AppendUnique(LIBS      = ['hddsGeant3', 'gelhad', 'hitutil'])


### PR DESCRIPTION
The fortran flag "-fno-agressive-loop-optimizations" was previously set
to be added for gcc-4.8/4.9. This commit adds it for gcc-5 and higher too.
