### PR TITLE
Fix usage of DistToRTwithTime() in p2pi_hists plugin

### DIFF
--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.cc
@@ -264,8 +264,8 @@ bool DCustomAction_p2pi_unusedHists::Perform_Action(JEventLoop* locEventLoop, co
 			const DBCALShower *locBCALShower = locBCALShowers[loc_j];
 			DVector3 bcal_pos(locBCALShower->x, locBCALShower->y, locBCALShower->z);
 				
-			double locFlightTime = 9.9E9, locPathLength = 9.9E9;
-			rt->DistToRTwithTime(bcal_pos, &locPathLength, &locFlightTime, SYS_BCAL);
+			double locFlightTime = 9.9E9, locPathLength = 9.9E9, locFlightTimeVariance = 9.9E9;
+			rt->DistToRTwithTime(bcal_pos, &locPathLength, &locFlightTime, &locFlightTimeVariance, SYS_BCAL);
 			
 			DVector3 proj_pos = rt->GetLastDOCAPoint();
 			if(proj_pos.Perp() < 65.0)


### PR DESCRIPTION
This commit fixes an error introduced by PR #51, which added the
flight-time variance as a parameter in DistToRTwithTime() but did
not update its call in the p2pi_hists plugin.
