### PR TITLE
Davidl hdgeant event counter

### DIFF
--- a/src/programs/Simulation/HDGeant/controlparams.h
+++ b/src/programs/Simulation/HDGeant/controlparams.h
@@ -11,6 +11,9 @@ typedef struct {
 	int driftclusters;
 	float tgwidth[2];
 	int runtime_geom;
+	int get_next_evt;
+	float trigger_time_signa_ns;
+	int event_count;
 }controlparams_t;
 extern controlparams_t controlparams_;
 

--- a/src/programs/Simulation/HDGeant/controlparams.inc
+++ b/src/programs/Simulation/HDGeant/controlparams.inc
@@ -2,6 +2,8 @@
       real tgtwidth
       integer get_next_evt
       real trigger_time_sigma_ns
+      integer event_count
       common /controlparams/ writenohits, showersincol, driftclusters
      +                       ,tgtwidth(2),runtime_geom,get_next_evt
      +                       ,trigger_time_sigma_ns
+     +                       ,event_count

--- a/src/programs/Simulation/HDGeant/gukine.F
+++ b/src/programs/Simulation/HDGeant/gukine.F
@@ -131,14 +131,15 @@
       UPWGHT = 1
       ISTORY = 0
 
-      ev = IDEVT
+      ev = event_count
       do i=1,10
         ev = ev/10.
         if (ev.lt.10) goto 2
       enddo
     2 if (int(ev).eq.ev) then
-        write(LOUT,*) IDEVT," events simulated"
+        write(LOUT,*) event_count," events simulated"
       endif
+      event_count = event_count + 1
 
 *     Get the current values of the random number seeds. Do this
 *     here so we can overwrite them in the first "if" block below

--- a/src/programs/Simulation/HDGeant/gustep.F
+++ b/src/programs/Simulation/HDGeant/gustep.F
@@ -489,7 +489,7 @@ c    +    .and.(vect(1)**2+vect(2)**2).gt.25.0) then
 
 #ifdef ACTIVE_COLLIMATOR_SIMS
       if (IDEVT.ne.evno) then
-        if (IDEVT.eq.1) then
+        if (event_count.eq.1) then
           call hbnt(ntacol,'active collimator ntuple, all events',' ')
           call hbname(ntacol,'charge',evno,ntacoldef)
           call hbnt(ntacol+1,'active collimator ntuple, charged events',

--- a/src/programs/Simulation/HDGeant/uginit.F
+++ b/src/programs/Simulation/HDGeant/uginit.F
@@ -195,6 +195,7 @@ c The following parameters are declared in controlparams.inc above.
       data tgtwidth/2*0/
       data get_next_evt/1/
       data trigger_time_sigma_ns/10./
+      data event_count/0/
 
 C  Use this parameter to set up a minimum photon energy 
 C  for the coherent bremsstrahlung beam generator - see beamgen.F


### PR DESCRIPTION
Fix the print out of number of events simulated so that it doesn't assume the
event numbers increase sequentially from 1. Input HDDM files generated by 
recon2mc keep the event number of the original raw data file and this propagates
through hdgeant into the output hddm file. These event numbers don't 
necessarily start from 1 and most likely do not have events in order of event number
due to multi-threading.
