### PR TITLE
Mcsmear runfix

### DIFF
--- a/src/programs/Simulation/mcsmear/MyProcessor.cc
+++ b/src/programs/Simulation/mcsmear/MyProcessor.cc
@@ -124,7 +124,7 @@ jerror_t MyProcessor::brun(JEventLoop *loop, int locRunNumber)
    if(!jcalib){
      _DBG_<<"ERROR - jcalib not set!"<<endl;
      _DBG_<<"ERROR - Exiting ..."<<endl;
-     return 0;
+     abort();
    }
    
    // get the TOF parameters

--- a/src/programs/Simulation/mcsmear/MyProcessor.cc
+++ b/src/programs/Simulation/mcsmear/MyProcessor.cc
@@ -23,6 +23,9 @@ extern char *OUTFILENAME;
 static pthread_mutex_t output_file_mutex;
 static pthread_t output_file_mutex_last_owner;
 
+#include <JANA/JCalibrationFile.h>
+static JCalibration *jcalib=NULL;
+
 void mcsmear_thread_HUP_sighandler(int sig)
 {
    jerr<<" Caught HUP signal for thread 0x"<<hex<<pthread_self()<<dec<<" thread exiting..."<<endl;
@@ -109,6 +112,203 @@ jerror_t MyProcessor::init(void)
    bzero(&output_file_mutex_last_owner, sizeof(pthread_t));
    
    return NOERROR;
+}
+
+jerror_t MyProcessor::brun(JEventLoop *loop, int locRunNumber)
+{
+   DApplication* locDApp = dynamic_cast<DApplication*>(japp);
+   jcalib = locDApp->GetJCalibration(locRunNumber);
+   DGeometry *dgeom=locDApp->GetDGeometry(locRunNumber);
+
+   // Make sure jcalib is set
+   if(!jcalib){
+     _DBG_<<"ERROR - jcalib not set!"<<endl;
+     _DBG_<<"ERROR - Exiting ..."<<endl;
+     return 0;
+   }
+   
+   // get the TOF parameters
+   {
+     cout<<"get TOF/tof_parms parameters from calibDB"<<endl;
+     map<string, double> tofparms;
+     jcalib->Get("TOF/tof_parms", tofparms);
+     TOF_SIGMA =  tofparms["TOF_SIGMA"];
+     TOF_PHOTONS_PERMEV =  tofparms["TOF_PHOTONS_PERMEV"];
+   }
+
+   // get the BCAL parameters
+   {
+     cout<<"get BCAL/bcal_parms parameters from calibDB"<<endl;
+     map<string, double> bcalparms;
+     jcalib->Get("BCAL/bcal_parms", bcalparms);
+     BCAL_DARKRATE_GHZ         =  bcalparms["BCAL_DARKRATE_GHZ"];
+     BCAL_SIGMA_SIG_RELATIVE   = bcalparms["BCAL_SIGMA_SIG_RELATIVE"];
+     BCAL_SIGMA_PED_RELATIVE   = bcalparms["BCAL_SIGMA_PED_RELATIVE"];
+     BCAL_SIPM_GAIN_VARIATION   = bcalparms["BCAL_SIPM_GAIN_VARIATION"];
+     BCAL_XTALK_FRACT         = bcalparms["BCAL_XTALK_FRACT"];
+     BCAL_INTWINDOW_NS         = bcalparms["BCAL_INTWINDOW_NS"];
+     BCAL_DEVICEPDE         = bcalparms["BCAL_DEVICEPDE"];
+     BCAL_SAMPLING_FRACT      = bcalparms["BCAL_SAMPLING_FRACT"];
+     BCAL_AVG_DARK_DIGI_VALS_PER_EVENT      = bcalparms["BCAL_AVG_DARK_DIGI_VALS_PER_EVENT"];
+     BCAL_PHOTONSPERSIDEPERMEV_INFIBER = bcalparms["BCAL_PHOTONSPERSIDEPERMEV_INFIBER"];
+     BCAL_SAMPLINGCOEFA = bcalparms["BCAL_SAMPLINGCOEFA"];
+     BCAL_SAMPLINGCOEFB = bcalparms["BCAL_SAMPLINGCOEFB"];
+     BCAL_TIMEDIFFCOEFA = bcalparms["BCAL_TIMEDIFFCOEFA"];
+     BCAL_TIMEDIFFCOEFB = bcalparms["BCAL_TIMEDIFFCOEFB"];
+     BCAL_TWO_HIT_RESOL = bcalparms["BCAL_TWO_HIT_RESOL"];
+   }
+
+   {
+     cout<<"get BCAL/attenuation_parameters from calibDB"<<endl;
+     vector< vector<double> > in_atten_parameters;
+     jcalib->Get("BCAL/attenuation_parameters", in_atten_parameters);
+     attenuation_parameters.clear();
+     int channel = 0;
+     for (int module=1; module<=BCAL_NUM_MODULES; module++) {
+   	  for (int layer=1; layer<=BCAL_NUM_LAYERS; layer++) {
+   		for (int sector=1; sector<=BCAL_NUM_SECTORS; sector++) {
+			//int cell_id = GetCalibIndex(module,layer,sector);
+
+			vector<double> new_params(3,0.);
+			//attenuation_parameters[cell_id][0] = in_atten_parameters[channel][0];
+			//attenuation_parameters[cell_id][1] = in_atten_parameters[channel][1];
+			//attenuation_parameters[cell_id][2] = in_atten_parameters[channel][2];
+			// hack to workaround odd CCDB behavior
+			//attenuation_parameters[cell_id][0] = in_atten_parameters[channel][1];
+			//attenuation_parameters[cell_id][1] = in_atten_parameters[channel][2];
+			//attenuation_parameters[cell_id][2] = in_atten_parameters[channel][0];
+			 
+			new_params[0] = in_atten_parameters[channel][0];
+			new_params[1] = in_atten_parameters[channel][1];
+			new_params[2] = in_atten_parameters[channel][2];
+			attenuation_parameters.push_back( new_params );
+
+			channel++;
+		}
+	  }
+     }
+   }
+
+   {
+     cout<<"get BCAL/effective_velocities parameters from calibDB"<<endl;
+     vector <double> effective_velocities_temp;
+     jcalib->Get("BCAL/effective_velocities", effective_velocities_temp);
+     for (unsigned int i = 0; i < effective_velocities_temp.size(); i++){
+       effective_velocities.push_back(effective_velocities_temp.at(i));
+     }
+   }
+
+   {
+     cout<<"get BCAL/digi_scales parameters from calibDB"<<endl;
+     map<string, double> bcaldigiscales;
+     jcalib->Get("BCAL/digi_scales", bcaldigiscales);
+     BCAL_NS_PER_ADC_COUNT = bcaldigiscales["BCAL_ADC_TSCALE"];
+     BCAL_NS_PER_TDC_COUNT = bcaldigiscales["BCAL_TDC_SCALE"];
+   }
+
+   {
+     cout<<"get BCAL/base_time_offset parameters from calibDB"<<endl;
+     map<string, double> bcaltimeoffsets;
+     jcalib->Get("BCAL/base_time_offset", bcaltimeoffsets);
+     BCAL_BASE_TIME_OFFSET = bcaltimeoffsets["BCAL_BASE_TIME_OFFSET"];
+     BCAL_TDC_BASE_TIME_OFFSET = bcaltimeoffsets["BCAL_TDC_BASE_TIME_OFFSET"];
+   }
+
+   {
+     cout<<"get FCAL/fcal_parms parameters from calibDB"<<endl;
+     map<string, double> fcalparms;
+     jcalib->Get("FCAL/fcal_parms", fcalparms);
+     if (FCAL_PHOT_STAT_COEF == 0.0)
+       FCAL_PHOT_STAT_COEF   = fcalparms["FCAL_PHOT_STAT_COEF"]; 
+     if (FCAL_BLOCK_THRESHOLD == 0.0)
+       FCAL_BLOCK_THRESHOLD  = fcalparms["FCAL_BLOCK_THRESHOLD"];
+   }
+   {
+     cout<<"get CDC/cdc_parms parameters from calibDB"<<endl;
+     map<string, double> cdcparms;
+     jcalib->Get("CDC/cdc_parms", cdcparms);
+     if (CDC_TDRIFT_SIGMA == 0.0)
+       CDC_TDRIFT_SIGMA   = cdcparms["CDC_TDRIFT_SIGMA"]; 
+     if (CDC_TIME_WINDOW == 0.0)
+       CDC_TIME_WINDOW    = cdcparms["CDC_TIME_WINDOW"];
+     if (CDC_PEDESTAL_SIGMA == 0.0)
+       CDC_PEDESTAL_SIGMA = cdcparms["CDC_PEDESTAL_SIGMA"]; 
+     if (CDC_THRESHOLD_FACTOR == 0.0)
+       CDC_THRESHOLD_FACTOR = cdcparms["CDC_THRESHOLD_FACTOR"];
+   }
+
+   {
+     cout<<"get FDC/fdc_parms parameters from calibDB"<<endl;
+     map<string, double> fdcparms;
+     jcalib->Get("FDC/fdc_parms", fdcparms);
+
+     if (FDC_TDRIFT_SIGMA == 0.0)
+       FDC_TDRIFT_SIGMA      = fdcparms["FDC_TDRIFT_SIGMA"];
+     if (FDC_CATHODE_SIGMA ==0.0)
+       FDC_CATHODE_SIGMA     = fdcparms["FDC_CATHODE_SIGMA"];
+     if (FDC_THRESHOLD_FACTOR == 0.0)
+       FDC_THRESHOLD_FACTOR = fdcparms["FDC_THRESHOLD_FACTOR"];
+     FDC_PED_NOISE         = fdcparms["FDC_PED_NOISE"];
+
+     if (FDC_TIME_WINDOW == 0.0)
+       FDC_TIME_WINDOW       = fdcparms["FDC_TIME_WINDOW"];
+
+     if (FDC_HIT_DROP_FRACTION == 0.0)
+       FDC_HIT_DROP_FRACTION = fdcparms["FDC_HIT_DROP_FRACTION"];  
+     if (FDC_THRESH_KEV == 0.0)
+       FDC_THRESH_KEV = fdcparms["FDC_THRESH_KEV"]; 
+   }
+
+   {
+     cout<<"get START_COUNTER/start_parms parameters from calibDB"<<endl;
+     map<string, double> startparms;
+     jcalib->Get("START_COUNTER/start_parms", startparms);
+
+     START_SIGMA = startparms["START_SIGMA"] ;
+     START_PHOTONS_PERMEV = startparms["START_PHOTONS_PERMEV"];
+
+   }
+
+   // hist file
+   fdc_drift_time_smear_hist=new TH2F("fdc_drift_time_smear_hist","Drift time smearing for FDC",
+                  300,0.0,0.6,400,-200,200);
+   fdc_drift_dist_smear_hist=new TH2F("fdc_drift_dist_smear_hist","Drift distance smearing for FDC",
+                  100,0.0,0.6,400,-0.5,0.5);
+   double tmax=TRIGGER_LOOKBACK_TIME+FDC_TIME_WINDOW;
+   int num_time_bins=int(FDC_TIME_WINDOW);
+   fdc_drift_time=new TH2F("fdc_drift_time","FDC drift distance vs. time",num_time_bins,TRIGGER_LOOKBACK_TIME,tmax,100,0,1.);
+   
+   fdc_anode_mult = new TH1F("fdc_anode_mult","wire hit multiplicity",20,-0.5,19.5);
+   fdc_cathode_charge = new TH1F("fdc_cathode_charge","charge on strips",1000,0,1000);
+
+   tmax=TRIGGER_LOOKBACK_TIME+CDC_TIME_WINDOW;
+   num_time_bins=int(CDC_TIME_WINDOW);
+   cdc_drift_time = new TH2F("cdc_drift_time","CDC drift distance vs time",num_time_bins,TRIGGER_LOOKBACK_TIME,tmax,80,0.,0.8);
+
+   cdc_drift_smear = new TH2F("cdc_drift_smear","CDC drift smearing",
+               100,0.0,800.0,100,-0.1,0.1);
+   
+   cdc_charge  = new TH1F("cdc_charge","Measured charge in straw",1000,-10e3,40e3);
+
+   // Get number of cdc wires per ring and the radii of each ring
+   vector<vector<DCDCWire *> >cdcwires;
+   dgeom->GetCDCWires(cdcwires);
+   for (unsigned int i=0;i<cdcwires.size();i++) {
+      NCDC_STRAWS.push_back(cdcwires[i].size());
+      CDC_RING_RADIUS.push_back(cdcwires[i][0]->origin.Perp());
+   }  
+   // Get the FDC z positions for the wire planes
+   dgeom->GetFDCZ(FDC_LAYER_Z);
+
+   // Coefficient used to calculate FDCsingle wire rate. We calculate
+   // it once here just to save calculating it for every wire in every event
+   FDC_RATE_COEFFICIENT = exp(-log(4.0)/23.0)/2.0/log(24.0)*FDC_TIME_WINDOW/1000.0E-9;
+   
+   // Something is a little off in my calculation above so I scale it down via
+   // an emprical factor:
+   FDC_RATE_COEFFICIENT *= 0.353;
+
+	return NOERROR;
 }
 
 //------------------------------------------------------------------

--- a/src/programs/Simulation/mcsmear/MyProcessor.h
+++ b/src/programs/Simulation/mcsmear/MyProcessor.h
@@ -15,15 +15,13 @@ using namespace jana;
 #include <fstream>
 #include <HDDM/hddm_s.hpp>
 
-
+#include "mcsmear_globals.h"
 
 class MyProcessor:public JEventProcessor
 {
    public:
       jerror_t init(void);                              ///< Called once at program start.
-      jerror_t brun(JEventLoop *loop, int runnumber) {  ///< Called everytime a new run number is detected.
-         return NOERROR;
-      }
+      jerror_t brun(JEventLoop *loop, int runnumber);  ///< Called everytime a new run number is detected.
       jerror_t evnt(JEventLoop *loop, int eventnumber); ///< Called every event.
       jerror_t erun(void) {                             ///< Called everytime run number changes, provided brun has been called.
          return NOERROR;

--- a/src/programs/Simulation/mcsmear/mcsmear.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear.cc
@@ -41,10 +41,6 @@ void Usage(void);
 
 extern void SetSeeds(const char *vals);
 
-#if ! USE_JANA
-void ctrlCHandleMCSmear(int x);
-#endif
-
 char *INFILENAME = NULL;
 char *OUTFILENAME = NULL;
 int QUIT = 0;
@@ -154,287 +150,34 @@ vector<double> CDC_RING_RADIUS;
 vector<double> FDC_LAYER_Z;
 double FDC_RATE_COEFFICIENT;
 
-#include <JANA/JCalibrationFile.h>
 using namespace jana;
-static JCalibration *jcalib=NULL;
 
 // histogram
 pthread_mutex_t root_mutex = PTHREAD_MUTEX_INITIALIZER;
-TH2F *fdc_drift_time_smear_hist;
-TH2F *fdc_drift_dist_smear_hist;
-TH2F *fdc_drift_time;
-TH1F *fdc_cathode_charge;
-TH2F *cdc_drift_time;
-TH1F *cdc_charge;
-TH1F *fdc_anode_mult;
-TH2F *cdc_drift_smear;
+TH2F *fdc_drift_time_smear_hist = NULL;
+TH2F *fdc_drift_dist_smear_hist = NULL;
+TH2F *fdc_drift_time = NULL;
+TH1F *fdc_cathode_charge = NULL;
+TH2F *cdc_drift_time = NULL;
+TH1F *cdc_charge = NULL;
+TH1F *fdc_anode_mult = NULL;
+TH2F *cdc_drift_smear = NULL;
 
 //-----------
 // main
 //-----------
 int main(int narg,char* argv[])
 {
-#if ! USE_JANA
-   // Set up to catch SIGINTs for graceful exits
-   signal(SIGINT,ctrlCHandleMCSmear);
-#endif
    ParseCommandLineArguments(narg, argv);
 
-   // Create DApplication object and use it to create JCalibration object
+   // Create DApplication object
    DApplication dapp(narg, argv);
    dapp.AddFactoryGenerator(new JFactoryGenerator_ThreadCancelHandler());
-   jcalib = dapp.GetJCalibration(1);
-
-   // Make sure jcalib is set
-   if(!jcalib){
-     _DBG_<<"ERROR - jcalib not set!"<<endl;
-     _DBG_<<"ERROR - Exiting ..."<<endl;
-     return 0;
-   }
    
-   // get the TOF parameters
-   {
-     cout<<"get TOF/tof_parms parameters from calibDB"<<endl;
-     map<string, double> tofparms;
-     jcalib->Get("TOF/tof_parms", tofparms);
-     TOF_SIGMA =  tofparms["TOF_SIGMA"];
-     TOF_PHOTONS_PERMEV =  tofparms["TOF_PHOTONS_PERMEV"];
-   }
-
-   // get the BCAL parameters
-   {
-     cout<<"get BCAL/bcal_parms parameters from calibDB"<<endl;
-     map<string, double> bcalparms;
-     jcalib->Get("BCAL/bcal_parms", bcalparms);
-     BCAL_DARKRATE_GHZ         =  bcalparms["BCAL_DARKRATE_GHZ"];
-     BCAL_SIGMA_SIG_RELATIVE   = bcalparms["BCAL_SIGMA_SIG_RELATIVE"];
-     BCAL_SIGMA_PED_RELATIVE   = bcalparms["BCAL_SIGMA_PED_RELATIVE"];
-     BCAL_SIPM_GAIN_VARIATION   = bcalparms["BCAL_SIPM_GAIN_VARIATION"];
-     BCAL_XTALK_FRACT         = bcalparms["BCAL_XTALK_FRACT"];
-     BCAL_INTWINDOW_NS         = bcalparms["BCAL_INTWINDOW_NS"];
-     BCAL_DEVICEPDE         = bcalparms["BCAL_DEVICEPDE"];
-     BCAL_SAMPLING_FRACT      = bcalparms["BCAL_SAMPLING_FRACT"];
-     BCAL_AVG_DARK_DIGI_VALS_PER_EVENT      = bcalparms["BCAL_AVG_DARK_DIGI_VALS_PER_EVENT"];
-     BCAL_PHOTONSPERSIDEPERMEV_INFIBER = bcalparms["BCAL_PHOTONSPERSIDEPERMEV_INFIBER"];
-     BCAL_SAMPLINGCOEFA = bcalparms["BCAL_SAMPLINGCOEFA"];
-     BCAL_SAMPLINGCOEFB = bcalparms["BCAL_SAMPLINGCOEFB"];
-     BCAL_TIMEDIFFCOEFA = bcalparms["BCAL_TIMEDIFFCOEFA"];
-     BCAL_TIMEDIFFCOEFB = bcalparms["BCAL_TIMEDIFFCOEFB"];
-     BCAL_TWO_HIT_RESOL = bcalparms["BCAL_TWO_HIT_RESOL"];
-   }
-
-   {
-     cout<<"get BCAL/attenuation_parameters from calibDB"<<endl;
-     vector< vector<double> > in_atten_parameters;
-     jcalib->Get("BCAL/attenuation_parameters", in_atten_parameters);
-     attenuation_parameters.clear();
-     int channel = 0;
-     for (int module=1; module<=BCAL_NUM_MODULES; module++) {
-   	  for (int layer=1; layer<=BCAL_NUM_LAYERS; layer++) {
-   		for (int sector=1; sector<=BCAL_NUM_SECTORS; sector++) {
-			//int cell_id = GetCalibIndex(module,layer,sector);
-
-			vector<double> new_params(3,0.);
-			//attenuation_parameters[cell_id][0] = in_atten_parameters[channel][0];
-			//attenuation_parameters[cell_id][1] = in_atten_parameters[channel][1];
-			//attenuation_parameters[cell_id][2] = in_atten_parameters[channel][2];
-			// hack to workaround odd CCDB behavior
-			//attenuation_parameters[cell_id][0] = in_atten_parameters[channel][1];
-			//attenuation_parameters[cell_id][1] = in_atten_parameters[channel][2];
-			//attenuation_parameters[cell_id][2] = in_atten_parameters[channel][0];
-			 
-			new_params[0] = in_atten_parameters[channel][0];
-			new_params[1] = in_atten_parameters[channel][1];
-			new_params[2] = in_atten_parameters[channel][2];
-			attenuation_parameters.push_back( new_params );
-
-			channel++;
-		}
-	  }
-     }
-   }
-
-   {
-     cout<<"get BCAL/effective_velocities parameters from calibDB"<<endl;
-     vector <double> effective_velocities_temp;
-     jcalib->Get("BCAL/effective_velocities", effective_velocities_temp);
-     for (unsigned int i = 0; i < effective_velocities_temp.size(); i++){
-       effective_velocities.push_back(effective_velocities_temp.at(i));
-     }
-   }
-
-   {
-     cout<<"get BCAL/digi_scales parameters from calibDB"<<endl;
-     map<string, double> bcaldigiscales;
-     jcalib->Get("BCAL/digi_scales", bcaldigiscales);
-     BCAL_NS_PER_ADC_COUNT = bcaldigiscales["BCAL_ADC_TSCALE"];
-     BCAL_NS_PER_TDC_COUNT = bcaldigiscales["BCAL_TDC_SCALE"];
-   }
-
-   {
-     cout<<"get BCAL/base_time_offset parameters from calibDB"<<endl;
-     map<string, double> bcaltimeoffsets;
-     jcalib->Get("BCAL/base_time_offset", bcaltimeoffsets);
-     BCAL_BASE_TIME_OFFSET = bcaltimeoffsets["BCAL_BASE_TIME_OFFSET"];
-     BCAL_TDC_BASE_TIME_OFFSET = bcaltimeoffsets["BCAL_TDC_BASE_TIME_OFFSET"];
-   }
-
-   {
-     cout<<"get FCAL/fcal_parms parameters from calibDB"<<endl;
-     map<string, double> fcalparms;
-     jcalib->Get("FCAL/fcal_parms", fcalparms);
-     if (FCAL_PHOT_STAT_COEF == 0.0)
-       FCAL_PHOT_STAT_COEF   = fcalparms["FCAL_PHOT_STAT_COEF"]; 
-     if (FCAL_BLOCK_THRESHOLD == 0.0)
-       FCAL_BLOCK_THRESHOLD  = fcalparms["FCAL_BLOCK_THRESHOLD"];
-   }
-   {
-     cout<<"get CDC/cdc_parms parameters from calibDB"<<endl;
-     map<string, double> cdcparms;
-     jcalib->Get("CDC/cdc_parms", cdcparms);
-     if (CDC_TDRIFT_SIGMA == 0.0)
-       CDC_TDRIFT_SIGMA   = cdcparms["CDC_TDRIFT_SIGMA"]; 
-     if (CDC_TIME_WINDOW == 0.0)
-       CDC_TIME_WINDOW    = cdcparms["CDC_TIME_WINDOW"];
-     if (CDC_PEDESTAL_SIGMA == 0.0)
-       CDC_PEDESTAL_SIGMA = cdcparms["CDC_PEDESTAL_SIGMA"]; 
-     if (CDC_THRESHOLD_FACTOR == 0.0)
-       CDC_THRESHOLD_FACTOR = cdcparms["CDC_THRESHOLD_FACTOR"];
-   }
-
-   {
-     cout<<"get FDC/fdc_parms parameters from calibDB"<<endl;
-     map<string, double> fdcparms;
-     jcalib->Get("FDC/fdc_parms", fdcparms);
-
-     if (FDC_TDRIFT_SIGMA == 0.0)
-       FDC_TDRIFT_SIGMA      = fdcparms["FDC_TDRIFT_SIGMA"];
-     if (FDC_CATHODE_SIGMA ==0.0)
-       FDC_CATHODE_SIGMA     = fdcparms["FDC_CATHODE_SIGMA"];
-     if (FDC_THRESHOLD_FACTOR == 0.0)
-       FDC_THRESHOLD_FACTOR = fdcparms["FDC_THRESHOLD_FACTOR"];
-     FDC_PED_NOISE         = fdcparms["FDC_PED_NOISE"];
-
-     if (FDC_TIME_WINDOW == 0.0)
-       FDC_TIME_WINDOW       = fdcparms["FDC_TIME_WINDOW"];
-
-     if (FDC_HIT_DROP_FRACTION == 0.0)
-       FDC_HIT_DROP_FRACTION = fdcparms["FDC_HIT_DROP_FRACTION"];  
-     if (FDC_THRESH_KEV == 0.0)
-       FDC_THRESH_KEV = fdcparms["FDC_THRESH_KEV"]; 
-   }
-
-   {
-     cout<<"get START_COUNTER/start_parms parameters from calibDB"<<endl;
-     map<string, double> startparms;
-     jcalib->Get("START_COUNTER/start_parms", startparms);
-
-     START_SIGMA = startparms["START_SIGMA"] ;
-     START_PHOTONS_PERMEV = startparms["START_PHOTONS_PERMEV"];
-
-   }
-
-   // hist file
    TFile *hfile = new TFile("smear.root","RECREATE","smearing histograms");
-   fdc_drift_time_smear_hist=new TH2F("fdc_drift_time_smear_hist","Drift time smearing for FDC",
-                  300,0.0,0.6,400,-200,200);
-   fdc_drift_dist_smear_hist=new TH2F("fdc_drift_dist_smear_hist","Drift distance smearing for FDC",
-                  100,0.0,0.6,400,-0.5,0.5);
-   double tmax=TRIGGER_LOOKBACK_TIME+FDC_TIME_WINDOW;
-   int num_time_bins=int(FDC_TIME_WINDOW);
-   fdc_drift_time=new TH2F("fdc_drift_time","FDC drift distance vs. time",num_time_bins,TRIGGER_LOOKBACK_TIME,tmax,100,0,1.);
-   
-   fdc_anode_mult = new TH1F("fdc_anode_mult","wire hit multiplicity",20,-0.5,19.5);
-   fdc_cathode_charge = new TH1F("fdc_cathode_charge","charge on strips",1000,0,1000);
 
-   tmax=TRIGGER_LOOKBACK_TIME+CDC_TIME_WINDOW;
-   num_time_bins=int(CDC_TIME_WINDOW);
-   cdc_drift_time = new TH2F("cdc_drift_time","CDC drift distance vs time",num_time_bins,TRIGGER_LOOKBACK_TIME,tmax,80,0.,0.8);
-
-   cdc_drift_smear = new TH2F("cdc_drift_smear","CDC drift smearing",
-               100,0.0,800.0,100,-0.1,0.1);
-   
-   cdc_charge  = new TH1F("cdc_charge","Measured charge in straw",1000,-10e3,40e3);
-
-
-
-#if ! USE_JANA
-   cout << " input file: " << INFILENAME << endl;
-   cout << " output file: " << OUTFILENAME << endl;
-   
-   // Open Input file
-   ifstream ifs(INFILENAME);
-   if (!ifs.is_open()) {
-      cout << " Error opening input file \"" << INFILENAME << "\"!" << endl;
-      exit(-1);
-   }
-   hddm_s::istream fin(ifs);
-   
-   // Output file
-   ofstream ofs(OUTFILENAME);
-   if (!ofs.is_open()){
-      cout << " Error opening output file \"" << OUTFILENAME << "\"!" << endl;
-      exit(-1);
-   }
-   hddm_s::HDDM fout(ofs);
-   
-   // Loop over events in input file
-   hddm_s::HDDM *record;
-   int NEvents = 0;
-   time_t last_time = time(NULL);
-   while (ifs->good()) {
-      fin >> *record;
-      NEvents++;
-      time_t now = time(NULL);
-      if(now != last_time){
-         cout << "  " << NEvents << " events processed      \r";
-         cout.flush();
-         last_time = now;
-      }
-      
-      // Smear values
-      Smear(record);
-      
-      // Write event to output file
-      *fout << *record;
-      
-      if (QUIT) break;
-   }
-   cout << endl;
-   
-   // close input and output files
-   ifs.close();
-   ofs.close();
-
-   cout << " " << NEvents << " events read" << endl;
-
-#else
-
-   DGeometry *dgeom=dapp.GetDGeometry(1);
-   
-   // Get number of cdc wires per ring and the radii of each ring
-   vector<vector<DCDCWire *> >cdcwires;
-   dgeom->GetCDCWires(cdcwires);
-   for (unsigned int i=0;i<cdcwires.size();i++) {
-      NCDC_STRAWS.push_back(cdcwires[i].size());
-      CDC_RING_RADIUS.push_back(cdcwires[i][0]->origin.Perp());
-   }  
-   // Get the FDC z positions for the wire planes
-   dgeom->GetFDCZ(FDC_LAYER_Z);
-
-   // Coefficient used to calculate FDCsingle wire rate. We calculate
-   // it once here just to save calculating it for every wire in every event
-   FDC_RATE_COEFFICIENT = exp(-log(4.0)/23.0)/2.0/log(24.0)*FDC_TIME_WINDOW/1000.0E-9;
-   
-   // Something is a little off in my calculation above so I scale it down via
-   // an emprical factor:
-   FDC_RATE_COEFFICIENT *= 0.353;
-
-   MyProcessor myproc;
-   
+   MyProcessor myproc;   
    dapp.Run(&myproc);
-
-#endif
    
    hfile->Write();
    hfile->Close();

--- a/src/programs/Simulation/mcsmear/mcsmear_globals.h
+++ b/src/programs/Simulation/mcsmear/mcsmear_globals.h
@@ -1,6 +1,6 @@
 #include <vector>
-#include "TH1F"
-#include "TH2F"
+#include "TH1F.h"
+#include "TH2F.h"
 
 extern vector<vector<float> >fdc_smear_parms; 
 extern TH2F *fdc_drift_time_smear_hist;
@@ -140,4 +140,58 @@ extern double TRIGGER_LOOKBACK_TIME;
 
 extern bool DROP_TRUTH_HITS;
 
+// Mutex used to control accessing the ROOT global memory
+extern pthread_mutex_t root_mutex;
 
+// Flag used specifically for BCAL
+extern bool SMEAR_BCAL;
+
+// The following are all false by default, but can be
+// set to true via command line parameters. Setting
+// one of these to true will turn OFF the feature.
+extern bool NO_E_SMEAR;
+extern bool NO_T_SMEAR;
+extern bool NO_DARK_PULSES;
+extern bool NO_SAMPLING_FLUCTUATIONS;
+extern bool NO_SAMPLING_FLOOR_TERM;
+extern bool NO_POISSON_STATISTICS;
+extern bool NO_THRESHOLD_CUT;
+
+extern double BCAL_FADC_TIME_RESOLUTION; // ns
+extern double BCAL_TDC_TIME_RESOLUTION; // ns
+extern double BCAL_ADC_THRESHOLD_MEV; // MeV
+
+// setup response parameters
+extern double BCAL_SAMPLINGCOEFA;               // 0.042 (from calibDB BCAL/bcal_parms)
+extern double BCAL_SAMPLINGCOEFB;               // 0.013 (from calibDB BCAL/bcal_parms)
+extern double BCAL_TWO_HIT_RESOL;               // 50. (from calibDB BCAL/bcal_parms)
+extern double BCAL_mevPerPE;                    // (defined below)
+extern double BCAL_NS_PER_ADC_COUNT;            // 0.0625 (defined in mcsmear.cc)
+extern double BCAL_NS_PER_TDC_COUNT;            // 0.0559 (defined in mcsmear.cc)
+extern double BCAL_MEV_PER_ADC_COUNT;           // 0.029 (defined in mcsmear.cc)
+
+extern vector<vector<double> > attenuation_parameters; // Avg. of 525 (from calibDB BCAL/attenuation_parameters)
+extern vector<double> effective_velocities;     // 16.75 (from calibDB BCAL/effective_velocities)
+
+extern int BCAL_NUM_MODULES;
+extern int BCAL_NUM_LAYERS;
+extern int BCAL_NUM_SECTORS;
+
+extern double BCAL_BASE_TIME_OFFSET;            // -100.0 (from calibDB BCAL/base_time_offset)
+extern double BCAL_TDC_BASE_TIME_OFFSET;        // -100.0 (from calibDB BCAL/base_time_offset)
+
+extern double BCAL_XTALK_FRACT;
+
+// The following are not currently in use
+extern double BCAL_DARKRATE_GHZ;                // 0.0176 (from calibDB BCAL/bcal_parms) for 4x4 array
+extern double BCAL_DEVICEPDE;                   // 0.21   (from calibDB BCAL/bcal_parms)
+extern double BCAL_SAMPLING_FRACT;              // 0.095  (from calibDB BCAL/bcal_parms)
+extern double BCAL_PHOTONSPERSIDEPERMEV_INFIBER;// 75 (from calibDB BCAL/bcal_parms)
+extern double BCAL_SIGMA_SIG_RELATIVE;          // 0.105  (from calibDB BCAL/bcal_parms)
+extern double BCAL_SIGMA_PED_RELATIVE;          // 0.139  (from calibDB BCAL/bcal_parms)
+extern double BCAL_SIPM_GAIN_VARIATION;         // 0.04   (from calibDB BCAL/bcal_parms)
+extern double BCAL_INTWINDOW_NS;                // 100    (from calibDB BCAL/bcal_parms)
+extern double BCAL_AVG_DARK_DIGI_VALS_PER_EVENT;// 240 used to set thresholds
+extern double BCAL_TIMEDIFFCOEFA;               // 0.07 * sqrt( 2 ) (from calibDB BCAL/bcal_parms)
+extern double BCAL_TIMEDIFFCOEFB;               // 0.00 * sqrt( 2 ) (from calibDB BCAL/bcal_parms)
+// end "not-in-use"

--- a/src/programs/Simulation/mcsmear/mcsmear_globals.h
+++ b/src/programs/Simulation/mcsmear/mcsmear_globals.h
@@ -1,0 +1,143 @@
+#include <vector>
+#include "TH1F"
+#include "TH2F"
+
+extern vector<vector<float> >fdc_smear_parms; 
+extern TH2F *fdc_drift_time_smear_hist;
+extern TH2F *fdc_drift_dist_smear_hist;
+extern TH2F *fdc_drift_time;
+extern TH1F *fdc_cathode_charge;
+extern TH2F *cdc_drift_time;
+extern TH1F *cdc_charge;
+extern TH1F *fdc_anode_mult;
+extern TH2F *cdc_drift_smear;
+
+extern vector<unsigned int> NCDC_STRAWS;
+extern vector<double> CDC_RING_RADIUS;
+
+extern vector<double> FDC_LAYER_Z;
+extern double FDC_RATE_COEFFICIENT;
+
+// Do we or do we not add noise hits
+extern bool ADD_NOISE;
+
+// Do we or do we not smear real hits
+extern bool SMEAR_HITS;
+
+// Use or ignore random number seeds found in HDDM file
+extern bool IGNORE_SEEDS;
+
+// The error on the drift time in the CDC. The drift times
+// for the actual CDC hits coming from the input file
+// are smeared by a gaussian with this sigma.
+extern double CDC_TDRIFT_SIGMA;
+
+// The time window for which CDC hits are accumulated.
+// This is used to determine the number of background
+// hits in the CDC for a given event.
+extern double CDC_TIME_WINDOW;
+
+// The error in the energy deposition measurement in the CDC due to pedestal noise
+extern double CDC_PEDESTAL_SIGMA;
+
+// Number of sigmas above threshold for sparcification of CDC data
+extern double CDC_THRESHOLD_FACTOR;
+ 
+// If the following flag is true, then include the drift-distance
+// dependency on the error in the FDC position. Otherwise, use a
+// flat distribution given by the FDC_TDRIFT_SIGMA below.
+extern bool FDC_USE_PARAMETERIZED_SIGMA;
+
+// The error on the drift time in the FDC. The drift times
+// for the actual FDC hits coming from the input file
+// are smeared by a gaussian with this sigma.
+extern double FDC_TDRIFT_SIGMA;
+
+// The error in the distance along the wire as measured by
+// the cathodes. This should NOT include the Lorentz
+// effect which is already included in hdgeant. It
+// should include any fluctuations due to ion trail density
+// etc.
+extern double FDC_CATHODE_SIGMA;
+
+// The FDC pedestal noise is used to smear the cathode ADC
+// values such that the position along the wire has the resolution
+// specified by FDC_CATHODE_SIGMA.
+extern double FDC_PED_NOISE; //pC (calculated from FDC_CATHODE_SIGMA in SmearFDC)
+
+// Number of sigmas above threshold for sparcification of FDC data
+extern double FDC_THRESHOLD_FACTOR;
+ 
+// If energy loss was turned off in the FDC then the pedestal
+// noise will not be scaled properly to give the nominal 200 micron
+// resolution along the wires. This flag is used to indicated
+// the magic scale factor should be applied to FDC_PED_NOISE
+// when it is calculated below to get the correct resolution.
+extern bool FDC_ELOSS_OFF;
+
+// Time window for acceptance of FDC hits
+extern double FDC_TIME_WINDOW;
+
+// Fraction of FDC hits to randomly drop (0=drop nothing 1=drop everything)
+extern double FDC_HIT_DROP_FRACTION;
+
+// FDC discriminator threshold in keV
+extern double FDC_THRESH_KEV;
+
+// Single FTOF bar energy threshold (applied after smearing)
+extern double FTOF_BAR_THRESHOLD;
+
+// Single STC paddle energy threshold (applied after smearing)
+extern double STC_PADDLE_THRESHOLD;
+
+// Single pair spectrometer energy threshold (applied after smearing)
+extern double PSC_THRESHOLD;
+
+// PS counter resolutions and energy reponses
+extern double PS_SIGMA; // ns
+extern double PSC_SIGMA; //ns
+extern double PS_NPIX_PER_GEV;
+extern double PSC_PHOTONS_PERMEV;
+
+// Tagging counter time resolutions (s)
+extern double TAGM_TSIGMA;
+extern double TAGH_TSIGMA;
+
+// Tagging counter fADC responses
+extern double TAGM_FADC_TSIGMA;
+extern double TAGH_FADC_TSIGMA;
+extern double TAGM_NPIX_PER_GEV;
+extern double TAGH_NPE_PER_GEV;
+
+// Photon-statistics factor for smearing hit energy (from Criss's MC)
+// (copied from DFCALMCResponse_factory.cc 7/2/2009 DL)
+extern double FCAL_PHOT_STAT_COEF;
+
+// Single block energy threshold (applied after smearing)
+extern double FCAL_BLOCK_THRESHOLD;
+
+// Forward TOF resolution
+extern double TOF_SIGMA;
+extern double TOF_PHOTONS_PERMEV;
+
+// Start counter resolution
+extern double START_SIGMA ;
+extern double START_PHOTONS_PERMEV;
+
+// Pair spectrometer resolution
+extern double PS_SIGMA;
+extern double PS_PHOTONS_PERMEV;
+
+// FMWPC resolutions and threshold
+extern double FMWPC_TSIGMA;
+extern double FMWPC_ASIGMA;
+extern double FMWPC_THRESHOLD;
+
+extern bool SMEAR_BCAL;
+
+// Beginning of readout window
+extern double TRIGGER_LOOKBACK_TIME;
+
+extern bool DROP_TRUTH_HITS;
+
+

--- a/src/programs/Simulation/mcsmear/smear.cc
+++ b/src/programs/Simulation/mcsmear/smear.cc
@@ -19,21 +19,12 @@ using namespace std;
 
 #include "DRandom2.h"
 
+#include "mcsmear_globals.h"
+
 #ifndef _DBG_
 #define _DBG_ cout<<__FILE__<<":"<<__LINE__<<" "
 #define _DBG__ cout<<__FILE__<<":"<<__LINE__<<endl
 #endif
-
-
-extern vector<vector<float> >fdc_smear_parms; 
-extern TH2F *fdc_drift_time_smear_hist;
-extern TH2F *fdc_drift_dist_smear_hist;
-extern TH2F *fdc_drift_time;
-extern TH1F *fdc_cathode_charge;
-extern TH2F *cdc_drift_time;
-extern TH1F *cdc_charge;
-extern TH1F *fdc_anode_mult;
-extern TH2F *cdc_drift_smear;
 
 void GetAndSetSeeds(hddm_s::HDDM *record);
 void SmearCDC(hddm_s::HDDM *record);
@@ -58,117 +49,16 @@ pthread_mutex_t mutex_fdc_smear_function = PTHREAD_MUTEX_INITIALIZER;
 
 bool CDC_GEOMETRY_INITIALIZED = false;
 int CDC_MAX_RINGS=0;
-extern vector<unsigned int> NCDC_STRAWS;
-extern vector<double> CDC_RING_RADIUS;
 
 DFCALGeometry *fcalGeom = NULL;
 DCCALGeometry *ccalGeom = NULL;
 bool FDC_GEOMETRY_INITIALIZED = false;
 unsigned int NFDC_WIRES_PER_PLANE;
-extern vector<double> FDC_LAYER_Z;
-extern double FDC_RATE_COEFFICIENT;
 
 double SampleGaussian(double sigma);
 double SamplePoisson(double lambda);
 double SampleRange(double x1, double x2);
 
-// Do we or do we not add noise hits
-extern bool ADD_NOISE;
-
-// Do we or do we not smear real hits
-extern bool SMEAR_HITS;
-
-// Use or ignore random number seeds found in HDDM file
-extern bool IGNORE_SEEDS;
-
-// The error on the drift time in the CDC. The drift times
-// for the actual CDC hits coming from the input file
-// are smeared by a gaussian with this sigma.
-extern double CDC_TDRIFT_SIGMA;
-
-// The time window for which CDC hits are accumulated.
-// This is used to determine the number of background
-// hits in the CDC for a given event.
-extern double CDC_TIME_WINDOW;
-
-// The error in the energy deposition measurement in the CDC due to pedestal noise
-extern double CDC_PEDESTAL_SIGMA;
-
-// Number of sigmas above threshold for sparcification of CDC data
-extern double CDC_THRESHOLD_FACTOR;
- 
-// If the following flag is true, then include the drift-distance
-// dependency on the error in the FDC position. Otherwise, use a
-// flat distribution given by the FDC_TDRIFT_SIGMA below.
-extern bool FDC_USE_PARAMETERIZED_SIGMA;
-
-// The error on the drift time in the FDC. The drift times
-// for the actual FDC hits coming from the input file
-// are smeared by a gaussian with this sigma.
-extern double FDC_TDRIFT_SIGMA;
-
-// The error in the distance along the wire as measured by
-// the cathodes. This should NOT include the Lorentz
-// effect which is already included in hdgeant. It
-// should include any fluctuations due to ion trail density
-// etc.
-extern double FDC_CATHODE_SIGMA;
-
-// The FDC pedestal noise is used to smear the cathode ADC
-// values such that the position along the wire has the resolution
-// specified by FDC_CATHODE_SIGMA.
-extern double FDC_PED_NOISE; //pC (calculated from FDC_CATHODE_SIGMA in SmearFDC)
-
-// Number of sigmas above threshold for sparcification of FDC data
-extern double FDC_THRESHOLD_FACTOR;
- 
-// If energy loss was turned off in the FDC then the pedestal
-// noise will not be scaled properly to give the nominal 200 micron
-// resolution along the wires. This flag is used to indicated
-// the magic scale factor should be applied to FDC_PED_NOISE
-// when it is calculated below to get the correct resolution.
-extern bool FDC_ELOSS_OFF;
-
-// Time window for acceptance of FDC hits
-extern double FDC_TIME_WINDOW;
-
-// Fraction of FDC hits to randomly drop (0=drop nothing 1=drop everything)
-extern double FDC_HIT_DROP_FRACTION;
-
-// FDC discriminator threshold in keV
-extern double FDC_THRESH_KEV;
-
-// Single FTOF bar energy threshold (applied after smearing)
-extern double FTOF_BAR_THRESHOLD;
-
-// Single STC paddle energy threshold (applied after smearing)
-extern double STC_PADDLE_THRESHOLD;
-
-// Single pair spectrometer energy threshold (applied after smearing)
-extern double PSC_THRESHOLD;
-
-// PS counter resolutions and energy reponses
-extern double PS_SIGMA; // ns
-extern double PSC_SIGMA; //ns
-extern double PS_NPIX_PER_GEV;
-extern double PSC_PHOTONS_PERMEV;
-
-// Tagging counter time resolutions (s)
-extern double TAGM_TSIGMA;
-extern double TAGH_TSIGMA;
-
-// Tagging counter fADC responses
-extern double TAGM_FADC_TSIGMA;
-extern double TAGH_FADC_TSIGMA;
-extern double TAGM_NPIX_PER_GEV;
-extern double TAGH_NPE_PER_GEV;
-
-// Photon-statistics factor for smearing hit energy (from Criss's MC)
-// (copied from DFCALMCResponse_factory.cc 7/2/2009 DL)
-extern double FCAL_PHOT_STAT_COEF;
-
-// Single block energy threshold (applied after smearing)
-extern double FCAL_BLOCK_THRESHOLD;
 
 // Photon-statistics factor for smearing hit energy for CompCal
 // (This is just a rough estimate 11/30/2010 DL)
@@ -179,29 +69,7 @@ double CCAL_PHOT_STAT_COEF = 0.035/2.0;
 double CCAL_BLOCK_THRESHOLD = 20.0*k_MeV;
 
 
-// Forward TOF resolution
-extern double TOF_SIGMA;
-extern double TOF_PHOTONS_PERMEV;
 
-// Start counter resolution
-extern double START_SIGMA ;
-extern double START_PHOTONS_PERMEV;
-
-// Pair spectrometer resolution
-extern double PS_SIGMA;
-extern double PS_PHOTONS_PERMEV;
-
-// FMWPC resolutions and threshold
-extern double FMWPC_TSIGMA;
-extern double FMWPC_ASIGMA;
-extern double FMWPC_THRESHOLD;
-
-extern bool SMEAR_BCAL;
-
-// Beginning of readout window
-extern double TRIGGER_LOOKBACK_TIME;
-
-extern bool DROP_TRUTH_HITS;
 
 // Polynomial interpolation on a grid.
 // Adapted from Numerical Recipes in C (2nd Edition), pp. 121-122.

--- a/src/programs/Simulation/mcsmear/smear_bcal.cc
+++ b/src/programs/Simulation/mcsmear/smear_bcal.cc
@@ -26,6 +26,8 @@ using namespace std;
 
 #include "DRandom2.h"
 
+#include "mcsmear_globals.h"
+
 #ifndef _DBG_
 #define _DBG_ cout<<__FILE__<<":"<<__LINE__<<" "
 #define _DBG__ cout<<__FILE__<<":"<<__LINE__<<endl
@@ -219,59 +221,6 @@ void FindHits(double thresh_MeV,
 void CopyBCALHitsToHDDM(map<int, fADCHitList> &fADCHits,
                         map<int, TDCHitList> &TDCHits,
                         hddm_s::HDDM *record);
-
-// Mutex used to control accessing the ROOT global memory
-extern pthread_mutex_t root_mutex;
-
-// Flag used specifically for BCAL
-extern bool SMEAR_BCAL;
-
-// The following are all false by default, but can be
-// set to true via command line parameters. Setting
-// one of these to true will turn OFF the feature.
-extern bool NO_E_SMEAR;
-extern bool NO_T_SMEAR;
-extern bool NO_DARK_PULSES;
-extern bool NO_SAMPLING_FLUCTUATIONS;
-extern bool NO_SAMPLING_FLOOR_TERM;
-extern bool NO_POISSON_STATISTICS;
-extern bool NO_THRESHOLD_CUT;
-
-extern double BCAL_FADC_TIME_RESOLUTION; // ns
-extern double BCAL_TDC_TIME_RESOLUTION; // ns
-extern double BCAL_ADC_THRESHOLD_MEV; // MeV
-
-// setup response parameters
-extern double BCAL_SAMPLINGCOEFA;               // 0.042 (from calibDB BCAL/bcal_parms)
-extern double BCAL_SAMPLINGCOEFB;               // 0.013 (from calibDB BCAL/bcal_parms)
-extern double BCAL_TWO_HIT_RESOL;               // 50. (from calibDB BCAL/bcal_parms)
-extern double BCAL_mevPerPE;                    // (defined below)
-extern double BCAL_NS_PER_ADC_COUNT;            // 0.0625 (defined in mcsmear.cc)
-extern double BCAL_NS_PER_TDC_COUNT;            // 0.0559 (defined in mcsmear.cc)
-extern double BCAL_MEV_PER_ADC_COUNT;           // 0.029 (defined in mcsmear.cc)
-
-extern vector<vector<double> > attenuation_parameters; // Avg. of 525 (from calibDB BCAL/attenuation_parameters)
-extern vector<double> effective_velocities;     // 16.75 (from calibDB BCAL/effective_velocities)
-
-extern int BCAL_NUM_MODULES;
-extern int BCAL_NUM_LAYERS;
-extern int BCAL_NUM_SECTORS;
-
-extern double BCAL_BASE_TIME_OFFSET;            // -100.0 (from calibDB BCAL/base_time_offset)
-extern double BCAL_TDC_BASE_TIME_OFFSET;        // -100.0 (from calibDB BCAL/base_time_offset)
-
-// The following are not currently in use
-//extern double BCAL_DARKRATE_GHZ;                // 0.0176 (from calibDB BCAL/bcal_parms) for 4x4 array
-//extern double BCAL_DEVICEPDE;                   // 0.21   (from calibDB BCAL/bcal_parms)
-//extern double BCAL_SAMPLING_FRACT;              // 0.095  (from calibDB BCAL/bcal_parms)
-//extern double BCAL_PHOTONSPERSIDEPERMEV_INFIBER;// 75 (from calibDB BCAL/bcal_parms) 
-//extern double BCAL_SIGMA_SIG_RELATIVE;          // 0.105  (from calibDB BCAL/bcal_parms)
-//extern double BCAL_SIGMA_PED_RELATIVE;          // 0.139  (from calibDB BCAL/bcal_parms)
-//extern double BCAL_SIPM_GAIN_VARIATION;         // 0.04   (from calibDB BCAL/bcal_parms)
-//extern double BCAL_INTWINDOW_NS;                // 100    (from calibDB BCAL/bcal_parms)
-//extern double BCAL_AVG_DARK_DIGI_VALS_PER_EVENT;// 240 used to set thresholds
-//extern double BCAL_TIMEDIFFCOEFA;               // 0.07 * sqrt( 2 ) (from calibDB BCAL/bcal_parms)
-//extern double BCAL_TIMEDIFFCOEFB;               // 0.00 * sqrt( 2 ) (from calibDB BCAL/bcal_parms)
 
 //-----------
 // SmearBCAL


### PR DESCRIPTION
This makes it so that mcsmear uses the correct run number for calibration constants (was using run = 1 before). 

Also, eradicate ability to use without JANA.  
