### PR TITLE
Throw exceptions on early CCDB error 

### DIFF
--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -186,7 +186,8 @@ jerror_t DEventSourceHDDM::GetObjects(JEvent &event, JFactory_base *factory)
          }
          // Get constants and do basic check on number of elements
          vector< map<string, float> > tvals;
-         jcalib->Get("FDC/strip_calib", tvals);
+         if(jcalib->Get("FDC/strip_calib", tvals))
+             throw runtime_error("Could not load CCDB table: FDC/strip_calib");
  
          if (tvals.size() != 192) {
             _DBG_ << "ERROR - strip calibration vectors are not the right size!"
@@ -237,7 +238,8 @@ jerror_t DEventSourceHDDM::GetObjects(JEvent &event, JFactory_base *factory)
       locGeometry->GetTargetZ(locTargetCenterZ);
 
       vector<double> locRFPeriodVector;
-      loop->GetCalib("PHOTON_BEAM/RF/rf_period", locRFPeriodVector);
+      if(loop->GetCalib("PHOTON_BEAM/RF/rf_period", locRFPeriodVector))
+          throw runtime_error("Could not load CCDB table: PHOTON_BEAM/RF/rf_period");
       double locRFBunchPeriod = locRFPeriodVector[0];
 
       LockRead();

--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -187,7 +187,7 @@ jerror_t DEventSourceHDDM::GetObjects(JEvent &event, JFactory_base *factory)
          // Get constants and do basic check on number of elements
          vector< map<string, float> > tvals;
          if(jcalib->Get("FDC/strip_calib", tvals))
-             throw runtime_error("Could not load CCDB table: FDC/strip_calib");
+             throw JException("Could not load CCDB table: FDC/strip_calib");
  
          if (tvals.size() != 192) {
             _DBG_ << "ERROR - strip calibration vectors are not the right size!"

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -166,7 +166,8 @@ jerror_t DEventSourceREST::GetObjects(JEvent &event, JFactory_base *factory)
 		locGeometry->GetTargetZ(locTargetCenterZ);
 
 		vector<double> locRFPeriodVector;
-		locEventLoop->GetCalib("PHOTON_BEAM/RF/rf_period", locRFPeriodVector);
+        if(locEventLoop->GetCalib("PHOTON_BEAM/RF/rf_period", locRFPeriodVector))
+            throw runtime_error("Could not load CCDB table: PHOTON_BEAM/RF/rf_period");
 		double locRFBunchPeriod = locRFPeriodVector[0];
 
 		LockRead();

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -167,7 +167,7 @@ jerror_t DEventSourceREST::GetObjects(JEvent &event, JFactory_base *factory)
 
 		vector<double> locRFPeriodVector;
         if(locEventLoop->GetCalib("PHOTON_BEAM/RF/rf_period", locRFPeriodVector))
-            throw runtime_error("Could not load CCDB table: PHOTON_BEAM/RF/rf_period");
+            throw JException("Could not load CCDB table: PHOTON_BEAM/RF/rf_period");
 		double locRFBunchPeriod = locRFPeriodVector[0];
 
 		LockRead();


### PR DESCRIPTION
Certain problems with the CCDB in DANA programs, like if an invalid variation is specified, can be difficult to diagnose.  Such errors are printed to the screen with useful error messages, but are often lost because execution continues until some code segfaults later on and a long, mostly-useless stack trace is printed out.

This commit attempts to provide an early exit (and clearer representation of the error) in the case of these problems by raising exceptions in the HDDM event sources, which are called early on, if the CCDB tables can not be loaded.
