### PR TITLE
Revert "Add FFREAD card to set run number."

### DIFF
--- a/src/programs/Simulation/HDGeant/control.in
+++ b/src/programs/Simulation/HDGeant/control.in
@@ -356,10 +356,4 @@ c DRAY 0 no delta ray production
 c      1 delta ray production with generation of secondaries (default)
 c      2 delta ray production without generation of secondaries
 
-c If RUNNO card gives a non-negative value, use that value to initialize
-c the calibration database and initialize the run number. Run number
-c encoded in hddm events will overwrite this run number. Particle gun
-c events will use this value.
-c RUNNO 1501
-
 END

--- a/src/programs/Simulation/HDGeant/controlparams.h
+++ b/src/programs/Simulation/HDGeant/controlparams.h
@@ -11,9 +11,6 @@ typedef struct {
 	int driftclusters;
 	float tgwidth[2];
 	int runtime_geom;
-  int get_next_evt;
-  float trigger_time_signa_ns;
-  int runno_ff;
 }controlparams_t;
 extern controlparams_t controlparams_;
 

--- a/src/programs/Simulation/HDGeant/controlparams.inc
+++ b/src/programs/Simulation/HDGeant/controlparams.inc
@@ -1,7 +1,7 @@
       integer writenohits, showersincol, driftclusters, runtime_geom
       real tgtwidth
-      integer get_next_evt, runno_ff
+      integer get_next_evt
       real trigger_time_sigma_ns
       common /controlparams/ writenohits, showersincol, driftclusters
      +                       ,tgtwidth(2),runtime_geom,get_next_evt
-     +                       ,trigger_time_sigma_ns,runno_ff
+     +                       ,trigger_time_sigma_ns

--- a/src/programs/Simulation/HDGeant/uginit.F
+++ b/src/programs/Simulation/HDGeant/uginit.F
@@ -274,8 +274,6 @@ C..geant..
       call FFKEY('driftclusters',driftclusters,1,'INTEGER')
       call FFKEY('tgtwidth',tgtwidth,2,'REAL')
       call FFKEY('trefsigma',trigger_time_sigma_ns,1,'REAL')
-      call FFKEY('runno',runno_ff,1,'INTEGER')
-      runno_ff = -1
       call gtgamaff()
       CALL GFFGO
 *
@@ -396,14 +394,6 @@ C..geant..
 *        call HDDSgeant3_runtime
 *      endif
       call Goptimize
-
-C Check for FFREAD card specifying run number, initialize geant run number, use 
-C for calibration database
-      if (runno_ff .ge. 0) then
-         myrunno = runno_ff
-         call seteventid(runno_ff,0)
-      endif
-
       call initcalibdb(bfield_type, bfield_map, PS_bfield_type, 
      +     PS_bfield_map, myrunno)
       call copytocplusplus(infile,outfile,postsmear,mcsmearopts


### PR DESCRIPTION
This reverts commit 08465513f0e053cb8db49a2b855cebfb7aec1369.

Conflicts:
    src/programs/Simulation/HDGeant/uginit.F
        This conflict was resolved by hand.

There is already a RUNG card provided by GEANT (a native FFREAD card). This pull request backs out the change to introduce the RUNNO as a GlueX-specific card. RUNNO was used to force CCDB to use a user-specified run rather than the one found in the input data (if such a run number exists).

We do need a similar mechanism. I propose we rethink our strategy and implement a new solution after some discussion.
