### PR TITLE
Re-enable the EVIO:LOOP_FOREVER feature. This was previously only wor…

### DIFF
--- a/src/libraries/DAQ/JEventSource_EVIO.cc
+++ b/src/libraries/DAQ/JEventSource_EVIO.cc
@@ -963,6 +963,11 @@ jerror_t JEventSource_EVIO::ReadEVIOEvent(uint32_t* &buff)
 						case HDEVIO::HDEVIO_EOF:
 							if(hdevio) delete hdevio;
 							hdevio = NULL;
+							if(LOOP_FOREVER && Nevents_read>=1){
+								cout << "LOOP_FOREVER: reopening " << this->source_name <<endl;
+								hdevio = new HDEVIO(this->source_name);
+								if( hdevio->is_open ) continue;
+							}
 							return NO_MORE_EVENTS_IN_SOURCE;
 							break;
 						default:


### PR DESCRIPTION
This was previously only working for pre-HDEVIO code which is now deprecated. This feature is useful for debugging online systems where you would like the event source to continually reopen the input file and read events from it so you don't have to keep restarting the process by hand.
