### PR TITLE
Add pulse-peak/integral to toStrings() for PS pairs

### DIFF
--- a/src/libraries/PAIR_SPECTROMETER/DPSCHit_factory.cc
+++ b/src/libraries/PAIR_SPECTROMETER/DPSCHit_factory.cc
@@ -243,6 +243,7 @@ jerror_t DPSCHit_factory::evnt(JEventLoop *loop, int eventnumber)
 	hit->module = module;
 	hit->time_fadc = numeric_limits<double>::quiet_NaN();
 	hit->integral = numeric_limits<double>::quiet_NaN();
+	hit->pulse_peak = numeric_limits<double>::quiet_NaN();
 	hit->npe_fadc = numeric_limits<double>::quiet_NaN();
 	hit->has_fADC = false;
 	_data.push_back(hit);

--- a/src/libraries/PAIR_SPECTROMETER/DPSCPair.h
+++ b/src/libraries/PAIR_SPECTROMETER/DPSCPair.h
@@ -19,12 +19,16 @@ class DPSCPair:public jana::JObject{
   pair<const DPSCHit*,const DPSCHit*> ee;	// first:North(left); second:South(right)		
   
   void toStrings(vector<pair<string,string> > &items)const{
-    AddString(items, "module_left", "%d", ee.first->module);
-    AddString(items, "module_right", "%d", ee.second->module);
-    AddString(items, "tl_tdc", "%f", ee.first->time_tdc);
-    AddString(items, "tr_tdc", "%f", ee.second->time_tdc);
-    AddString(items, "tl_fadc", "%f", ee.first->time_fadc);
-    AddString(items, "tr_fadc", "%f", ee.second->time_fadc);
+    AddString(items, "module_lhit", "%d", ee.first->module);
+    AddString(items, "module_rhit", "%d", ee.second->module);
+    AddString(items, "t_tdc_lhit", "%f", ee.first->time_tdc);
+    AddString(items, "t_tdc_rhit", "%f", ee.second->time_tdc);
+    AddString(items, "t_fadc_lhit", "%f", ee.first->time_fadc);
+    AddString(items, "t_fadc_rhit", "%f", ee.second->time_fadc);
+    AddString(items, "integral_lhit", "%f", ee.first->integral);
+    AddString(items, "integral_rhit", "%f", ee.second->integral);
+    AddString(items, "pulse_peak_lhit", "%f", ee.first->pulse_peak);
+    AddString(items, "pulse_peak_rhit", "%f", ee.second->pulse_peak);
   }
 		
 };

--- a/src/libraries/PAIR_SPECTROMETER/DPSPair.h
+++ b/src/libraries/PAIR_SPECTROMETER/DPSPair.h
@@ -19,13 +19,17 @@ class DPSPair:public jana::JObject{
   pair<const DPSHit*,const DPSHit*> ee;	// first:North(left); second:South(right)	
 
   void toStrings(vector<pair<string,string> > &items)const{
-    AddString(items, "column_left", "%d", ee.first->column);
-    AddString(items, "column_right", "%d", ee.second->column);
-    AddString(items, "Epair", "%f", ee.first->E+ee.second->E);
-    AddString(items, "El", "%f", ee.first->E);
-    AddString(items, "Er", "%f", ee.second->E);
-    AddString(items, "tl", "%f", ee.first->t);
-    AddString(items, "tr", "%f", ee.second->t);
+    AddString(items, "column_lhit", "%d", ee.first->column);
+    AddString(items, "column_rhit", "%d", ee.second->column);
+    AddString(items, "E_pair", "%f", ee.first->E+ee.second->E);
+    AddString(items, "E_lhit", "%f", ee.first->E);
+    AddString(items, "E_rhit", "%f", ee.second->E);
+    AddString(items, "t_lhit", "%f", ee.first->t);
+    AddString(items, "t_rhit", "%f", ee.second->t);
+    AddString(items, "integral_lhit", "%f", ee.first->integral);
+    AddString(items, "integral_rhit", "%f", ee.second->integral);
+    AddString(items, "pulse_peak_lhit", "%f", ee.first->pulse_peak);
+    AddString(items, "pulse_peak_rhit", "%f", ee.second->pulse_peak);
   }
 		
 };

--- a/src/libraries/TAGGER/DTAGMHit_factory.cc
+++ b/src/libraries/TAGGER/DTAGMHit_factory.cc
@@ -225,6 +225,7 @@ jerror_t DTAGMHit_factory::evnt(JEventLoop *loop, int eventnumber)
 		hit->time_fadc = 0;
 		hit->npix_fadc = 0;
 		hit->integral = 0;
+		hit->pulse_peak = 0;
 		hit->has_fADC=false;
 		_data.push_back(hit);
 	    }


### PR DESCRIPTION
These items have been added so that they are available as ROOT
branches in the output of the "janaroot" plugin.

PSC/TAGM hits: Set pulse peak (0/NaN) when there is no fADC hit.
