### PR TITLE
Davidl supress clang3.70 warnings

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisUtilities.h
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.h
@@ -108,7 +108,7 @@ class DAnalysisUtilities : public JObject
 
 	private:
 
-		unsigned int DEBUG_LEVEL;
+//		unsigned int DEBUG_LEVEL;
 
 		double dTargetZCenter;
 		const DParticleID* dPIDAlgorithm;

--- a/src/libraries/ANALYSIS/DHistogramActions_Thrown.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Thrown.h
@@ -454,7 +454,7 @@ class DHistogramAction_TruePID : public DAnalysisAction
 	public:
 		DHistogramAction_TruePID(const DReaction* locReaction, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Hist_TruePID", false, locActionUniqueString),
-		dNumPBins(300), dNum2DPBins(150), dNumThetaBins(140), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinThrownMatchFOM(5.73303E-7)
+		dNumPBins(300), dNum2DPBins(150), dNumThetaBins(140), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0)/*, dMinThrownMatchFOM(5.73303E-7)*/
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -466,7 +466,7 @@ class DHistogramAction_TruePID : public DAnalysisAction
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 		void Initialize(JEventLoop* locEventLoop);
 
-		double dMinThrownMatchFOM;
+//		double dMinThrownMatchFOM;
 		const DAnalysisUtilities* dAnalysisUtilities;
 
 		TH1I* dHist_TruePIDStatus;

--- a/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.h
+++ b/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.h
@@ -53,7 +53,7 @@ class DTrackTimeBased_factory_Combo:public jana::JFactory<DTrackTimeBased>
 
 		map<Particle_t, deque<Particle_t> > dParticleIDsToTry;
 
-		const DDetectorMatches* dDetectorMatches;
+//		const DDetectorMatches* dDetectorMatches;
 		vector<const DReaction*> dReactions;
 		map<const DReaction*, set<Particle_t> > dPositivelyChargedPIDs;
 		map<const DReaction*, set<Particle_t> > dNegativelyChargedPIDs;

--- a/src/libraries/BCAL/DBCALClump_factory.cc
+++ b/src/libraries/BCAL/DBCALClump_factory.cc
@@ -23,7 +23,7 @@ jerror_t DBCALClump_factory::init(void)
 //----------------
 // init
 //----------------
-jerror_t DBCALClump_factory::brun(JEventLoop *loop)
+jerror_t DBCALClump_factory::brun(JEventLoop *loop, int32_t runnumber)
 {
   map<string, double> bcalparms;
 

--- a/src/libraries/BCAL/DBCALClump_factory.h
+++ b/src/libraries/BCAL/DBCALClump_factory.h
@@ -42,7 +42,7 @@ class DBCALClump_factory : public JFactory<DBCALClump> {
  private:
   
   jerror_t init(void);
-  jerror_t brun(JEventLoop *loop);
+  jerror_t brun(JEventLoop *loop, int32_t runnumber);
   jerror_t evnt(JEventLoop *loop, int eventnumber);
   
 };

--- a/src/libraries/BCAL/DBCALPoint_factory.cc
+++ b/src/libraries/BCAL/DBCALPoint_factory.cc
@@ -15,9 +15,9 @@ using namespace jana;
 #include "units.h"
 
 /// temp
-static const int BCAL_NUM_MODULES  = 48;
-static const int BCAL_NUM_LAYERS   =  4;
-static const int BCAL_NUM_SECTORS  =  4;
+//static const int BCAL_NUM_MODULES  = 48;
+//static const int BCAL_NUM_LAYERS   =  4;
+//static const int BCAL_NUM_SECTORS  =  4;
 
 
 //----------------

--- a/src/libraries/FDC/DFDCPseudo_factory.h
+++ b/src/libraries/FDC/DFDCPseudo_factory.h
@@ -117,7 +117,8 @@ class DFDCPseudo_factory : public JFactory<DFDCPseudo> {
 		double r2_out,r2_in;
 		double STRIP_ANODE_TIME_CUT;
 		unsigned int MAX_ALLOWED_FDC_HITS;
-		bool DEBUG_HISTS,USE_FDC,MATCH_TRUTH_HITS;
+//		bool DEBUG_HISTS,USE_FDC,MATCH_TRUTH_HITS;
+		bool DEBUG_HISTS,USE_FDC;
 		double MIDDLE_STRIP_THRESHOLD;
 		double FDC_RES_PAR1,FDC_RES_PAR2;
 
@@ -127,7 +128,7 @@ class DFDCPseudo_factory : public JFactory<DFDCPseudo> {
 		TH2F *Hxy[24],*ut_vs_u,*vt_vs_v;
 		TH2F *v_vs_u,*dx_vs_dE;
 
-		JStreamLog* _log;
+//		JStreamLog* _log;
 };
 
 #endif // DFACTORY_DFDCPSEUDO_H

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapNoField.cc
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapNoField.cc
@@ -2,7 +2,7 @@
 //
 //    File: DMagneticFieldMapNoField.cc
 
-
+#include <string>
 using namespace std;
 
 #include "DMagneticFieldMapNoField.h"

--- a/src/libraries/PAIR_SPECTROMETER/DPSCPair_factory.cc
+++ b/src/libraries/PAIR_SPECTROMETER/DPSCPair_factory.cc
@@ -57,7 +57,7 @@ jerror_t DPSCPair_factory::evnt(JEventLoop *loop, int eventnumber)
       for (unsigned int j=i+1; j < hits.size(); j++) {
 	if (!hits[i]->has_TDC||!hits[j]->has_TDC) continue;
 	if (!hits[i]->has_fADC||!hits[j]->has_fADC) continue;
-	if (fabs(hits[i]->arm-hits[j]->arm)==1&&fabs(hits[i]->t-hits[j]->t)<DELTA_T_PAIR_MAX) {
+	if (std::abs(hits[i]->arm-hits[j]->arm)==1&&fabs(hits[i]->t-hits[j]->t)<DELTA_T_PAIR_MAX) {
 	  if (hits[i]->arm==0) {
 	    ee.first = hits[i];
 	    ee.second = hits[j];

--- a/src/libraries/PAIR_SPECTROMETER/DPSPair_factory.cc
+++ b/src/libraries/PAIR_SPECTROMETER/DPSPair_factory.cc
@@ -55,7 +55,7 @@ jerror_t DPSPair_factory::evnt(JEventLoop *loop, int eventnumber)
   if (hits.size()>1) {
     for (unsigned int i=0; i < hits.size()-1; i++) {
       for (unsigned int j=i+1; j < hits.size(); j++) {
-	if (fabs(hits[i]->arm-hits[j]->arm)==1&&fabs(hits[i]->t-hits[j]->t)<DELTA_T_PAIR_MAX) {
+	if (std::abs(hits[i]->arm-hits[j]->arm)==1&&fabs(hits[i]->t-hits[j]->t)<DELTA_T_PAIR_MAX) {
 	  if (hits[i]->arm==0) {
 	    ee.first = hits[i];
 	    ee.second = hits[j];

--- a/src/libraries/PID/DKinematicData.cc
+++ b/src/libraries/PID/DKinematicData.cc
@@ -14,7 +14,7 @@
 
 #include "DRandom.h"
 
-const double kLarge = 1.e20;
+//const double kLarge = 1.e20;
 
 // B field constant to convert curvature to momentum
 // const double kBfieldConstant = -0.0299792458;

--- a/src/libraries/TRACKING/DRiemannFit.h
+++ b/src/libraries/TRACKING/DRiemannFit.h
@@ -72,9 +72,9 @@ class DRiemannFit{
 
   // Cirlce fit parameters
   double N[3]; 
-  double varN[3][3];
+//  double varN[3][3];
   double dist_to_origin;
-  double xavg[3],var_avg;
+//  double xavg[3],var_avg;
 };
 
 #endif //_DRIEMANN_FIT_H_

--- a/src/libraries/TRACKING/DTrackCandidate_factory.h
+++ b/src/libraries/TRACKING/DTrackCandidate_factory.h
@@ -139,7 +139,7 @@ class DTrackCandidate_factory:public JFactory<DTrackCandidate>{
   int DEBUG_LEVEL,MIN_NUM_HITS;
   bool DEBUG_HISTS;
   TH2F *match_dist,*match_dist_vs_p;
-  TH2F *match_center_dist2;
+//  TH2F *match_center_dist2;
 
   double FactorForSenseOfRotation;
   DVector3 cdc_endplate;

--- a/src/libraries/TRACKING/DTrackFitterALT1.cc
+++ b/src/libraries/TRACKING/DTrackFitterALT1.cc
@@ -4,7 +4,7 @@
 // Created: Tue Sep  2 11:18:22 EDT 2008
 // Creator: davidl
 //
-namespace{const char* GetMyID(){return "$Id$";}}
+//namespace{const char* GetMyID(){return "$Id$";}}
 
 #include <cmath>
 using namespace std;

--- a/src/libraries/TRACKING/DTrackFitterALT1.h
+++ b/src/libraries/TRACKING/DTrackFitterALT1.h
@@ -114,10 +114,10 @@ class DTrackFitterALT1:public DTrackFitter{
 		DCoordinateSystem *target;
 		
 		int eventnumber;
-		const JGeometry *dgeom;
+//		const JGeometry *dgeom;
 		vector<DReferenceTrajectory*>rtv;
 		DReferenceTrajectory *rt, *tmprt;
-		bool hit_based;
+//		bool hit_based;
 		bool DEBUG_HISTS;
 		int  DEBUG_LEVEL;
 		double MAX_CHISQ_DIFF;

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -7096,7 +7096,7 @@ jerror_t DTrackFitterKalmanSIMD::SmoothCentral(void){
             A=cdc_updates[id].C*JT*C.InvertSym();
 	    AT=A.Transpose();
             Ss=cdc_updates[id].S+A*(Ss-S);
-	    if (!finite(Ss(state_q_over_pt))){
+	    if (!isfinite(Ss(state_q_over_pt))){
 	     if (DEBUG_LEVEL>5) _DBG_ << "Invalid values for smoothed parameters..." << endl;
 	      return VALUE_OUT_OF_RANGE;
 	    }
@@ -7194,7 +7194,7 @@ jerror_t DTrackFitterKalmanSIMD::SmoothForwardCDC(void){
 
             A=cdc_updates[cdc_index].C*JT*C.InvertSym();
             Ss=cdc_updates[cdc_index].S+A*(Ss-S);
-	    if (!finite(Ss(state_q_over_p))){
+	    if (!isfinite(Ss(state_q_over_p))){
 	     if (DEBUG_LEVEL>5) _DBG_ << "Invalid values for smoothed parameters..." << endl;
 	      return VALUE_OUT_OF_RANGE;
 	    }

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD_ALT1.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD_ALT1.cc
@@ -965,7 +965,7 @@ jerror_t DTrackFitterKalmanSIMD_ALT1::SmoothForward(void){
 	A=fdc_updates[id].C*JT*C.InvertSym();
 	Ss=fdc_updates[id].S+A*(Ss-S);
 	
-	if (!finite(Ss(state_q_over_p))){ 
+	if (!isfinite(Ss(state_q_over_p))){ 
 	  if (DEBUG_LEVEL>5) _DBG_ << "Invalid values for smoothed parameters..." << endl;
 	  return VALUE_OUT_OF_RANGE;
 	}
@@ -1047,7 +1047,7 @@ jerror_t DTrackFitterKalmanSIMD_ALT1::SmoothForward(void){
 	A=cdc_updates[id].C*JT*C.InvertSym();
 	Ss=cdc_updates[id].S+A*(Ss-S);
 
-	if (!finite(Ss(state_q_over_p))){
+	if (!isfinite(Ss(state_q_over_p))){
 	  if (DEBUG_LEVEL>5) _DBG_ << "Invalid values for smoothed parameters..." << endl;
 	  return VALUE_OUT_OF_RANGE;
 	}

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.h
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.h
@@ -51,7 +51,7 @@ class DTrackTimeBased_factory:public jana::JFactory<DTrackTimeBased>{
   bool PID_FORCE_TRUTH;
   unsigned int MIN_CDC_HITS_FOR_TB_FORWARD_TRACKING;
   bool BYPASS_TB_FOR_FORWARD_TRACKS;
-  bool SKIP_MASS_HYPOTHESES_TIMEBASED;
+//  bool SKIP_MASS_HYPOTHESES_TIMEBASED;
   bool USE_HITS_FROM_WIREBASED_FIT;
 
   DTrackFitter *fitter;
@@ -91,8 +91,10 @@ class DTrackTimeBased_factory:public jana::JFactory<DTrackTimeBased>{
   // Geometry
   const DGeometry *geom;
 
-  double mPathLength,mEndTime,mStartTime,mFlightTime;
-  DetectorSystem_t mDetector, mStartDetector;
+//  double mPathLength,mEndTime,mStartTime,mFlightTime;
+  double mStartTime;
+//  DetectorSystem_t mDetector, mStartDetector;
+  DetectorSystem_t mStartDetector;
   int mNumHypPlus,mNumHypMinus;
   bool dIsNoFieldFlag;
   bool USE_SC_TIME; // use start counter hits for t0
@@ -100,11 +102,11 @@ class DTrackTimeBased_factory:public jana::JFactory<DTrackTimeBased>{
   bool USE_BCAL_TIME; // use bcal hits for t0
   bool USE_TOF_TIME; // use tof hits for t0
   bool SKIP_MASS_HYPOTHESES_WIRE_BASED;
-  double SC_DPHI_CUT_WB;
+//  double SC_DPHI_CUT_WB;
 
   // start counter geometry
-  double sc_light_guide_length_cor;
-  double sc_angle_cor;
+//  double sc_light_guide_length_cor;
+//  double sc_angle_cor;
   vector<DVector3>sc_pos;
   vector<DVector3>sc_norm;
 

--- a/src/libraries/TRIGGER/DMCTrigger_factory.h
+++ b/src/libraries/TRIGGER/DMCTrigger_factory.h
@@ -42,7 +42,7 @@ class DMCTrigger_factory:public jana::JFactory<DMCTrigger>{
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
-		bool REQUIRE_START_COUNTER;
+//		bool REQUIRE_START_COUNTER;
 		double unattenuate_to_center;
 };
 

--- a/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_cuts.h
+++ b/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_cuts.h
@@ -41,14 +41,14 @@ class DCustomAction_p2gamma_cuts : public DAnalysisAction
 //		const DAnalysisUtilities* dAnalysisUtilities;
 
 		//Store any histograms as member variables here
-		TH1I *dEgamma;
+//		TH1I *dEgamma;
 
-		TH2I *dMM2_M2g, *dProton_dEdx_P, *dProton_P_Theta, *dProtonPhi_Egamma, *dProtonPhi_Theta, *dProtonPhi_t;
-		TH2I *dPi0Phi_Egamma, *dPi0Phi_Theta, *dDeltaE_M2g, *dPi0EgammaCorr;
-		TH2I *dMM2_M2g_ProtonTag, *dDeltaE_M2g_ProtonTag, *dMM2_DeltaE_ProtonTag;
-		TH2I *dMM2_M2g_CoplanarTag, *dDeltaE_M2g_CoplanarTag, *dMM2_DeltaE_CoplanarTag;
-		TH2I *dDeltaPhi_M2g, *dPhi2g_PhiP;
-		TH2I *dEgamma_M2g_ProtonTag;
+//		TH2I *dMM2_M2g, *dProton_dEdx_P, *dProton_P_Theta, *dProtonPhi_Egamma, *dProtonPhi_Theta, *dProtonPhi_t;
+//		TH2I *dPi0Phi_Egamma, *dPi0Phi_Theta, *dDeltaE_M2g, *dPi0EgammaCorr;
+//		TH2I *dMM2_M2g_ProtonTag, *dDeltaE_M2g_ProtonTag, *dMM2_DeltaE_ProtonTag;
+//		TH2I *dMM2_M2g_CoplanarTag, *dDeltaE_M2g_CoplanarTag, *dMM2_DeltaE_CoplanarTag;
+//		TH2I *dDeltaPhi_M2g, *dPhi2g_PhiP;
+//		TH2I *dEgamma_M2g_ProtonTag;
 };
 
 #endif // _DCustomAction_p2gamma_cuts_

--- a/src/plugins/monitoring/BCAL_Eff/JEventProcessor_BCAL_Eff.h
+++ b/src/plugins/monitoring/BCAL_Eff/JEventProcessor_BCAL_Eff.h
@@ -35,7 +35,7 @@ class JEventProcessor_BCAL_Eff : public jana::JEventProcessor
 
 
 	private:
-		const DAnalysisUtilities* dAnalysisUtilities;
+//		const DAnalysisUtilities* dAnalysisUtilities;
 		jerror_t init(void);						///< Called once at program start.
 		jerror_t brun(jana::JEventLoop* locEventLoop, int locRunNumber);	///< Called every time a new run number is detected.
 		jerror_t evnt(jana::JEventLoop* locEventLoop, int locEventNumber);	///< Called every event.

--- a/src/plugins/monitoring/TAGM_online/JEventProcessor_TAGM_online.cc
+++ b/src/plugins/monitoring/TAGM_online/JEventProcessor_TAGM_online.cc
@@ -24,14 +24,14 @@ using namespace jana;
 #include <TH2.h>
 
 // Define some constants
-const uint32_t NROWS = 5;
+//const uint32_t NROWS = 5;
 const uint32_t NCOLUMNS = 100;
 const uint32_t NSINGLES = 20;
 
 const float MIN_ADC_PINT_LOG10 = 0.;
 const float MAX_ADC_PINT_LOG10 = 5.;
 const uint32_t BINCOUNT_ADC_PINT = 200;
-const float ADC_PINT_PER_PIXEL = 6.5;
+//const float ADC_PINT_PER_PIXEL = 6.5;
 const float MIN_HIT_NPIX = 0.;
 const float MAX_HIT_NPIX = 1000.;
 const uint32_t BINCOUNT_HIT_NPIX = 200;

--- a/src/programs/Utilities/hddm/hddm-xml.cpp
+++ b/src/programs/Utilities/hddm/hddm-xml.cpp
@@ -414,7 +414,7 @@ int main(int argC, char* argV[])
          ifx = new xstream::xdr::istream(isbuf);
          memcpy(new_buffer,event_buffer,4);
          *ifx >> tsize;
-         delete event_buffer;
+         delete[] event_buffer;
          event_buffer = new_buffer;
       }
       ifs->read(event_buffer+4,tsize);


### PR DESCRIPTION
The latest version of clang (3.7.0) gives numerous warnings complimenting other compilers. Many of these were for data members of classes that were never used in the code. It's worthwhile to clean these up just so people browsing the code won't be misled into thinking they hold valid values.
