### PR TITLE
Fixed issues with ST_online plugins

### DIFF
--- a/src/plugins/monitoring/ST_online_lowlevel/JEventProcessor_ST_online_lowlevel.cc
+++ b/src/plugins/monitoring/ST_online_lowlevel/JEventProcessor_ST_online_lowlevel.cc
@@ -38,7 +38,7 @@ using std::string;
 //**************************************************************
 const uint32_t NCHANNELS  = 30;     // number of scintillator paddles
 const float_t  ADC_PT_RES = 0.0625; // fADC250 pulse time resolution (ns)
-const float_t  TDC_RES    = 0.0559; // f1TDC resolution (ns)
+//const float_t  TDC_RES    = 0.0559; // f1TDC resolution (ns)
 //***************** Declare Two Dimensional Histograms*************
 //*****************************************************************
 static TH2I *h2_st_adc_tdc_multi;
@@ -368,7 +368,7 @@ jerror_t JEventProcessor_ST_online_lowlevel::evnt(JEventLoop *loop, int eventnum
 		  if (!bool_sec150[hit_sector_adc_index])
 		    {
 		      bool_sec150[hit_sector_adc_index] = true;
-		      if (bool_sec150[hit_sector_adc_index]);
+		      if (bool_sec150[hit_sector_adc_index])
 		      {
 			
 			for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
@@ -385,7 +385,7 @@ jerror_t JEventProcessor_ST_online_lowlevel::evnt(JEventLoop *loop, int eventnum
 		  if (!bool_sec[hit_sector_adc_index])
 		    {
 		      bool_sec[hit_sector_adc_index] = true;
-		      if (bool_sec[hit_sector_adc_index]);
+		      if (bool_sec[hit_sector_adc_index])
 		      {
 			
 			for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
@@ -402,7 +402,7 @@ jerror_t JEventProcessor_ST_online_lowlevel::evnt(JEventLoop *loop, int eventnum
 		  if (!bool_sec1000[hit_sector_adc_index])
 		    {
 		      bool_sec1000[hit_sector_adc_index] = true;
-		      if (bool_sec1000[hit_sector_adc_index]);
+		      if (bool_sec1000[hit_sector_adc_index])
 		      {
 			
 			for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
@@ -420,7 +420,7 @@ jerror_t JEventProcessor_ST_online_lowlevel::evnt(JEventLoop *loop, int eventnum
 		  if (!bool_sec2000[hit_sector_adc_index])
 		    {
 		      bool_sec2000[hit_sector_adc_index] = true;
-		      if (bool_sec2000[hit_sector_adc_index]);
+		      if (bool_sec2000[hit_sector_adc_index])
 		      {
 			
 			for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
@@ -438,7 +438,7 @@ jerror_t JEventProcessor_ST_online_lowlevel::evnt(JEventLoop *loop, int eventnum
 		  if (!bool_sec3000[hit_sector_adc_index])
 		    {
 		      bool_sec3000[hit_sector_adc_index] = true;
-		      if (bool_sec3000[hit_sector_adc_index]);
+		      if (bool_sec3000[hit_sector_adc_index])
 		      {
 			
 			for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
@@ -456,7 +456,7 @@ jerror_t JEventProcessor_ST_online_lowlevel::evnt(JEventLoop *loop, int eventnum
 		  if (!bool_sec4000[hit_sector_adc_index])
 		    {
 		      bool_sec4000[hit_sector_adc_index] = true;
-		      if (bool_sec4000[hit_sector_adc_index]);
+		      if (bool_sec4000[hit_sector_adc_index])
 		      {
 			for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
 			  {

--- a/src/plugins/monitoring/ST_online_tracking/JEventProcessor_ST_online_tracking.cc
+++ b/src/plugins/monitoring/ST_online_tracking/JEventProcessor_ST_online_tracking.cc
@@ -31,7 +31,7 @@ using namespace std;
 #include "TRACKING/DTrackTimeBased.h"
 
 // Define some constants
-const uint32_t  RAD2DEG       = 57.29577951;      // Convert radians to degrees
+const double    RAD2DEG       = 57.29577951;      // Convert radians to degrees
 const uint32_t  NCHANNELS     = 30;              // number of scintillator paddles
 
 // Declare 2D tracking histos


### PR DESCRIPTION
Fixed several places where a semi-colon was following an if() statement but before the opening curly bracket on the next line. This prevented the if statement from actually being a condition for the bracketed code to be run.  (n.b. This was pointed out by the clang 3.7.0 compiler.)

Also made RAD2DEG a double (was a uint32_t.)
