### PR TITLE
Fix compile problem in HDEVIO.

### DIFF
--- a/src/libraries/DAQ/HDEVIO.cc
+++ b/src/libraries/DAQ/HDEVIO.cc
@@ -5,6 +5,7 @@
 // Creator: davidl (on Darwin harriet 13.4.0 i386)
 //
 
+#include <stdlib.h>
 #include <string.h>
 
 #include "HDEVIO.h"


### PR DESCRIPTION
Add include of stdlib.h to fix compiler error of HDEVIO introduced with my last commit.
