### PR TITLE
Bcal flight time variance

### DIFF
--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -2200,7 +2200,7 @@ jerror_t DEventSourceHDDM::Extract_DTrackTimeBased(hddm_s::HDDM *record,
       if (rt) {
          rt->SetMass(track->mass());
          rt->SetDGeometry(geom);
-         rt->Swim(pos, mom, track->charge());
+         rt->Swim(pos, mom, track->charge(),&errMatrix);
          rts.push_back(rt);
       }
       track->rt = rt;

--- a/src/libraries/PID/DChargedTrackHypothesis_factory.cc
+++ b/src/libraries/PID/DChargedTrackHypothesis_factory.cc
@@ -140,8 +140,9 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory::Create_ChargedTrackHyp
 		locChargedTrackHypothesis->setPathLength(locBCALShowerMatchParams.dPathLength, 0.0);
 //		double locFlightTimePCorrelation = locDetectorMatches->Get_FlightTimePCorrelation(locTrackTimeBased, SYS_BCAL); //uncomment when ready!!
 //		Add_TimeToTrackingMatrix(locChargedTrackHypothesis, locBCALShowerMatchParams.dFlightTimeVariance, locBCALShower->tErr*locBCALShower->tErr, locFlightTimePCorrelation); //uncomment when ready!!
-		locCovarianceMatrix(6, 6) = 0.00255*pow(locChargedTrackHypothesis->momentum().Mag(), -2.52) + 0.220; //delete when ready!!
-		locCovarianceMatrix(6, 6) *= locCovarianceMatrix(6, 6); //delete when ready!!
+		//locCovarianceMatrix(6, 6) = 0.00255*pow(locChargedTrackHypothesis->momentum().Mag(), -2.52) + 0.220; //delete when ready!!
+		//locCovarianceMatrix(6, 6) *= locCovarianceMatrix(6, 6); //delete when ready!!
+		locCovarianceMatrix(6,6)=0.3*0.3+locBCALShowerMatchParams.dFlightTimeVariance;
 
 		//add associated objects
 		vector<DBCALShowerMatchParams> locShowerMatchParams;

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -522,7 +522,11 @@ bool DParticleID::MatchToBCAL(const DKinematicData* locTrack, const DReferenceTr
 	DVector3 bcal_pos(locBCALShower->x, locBCALShower->y, locBCALShower->z); 
 
 	double locFlightTime = 9.9E9, locPathLength = 9.9E9;
-	double d = rt->DistToRTwithTime(bcal_pos, &locPathLength, &locFlightTime, SYS_BCAL);
+	double locFlightTimeVariance=9.9E9;
+	double d = rt->DistToRTwithTime(bcal_pos, &locPathLength,
+					&locFlightTime, &locFlightTimeVariance,
+					SYS_BCAL);
+
 
 	if(!isfinite(d))
 		return false;
@@ -588,7 +592,7 @@ bool DParticleID::MatchToBCAL(const DKinematicData* locTrack, const DReferenceTr
 	locShowerMatchParams.dBCALShower = locBCALShower;
 	locShowerMatchParams.dx = 0.0; //SET ME!!!!
 	locShowerMatchParams.dFlightTime = locFlightTime;
-	locShowerMatchParams.dFlightTimeVariance = 0.0; //SET ME!!!!
+	locShowerMatchParams.dFlightTimeVariance = locFlightTimeVariance;
 	locShowerMatchParams.dPathLength = locPathLength;
 	locShowerMatchParams.dDeltaPhiToShower = dphi_min;
 	locShowerMatchParams.dDeltaZToShower = dz;
@@ -1259,7 +1263,7 @@ bool DParticleID::Distance_ToTrack(const DBCALShower* locBCALShower, const DRefe
 	DVector3 bcal_pos(locBCALShower->x, locBCALShower->y, locBCALShower->z); 
 
 	double locFlightTime = 9.9E9, locPathLength = 9.9E9;
-	locDistance = rt->DistToRTwithTime(bcal_pos, &locPathLength, &locFlightTime,SYS_BCAL);
+	locDistance = rt->DistToRTwithTime(bcal_pos, &locPathLength, &locFlightTime,NULL,SYS_BCAL);
 	if(!isfinite(locDistance))
 		return false;
 

--- a/src/libraries/TRACKING/DReferenceTrajectory.cc
+++ b/src/libraries/TRACKING/DReferenceTrajectory.cc
@@ -1135,6 +1135,7 @@ int DReferenceTrajectory::InsertSteps(const swim_step_t *start_step, double delt
 // DistToRTwithTime
 //---------------------------------
 double DReferenceTrajectory::DistToRTwithTime(DVector3 hit, double *s,double *t,
+					      double *var_t,
 					      DetectorSystem_t detector) const{
   double dist=DistToRT(hit,s,detector);
   if (s!=NULL && t!=NULL) 
@@ -1143,12 +1144,18 @@ double DReferenceTrajectory::DistToRTwithTime(DVector3 hit, double *s,double *t,
     {
       *s = 1.0E6;
       *t = 1.0E6;
+      if (var_t!=NULL){
+	*var_t=1.0E6;
+      }
     }
     else
     {
       double p_sq=last_swim_step->mom.Mag2();
       double one_over_beta=sqrt(1.+mass_sq/p_sq);
       *t=last_swim_step->t+(*s-last_swim_step->s)*one_over_beta/SPEED_OF_LIGHT;
+      if (var_t!=NULL){
+	*var_t=last_swim_step->cov_t_t;
+      }
     }
   }
   return dist;

--- a/src/libraries/TRACKING/DReferenceTrajectory.h
+++ b/src/libraries/TRACKING/DReferenceTrajectory.h
@@ -87,7 +87,7 @@ class DReferenceTrajectory{
 		double DistToRT(double x, double y, double z) const {return DistToRT(DVector3(x,y,z));}
 		double DistToRT(DVector3 hit, double *s=NULL,DetectorSystem_t detector=SYS_NULL) const;
 		double DistToRTwithTime(DVector3 hit, double *s=NULL,
-					double *t=NULL,
+					double *t=NULL,double *var_t=NULL,
 					DetectorSystem_t detector=SYS_NULL) const;
 		double DistToRT(const DCoordinateSystem *wire, double *s=NULL) const;
 		double DistToRTBruteForce(const DCoordinateSystem *wire, double *s=NULL) const;

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -868,7 +868,7 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
       rt->SetMass(mass);
       rt->SetDGeometry(geom);
       rt->q = timebased_track->charge();
-      rt->Swim(timebased_track->position(), timebased_track->momentum(), timebased_track->charge());
+      rt->Swim(timebased_track->position(), timebased_track->momentum(), timebased_track->charge(),&timebased_track->errorMatrix());
 
       if(rt->Nswim_steps <= 1)
       {
@@ -1006,7 +1006,7 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
   rt->SetMass(my_mass);
   rt->SetDGeometry(geom);
   rt->q = timebased_track->charge();
-  rt->Swim(timebased_track->position(), timebased_track->momentum(), timebased_track->charge());
+  rt->Swim(timebased_track->position(), timebased_track->momentum(), timebased_track->charge(),&timebased_track->errorMatrix());
   timebased_track->rt=rt;
   
   // Get the hits used in the fit and add them as associated objects 


### PR DESCRIPTION
Propagate variance in the flight time (computed in DReferenceTrajectory if the covariance matrix is added as an argument to rt->Swim) up to the BCAL track matching objects.
