### PR TITLE
Flight time variance for tof fcal sc

### DIFF
--- a/src/libraries/PID/DChargedTrackHypothesis_factory.cc
+++ b/src/libraries/PID/DChargedTrackHypothesis_factory.cc
@@ -117,7 +117,7 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory::Create_ChargedTrackHyp
 		double locPropagatedTimeUncertainty = 0.3;
 //		double locFlightTimePCorrelation = locDetectorMatches->Get_FlightTimePCorrelation(locTrackTimeBased, SYS_START); //uncomment when ready!!
 //		Add_TimeToTrackingMatrix(locChargedTrackHypothesis, locSCHitMatchParams.dFlightTimeVariance, locSCHitMatchParams.dHitTimeVariance, locFlightTimePCorrelation); //uncomment when ready!!
-		locCovarianceMatrix(6, 6) = locPropagatedTimeUncertainty*locPropagatedTimeUncertainty; //delete when ready!!
+		locCovarianceMatrix(6, 6) = 0.3*0.3+locSCHitMatchParams.dFlightTimeVariance;
 
 		if(locEventRFBunch->dTimeSource == SYS_NULL)
 			locChargedTrackHypothesis->setT0(locPropagatedTime, locPropagatedTimeUncertainty, SYS_START); //update when ready
@@ -164,7 +164,7 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory::Create_ChargedTrackHyp
 			locChargedTrackHypothesis->setPathLength(locTOFHitMatchParams.dPathLength, 0.0);
 //			double locFlightTimePCorrelation = locDetectorMatches->Get_FlightTimePCorrelation(locTrackTimeBased, SYS_TOF); //uncomment when ready!!
 //			Add_TimeToTrackingMatrix(locChargedTrackHypothesis, locTOFHitMatchParams.dFlightTimeVariance, locTOFHitMatchParams.dHitTimeVariance, locFlightTimePCorrelation); //uncomment when ready!!
-			locCovarianceMatrix(6, 6) = 0.08*0.08; //delete when ready!!
+			locCovarianceMatrix(6, 6) = 0.1*0.1+locTOFHitMatchParams.dFlightTimeVariance; 
 		}
 
 		//add associated objects
@@ -188,7 +188,7 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory::Create_ChargedTrackHyp
 			locChargedTrackHypothesis->setPathLength(locFCALShowerMatchParams.dPathLength, 0.0);
 //			double locFlightTimePCorrelation = locDetectorMatches->Get_FlightTimePCorrelation(locTrackTimeBased, SYS_FCAL); //uncomment when ready!!
 //			Add_TimeToTrackingMatrix(locChargedTrackHypothesis, locFCALShowerMatchParams.dFlightTimeVariance, locFCALShower->dCovarianceMatrix(4, 4), locFlightTimePCorrelation); //uncomment when ready!!
-			locCovarianceMatrix(6, 6) = 0.6*0.6; // straight-line fit to high momentum data //delete when ready!!
+			locCovarianceMatrix(6, 6) = 0.5*0.5+locFCALShowerMatchParams.dFlightTimeVariance;
 		}
 
 		//add associated objects

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -509,7 +509,7 @@ bool DParticleID::MatchToBCAL(const DReferenceTrajectory* rt, const vector<const
 	Get_BestBCALMatchParams(rt->swim_steps[0].mom, locShowerMatchParamsVector, locBestMatchParams);
 	locStartTime = locBestMatchParams.dBCALShower->t - locBestMatchParams.dFlightTime;
 //	locTimeVariance = locBestMatchParams.dFlightTimeVariance + locBestMatchParams.dBCALShower->dCovarianceMatrix(4, 4); //uncomment when ready!!
-	locTimeVariance = 0.5*0.5;
+	locTimeVariance = 0.3*0.3+locBestMatchParams.dFlightTimeVariance;
 
 	return true;
 }
@@ -627,7 +627,7 @@ bool DParticleID::MatchToTOF(const DReferenceTrajectory* rt, const vector<const 
 	Get_BestTOFMatchParams(locTOFHitMatchParamsVector, locBestMatchParams);
 	locStartTime = locBestMatchParams.dHitTime - locBestMatchParams.dFlightTime;
 //	locTimeVariance = locBestMatchParams.dFlightTimeVariance + locBestMatchParams.dHitTimeVariance; //uncomment when ready!
-	locTimeVariance = 0.1*0.1;
+	locTimeVariance = 0.1*0.1+locBestMatchParams.dFlightTimeVariance;
 
 	return true;
 }
@@ -642,7 +642,8 @@ bool DParticleID::MatchToTOF(const DKinematicData* locTrack, const DReferenceTra
 	DVector3 norm(0.0, 0.0, 1.0); //normal vector to TOF plane
 	DVector3 proj_pos, proj_mom;
 	double locPathLength = 9.9E9, locFlightTime = 9.9E9;
-	if(rt->GetIntersectionWithPlane(tof_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime,SYS_TOF) != NOERROR)
+	double locFlightTimeVariance=9.9E9;
+	if(rt->GetIntersectionWithPlane(tof_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime,&locFlightTimeVariance,SYS_TOF) != NOERROR)
 		return false;
 
 	// Check that the hit is not out of time with respect to the track
@@ -745,7 +746,7 @@ bool DParticleID::MatchToTOF(const DKinematicData* locTrack, const DReferenceTra
 
 	locTOFHitMatchParams.dEdx = locHitEnergy/dx;
 	locTOFHitMatchParams.dFlightTime = locFlightTime;
-	locTOFHitMatchParams.dFlightTimeVariance = 0.0; //SET ME!!!
+	locTOFHitMatchParams.dFlightTimeVariance = locFlightTimeVariance;
 	locTOFHitMatchParams.dPathLength = locPathLength;
 	locTOFHitMatchParams.dDeltaXToHit = locDeltaX;
 	locTOFHitMatchParams.dDeltaYToHit = locDeltaY;
@@ -765,8 +766,8 @@ bool DParticleID::PredictFCALHit(const DReferenceTrajectory *rt,
   DVector3 fcal_pos(0,0,dFCALz);
   DVector3 norm(0.0, 0.0, 1.0); //normal vector to FCAL plane
   DVector3 proj_mom,proj_pos;
-  double locPathLength = 9.9E9, locFlightTime = 9.9E9;
-  if(rt->GetIntersectionWithPlane(fcal_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime,SYS_FCAL) != NOERROR)
+  if(rt->GetIntersectionWithPlane(fcal_pos, norm, proj_pos, proj_mom,
+				  NULL,NULL,NULL,SYS_FCAL) != NOERROR)
     return false;
 
   if (intersection) *intersection=proj_pos;
@@ -818,8 +819,8 @@ bool DParticleID::PredictTOFPaddles(const DReferenceTrajectory *rt,
   DVector3 tof_pos(0,0,dTOFGeometry->CenterMPlane);
   DVector3 norm(0.0, 0.0, 1.0); //normal vector to TOF plane
   DVector3 proj_mom,proj_pos;
-  double locPathLength = 9.9E9, locFlightTime = 9.9E9;
-  if(rt->GetIntersectionWithPlane(tof_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime,SYS_TOF) != NOERROR)
+  if(rt->GetIntersectionWithPlane(tof_pos, norm, proj_pos, proj_mom, 
+				  NULL,NULL,NULL,SYS_TOF) != NOERROR)
     return false;
 
   double x=proj_pos.x();
@@ -863,7 +864,7 @@ bool DParticleID::MatchToFCAL(const DReferenceTrajectory* rt, const vector<const
 
 	locStartTime = locBestMatchParams.dFCALShower->getTime() - locBestMatchParams.dFlightTime;
 //	locTimeVariance = locBestMatchParams.dFlightTimeVariance + locBestMatchParams.dFCALShower->dCovarianceMatrix(4, 4); //uncomment when ready!
-	locTimeVariance = 0.5*0.5;
+	locTimeVariance = 0.5*0.5+locBestMatchParams.dFlightTimeVariance;
 
 	return true;
 }
@@ -878,7 +879,8 @@ bool DParticleID::MatchToFCAL(const DKinematicData* locTrack, const DReferenceTr
 	DVector3 norm(0.0, 0.0, 1.0); //normal vector for the FCAL plane
 	DVector3 proj_pos, proj_mom;
 	double locPathLength = 9.9E9, locFlightTime = 9.9E9;
-	if(rt->GetIntersectionWithPlane(fcal_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime, SYS_FCAL) != NOERROR)
+	double locFlightTimeVariance=9.9E9;
+	if(rt->GetIntersectionWithPlane(fcal_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime, &locFlightTimeVariance,SYS_FCAL) != NOERROR)
 		return false;
 
 	// Check that the hit is not out of time with respect to the track
@@ -915,7 +917,7 @@ bool DParticleID::MatchToFCAL(const DKinematicData* locTrack, const DReferenceTr
 	locShowerMatchParams.dFCALShower = locFCALShower;
 	locShowerMatchParams.dx = 45.0*p/(proj_mom.Dot(norm));
 	locShowerMatchParams.dFlightTime = locFlightTime;
-	locShowerMatchParams.dFlightTimeVariance = 0.0; //SET ME!!!
+	locShowerMatchParams.dFlightTimeVariance = locFlightTimeVariance;
 	locShowerMatchParams.dPathLength = locPathLength;
 	locShowerMatchParams.dDOCAToShower = d;
 
@@ -952,7 +954,7 @@ bool DParticleID::MatchToSC(const DReferenceTrajectory* rt, const vector<const D
 
 	locStartTime = locBestMatchParams.dHitTime - locBestMatchParams.dFlightTime;
 //	locTimeVariance = locBestMatchParams.dFlightTimeVariance - locBestMatchParams.dHitTimeVariance; //uncomment when ready!
-	locTimeVariance = 0.3*0.3;
+	locTimeVariance = 0.3*0.3+locBestMatchParams.dFlightTimeVariance;
 
 	return true;
 }
@@ -970,13 +972,14 @@ bool DParticleID::MatchToSC(const DKinematicData* locTrack, const DReferenceTraj
 	// Find intersection with a "barrel" approximation for the start counter
 	DVector3 proj_pos(NaN,NaN,NaN), proj_mom(NaN,NaN,NaN);
 	double locPathLength = 9.9E9, locFlightTime = 9.9E9;
+	double locFlightTimeVariance=9.9E9;
 	unsigned int sc_index=locSCHit->sector-1;
 	
 	if(rt->GetIntersectionWithPlane(sc_pos[sc_index][0],
 					sc_norm[sc_index][0], 
 					proj_pos, proj_mom, 
-					&locPathLength, 
-					&locFlightTime) != NOERROR)
+					&locPathLength, &locFlightTime,
+					&locFlightTimeVariance) != NOERROR)
 		return false;
 	// Check that the intersection isn't upstream of the paddle
 	double myz = proj_pos.z();
@@ -1049,8 +1052,8 @@ bool DParticleID::MatchToSC(const DKinematicData* locTrack, const DReferenceTraj
 	      if(rt->GetIntersectionWithPlane(sc_pos[sc_index][loc_i],
 					      sc_norm[sc_index][loc_i], 
 					      proj_pos, proj_mom, 
-					      &locPathLength, 
-					      &locFlightTime) != NOERROR)
+					      &locPathLength, &locFlightTime, 
+					      &locFlightTimeVariance) != NOERROR)
 		continue;
 	      myz = proj_pos.z();
 	      norm=sc_norm[sc_index][loc_i];
@@ -1141,7 +1144,7 @@ bool DParticleID::MatchToSC(const DKinematicData* locTrack, const DReferenceTraj
 	locSCHitMatchParams.dHitTime = locCorrectedHitTime;
 	locSCHitMatchParams.dHitTimeVariance = 0.0; //SET ME!!!
 	locSCHitMatchParams.dFlightTime = locFlightTime;
-	locSCHitMatchParams.dFlightTimeVariance = 0.0; //SET ME!!!
+	locSCHitMatchParams.dFlightTimeVariance = locFlightTimeVariance;
 	locSCHitMatchParams.dPathLength = locPathLength;
 	locSCHitMatchParams.dDeltaPhiToHit = dphi;
 
@@ -1296,7 +1299,7 @@ bool DParticleID::Distance_ToTrack(const DFCALShower* locFCALShower, const DRefe
 	DVector3 norm(0.0, 0.0, 1.0); //normal vector for the FCAL plane
 	DVector3 proj_pos, proj_mom;
 	double locPathLength = 9.9E9, locFlightTime = 9.9E9;
-	if(rt->GetIntersectionWithPlane(fcal_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime,SYS_FCAL) != NOERROR)
+	if(rt->GetIntersectionWithPlane(fcal_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime,NULL,SYS_FCAL) != NOERROR)
 		return false;
 
 	// Check that the hit is not out of time with respect to the track
@@ -1318,7 +1321,7 @@ bool DParticleID::Distance_ToTrack(const DTOFPoint* locTOFPoint, const DReferenc
 	DVector3 norm(0.0, 0.0, 1.0); //normal vector to TOF plane
 	DVector3 proj_pos, proj_mom;
 	double locPathLength = 9.9E9, locFlightTime = 9.9E9;
-	if(rt->GetIntersectionWithPlane(tof_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime, SYS_TOF) != NOERROR)
+	if(rt->GetIntersectionWithPlane(tof_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime, NULL, SYS_TOF) != NOERROR)
 		return false;
 
 	// Check that the hit is not out of time with respect to the track

--- a/src/libraries/TRACKING/DReferenceTrajectory.cc
+++ b/src/libraries/TRACKING/DReferenceTrajectory.cc
@@ -1009,6 +1009,9 @@ jerror_t DReferenceTrajectory::GetIntersectionWithPlane(const DVector3 &origin, 
 			  double one_over_beta=sqrt(1.+mass_sq/p_sq);
 			  *t = step->t+ds*one_over_beta/SPEED_OF_LIGHT;
 			}
+			if (var_t){
+			  *var_t=step->cov_t_t;
+			}
 			
 			// Success. Go ahead and return
 			return NOERROR;

--- a/src/libraries/TRACKING/DReferenceTrajectory.cc
+++ b/src/libraries/TRACKING/DReferenceTrajectory.cc
@@ -863,12 +863,12 @@ jerror_t DReferenceTrajectory::GetIntersectionWithRadius(double R,
 //---------------------------------
 // GetIntersectionWithPlane
 //---------------------------------
-jerror_t DReferenceTrajectory::GetIntersectionWithPlane(const DVector3 &origin, const DVector3 &norm, DVector3 &pos, double *s,double *t,DetectorSystem_t detector) const{
+jerror_t DReferenceTrajectory::GetIntersectionWithPlane(const DVector3 &origin, const DVector3 &norm, DVector3 &pos, double *s,double *t,double *var_t,DetectorSystem_t detector) const{
   DVector3 dummy;
-  return GetIntersectionWithPlane(origin,norm,pos,dummy,s,t,detector);
+  return GetIntersectionWithPlane(origin,norm,pos,dummy,s,t,var_t,detector);
 }
 jerror_t DReferenceTrajectory::GetIntersectionWithPlane(const DVector3 &origin, const DVector3 &norm, DVector3 &pos, DVector3 &p_at_intersection, double *s,
-							double *t,DetectorSystem_t detector) const
+							double *t,double *var_t,DetectorSystem_t detector) const
 {
 	/// Get the intersection point of this trajectory with a plane.
 	/// The plane is specified by <i>origin</i> and <i>norm</i>. The
@@ -1031,6 +1031,10 @@ jerror_t DReferenceTrajectory::GetIntersectionWithPlane(const DVector3 &origin, 
 	if (t){
 	  double one_over_beta=sqrt(1.+mass_sq/p_sq);
 	  *t = step->t+ds*one_over_beta/SPEED_OF_LIGHT;
+	}
+	// Flight time variance
+	if (var_t){
+	  *var_t=step->cov_t_t;
 	}
 
 	return NOERROR;

--- a/src/libraries/TRACKING/DReferenceTrajectory.h
+++ b/src/libraries/TRACKING/DReferenceTrajectory.h
@@ -107,8 +107,8 @@ class DReferenceTrajectory{
 			      const DCoordinateSystem *wire=NULL);
 
 		int InsertSteps(const swim_step_t *start_step, double delta_s, double step_size=0.02); 
-		jerror_t GetIntersectionWithPlane(const DVector3 &origin, const DVector3 &norm, DVector3 &pos, double *s=NULL,double *t=NULL,DetectorSystem_t detector=SYS_NULL) const;	
-		jerror_t GetIntersectionWithPlane(const DVector3 &origin, const DVector3 &norm, DVector3 &pos, DVector3 &p_at_intersection,double *s=NULL,double *t=NULL,DetectorSystem_t detector=SYS_NULL) const;
+		jerror_t GetIntersectionWithPlane(const DVector3 &origin, const DVector3 &norm, DVector3 &pos, double *s=NULL,double *t=NULL,double *var_t=NULL,DetectorSystem_t detector=SYS_NULL) const;	
+		jerror_t GetIntersectionWithPlane(const DVector3 &origin, const DVector3 &norm, DVector3 &pos, DVector3 &p_at_intersection,double *s=NULL,double *t=NULL,double *var_t=NULL,DetectorSystem_t detector=SYS_NULL) const;
 		jerror_t GetIntersectionWithRadius(double R,DVector3 &mypos,
 						   double *s=NULL,
 						   double *t=NULL,

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.cc
@@ -326,7 +326,7 @@ bool DCustomAction_p2pi_unusedHists::Perform_Action(JEventLoop* locEventLoop, co
 			DVector3 norm(0.0, 0.0, 1.0); //normal vector for the FCAL plane
 			DVector3 proj_pos, proj_mom;
 			double locPathLength = 9.9E9, locFlightTime = 9.9E9;
-			if(rt->GetIntersectionWithPlane(fcal_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime, SYS_FCAL) != NOERROR)
+			if(rt->GetIntersectionWithPlane(fcal_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime, NULL, SYS_FCAL) != NOERROR)
 				continue;
 			
 			double dd = (fcal_pos - proj_pos).Mag();

--- a/src/programs/Analysis/hdview2/MyProcessor.cc
+++ b/src/programs/Analysis/hdview2/MyProcessor.cc
@@ -1855,7 +1855,7 @@ void MyProcessor::GetIntersectionWithCalorimeter(const DKinematicData* kd, DVect
 	DVector3 norm(0.0, 0.0, -1.0);
 	//rt.GetIntersectionWithPlane(origin, norm, pos_fcal, &s_fcal); // This gives different answer than below!
 	DVector3 p_at_intersection;
-	rt.GetIntersectionWithPlane(origin, norm, pos_fcal, p_at_intersection, &s_fcal, NULL, SYS_FCAL);
+	rt.GetIntersectionWithPlane(origin, norm, pos_fcal, p_at_intersection, &s_fcal, NULL, NULL, SYS_FCAL);
 	if(pos_fcal.Perp()<FCAL_Rmin || pos_fcal.Perp()>FCAL_Rmax || !isfinite(pos_fcal.Z()))s_fcal = 1.0E6;
 	
 	// Find intersection with BCAL


### PR DESCRIPTION
Pass variance for flight time up to the matching code for FCAL (BCAL was changed already), TOF and start counter and fill dFlightTimeVariance elements of the match parameter objects.
