### PR TITLE
Fix for BCAL_online with simulated data

### DIFF
--- a/src/plugins/monitoring/BCAL_online/JEventProcessor_BCAL_online.cc
+++ b/src/plugins/monitoring/BCAL_online/JEventProcessor_BCAL_online.cc
@@ -516,7 +516,8 @@ jerror_t JEventProcessor_BCAL_online::evnt(JEventLoop *loop, int eventnumber) {
 		bcal_tdc_digi_time->Fill(hit->time);
 		vector<const DF1TDCHit*> f1tdchits;
 		hit->Get(f1tdchits);
-		bcal_tdc_digi_reltime->Fill(f1tdchits[0]->time,f1tdchits[0]->trig_time);
+        if(f1tdchits.size() > 0)
+            bcal_tdc_digi_reltime->Fill(f1tdchits[0]->time,f1tdchits[0]->trig_time);
 
 		int layer = hit->layer;
 		int glosect = DBCALGeometry::getglobalsector(hit->module, hit->sector);


### PR DESCRIPTION
Small fix to crashes in BCAL_online plugin with simulated data, caused by trying to access DF1TDCHit objects without checking to see if they exist or not.
