### PR TITLE
Fixed memory leak that occurred when forcing F125 or F250 pulse pedestal emulation.

### DIFF
--- a/src/libraries/DAQ/JEventSource_EVIO.cc
+++ b/src/libraries/DAQ/JEventSource_EVIO.cc
@@ -1959,7 +1959,7 @@ void JEventSource_EVIO::EmulateDf250PulseTime(vector<JObject*> &wrd_objs, vector
 				delete pp;
 			}
 		}
-		pt_objs = emulated_pp_objs;
+		pp_objs = emulated_pp_objs;
 	}
 
 
@@ -2209,7 +2209,7 @@ void JEventSource_EVIO::EmulateDf125PulseTime(vector<JObject*> &wrd_objs, vector
 				delete pp;
 			}
 		}
-		pt_objs = emulated_pp_objs;
+		pp_objs = emulated_pp_objs;
 	}
 
 	uint32_t Nped_samples = 4;   // number of samples to use for pedestal calculation (PED_SAMPLE)


### PR DESCRIPTION
Thanks to Lubomir for exposing this memory leak. It only happens if EVIO:F125_PP_MULATION_MODE or EVIO:F250_PP_EMULATION_MODE were set to "1".
