### PR TITLE
Updated fa125 pulse time emulator and added decoder for new CDC pulse data type, #5 

### DIFF
--- a/src/libraries/DAQ/JEventSource_EVIO.cc
+++ b/src/libraries/DAQ/JEventSource_EVIO.cc
@@ -143,6 +143,26 @@ JEventSource_EVIO::JEventSource_EVIO(const char* source_name):JEventSource(sourc
 	F125_NSPED = 16;
 	F125_TIME_UPSAMPLE = true;
 
+    F125_CDC_WS = 46;       // hit window start - must be >= F125_CDC_NP
+    F125_CDC_WE = 150;      // hit window end - must be at least 20 less than number of samples available
+    F125_CDC_IE = 200;      // end integration at the earlier of WE, or this many samples after threshold crossing of TH  
+    F125_CDC_NP = 16;       // # samples used for pedestal used to find hit. 2**integer
+    F125_CDC_NP2 = 16;      // # samples used for pedestal calculated just before hit. 2**integer
+    F125_CDC_PG = 4;        // # samples between hit threshold crossing and local pedestal sample
+    F125_CDC_H = 125;       // 5 sigma hit threshold
+    F125_CDC_TH = 100;      // 4 sigma high timing threshold
+    F125_CDC_TL = 25;       // 1 sigma low timing threshold
+
+    F125_FDC_WS = 30;       // hit window start - must be >= F125_FDC_NP
+    F125_FDC_WE = 52;      // hit window end - must be at least 20 less than number of samples available
+    F125_FDC_IE = 10;      // end integration at the earlier of WE, or this many samples after threshold crossing of TH  
+    F125_FDC_NP = 16;       // # samples used for pedestal used to find hit. 2**integer
+    F125_FDC_NP2 = 16;      // # samples used for pedestal calculated just before hit. 2**integer
+    F125_FDC_PG = 4;        // # samples between hit threshold crossing and local pedestal sample
+    F125_FDC_H = 125;       // 5 sigma hit threshold
+    F125_FDC_TH = 100;      // 4 sigma high timing threshold
+    F125_FDC_TL = 25;       // 1 sigma low timing threshold
+
 	USER_RUN_NUMBER = 0;
 	F125PULSE_NUMBER_FILTER = 1000;
 	F250PULSE_NUMBER_FILTER = 1000;
@@ -201,6 +221,28 @@ JEventSource_EVIO::JEventSource_EVIO(const char* source_name):JEventSource(sourc
 		gPARMS->SetDefaultParameter("EVIO:RUN_NUMBER", USER_RUN_NUMBER, "User-supplied run number. Override run number from other sources with this.(will be ignored if set to zero)");
 		gPARMS->SetDefaultParameter("EVIO:F125PULSE_NUMBER_FILTER", F125PULSE_NUMBER_FILTER, "Ignore data for DF125XXX objects with a pulse number equal or greater than this.");
 		gPARMS->SetDefaultParameter("EVIO:F250PULSE_NUMBER_FILTER", F250PULSE_NUMBER_FILTER, "Ignore data for DF250XXX objects with a pulse number equal or greater than this.");
+
+
+		gPARMS->SetDefaultParameter("EVIO:F125_CDC_WS", F125_CDC_WS, "FA125 emulation: CDC hit window start.");
+		gPARMS->SetDefaultParameter("EVIO:F125_CDC_WE", F125_CDC_WE, "FA125 emulation: CDC hit window end.");
+		gPARMS->SetDefaultParameter("EVIO:F125_CDC_IE", F125_CDC_IE, "FA125 emulation: CDC number of integrated samples, unless WE is reached.");
+		gPARMS->SetDefaultParameter("EVIO:F125_CDC_NP", F125_CDC_NP, "FA125 emulation: CDC number of samples in initial pedestal window.");
+		gPARMS->SetDefaultParameter("EVIO:F125_CDC_NP2", F125_CDC_NP2, "FA125 emulation: CDC number of samples in local pedestal window.");
+		gPARMS->SetDefaultParameter("EVIO:F125_CDC_PG", F125_CDC_PG, "FA125 emulation: CDC gap between pedestal and hit threshold crossing.");
+		gPARMS->SetDefaultParameter("EVIO:F125_CDC_H", F125_CDC_H, "FA125 emulation: CDC hit threshold.");
+		gPARMS->SetDefaultParameter("EVIO:F125_CDC_TH", F125_CDC_TH, "FA125 emulation: CDC high timing threshold.");
+		gPARMS->SetDefaultParameter("EVIO:F125_CDC_TL", F125_CDC_TL, "FA125 emulation: CDC low timing threshold.");
+
+		gPARMS->SetDefaultParameter("EVIO:F125_FDC_WS", F125_FDC_WS, "FA125 emulation: FDC hit window start.");
+		gPARMS->SetDefaultParameter("EVIO:F125_FDC_WE", F125_FDC_WE, "FA125 emulation: FDC hit window end.");
+		gPARMS->SetDefaultParameter("EVIO:F125_FDC_IE", F125_FDC_IE, "FA125 emulation: FDC number of integrated samples, unless WE is reached.");
+		gPARMS->SetDefaultParameter("EVIO:F125_FDC_NP", F125_FDC_NP, "FA125 emulation: FDC number of samples in initial pedestal window.");
+		gPARMS->SetDefaultParameter("EVIO:F125_FDC_NP2", F125_FDC_NP2, "FA125 emulation: FDC number of samples in local pedestal window.");
+		gPARMS->SetDefaultParameter("EVIO:F125_FDC_PG", F125_FDC_PG, "FA125 emulation: FDC gap between pedestal and hit threshold crossing.");
+		gPARMS->SetDefaultParameter("EVIO:F125_FDC_H", F125_FDC_H, "FA125 emulation: FDC hit threshold.");
+		gPARMS->SetDefaultParameter("EVIO:F125_FDC_TH", F125_FDC_TH, "FA125 emulation: FDC high timing threshold.");
+		gPARMS->SetDefaultParameter("EVIO:F125_FDC_TL", F125_FDC_TL, "FA125 emulation: FDC low timing threshold.");
+
 
 		F250_PI_EMULATION_MODE = (EmulationModeType)f250_pi_emulation_mode;
 		F250_PT_EMULATION_MODE = (EmulationModeType)f250_pt_emulation_mode;
@@ -1809,6 +1851,13 @@ void JEventSource_EVIO::EmulateDf250PulseIntegral(vector<JObject*> &wrd_objs, ve
 void JEventSource_EVIO::EmulateDf125PulseIntegral(vector<JObject*> &wrd_objs, vector<JObject*> &pi_objs,
 						  vector<JObject*> &pt_objs)
 {
+	if(VERBOSE>3) evioout << " EmulateDf125PulseIntegral has been disabled" <<endl;
+    return;
+
+    // total cop-out by Naomi who cannot see how to make this not crash (even before the code was modified)
+    //
+    // The code below has been modified to emulate new fa125-style PI for the CDC.
+
 	if(VERBOSE>3) evioout << " Entering  EmulateDf125PulseIntegral ..." <<endl;
 
 	// If emulation is being forced, then delete any existing objects.
@@ -1876,13 +1925,13 @@ void JEventSource_EVIO::EmulateDf125PulseIntegral(vector<JObject*> &wrd_objs, ve
 			}
 		}
 		
-		// Choose value of NSA and NSB based on rocid (eechh!)
-		uint32_t NSA = F125_NSA;
-		uint32_t NSB = F125_NSB;
-		if(wrd->rocid>=24 && wrd->rocid<=28){
-			NSA = F125_NSA_CDC;
-			NSB = F125_NSB_CDC;
-		}
+		// // Choose value of NSA and NSB based on rocid (eechh!)
+		// uint32_t NSA = F125_NSA;
+		// uint32_t NSB = F125_NSB;
+		// if(wrd->rocid>=24 && wrd->rocid<=28){
+		// 	NSA = F125_NSA_CDC;
+		// 	NSB = F125_NSB_CDC;
+		// }
  
 		// Get a vector of the samples for this channel
 		const vector<uint16_t> &samplesvector = wrd->samples;
@@ -1892,22 +1941,37 @@ void JEventSource_EVIO::EmulateDf125PulseIntegral(vector<JObject*> &wrd_objs, ve
 		// loop over all samples to calculate integral
 		uint32_t nsamples_used = 0;
 
-		uint32_t BinTC = T==NULL ? 0:(T->time >> 6);
-		uint32_t StartSample = BinTC - NSB;
-		if( NSB > BinTC) {
-		  StartSample = 0;
-		} 
-		uint32_t EndSample = BinTC + NSA;
-		if (EndSample>nsamples-1){
-		  EndSample = nsamples;
-		}
-		for (uint32_t c_samp=StartSample; c_samp<EndSample; c_samp++) {
+		// uint32_t BinTC = T==NULL ? 0:(T->time >> 6);
+		// uint32_t StartSample = BinTC - NSB;
+		// if( NSB > BinTC) {
+		//   StartSample = 0;
+		// } 
+		// uint32_t EndSample = BinTC + NSA;
+		// if (EndSample>nsamples-1){
+		//   EndSample = nsamples;
+		// }
+
+        // skip this if no time info
+        if (!T) {
+          signalsum = 0;
+        } else if (!T->time) {
+          signalsum = 0;
+        } else {
+
+          // find sample containing time, time is now in units of sample/10
+	  	  uint32_t StartSample = (uint32_t)(0.1*T->time);
+
+          // CDC integration runs until NU samples before end of window (constant NU=20 in firmware)
+		  uint32_t EndSample = nsamples-20;
+
+  		  for (uint32_t c_samp=StartSample; c_samp<EndSample; c_samp++) {
 			signalsum += samplesvector[c_samp];
 			nsamples_used++;
-		}
+		  }
+        }
 		
-		// Apply sparsification threshold
-		if(signalsum < F125_SPARSIFICATION_THRESHOLD) continue;
+		// Apply sparsification threshold - T->t should be 0 if pulse is below threshold
+		// if(signalsum < F125_SPARSIFICATION_THRESHOLD) continue;
 		
 		// create new Df125PulseIntegral object
 		Df125PulseIntegral *myDf125PulseIntegral = new Df125PulseIntegral;
@@ -2185,6 +2249,9 @@ void JEventSource_EVIO::EmulateDf125PulseTime(vector<JObject*> &wrd_objs, vector
 	/// version used for 2014 commissioning data. When the upsampling algorithm
 	/// is implemented in firmware, the units reported by the firmware will
 	/// change to 1/10 of a sample!  2/9/2014 DL
+    ///
+    /// Changed the units to 1/10 sample to match the firmware 3 Nov 2015 NSJ.
+
 
 	if(VERBOSE>3) evioout << " Entering  EmulateDf125PulseTime ..." <<endl;
 
@@ -2300,7 +2367,8 @@ void JEventSource_EVIO::EmulateDf125PulseTime(vector<JObject*> &wrd_objs, vector
 
 		if(F125_TIME_UPSAMPLE){
 			fa125_algos_data_t fa125_algos_data;
-			fa125_algos(rocid, samplesvector, fa125_algos_data);
+			//fa125_algos(rocid, samplesvector, fa125_algos_data);
+ 	    	fa125_algos(rocid, samplesvector, fa125_algos_data, F125_CDC_WS, F125_CDC_WE, F125_CDC_IE, F125_CDC_NP, F125_CDC_NP2, F125_CDC_PG, F125_CDC_H, F125_CDC_TH, F125_CDC_TL, F125_FDC_WS, F125_FDC_WE, F125_FDC_IE, F125_FDC_NP, F125_FDC_NP2, F125_FDC_PG, F125_FDC_H, F125_FDC_TH, F125_FDC_TL);
 			
 			found_hit      = true;
 			time           = fa125_algos_data.time;
@@ -2313,7 +2381,7 @@ void JEventSource_EVIO::EmulateDf125PulseTime(vector<JObject*> &wrd_objs, vector
 			// sample while the f250 algorithm reports it in units of 1/64
 			// of a sample. Convert to units of 1/64 of a sample here to
 			// make this consistent with the other algorithms.
-			time = (time*64)/10;
+            //			time = (time*64)/10;  //removed 4Nov2015 NSJ
 			
 			// In Naomi's original code, she checked if maxamp was >0 to decide
 			// whether to add the value to the tree. Note that this ignored the
@@ -3693,6 +3761,67 @@ void JEventSource_EVIO::Parsef125Bank(int32_t rocid, const uint32_t* &iptr, cons
 				if(VERBOSE>7) evioout << "      FADC125 Window Raw Data"<<endl;
 				MakeDf125WindowRawData(objs, rocid, slot, itrigger, iptr);
 				break;
+
+            case 5: // new CDC format
+
+				if(VERBOSE>7) evioout << "      FADC125 CDC Pulse Data"<<endl;
+
+				channel = (*iptr>>20) & 0x7F;
+				pulse_number = (*iptr>>15) & 0x1F;
+				pulse_time = (*iptr>>4) & 0x7FF;
+				quality_factor = (*iptr>>3) & 0x1; //time QF bit
+
+	            if(VERBOSE>8) evioout << "        First word " << hex << (*iptr) << dec << endl;
+	            if(VERBOSE>8) evioout << "        pulse_time = " << hex << pulse_time << dec << " " << pulse_time << endl;
+
+ 				if( (objs!=NULL) && (pulse_number<F125PULSE_NUMBER_FILTER) && (F125_PT_EMULATION_MODE!=kEmulationAlways) ) {
+					objs->hit_objs.push_back(new Df125PulseTime(rocid, slot, channel, itrigger, pulse_number, quality_factor, pulse_time));
+				}
+
+				quality_factor = (*iptr>>0) & 0x7; //overflow count
+                iptr++; 
+
+	            if(VERBOSE>8) evioout << "        Second word " << hex << (*iptr) << dec << endl;
+
+				if(((*iptr>>31) & 0x1) == 0){  // make sure it is a continuation word
+                  pedestal = (*iptr>>23) & 0xFF;
+                  sum = (*iptr>>9) & 0x3FFF;
+                  pulse_peak = (*iptr>>0) & 0x1FF;
+
+				}else{
+                  pedestal = 0;
+                  sum = 0;
+                  pulse_peak = 0;
+  
+                  iptr--;
+				}
+
+	            if(VERBOSE>8) evioout << "        pedestal = " << hex << pedestal << dec << " " << pedestal << endl;
+	            if(VERBOSE>8) evioout << "        amplitude = " << hex << pulse_peak << dec << " " << pulse_peak << endl;
+	            if(VERBOSE>8) evioout << "        integral = " << hex << sum << dec << " " << sum << endl;
+
+				if( (objs!=NULL) && (pulse_number<F125PULSE_NUMBER_FILTER) && (F125_PP_EMULATION_MODE!=kEmulationAlways) ) {
+					objs->hit_objs.push_back(new Df125PulsePedestal(rocid, slot, channel, itrigger, pulse_number, pedestal, pulse_peak));
+				}
+
+				nsamples_integral = 0;  // must be overwritten later in GetObjects with value from Df125Config value
+				nsamples_pedestal = 1;  // The firmware returns an already divided pedestal
+
+                if (last_slot == slot && last_channel == channel) pulse_number = 1;
+                last_slot = slot;
+                last_channel = channel;
+				if( (objs!=NULL) && (pulse_number<F125PULSE_NUMBER_FILTER) ) {
+					objs->hit_objs.push_back(new Df125PulseIntegral(rocid, slot, channel, itrigger, pulse_number, 
+						quality_factor, sum, pedestal, nsamples_integral, nsamples_pedestal));
+				}
+
+
+				last_pulse_time_channel = channel;
+				break;
+
+
+
+
 			case 7: // Pulse Integral
 				if(VERBOSE>7) evioout << "      FADC125 Pulse Integral"<<endl;
 				channel = (*iptr>>20) & 0x7F;
@@ -3729,9 +3858,9 @@ void JEventSource_EVIO::Parsef125Bank(int32_t rocid, const uint32_t* &iptr, cons
 					objs->hit_objs.push_back(new Df125PulsePedestal(rocid, slot, channel, itrigger, pulse_number, pedestal, pulse_peak));
 				}
 				break;
-			case 5: // Window Sum
-			case 6: // Pulse Raw Data
-			case 9: // Streaming Raw Data
+
+			case 6: // FDC Data
+			case 9: // FDC Data
 			case 13: // Event Trailer
 			case 14: // Data not valid (empty module)
 			case 15: // Filler (non-data) word

--- a/src/libraries/DAQ/JEventSource_EVIO.h
+++ b/src/libraries/DAQ/JEventSource_EVIO.h
@@ -243,6 +243,29 @@ class JEventSource_EVIO: public jana::JEventSource{
 		uint32_t F125_NSPED;                       ///< Number of samples to integrate for pedestal during emulation
 		uint32_t F125_TIME_UPSAMPLE;               ///< Use the CMU upsampling algorithm when emulating f125 pulse times
 
+
+        uint32_t F125_CDC_WS;                      ///< FA125 emulation CDC hit window start
+        uint32_t F125_CDC_WE;                      ///< FA125 emulation CDC hit window end
+        uint32_t F125_CDC_IE;                      ///< FA125 emulation CDC number of integrated samples (unless WE is reached)
+        uint32_t F125_CDC_NP;                      ///< FA125 emulation CDC initial pedestal samples
+        uint32_t F125_CDC_NP2;                     ///< FA125 emulation CDC local pedestal samples
+        uint32_t F125_CDC_PG;                      ///< FA125 emulation CDC gap between pedestal and hit threshold crossing
+        uint32_t F125_CDC_H;                       ///< FA125 emulation CDC hit threshold
+        uint32_t F125_CDC_TH;                      ///< FA125 emulation CDC high timing threshold
+        uint32_t F125_CDC_TL;                      ///< FA125 emulation CDC low timing threshold
+
+        uint32_t F125_FDC_WS;                      ///< FA125 emulation FDC hit window start
+        uint32_t F125_FDC_WE;                      ///< FA125 emulation FDC hit window end
+        uint32_t F125_FDC_IE;                      ///< FA125 emulation FDC number of integrated samples (unless WE is reached)
+        uint32_t F125_FDC_NP;                      ///< FA125 emulation FDC initial pedestal samples
+        uint32_t F125_FDC_NP2;                     ///< FA125 emulation FDC local pedestal samples
+        uint32_t F125_FDC_PG;                      ///< FA125 emulation FDC gap between pedestal and hit threshold crossing
+        uint32_t F125_FDC_H;                       ///< FA125 emulation FDC hit threshold
+        uint32_t F125_FDC_TH;                      ///< FA125 emulation FDC high timing threshold
+        uint32_t F125_FDC_TL;                      ///< FA125 emulation FDC low timing threshold
+
+
+
 		uint32_t USER_RUN_NUMBER;            ///< Run number supplied by user
 		uint32_t F125PULSE_NUMBER_FILTER;    ///< Discard DF125PulseXXX objects with pulse number equal or greater than this
 		uint32_t F250PULSE_NUMBER_FILTER;    ///< Discard DF250PulseXXX objects with pulse number equal or greater than this

--- a/src/libraries/DAQ/fa125algo.h
+++ b/src/libraries/DAQ/fa125algo.h
@@ -3,48 +3,9 @@
 //
 
 // This file and the fa125algo.cc file were made by splitting the file
-// fa125algo.inc.C sent to me by Naomi via e-mail on 3/18/2015. Here is
-// here message from that e-mail:
+// fa125algo.inc.C sent to me by Naomi via e-mail on 3/18/2015. 
 //
-//==============================================================================
-//	Hi David,
-//
-//	I have attached a new version of the fa125 new algorithm emulation code
-//	which has one set of constants for the CDC, another lovely set of
-//	constants for the FDC, and it chooses which set to use after looking at
-//	the rocid   :-)  but before calling the algorithm function (as sending
-//	rocid to the algorithm code is taking the ugliness too far).
-//	I put in my best guess at the constants.
-//
-//	Also I cleaned out some of the diagnostic-type-parameters which nobody
-//	else would be interested in.
-//
-//	The constants which would be altered the most often would be the hit
-//	window start and end, and the hit and timing thresholds.
-//	eg for the CDC
-//
-//	#define CDC_WS 46       //hit window start
-//	#define CDC_WE 150      //hit window end
-//
-//	#define CDC_H 125       // 5 sigma hit threshold
-//	#define CDC_TH 100      // 4 sigma threshold
-//	#define CDC_TL 25       // 1 sigma threshold
-//
-//	If you wish to make any accessible as hd_root command line options, those
-//	(and the equivalent for the FDC) would be the best candidates.
-//
-//	The attached code can run on the DAQTree plugin output & makes a root file
-//	(with a horrible name) containing its calculations.  The DAQTree itrigger
-//	values are still crazy.
-//
-//	Please let me know if there is anything I can do to this to make it easier
-//	to implement.
-//
-//	Best,
-//
-//	Naomi.
-//==============================================================================
-
+// Updated 10.27.15 NSJ
 
 #include <stdint.h>
 #include <vector>
@@ -66,60 +27,49 @@ class fa125_algos_data_t{
 		Int_t overflows;
 		Int_t maxamp;
 		// Int_t adc[]; // Commented out since this is input
-		Int_t NSAMPLES;
 		Int_t WINDOW_START;
 		Int_t WINDOW_END;
-		Int_t HIT_THRES;
+		Int_t INT_END;
+
 		Int_t NPED;
 		Int_t NPED2;
+        Int_t PG;
+
+		Int_t HIT_THRES;
 		Int_t HIGH_THRESHOLD;
 		Int_t LOW_THRESHOLD;
-		Int_t ROUGH_DT;
-		Int_t INT_SAMPLE;
-		Int_t INT_END;
-		Int_t LIMIT_PED_MAX;
-		Int_t LIMIT_ADC_MAX;
-		Int_t XTHR_SAMPLE;
-		Int_t PED_SAMPLE;
-		Int_t SET_ADC_MIN;
-		Int_t LIMIT_UPS_ERR;
 };
 
 
 
 // FA125 emulation functions cdc_hit, cdc_time etc
 
+// Peak amplitude and integral are returned without pedestal subtraction
 
   // cdc_time q_code values:
-  //
-  //   0: Good
-  //   1: ADC data did not go over threshold adc_thres_hi 
-  //   2: Leading edge time is outside the upsampled region (cross adc_thres_lo too late in the buffer subset ) 
-  //   3: Last upsampled point is <= low timing threshold
-  //   4: Upsampled points did not go below low timing threshold
-  //   5: ADC sample value of 0 found
-  //   6: ADC sample value > ADC_LIMIT found
-  //   7: Pedestal ADC[PED_SAMPLE] value > LIMIT_PED_MAX found
-  //   8: Upsampled point is below 0
-  //   9: Upsampling error is > SET_UPS_TOL
+
+  // q_code  Time returned       Condition
+  // 0       Leading edge time   Good 
+  // 1       X*10 - 29           Sample value of 0 found 
+  // 1       X*10 - 28           Sample value greater than PED_MAX found in adc[0 to PED]
+  // 1       X*10 - 27           Sample values lie below the high timing threshold 
+  // 1       TCL*10 + 4          Low timing threshold crossing sample TCL occurs too late to upsample
+  // 1       TCL*10 + 5          One or more upsampled values are negative 
+  // 1       TCL*10 + 9          The upsampled values are too low
 
 
-  // calc pedestal as mean of NPED samples before trigger and again as mean of NPED2 samples before hit
-  // hit search is from samples WINDOW_START to WINDOW_END
-  // pedestal is not subtracted from max amplitude
-
-
-
-void cdc_hit(Int_t&, Int_t&, Int_t&, Int_t[], Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t);   // look for a hit
-void cdc_time(Int_t&, Int_t&, Int_t&, Int_t[], Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t);  // find hit time
+void cdc_hit(Int_t&, Int_t&, Int_t&, Int_t[], Int_t, Int_t, Int_t, Int_t, Int_t, Int_t);   // look for a hit
+void cdc_time(Int_t&, Int_t&, Int_t[], Int_t, Int_t, Int_t, Int_t); // find hit time
 void cdc_integral(Long_t&, Int_t&, Int_t, Int_t[], Int_t, Int_t); // find integral
 void cdc_max(Int_t&, Int_t, Int_t[], Int_t); // find first max amplitude after hit
-void upsamplei(Int_t[], Int_t, Int_t[], const Int_t);   // upsample
+void upsamplei(Int_t[], Int_t, Int_t[], Int_t);   // upsample
 
-void fa125_algos(Int_t&, Int_t&, Int_t&, Long_t&, Int_t&, Int_t&, Int_t[], Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t);
+void fa125_algos(Int_t&, Int_t&, Int_t&, Long_t&, Int_t&, Int_t&, Int_t[], Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t);
 
+//	fa125_algos(d.time, d.q_code, d.pedestal, d.integral, d.overflows, d.maxamp, adc, d.WINDOW_START, d.WINDOW_END, d.INT_END, d.NPED, d.NPED2, d.PG, d.HIT_THRES, d.HIGH_THRESHOLD, d.LOW_THRESHOLD);
 
 // Alternate form that wraps original defined above. (See comment just above
 // fa125_algos_data_t class definition)
-void fa125_algos(int rocid, vector<uint16_t> samples, fa125_algos_data_t &fa125_algos_data);
+//void fa125_algos(int rocid, vector<uint16_t> samples, fa125_algos_data_t &fa125_algos_data);
 
+void fa125_algos(int rocid, vector<uint16_t> samples, fa125_algos_data_t &fa125_algos_data, uint32_t CDC_WS, uint32_t CDC_WE, uint32_t CDC_IE, uint32_t CDC_NP, uint32_t CDC_NP2, uint32_t CDC_PG, uint32_t CDC_H, uint32_t CDC_TH, uint32_t CDC_TL, uint32_t FDC_WS, uint32_t FDC_WE, uint32_t FDC_IE, uint32_t FDC_NP, uint32_t FDC_NP2, uint32_t FDC_PG, uint32_t FDC_H, uint32_t FDC_TH, uint32_t FDC_TL);


### PR DESCRIPTION
Updated fa125 time emulation code to match the firmware.
Added many gPARMS to enable the configuration params to be set in the command line.

Added decoder for new fa125 data type 5, CDC pulse data

This was done by putting new quantities into the existing Df125PulsePedestal, Df125PulseTime and Df125PulseIntegral.  The quality_factor in Df125PulseIntegral is the number of overflows.  The quality_factor in Df125PulseTime is the time quality factor.  

fa125 pulse integral emulation now segfaults so I disabled it!  I did update the PI emulation but it segfaulted before I did that.  I expect the fa125 objects might be being restructured soon so I'm going ahead with the push despite this handicap because the EVIO decoder is a lot more useful than the PI emulation.  (hd_root did not segfault with PI emulation switched off, I just disabled it to make sure that it's always switched off)
