### PR TITLE
Remove undefined symbol from BCAL plugins for RootSpy

### DIFF
--- a/src/libraries/BCAL/DBCALGeometry.cc
+++ b/src/libraries/BCAL/DBCALGeometry.cc
@@ -11,7 +11,7 @@
 #include <cmath>
 #include "DBCALGeometry.h"
 
-#include <HDGEOMETRY/DGeometry.h>
+//#include <HDGEOMETRY/DGeometry.h>
 
 // On each module there is a 10x4 (r/phi) array of SiPMs
 
@@ -45,7 +45,7 @@ int DBCALGeometry::NSUMLAYSOUT[] = {1,1,1,1};
 
 int DBCALGeometry::NBCALSECSIN = 4/DBCALGeometry::NSUMSECSIN;
 int DBCALGeometry::NBCALSECSOUT = 4/DBCALGeometry::NSUMSECSOUT;
-float DBCALGeometry::BCAL_PHI_SHIFT = 0.0; // will be overwritten in constructor
+//float DBCALGeometry::BCAL_PHI_SHIFT = 0.0; // will be overwritten in constructor
 
 float DBCALGeometry::BCALINNERRAD = 64.3;   
 float DBCALGeometry::BCALOUTERRAD = 86.17;
@@ -106,13 +106,13 @@ DBCALGeometry::DBCALGeometry()
   }
   
   //Get pointer to DGeometry object
-  DApplication* dapp=dynamic_cast<DApplication*>(japp);
-  const DGeometry *dgeom  = dapp->GetDGeometry(9999);
+  //DApplication* dapp=dynamic_cast<DApplication*>(japp);
+  //const DGeometry *dgeom  = dapp->GetDGeometry(9999);
 
   // Get overall phi shift of BCAL
-  double my_BCAL_PHI_SHIFT;
-  dgeom->GetBCALPhiShift(my_BCAL_PHI_SHIFT);
-  BCAL_PHI_SHIFT = (float)(my_BCAL_PHI_SHIFT*M_PI/180.0);  // convert to radians
+  //double my_BCAL_PHI_SHIFT;
+  //dgeom->GetBCALPhiShift(my_BCAL_PHI_SHIFT);
+  //BCAL_PHI_SHIFT = (float)(my_BCAL_PHI_SHIFT*M_PI/180.0);  // convert to radians
 
 }
 

--- a/src/libraries/BCAL/DBCALGeometry.h
+++ b/src/libraries/BCAL/DBCALGeometry.h
@@ -62,7 +62,7 @@ public:
   static int NBCALSECSIN;        ///<number of sectors in inner region
   static int NBCALSECSOUT;       ///<number of sectors in outer region
   static float BCALINNERRAD;     ///< innner radius of BCAL in cm
-  static float BCAL_PHI_SHIFT;   ///< overall phi roation of BCAL in radians
+  //static float BCAL_PHI_SHIFT;   ///< overall phi roation of BCAL in radians
 
   // Enter the index of the SiPM that designates the first
   // (counting radially outward) of the outer cells (default 7)

--- a/src/plugins/monitoring/BCAL_Eff/SConscript
+++ b/src/plugins/monitoring/BCAL_Eff/SConscript
@@ -8,7 +8,6 @@ env = env.Clone()
 
 sbms.AddROOTSpyMacros(env)
 sbms.AddDANA(env)
-env.Append(LIBS=['DANA','HDDM','PID', 'xstream', 'ANALYSIS','FCAL','TAGGER'])  # this avoids undefined references for _ZTI12DApplication when attaching plugin to RootSpy
 sbms.plugin(env)
 
 

--- a/src/plugins/monitoring/BCAL_inv_mass/SConscript
+++ b/src/plugins/monitoring/BCAL_inv_mass/SConscript
@@ -8,7 +8,6 @@ env = env.Clone()
 
 sbms.AddROOTSpyMacros(env)
 sbms.AddDANA(env)
-env.Append(LIBS=['DANA','HDDM','PID', 'xstream', 'ANALYSIS','FCAL','TAGGER'])  # this avoids undefined references for _ZTI12DApplication when attaching plugin to RootSpy
 sbms.plugin(env)
 
 

--- a/src/plugins/monitoring/BCAL_online/SConscript
+++ b/src/plugins/monitoring/BCAL_online/SConscript
@@ -8,7 +8,6 @@ env = env.Clone()
 
 sbms.AddROOTSpyMacros(env)
 sbms.AddDANA(env)
-env.Append(LIBS=['DANA','HDDM','PID', 'xstream', 'ANALYSIS','FCAL','TAGGER'])  # this avoids undefined references for _ZTI12DApplication when attaching plugin to RootSpy
 sbms.plugin(env)
 
 


### PR DESCRIPTION
There was an undefined-symbol runtime error when attaching BCAL plugins
to RootSpy for testing. The offending symbol was "typeinfo for DApplication".
A workaround was previously introduced which appended additional libraries
until all symbols were defined. While this fixed the problem at the time, it
resulted in a size increase of a few times for the shared objects, and is no
longer functioning at this time.

The undefined "typeinfo for DApplication" can be traced to the DBCALGeometry
constructor, where a pointer to DApplication is used to access the geometry
information and calculate the BCAL_PHI_SHIFT data member. As this is the only
place where DApplication is used in DBCALGeometry and BCAL_PHI_SHIFT is no
longer in use, the relevant code has been commented out.
