### PR TITLE
DGeometry BCAL methods and DBCALGeometry.

### DIFF
--- a/src/libraries/BCAL/DBCALCluster.cc
+++ b/src/libraries/BCAL/DBCALCluster.cc
@@ -26,7 +26,7 @@ DBCALCluster::DBCALCluster(double z_target_center) : m_z_target_center(z_target_
 float
 DBCALCluster::t0() const {
   
-  float path = DBCALGeometry::BCALINNERRAD / sin( m_theta );
+  float path = DBCALGeometry::GetBCAL_inner_rad() / sin( m_theta );
   
   return m_t - ( path / ( 30 * k_cm / k_nsec ) );
 }
@@ -218,7 +218,7 @@ DBCALCluster::makeFromPoints(){
   // Using m_E_points because the cluster z position only depends on the point z positions
   // and point energies.
   double sigma_z = sqrt(1.394*1.394/m_E_points + 0.859*0.859);
-  m_sig_theta = sigma_z*sin(m_theta)*sin(m_theta)/DBCALGeometry::BCALINNERRAD;
+  m_sig_theta = sigma_z*sin(m_theta)*sin(m_theta)/DBCALGeometry::GetBCAL_inner_rad();
   
   m_phi = atan2(sum_sin_phi,sum_cos_phi);
   if( m_phi < 0 ) m_phi += 2*PI;
@@ -267,8 +267,8 @@ DBCALCluster::makeFromPoints(){
   double z = m_rho*cos(m_theta) + m_z_target_center;
   double r = m_rho*sin(m_theta); 
 
-  double bcal_down = DBCALGeometry::GLOBAL_CENTER + DBCALGeometry::BCALFIBERLENGTH/2.0;
-  double bcal_up = DBCALGeometry::GLOBAL_CENTER - DBCALGeometry::BCALFIBERLENGTH/2.0;
+  double bcal_down = DBCALGeometry::GetBCAL_center() + DBCALGeometry::GetBCAL_length()/2.0;
+  double bcal_up = DBCALGeometry::GetBCAL_center() - DBCALGeometry::GetBCAL_length()/2.0;
   if (z > bcal_down) z = bcal_down;
   if (z < bcal_up) z = bcal_up;
 

--- a/src/libraries/BCAL/DBCALCluster_factory.cc
+++ b/src/libraries/BCAL/DBCALCluster_factory.cc
@@ -315,7 +315,7 @@ DBCALCluster_factory::clusterize( vector< const DBCALPoint* > points , vector< c
         // for z with respect to target at this radius
          
         double z = (**clust).rho()*cos((**clust).theta()) + m_z_target_center;
-        double d = ( ((**ht).end == 0) ? (z  - DBCALGeometry::GLOBAL_CENTER + DBCALGeometry::BCALFIBERLENGTH/2.0) : (DBCALGeometry::GLOBAL_CENTER + DBCALGeometry::BCALFIBERLENGTH/2.0 - z));  // d gives the distance to upstream or downstream end of BCAL depending on where the hit was with respect to the cluster z position.
+        double d = ( ((**ht).end == 0) ? (z  - DBCALGeometry::GetBCAL_center() + DBCALGeometry::GetBCAL_length()/2.0) : (DBCALGeometry::GetBCAL_center() + DBCALGeometry::GetBCAL_length()/2.0 - z));  // d gives the distance to upstream or downstream end of BCAL depending on where the hit was with respect to the cluster z position.
         double lambda = attenuation_parameters[channel_calib][0];
         double hit_E = (**ht).E;
         double hit_E_unattenuated = hit_E/exp(-d/lambda);  // hit energy unattenuated wrt the cluster z position
@@ -409,8 +409,8 @@ DBCALCluster_factory::overlap( const DBCALCluster& highEClust,
   const double delta_z_force_merge_low_E = 40.0*k_cm;
   const double low_E = .04*k_GeV;
   
-  double z1 = DBCALGeometry::BCALINNERRAD/tan(highEClust.theta());
-  double z2 = DBCALGeometry::BCALINNERRAD/tan(lowEClust.theta());
+  double z1 = DBCALGeometry::GetBCAL_inner_rad()/tan(highEClust.theta());
+  double z2 = DBCALGeometry::GetBCAL_inner_rad()/tan(lowEClust.theta());
   double delta_z = fabs(z1-z2);
 
   bool theta_match = (sigTheta < m_mergeSig) || (delta_z < delta_z_force_merge) || (delta_z < delta_z_force_merge_low_E && lowEClust.E() < low_E);
@@ -510,7 +510,7 @@ DBCALCluster_factory::overlap( const DBCALCluster& clust,
   // given the location of the cluster, we need the best guess
   // for z with respect to target at this radius
   double z = clust.rho()*cos(clust.theta()) + m_z_target_center;        
-  double d = ( (hit->end == 0) ? (z - DBCALGeometry::GLOBAL_CENTER + DBCALGeometry::BCALFIBERLENGTH/2.0) : (DBCALGeometry::GLOBAL_CENTER + DBCALGeometry::BCALFIBERLENGTH/2.0 - z));  // d gives the distance to upstream or downstream end of BCAL depending on where the hit was with respect to the cluster z position.
+  double d = ( (hit->end == 0) ? (z - DBCALGeometry::GetBCAL_center() + DBCALGeometry::GetBCAL_length()/2.0) : (DBCALGeometry::GetBCAL_center() + DBCALGeometry::GetBCAL_length()/2.0 - z));  // d gives the distance to upstream or downstream end of BCAL depending on where the hit was with respect to the cluster z position.
   double time_corr = hit->t - d/effective_velocities[channel_calib];  // hit time corrected to the interaction point in the bar.        
   double time_diff = TMath::Abs(clust.t() - time_corr); // time cut between cluster time and hit time - 20 ns is a very loose time cut.
   

--- a/src/libraries/BCAL/DBCALGeometry.h
+++ b/src/libraries/BCAL/DBCALGeometry.h
@@ -61,22 +61,32 @@ public:
   static int NSUMSECSOUT;        ///< for the outer layer(s), the number of SiPM that will be summed in the azimuthal direction
   static int NBCALSECSIN;        ///<number of sectors in inner region
   static int NBCALSECSOUT;       ///<number of sectors in outer region
-  static float BCALINNERRAD;     ///< innner radius of BCAL in cm
-  //static float BCAL_PHI_SHIFT;   ///< overall phi roation of BCAL in radians
 
   // Enter the index of the SiPM that designates the first
   // (counting radially outward) of the outer cells (default 7)
   static const int BCALMID=7;         ///< first outer layer (default 7)
 
   static float m_radius[11];
-  static float fADC_radius[5];
   static float BCALMIDRAD;       ///< mid radius of BCAL in cm (boundary between inner and outer layers)
   static float BCALOUTERRAD;     ///< outer radius of BCAL in cm
-  static float BCALFIBERLENGTH;  ///< BCAL Scintilator fiber lenth in cm
-  static float GLOBAL_CENTER;    ///< center of BCAL in gloobal coordinate system
   
   static float ATTEN_LENGTH;     ///< attenuation length
   static float C_EFFECTIVE;      ///< speed of light in fibers 
+
+  // Methods to access and initialize the private variables
+  static bool initialized;
+
+  static void Initialize();
+
+  static float GetBCAL_inner_rad();
+
+  static float* GetBCAL_radii();
+
+  static float GetBCAL_center();
+
+  static float GetBCAL_length();
+
+  static float GetBCAL_phi_shift();
   
   static bool summingOn() {
   
@@ -110,6 +120,14 @@ public:
   static int getglobalsector(int module, int sector);
   static int getsector(int globalsector);
   static int getmodule(int globalsector);
+
+private:
+
+  static float BCALINNERRAD;     ///< innner radius of BCAL in cm
+  static float fADC_radius[5];   ///< BCAL layer radii (4 layers total)
+  static float GLOBAL_CENTER;    ///< center of BCAL in gloobal coordinate system
+  static float BCALFIBERLENGTH;  ///< BCAL Scintilator fiber lenth in cm
+  static float BCAL_PHI_SHIFT;     ///< overall phi roation of BCAL in radians
 
 };
 

--- a/src/libraries/BCAL/DBCALPoint.cc
+++ b/src/libraries/BCAL/DBCALPoint.cc
@@ -31,7 +31,7 @@ DBCALPoint::DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2,
 
   // save typing
   
-  float fibLen = DBCALGeometry::BCALFIBERLENGTH;
+  float fibLen = DBCALGeometry::GetBCAL_length();
   float cEff = DBCALGeometry::C_EFFECTIVE;
 
   // figure out which hit is upstream and which is downstream
@@ -50,7 +50,7 @@ DBCALPoint::DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2,
   m_zLocal = 0.5 * cEff * ( tUp - tDown ); 
 
   // set the z position relative to the center of the target
-  m_z = m_zLocal + DBCALGeometry::GLOBAL_CENTER - z_target_center;
+  m_z = m_zLocal + DBCALGeometry::GetBCAL_center() - z_target_center;
   //At this point m_z may be unphysical, i.e. it may be outside the BCAL.
   //For the time being, this is okay. Forcing the z-position inside the
   //BCAL at this point will bias the clustering procedure:
@@ -119,7 +119,7 @@ DBCALPoint::tInnerRadius() const {
  
   // the path length in the module
   
-  float modulePath = m_rho - DBCALGeometry::BCALINNERRAD / sin( m_theta );
+  float modulePath = m_rho - DBCALGeometry::GetBCAL_inner_rad() / sin( m_theta );
   
   // retard the time by that distance divided by the speed of light
 

--- a/src/libraries/BCAL/DBCALPoint_factory.cc
+++ b/src/libraries/BCAL/DBCALPoint_factory.cc
@@ -144,7 +144,7 @@ jerror_t DBCALPoint_factory::evnt(JEventLoop *loop, int eventnumber) {
     //int id = DBCALGeometry::cellId( uphit->module, uphit->layer, uphit->sector );  // key the cell identification off of the upstream cell
     int table_id = GetCalibIndex( uphit->module, uphit->layer, uphit->sector );  // key the cell identification off of the upstream cell
 
-    float fibLen = DBCALGeometry::BCALFIBERLENGTH;
+    float fibLen = DBCALGeometry::GetBCAL_length();
     //float cEff = DBCALGeometry::C_EFFECTIVE;    
     float cEff = GetEffectiveVelocity(table_id);
 

--- a/src/libraries/BCAL/DBCALShower_factory_CURVATURE.cc
+++ b/src/libraries/BCAL/DBCALShower_factory_CURVATURE.cc
@@ -382,8 +382,8 @@ jerror_t DBCALShower_factory_CURVATURE::evnt(JEventLoop *loop, int eventnumber)
     sig_t = sqrt(sig_t - t*t)/sqrt(n_eff);
 
     // Force showers to be inside the BCal's z-coordinate range.
-    double bcal_down = DBCALGeometry::GLOBAL_CENTER + DBCALGeometry::BCALFIBERLENGTH/2.0 - m_zTarget;
-    double bcal_up = DBCALGeometry::GLOBAL_CENTER - DBCALGeometry::BCALFIBERLENGTH/2.0 - m_zTarget;
+    double bcal_down = DBCALGeometry::GetBCAL_center() + DBCALGeometry::GetBCAL_length()/2.0 - m_zTarget;
+    double bcal_up = DBCALGeometry::GetBCAL_center() - DBCALGeometry::GetBCAL_length()/2.0 - m_zTarget;
     if (z > bcal_down) z = bcal_down;
     if (z < bcal_up) z = bcal_up;
 
@@ -404,7 +404,7 @@ jerror_t DBCALShower_factory_CURVATURE::evnt(JEventLoop *loop, int eventnumber)
     // for slices of z.  These fit parameters (scale and nonlin) are then plotted 
     // as a function of z and fit.
     float r = sqrt( shower->x * shower->x + shower->y * shower->y );
-    float zEntry = ( shower->z - m_zTarget ) * ( DBCALGeometry::BCALINNERRAD / r );
+    float zEntry = ( shower->z - m_zTarget ) * ( DBCALGeometry::GetBCAL_inner_rad() / r );
     float scale = m_scaleZ_p0  + m_scaleZ_p1*zEntry + m_scaleZ_p2*(zEntry*zEntry) + m_scaleZ_p3*(zEntry*zEntry*zEntry);
     float nonlin = m_nonlinZ_p0  + m_nonlinZ_p1*zEntry + m_nonlinZ_p2*(zEntry*zEntry) + m_nonlinZ_p3*(zEntry*zEntry*zEntry);
 

--- a/src/libraries/BCAL/DBCALShower_factory_IU.cc
+++ b/src/libraries/BCAL/DBCALShower_factory_IU.cc
@@ -87,7 +87,7 @@ DBCALShower_factory_IU::evnt( JEventLoop *loop, int eventnumber ){
     //so we need to make an adjustment so that the shower t is the time at
     //the shower location (x,y,z)
     double t = (**clItr).t();
-    double inner_rad = DBCALGeometry::BCALINNERRAD;
+    double inner_rad = DBCALGeometry::GetBCAL_inner_rad();
     double dist_in_BCAL = rho - inner_rad/sinTh;
     t = t + dist_in_BCAL/(30*k_cm/k_nsec);
     shower->t = t;
@@ -150,7 +150,7 @@ DBCALShower_factory_IU::evnt( JEventLoop *loop, int eventnumber ){
     
     float r = sqrt( shower->x * shower->x + shower->y * shower->y );
     
-    float zEntry = ( shower->z - m_zTarget ) * ( DBCALGeometry::BCALINNERRAD / r );
+    float zEntry = ( shower->z - m_zTarget ) * ( DBCALGeometry::GetBCAL_inner_rad() / r );
     
     float scale = m_scaleZ_p0  + m_scaleZ_p1*zEntry + 
     m_scaleZ_p2*(zEntry*zEntry) + m_scaleZ_p3*(zEntry*zEntry*zEntry);

--- a/src/libraries/BCAL/DBCALShower_factory_KLOE.cc
+++ b/src/libraries/BCAL/DBCALShower_factory_KLOE.cc
@@ -108,8 +108,8 @@ jerror_t DBCALShower_factory_KLOE::brun(JEventLoop *loop, int runnumber)
     ATTEN_LENGTH = bcalGeom.ATTEN_LENGTH;
     C_EFFECTIVE = bcalGeom.C_EFFECTIVE;
     
-    fiberLength = bcalGeom.BCALFIBERLENGTH; // fiber length in cm
-    zOffset = bcalGeom.GLOBAL_CENTER;
+    fiberLength = bcalGeom.GetBCAL_length(); // fiber length in cm
+    zOffset = bcalGeom.GetBCAL_center();
 
     //the following uses some sad notation in which modmin=0 and modmax=48, when in fact there are 48 modules labelled either 0-47 or 1-48 depending on one's whim, although if we are using the methods from DBCALGeometry (e.g. cellId()), we must start counting from 1 and if we are accessing arrays we must of course start from 0
     int   modmin = 0;
@@ -123,7 +123,7 @@ jerror_t DBCALShower_factory_KLOE::brun(JEventLoop *loop, int runnumber)
     int   colmin2=0;
     int   colmax2=bcalGeom.NBCALSECSOUT;
     
-    float r_inner= bcalGeom.BCALINNERRAD;
+    float r_inner= bcalGeom.GetBCAL_inner_rad();
     
     for (int i = (rowmin1+1); i < (rowmax1+1); i++){
         //this loop starts from 1, so we can use i in cellId with no adjustment
@@ -304,7 +304,7 @@ jerror_t DBCALShower_factory_KLOE::evnt(JEventLoop *loop, int eventnumber)
   
         float r = sqrt( shower->x * shower->x + shower->y * shower->y );
       
-        float zEntry = ( shower->z - m_z_target_center ) * ( DBCALGeometry::BCALINNERRAD / r );
+        float zEntry = ( shower->z - m_z_target_center ) * ( DBCALGeometry::GetBCAL_inner_rad() / r );
       
         float scale = m_scaleZ_p0  + m_scaleZ_p1*zEntry + 
             m_scaleZ_p2*(zEntry*zEntry) + m_scaleZ_p3*(zEntry*zEntry*zEntry);

--- a/src/libraries/HDGEOMETRY/DGeometry.cc
+++ b/src/libraries/HDGEOMETRY/DGeometry.cc
@@ -1354,10 +1354,47 @@ bool DGeometry::GetCDCEndplate(double &z,double &dz,double &rmin,double &rmax)
 //---------------------------------
 // GetBCALRmin
 //---------------------------------
-bool DGeometry::GetBCALRmin(double &bcal_rmin) const
+// Including the support plate
+bool DGeometry::GetBCALRmin(float &bcal_rmin) const
 {
+	vector<float> bcal_mother_Rio_Z;
+	bool good = Get("//BarrelEMcal_s/section/tubs[@name='BCAL']/@Rio_Z", bcal_mother_Rio_Z);
+	if(!good){
+		_DBG_<<"Unable to retrieve BCAL mother RioZ info."<<endl;
+		bcal_rmin = 0.0;
+		return false;
+	}
+	if(bcal_mother_Rio_Z.size() == 3){
+		bcal_rmin = bcal_mother_Rio_Z[0];
+		return true;
+	}
+	else{
+		_DBG_<<"Wrong vector size for BCAL mother RioZ!!!"<<endl;
+		bcal_rmin = 0.0;
+		return false;
+	}
+}
 
-	return false;
+//---------------------------------
+// GetBCALfADCRadii
+//---------------------------------
+bool DGeometry::GetBCALfADCRadii(vector<float> &fADC_radii) const
+{
+   vector<float> BM[5];
+
+   if(!Get("//BarrelEMcal_s/section/tubs[@name='BM01']/@Rio_Z", BM[0])) return false;
+   if(!Get("//BarrelEMcal_s/section/tubs[@name='BM02']/@Rio_Z", BM[1])) return false;
+   if(!Get("//BarrelEMcal_s/section/tubs[@name='BM04']/@Rio_Z", BM[2])) return false;
+   if(!Get("//BarrelEMcal_s/section/tubs[@name='BMF7']/@Rio_Z", BM[3])) return false;
+   if(!Get("//BarrelEMcal_s/section/tubs[@name='BMFA']/@Rio_Z", BM[4])) return false;
+
+   fADC_radii.push_back(BM[0][0]);
+   fADC_radii.push_back(BM[1][0]);
+   fADC_radii.push_back(BM[2][0]);
+   fADC_radii.push_back(BM[3][0]);
+   fADC_radii.push_back(BM[4][1]);
+
+   return true;
 }
 
 //---------------------------------
@@ -1365,43 +1402,101 @@ bool DGeometry::GetBCALRmin(double &bcal_rmin) const
 //---------------------------------
 bool DGeometry::GetBCALNmodules(unsigned int &bcal_nmodules) const
 {
-
-	return false;
+	vector<unsigned int> ncopy;
+	bool good = Get("//BarrelEMcal_s/section/composition/mposPhi/@ncopy", ncopy);
+	if(!good){
+		_DBG_<<"Unable to retrieve BCAL barrelModule ncopy info."<<endl;
+		bcal_nmodules = 0;
+		return false;
+	}
+	if(ncopy.size() == 1){
+		bcal_nmodules = ncopy[0];
+		return true;
+	}else{
+		_DBG_<<"Wrong vector size for BCAL barrelModule ncopy!!!"<<endl;
+		bcal_nmodules = 0;
+		return false;
+	}
 }
 
 //---------------------------------
 // GetBCALCenterZ
 //---------------------------------
-bool DGeometry::GetBCALCenterZ(double &bcal_center_z) const
+bool DGeometry::GetBCALCenterZ(float &bcal_center_z) const
 {
+	vector<float> z0;
+	bool good = Get("//BarrelEMcal_s/section/parameters/real[@name='z0']/@value", z0);
+	if(!good){
+		_DBG_<<"Unable to retrieve BCAL parameters z0 info."<<endl;
+		bcal_center_z = 0.0;
+		return false;
+	}
+	if(z0.size() == 1){
+		bcal_center_z = z0[0];
+		return true;
+	}else{
+		_DBG_<<"Wrong vector size for BCAL parameters z0!!!"<<endl;
+		bcal_center_z = 0.0;
+		return false;
+	}
 
-	return false;
 }
 
 //---------------------------------
 // GetBCALLength
 //---------------------------------
-bool DGeometry::GetBCALLength(double &bcal_length) const
+// The lightguides are not included
+bool DGeometry::GetBCALLength(float &bcal_length) const
 {
-
-	return false;
+	vector<float> module_length;
+	bool good = Get("//BarrelEMcal_s/section/tubs[@name='BM01']/@Rio_Z", module_length);
+	if(!good){
+		_DBG_<<"Unable to retrieve BCAL submodule RioZ info."<<endl;
+		bcal_length = 0.0;
+		return false;
+	}
+	if(module_length.size() == 3){
+		bcal_length = module_length[2];
+		return true;
+	}
+	else{
+		_DBG_<<"Wrong vector size for BCAL submodule RioZ!!!"<<endl;
+		bcal_length = 0.0;
+		return false;
+	}
 }
 
 //---------------------------------
 // GetBCALDepth
 //---------------------------------
-bool DGeometry::GetBCALDepth(double &bcal_depth) const
+// Including the support plate and the support bar
+bool DGeometry::GetBCALDepth(float &bcal_depth) const
 {
+	vector<float> bcal_moth_Rio_Z;
+	bool good = Get("//BarrelEMcal_s/section/tubs[@name='BCAL']/@Rio_Z", bcal_moth_Rio_Z);
+	if(!good){
+		_DBG_<<"Unable to retrieve BCAL mother RioZ info."<<endl;
+		bcal_depth = 0.0;
+		return false;
+	}
+	if(bcal_moth_Rio_Z.size() == 3){
+		bcal_depth = bcal_moth_Rio_Z[1] - bcal_moth_Rio_Z[0];
+		return true;
+	}
+	else{
+		_DBG_<<"Wrong vector size for BCAL mother RioZ!!!"<<endl;
+		bcal_depth = 0.0;
+		return false;
+	}
 
-	return false;
 }
 
 //---------------------------------
 // GetBCALPhiShift
 //---------------------------------
-bool DGeometry::GetBCALPhiShift(double &bcal_phi_shift) const
+bool DGeometry::GetBCALPhiShift(float &bcal_phi_shift) const
 {
-	vector<double> Phi0;
+	vector<float> Phi0;
 	bool good = Get("//BarrelEMcal_s/section/composition/mposPhi/@Phi0", Phi0);
 	if(!good) return false;
 	if(Phi0.size() == 1){

--- a/src/libraries/HDGEOMETRY/DGeometry.h
+++ b/src/libraries/HDGEOMETRY/DGeometry.h
@@ -133,12 +133,13 @@ class DGeometry{
 				       vector<vector<cdc_offset_t> >&cdc_offsets,
 				       vector<DCDCWire*> &stereowires) const;
 
-		bool GetBCALRmin(double &bcal_rmin) const; ///< minimum distance of BCAL module from beam line
+		bool GetBCALRmin(float &bcal_rmin) const; ///< minimum distance of BCAL module from beam line
+		bool GetBCALfADCRadii(vector<float> &fADC_radii) const; ///< fADC radii including the outer radius of the last layer
 		bool GetBCALNmodules(unsigned int &bcal_nmodules) const; ///< Number of BCAL modules
-		bool GetBCALCenterZ(double &bcal_center_z) const; ///< z-location of center of BCAL module in cm
-		bool GetBCALLength(double &bcal_length) const; ///< length of BCAL module in cm
-		bool GetBCALDepth(double &bcal_depth) const; ///< depth (or height) of BCAL module in cm
-		bool GetBCALPhiShift(double &bcal_phi_shift) const; ///< phi angle in degrees that first BCAL module is shifted from being centered at ph=0.0
+		bool GetBCALCenterZ(float &bcal_center_z) const; ///< z-location of center of BCAL module in cm
+		bool GetBCALLength(float &bcal_length) const; ///< length of BCAL module in cm
+		bool GetBCALDepth(float &bcal_depth) const; ///< depth (or height) of BCAL module in cm
+		bool GetBCALPhiShift(float &bcal_phi_shift) const; ///< phi angle in degrees that first BCAL module is shifted from being centered at ph=0.0
 		
 		bool GetFCALZ(double &z_fcal) const; ///< z-location of front face of FCAL in cm
 		bool GetTOFZ(vector<double> &z_tof) const; ///< z-location of front face of each of TOF in cm

--- a/src/libraries/TRIGGER/DMCTrigger_factory.cc
+++ b/src/libraries/TRIGGER/DMCTrigger_factory.cc
@@ -34,7 +34,7 @@ jerror_t DMCTrigger_factory::init(void)
 jerror_t DMCTrigger_factory::brun(jana::JEventLoop *eventLoop, int runnumber)
 {
 	// Get attenuation parameters
-	double L_over_2 = DBCALGeometry::BCALFIBERLENGTH/2.0;
+	double L_over_2 = DBCALGeometry::GetBCAL_length()/2.0;
 	double Xo = DBCALGeometry::ATTEN_LENGTH;
 	unattenuate_to_center = exp(+L_over_2/Xo);
 

--- a/src/plugins/Analysis/bcal_calib_cosmic_cdc/JEventProcessor_bcal_calib_cosmic_cdc.cc
+++ b/src/plugins/Analysis/bcal_calib_cosmic_cdc/JEventProcessor_bcal_calib_cosmic_cdc.cc
@@ -166,11 +166,13 @@ jerror_t JEventProcessor_bcal_calib_cosmic_cdc::evnt(JEventLoop *loop, int event
 				   cdcpos.x(), cdcpos.y(), cdcpos.z(), cdcmom.x(), cdcmom.y(), cdcmom.z(),track_m,track_c,chisq,Ndof);
 		/// Store the parameters for both track intersections with the 5 layers
 		float r[5], phi[2][5], x[2][5], y[2][5];
+		float* bcal_radii;
+		bcal_radii = DBCALGeometry::GetBCAL_radii();
 		/// For each layer boundary, calculate the intersection of the DTrackCandidate
 		/// with the circle and store the r and phi value for both intersections.
 		for (int laybound=0; laybound<=4; laybound++) {
 
-			r[laybound] =  DBCALGeometry::fADC_radius[laybound];
+			r[laybound] =  DBCALGeometry::bcal_radii[laybound];
 			
 			float A = 1 + track_m*track_m;
 			float B = 2 * track_m * track_c;

--- a/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.cc
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.cc
@@ -234,8 +234,8 @@ jerror_t JEventProcessor_BCAL_TDC_Timing::evnt(JEventLoop *loop, int eventnumber
                     char name[200];
                     sprintf(name , "Module %.2i Layer %.2i Sector %.2i", thisPoint->module(), thisPoint->layer(), thisPoint->sector());
                     // These results are in slightly different coordinate systems. We want one where the center of the BCAL is z=0
-                    double localTrackHitZ = proj_pos.z() - DBCALGeometry::GLOBAL_CENTER;
-                    double localBCALHitZ = thisPoint->z() - DBCALGeometry::GLOBAL_CENTER + Z_TARGET;
+                    double localTrackHitZ = proj_pos.z() - DBCALGeometry::GetBCAL_center();
+                    double localBCALHitZ = thisPoint->z() - DBCALGeometry::GetBCAL_center() + Z_TARGET;
                     Fill2DHistogram ("BCAL_TDC_Offsets", "Z Position", name,
                             localTrackHitZ, localBCALHitZ,
                             "Z_{point} Vs. Z_{Track}; Z_{Track} [cm]; Z_{Point} [cm]",

--- a/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
+++ b/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
@@ -198,7 +198,7 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::evnt(JEventLoop *loop, int 
 
 		//float timediff = t_ADCus_vec[0]-t_ADCds_vec[0];
 		//float zpos = (timediff)*17./2;
-		float zpos = point->z() - DBCALGeometry::GLOBAL_CENTER + z_target_center;
+		float zpos = point->z() - DBCALGeometry::GetBCAL_center() + z_target_center;
 		float intratio = (float)integralUS/(float)integralDS;
 		float logintratio = log(intratio);
 		if (VERBOSE>4) printf("%5i  %2i %i %i  %8.1f  %8.1f  %8.3f  %8.3f  %8.3f\n", 

--- a/src/programs/Analysis/hdview2/hdv_mainframe.cc
+++ b/src/programs/Analysis/hdview2/hdv_mainframe.cc
@@ -106,9 +106,9 @@ hdv_mainframe::hdv_mainframe(const TGWindow *p, UInt_t w, UInt_t h):TGMainFrame(
   TARGET_Zlen = my_TARGET_Zlen;
 
   // Get overall phi shift of BCAL
-  double my_BCAL_PHI_SHIFT;
+  float my_BCAL_PHI_SHIFT;
   dgeom->GetBCALPhiShift(my_BCAL_PHI_SHIFT);
-  BCAL_PHI_SHIFT = (float)(my_BCAL_PHI_SHIFT*TMath::DegToRad());  // convert to radians
+  BCAL_PHI_SHIFT = my_BCAL_PHI_SHIFT*TMath::DegToRad();  // convert to radians
 
   UInt_t MainWidth = w;
   


### PR DESCRIPTION
DGeometry BCAL methods filled and DBCALGeometry has been modified where necessary to reflect these changes. The old DBCALGeometry variables that have been modified are now private. These are:
- float BCALINNERRAD
- float fADC_radius[5]
- float GLOBAL_CENTER
- float BCALFIBERLENGTH
- float BCAL_PHI_SHIFT

To access the values that these variables hold (HDDS values) one must now use the following methods respectively:
- float GetBCAL_inner_rad();
- float\* GetBCAL_radii();
- float GetBCAL_center();
- float GetBCAL_length();
- float GetBCAL_phi_shift();
