### PR TITLE
Comment out code added for RootSpy-macro testing

### DIFF
--- a/src/plugins/monitoring/BCAL_Eff/SConscript
+++ b/src/plugins/monitoring/BCAL_Eff/SConscript
@@ -8,7 +8,7 @@ env = env.Clone()
 
 sbms.AddROOTSpyMacros(env)
 sbms.AddDANA(env)
-env.Append(LIBS=['DANA','HDDM','PID', 'xstream', 'ANALYSIS','FCAL','TAGGER'])  # this avoids undefined references for _ZTI12DApplication when attaching plugin to RootSpy
+#env.Append(LIBS=['DANA','HDDM','PID', 'xstream', 'ANALYSIS','FCAL','TAGGER'])  # this avoids undefined references for _ZTI12DApplication when attaching plugin to RootSpy
 sbms.plugin(env)
 
 

--- a/src/plugins/monitoring/BCAL_inv_mass/SConscript
+++ b/src/plugins/monitoring/BCAL_inv_mass/SConscript
@@ -8,7 +8,7 @@ env = env.Clone()
 
 sbms.AddROOTSpyMacros(env)
 sbms.AddDANA(env)
-env.Append(LIBS=['DANA','HDDM','PID', 'xstream', 'ANALYSIS','FCAL','TAGGER'])  # this avoids undefined references for _ZTI12DApplication when attaching plugin to RootSpy
+#env.Append(LIBS=['DANA','HDDM','PID', 'xstream', 'ANALYSIS','FCAL','TAGGER'])  # this avoids undefined references for _ZTI12DApplication when attaching plugin to RootSpy
 sbms.plugin(env)
 
 

--- a/src/plugins/monitoring/BCAL_online/SConscript
+++ b/src/plugins/monitoring/BCAL_online/SConscript
@@ -8,7 +8,7 @@ env = env.Clone()
 
 sbms.AddROOTSpyMacros(env)
 sbms.AddDANA(env)
-env.Append(LIBS=['DANA','HDDM','PID', 'xstream', 'ANALYSIS','FCAL','TAGGER'])  # this avoids undefined references for _ZTI12DApplication when attaching plugin to RootSpy
+#env.Append(LIBS=['DANA','HDDM','PID', 'xstream', 'ANALYSIS','FCAL','TAGGER'])  # this avoids undefined references for _ZTI12DApplication when attaching plugin to RootSpy
 sbms.plugin(env)
 
 


### PR DESCRIPTION
Additional libraries are needed when attaching monitoring plugins
directly to RootSpy for testing. However, this results in a very
bloated shared object file, and is unnecessary for production use
of RootSpy and usage of plugins with hd_root/hd_ana. These lines
can be added back on a case by base basis when one needs to test
their RootSpy macro by attaching it to RootSpy. It should be noted
that this process is necessary for all monitoring plugins, not only
the BCAL ones.
