### PR TITLE
Remove unsupported compiler flag for clang builds

### DIFF
--- a/src/SConstruct
+++ b/src/SConstruct
@@ -69,6 +69,15 @@ env.Replace( CXX = os.getenv('CXX', 'c++'),
              CC  = os.getenv('CC' , 'cc'),
              FC  = os.getenv('FC' , 'gfortran') )
 
+# Get compiler name
+compiler = 'unknown'
+compiler_string = subprocess.Popen([env['CC'],"-v"], stderr=subprocess.PIPE).communicate()[1]
+if 'clang' in compiler_string:
+	compiler = 'clang'
+if 'gcc' in compiler_string and 'clang' not in compiler_string:
+	compiler = 'gcc'
+env.Replace(COMPILER = compiler)
+
 # Add libraries and libraries/include to include search path
 env.PrependUnique(CPPPATH = ['#', '#libraries', '#libraries/include'])
 

--- a/src/libraries/HDGEOMETRY/SConscript
+++ b/src/libraries/HDGEOMETRY/SConscript
@@ -6,6 +6,8 @@ import sbms
 Import('*')
 env = env.Clone()
 
+sbms.AddDANA(env)
+
 # Compilation of DRootGeom.cc always takes forever
 # on the first pass with it eventually re-trying
 # with the fvar-tracking-assignments turned off.
@@ -15,13 +17,12 @@ env = env.Clone()
 # file using a different CXXFLAGS definition. Remove
 # the following three lines to revert to the old 
 # behavior.
+if env['COMPILER'] == 'gcc':
+	env.AppendUnique(IGNORE_SOURCES=['DRootGeom.cc'])
+	cxxflags = '%s -fvar-tracking-assignments-toggle' % env['CXXFLAGS']
+	env.AppendUnique(MISC_OBJECTS=[env.Object('DRootGeom.cc', CXXFLAGS=cxxflags)])
 
-env.AppendUnique(IGNORE_SOURCES=['DRootGeom.cc'])
-cxxflags = '%s -fvar-tracking-assignments-toggle' % env['CXXFLAGS']
-env.AppendUnique(MISC_OBJECTS=[env.Object('DRootGeom.cc', CXXFLAGS=cxxflags)])
 
-
-sbms.AddDANA(env)
 sbms.library(env)
 
 


### PR DESCRIPTION
The following error was observed when compiling with clang:
clang: error: unknown argument: '-fvar-tracking-assignments-toggle'

clang does not support the -fvar-tracking-assignments-toggle flag;
This commit checks to see if the gcc compiler is in use before adding
this flag.

Also, it ensures that the -std=c++11 flag is added to the list of flags
for compiling "DRootGeom.cc" against ROOT6.
