### PR TITLE
Rf upgrade

### DIFF
--- a/src/libraries/ANALYSIS/DEventRFBunch_factory_Combo.cc
+++ b/src/libraries/ANALYSIS/DEventRFBunch_factory_Combo.cc
@@ -30,9 +30,9 @@ jerror_t DEventRFBunch_factory_Combo::brun(jana::JEventLoop *locEventLoop, int r
 	gPARMS->SetDefaultParameter("COMBO:TRACK_SELECT_TAG", dTrackSelectionTag);
 	gPARMS->SetDefaultParameter("COMBO:SHOWER_SELECT_TAG", dShowerSelectionTag);
 
-	vector<double> locRFPeriodVector;
-	locEventLoop->GetCalib("PHOTON_BEAM/RF/rf_period", locRFPeriodVector);
-	dRFBunchPeriod = locRFPeriodVector[0];
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
 
 	DApplication *locApplication = dynamic_cast<DApplication*> (locEventLoop->GetJApplication());
 	DGeometry *locGeometry = locApplication ? locApplication->GetDGeometry(runnumber):NULL;
@@ -322,7 +322,7 @@ jerror_t DEventRFBunch_factory_Combo::evnt(jana::JEventLoop *locEventLoop, int e
 		// Find # RF Bunch Shifts
 		int locNumParticleVotes = 0;
 		int locNumBunchShifts = Find_BestRFBunchShift(locRFTime, locPropagatedTimes, locNumParticleVotes);
-		double locNewRFTime = locRFTime + (double)(locNumBunchShifts)*dRFBunchPeriod;
+		double locNewRFTime = locRFTime + (double)(locNumBunchShifts)*dBeamBunchPeriod;
 
 		//Hist
 		bool locIsAllTruePID = false;
@@ -437,38 +437,38 @@ int DEventRFBunch_factory_Combo::Find_BestRFBunchShift(double locRFHitTime, cons
 	if(locTimes.empty())
 		return 0; //shouldn't happen ...
 
-	map<int, pair<unsigned int, double> > locNumRFBucketsShiftedMap;
+	map<int, pair<unsigned int, double> > locNumBeamBucketsShiftedMap;
 	int locBestRFBunchShift = 0;
 	for(unsigned int loc_i = 0; loc_i < locTimes.size(); ++loc_i)
 	{
 		double locDeltaT = locTimes[loc_i] - locRFHitTime;
-		int locNumRFBucketsShifted = (locDeltaT > 0.0) ? int(locDeltaT/dRFBunchPeriod + 0.5) : int(locDeltaT/dRFBunchPeriod - 0.5);
-		locDeltaT -= dRFBunchPeriod*double(locNumRFBucketsShifted);
+		int locNumBeamBucketsShifted = (locDeltaT > 0.0) ? int(locDeltaT/dBeamBunchPeriod + 0.5) : int(locDeltaT/dBeamBunchPeriod - 0.5);
+		locDeltaT -= dBeamBunchPeriod*double(locNumBeamBucketsShifted);
 
-		if(locNumRFBucketsShiftedMap.find(locNumRFBucketsShifted) == locNumRFBucketsShiftedMap.end())
-			locNumRFBucketsShiftedMap[locNumRFBucketsShifted] = pair<unsigned int, double>(1, locDeltaT*locDeltaT);
+		if(locNumBeamBucketsShiftedMap.find(locNumBeamBucketsShifted) == locNumBeamBucketsShiftedMap.end())
+			locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted] = pair<unsigned int, double>(1, locDeltaT*locDeltaT);
 		else
 		{
-			++(locNumRFBucketsShiftedMap[locNumRFBucketsShifted].first);
-			locNumRFBucketsShiftedMap[locNumRFBucketsShifted].second += locDeltaT*locDeltaT;
+			++(locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted].first);
+			locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted].second += locDeltaT*locDeltaT;
 		}
-		if(locNumRFBucketsShifted == locBestRFBunchShift)
+		if(locNumBeamBucketsShifted == locBestRFBunchShift)
 			continue;
 
-		unsigned int locBestNumTracks = locNumRFBucketsShiftedMap[locBestRFBunchShift].first;
-		unsigned int locNumTracks = locNumRFBucketsShiftedMap[locNumRFBucketsShifted].first;
+		unsigned int locBestNumTracks = locNumBeamBucketsShiftedMap[locBestRFBunchShift].first;
+		unsigned int locNumTracks = locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted].first;
 		if(locNumTracks > locBestNumTracks)
-			locBestRFBunchShift = locNumRFBucketsShifted;
+			locBestRFBunchShift = locNumBeamBucketsShifted;
 		else if(locNumTracks == locBestNumTracks)
 		{
-			double locBestDeltaTSq = locNumRFBucketsShiftedMap[locBestRFBunchShift].second;
-			double locDeltaTSq = locNumRFBucketsShiftedMap[locNumRFBucketsShifted].second;
+			double locBestDeltaTSq = locNumBeamBucketsShiftedMap[locBestRFBunchShift].second;
+			double locDeltaTSq = locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted].second;
 			if(locDeltaTSq < locBestDeltaTSq)
-				locBestRFBunchShift = locNumRFBucketsShifted;
+				locBestRFBunchShift = locNumBeamBucketsShifted;
 		}
 	}
 
-	locBestNumVotes = locNumRFBucketsShiftedMap[locBestRFBunchShift].first;
+	locBestNumVotes = locNumBeamBucketsShiftedMap[locBestRFBunchShift].first;
 	return locBestRFBunchShift;
 }
 

--- a/src/libraries/ANALYSIS/DEventRFBunch_factory_Combo.h
+++ b/src/libraries/ANALYSIS/DEventRFBunch_factory_Combo.h
@@ -63,7 +63,7 @@ class DEventRFBunch_factory_Combo:public jana::JFactory<DEventRFBunch>
 		string dShowerSelectionTag;
 		string dTrackSelectionTag;
 
-		double dRFBunchPeriod;
+		double dBeamBunchPeriod;
 		double dTargetCenterZ;
 		double dMinThrownMatchFOM;
 

--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -237,15 +237,15 @@ jerror_t DEventSourceHDDM::GetObjects(JEvent &event, JFactory_base *factory)
       double locTargetCenterZ = 0.0;
       locGeometry->GetTargetZ(locTargetCenterZ);
 
-      vector<double> locRFPeriodVector;
-      if(loop->GetCalib("PHOTON_BEAM/RF/rf_period", locRFPeriodVector))
-          throw runtime_error("Could not load CCDB table: PHOTON_BEAM/RF/rf_period");
-      double locRFBunchPeriod = locRFPeriodVector[0];
+      vector<double> locBeamPeriodVector;
+      if(loop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector))
+          throw runtime_error("Could not load CCDB table: PHOTON_BEAM/RF/beam_period");
+      double locBeamBunchPeriod = locBeamPeriodVector[0];
 
       LockRead();
       {
          dTargetCenterZMap[locRunNumber] = locTargetCenterZ;
-         dRFBunchPeriodMap[locRunNumber] = locRFBunchPeriod;
+         dBeamBunchPeriodMap[locRunNumber] = locBeamBunchPeriod;
       }
       UnlockRead();
    }
@@ -454,7 +454,7 @@ jerror_t DEventSourceHDDM::Extract_DRFTime(hddm_s::HDDM *record,
 		return OBJECT_NOT_AVAILABLE; //Experimental data & it's missing: bail
 
 	//Is MC data. Either:
-		//No tag: return t = 0.0, but true t is 0.0 +/- n*locRFBunchPeriod: must select the correct beam bunch
+		//No tag: return t = 0.0, but true t is 0.0 +/- n*locBeamBunchPeriod: must select the correct beam bunch
 		//TRUTH tag: get exact t from DBeamPhoton tag MCGEN
 
 	if(tag == "TRUTH")
@@ -466,22 +466,22 @@ jerror_t DEventSourceHDDM::Extract_DRFTime(hddm_s::HDDM *record,
 	}
 	else
 	{
-		double locRFBunchPeriod = 0.0;
+		double locBeamBunchPeriod = 0.0;
 		int locRunNumber = locEventLoop->GetJEvent().GetRunNumber();
 		LockRead();
 		{
-			locRFBunchPeriod = dRFBunchPeriodMap[locRunNumber];
+			locBeamBunchPeriod = dBeamBunchPeriodMap[locRunNumber];
 		}
 		UnlockRead();
 
-		//start with true RF time, increment/decrement by multiples of locRFBunchPeriod ns until closest to 0
+		//start with true RF time, increment/decrement by multiples of locBeamBunchPeriod ns until closest to 0
 		double locTime = locMCGENPhotons[0]->time();
-		int locNumRFBuckets = int(locTime/locRFBunchPeriod);
-		locTime -= double(locNumRFBuckets)*locRFBunchPeriod;
-		while(locTime > 0.5*locRFBunchPeriod)
-			locTime -= locRFBunchPeriod;
-		while(locTime < -0.5*locRFBunchPeriod)
-			locTime += locRFBunchPeriod;
+		int locNumRFBuckets = int(locTime/locBeamBunchPeriod);
+		locTime -= double(locNumRFBuckets)*locBeamBunchPeriod;
+		while(locTime > 0.5*locBeamBunchPeriod)
+			locTime -= locBeamBunchPeriod;
+		while(locTime < -0.5*locBeamBunchPeriod)
+			locTime += locBeamBunchPeriod;
 
 		DRFTime *locRFTime = new DRFTime;
 		locRFTime->dTime = locTime;

--- a/src/libraries/HDDM/DEventSourceHDDM.h
+++ b/src/libraries/HDDM/DEventSourceHDDM.h
@@ -157,7 +157,7 @@ class DEventSourceHDDM:public JEventSource
       list<DReferenceTrajectory*> rt_pool;
 
       map<unsigned int, double> dTargetCenterZMap; //unsigned int is run number
-      map<unsigned int, double> dRFBunchPeriodMap; //unsigned int is run number
+      map<unsigned int, double> dBeamBunchPeriodMap; //unsigned int is run number
 
       JCalibration *jcalib;
       float uscale[192],vscale[192];

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -165,15 +165,15 @@ jerror_t DEventSourceREST::GetObjects(JEvent &event, JFactory_base *factory)
 		double locTargetCenterZ = 0.0;
 		locGeometry->GetTargetZ(locTargetCenterZ);
 
-		vector<double> locRFPeriodVector;
-        if(locEventLoop->GetCalib("PHOTON_BEAM/RF/rf_period", locRFPeriodVector))
-            throw JException("Could not load CCDB table: PHOTON_BEAM/RF/rf_period");
-		double locRFBunchPeriod = locRFPeriodVector[0];
+		vector<double> locBeamPeriodVector;
+        if(locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector))
+            throw JException("Could not load CCDB table: PHOTON_BEAM/RF/beam_period");
+		double locBeamBunchPeriod = locBeamPeriodVector[0];
 
 		LockRead();
 		{
 			dTargetCenterZMap[locRunNumber] = locTargetCenterZ;
-			dRFBunchPeriodMap[locRunNumber] = locRFBunchPeriod;
+			dBeamBunchPeriodMap[locRunNumber] = locBeamBunchPeriod;
 		}
 		UnlockRead();
 	}
@@ -340,7 +340,7 @@ jerror_t DEventSourceREST::Extract_DRFTime(hddm_r::HDDM *record,
 		return OBJECT_NOT_AVAILABLE; //Experimental data & it's missing: bail
 
 	//Is MC data. Either:
-		//No tag: return photon_time propagated by +/- n*locRFBunchPeriod to get close to 0.0
+		//No tag: return photon_time propagated by +/- n*locBeamBunchPeriod to get close to 0.0
 		//TRUTH tag: get exact t from DBeamPhoton tag MCGEN
 
 	if(tag == "TRUTH")
@@ -352,22 +352,22 @@ jerror_t DEventSourceREST::Extract_DRFTime(hddm_r::HDDM *record,
 	}
 	else
 	{
-		double locRFBunchPeriod = 0.0;
+		double locBeamBunchPeriod = 0.0;
 		int locRunNumber = locEventLoop->GetJEvent().GetRunNumber();
 		LockRead();
 		{
-			locRFBunchPeriod = dRFBunchPeriodMap[locRunNumber];
+			locBeamBunchPeriod = dBeamBunchPeriodMap[locRunNumber];
 		}
 		UnlockRead();
 
-		//start with true RF time, increment/decrement by multiples of locRFBunchPeriod ns until closest to 0
+		//start with true RF time, increment/decrement by multiples of locBeamBunchPeriod ns until closest to 0
 		double locTime = locMCGENPhotons[0]->time();
-		int locNumRFBuckets = int(locTime/locRFBunchPeriod);
-		locTime -= double(locNumRFBuckets)*locRFBunchPeriod;
-		while(locTime > 0.5*locRFBunchPeriod)
-			locTime -= locRFBunchPeriod;
-		while(locTime < -0.5*locRFBunchPeriod)
-			locTime += locRFBunchPeriod;
+		int locNumRFBuckets = int(locTime/locBeamBunchPeriod);
+		locTime -= double(locNumRFBuckets)*locBeamBunchPeriod;
+		while(locTime > 0.5*locBeamBunchPeriod)
+			locTime -= locBeamBunchPeriod;
+		while(locTime < -0.5*locBeamBunchPeriod)
+			locTime += locBeamBunchPeriod;
 
 		DRFTime *locRFTime = new DRFTime;
 		locRFTime->dTime = locTime;

--- a/src/libraries/HDDM/DEventSourceREST.h
+++ b/src/libraries/HDDM/DEventSourceREST.h
@@ -87,7 +87,7 @@ class DEventSourceREST:public JEventSource
    // store any data here that might change from event to event.
 
 	map<unsigned int, double> dTargetCenterZMap; //unsigned int is run number
-	map<unsigned int, double> dRFBunchPeriodMap; //unsigned int is run number
+	map<unsigned int, double> dBeamBunchPeriodMap; //unsigned int is run number
 
    std::ifstream *ifs;		// input hddm file ifstream
    hddm_r::istream *fin;	// provides hddm layer on top of ifstream

--- a/src/libraries/PID/DEventRFBunch_factory.cc
+++ b/src/libraries/PID/DEventRFBunch_factory.cc
@@ -26,9 +26,9 @@ jerror_t DEventRFBunch_factory::brun(jana::JEventLoop *locEventLoop, int runnumb
 	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
 	DGeometry* locGeometry = locApplication->GetDGeometry(runnumber);
 
-	vector<double> locRFPeriodVector;
-	locEventLoop->GetCalib("PHOTON_BEAM/RF/rf_period", locRFPeriodVector);
-	dRFBunchPeriod = locRFPeriodVector[0];
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
 
 	double locTargetCenterZ;
 	locGeometry->GetTargetZ(locTargetCenterZ);
@@ -128,7 +128,7 @@ jerror_t DEventRFBunch_factory::Select_RFBunch(JEventLoop* locEventLoop, vector<
 		return Create_NaNRFBunch();
 
 	DEventRFBunch* locEventRFBunch = new DEventRFBunch;
-	locEventRFBunch->dTime = locRFTime->dTime + dRFBunchPeriod*double(locBestRFBunchShift);
+	locEventRFBunch->dTime = locRFTime->dTime + dBeamBunchPeriod*double(locBestRFBunchShift);
 	locEventRFBunch->dTimeVariance = locRFTime->dTimeVariance;
 	locEventRFBunch->dNumParticleVotes = locHighestNumVotes;
 	locEventRFBunch->dTimeSource = SYS_RF;
@@ -139,29 +139,29 @@ jerror_t DEventRFBunch_factory::Select_RFBunch(JEventLoop* locEventLoop, vector<
 
 int DEventRFBunch_factory::Conduct_Vote(JEventLoop* locEventLoop, double locRFTime, vector<pair<double, const JObject*> >& locTimes, bool locUsedTracksFlag, int& locHighestNumVotes)
 {
-	map<int, vector<const JObject*> > locNumRFBucketsShiftedMap;
+	map<int, vector<const JObject*> > locNumBeamBucketsShiftedMap;
 	set<int> locBestRFBunchShifts;
 
-	locHighestNumVotes = Find_BestRFBunchShifts(locRFTime, locTimes, locNumRFBucketsShiftedMap, locBestRFBunchShifts);
+	locHighestNumVotes = Find_BestRFBunchShifts(locRFTime, locTimes, locNumBeamBucketsShiftedMap, locBestRFBunchShifts);
 	if(locBestRFBunchShifts.size() == 1)
 		return *locBestRFBunchShifts.begin();
 
 	//tied: break with beam photons
 	vector<const DBeamPhoton*> locBeamPhotons;
 	locEventLoop->Get(locBeamPhotons);
-	if(Break_TieVote_BeamPhotons(locBeamPhotons, locRFTime, locNumRFBucketsShiftedMap, locBestRFBunchShifts, locHighestNumVotes))
+	if(Break_TieVote_BeamPhotons(locBeamPhotons, locRFTime, locNumBeamBucketsShiftedMap, locBestRFBunchShifts, locHighestNumVotes))
 		return *locBestRFBunchShifts.begin();
 
 	//still tied
 	if(locUsedTracksFlag)
 	{
 		//break tie with total track hits (ndf), else break with total tracking chisq
-		return Break_TieVote_Tracks(locNumRFBucketsShiftedMap, locBestRFBunchShifts);
+		return Break_TieVote_Tracks(locNumBeamBucketsShiftedMap, locBestRFBunchShifts);
 	}
 	else //neutrals
 	{
 		//break tie with highest total shower energy
-		return Break_TieVote_Neutrals(locNumRFBucketsShiftedMap, locBestRFBunchShifts);
+		return Break_TieVote_Neutrals(locNumBeamBucketsShiftedMap, locBestRFBunchShifts);
 	}
 }
 
@@ -210,7 +210,7 @@ bool DEventRFBunch_factory::Find_TrackTimes_NonSC(const DDetectorMatches* locDet
 		double locP = locTrackTimeBased->momentum().Mag();
 		//at 250 MeV/c, BCAL t-resolution is ~310ps (3sigma = 920ps), BCAL delta-t error is ~40ps: ~960 ps < 1 ns: OK!!
 		//at 225 MeV/c, BCAL t-resolution is ~333ps (3sigma = 999ps), BCAL delta-t error is ~40ps: ~1040ps: bad at 499 MHz
-		if((locP < 0.25) && (dRFBunchPeriod < 2.005))
+		if((locP < 0.25) && (dBeamBunchPeriod < 2.005))
 			continue; //too slow for the BCAL to distinguish RF bunch
 
 		DBCALShowerMatchParams locBCALShowerMatchParams;
@@ -249,34 +249,34 @@ bool DEventRFBunch_factory::Find_NeutralTimes(JEventLoop* locEventLoop, vector<p
 	return (locTimes.size() > 1);
 }
 
-int DEventRFBunch_factory::Find_BestRFBunchShifts(double locRFHitTime, const vector<pair<double, const JObject*> >& locTimes, map<int, vector<const JObject*> >& locNumRFBucketsShiftedMap, set<int>& locBestRFBunchShifts)
+int DEventRFBunch_factory::Find_BestRFBunchShifts(double locRFHitTime, const vector<pair<double, const JObject*> >& locTimes, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts)
 {
 	//then find the #beam buckets the RF time needs to shift to match it
 	int locHighestNumVotes = 0;
-	locNumRFBucketsShiftedMap.clear();
+	locNumBeamBucketsShiftedMap.clear();
 	locBestRFBunchShifts.clear();
 
 	for(unsigned int loc_i = 0; loc_i < locTimes.size(); ++loc_i)
 	{
 		double locDeltaT = locTimes[loc_i].first - locRFHitTime;
-		int locNumRFBucketsShifted = (locDeltaT > 0.0) ? int(locDeltaT/dRFBunchPeriod + 0.5) : int(locDeltaT/dRFBunchPeriod - 0.5);
-		locNumRFBucketsShiftedMap[locNumRFBucketsShifted].push_back(locTimes[loc_i].second);
+		int locNumBeamBucketsShifted = (locDeltaT > 0.0) ? int(locDeltaT/dBeamBunchPeriod + 0.5) : int(locDeltaT/dBeamBunchPeriod - 0.5);
+		locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted].push_back(locTimes[loc_i].second);
 
-		int locNumVotesThisShift = locNumRFBucketsShiftedMap[locNumRFBucketsShifted].size();
+		int locNumVotesThisShift = locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted].size();
 		if(locNumVotesThisShift > locHighestNumVotes)
 		{
 			locHighestNumVotes = locNumVotesThisShift;
 			locBestRFBunchShifts.clear();
-			locBestRFBunchShifts.insert(locNumRFBucketsShifted);
+			locBestRFBunchShifts.insert(locNumBeamBucketsShifted);
 		}
 		else if(locNumVotesThisShift == locHighestNumVotes)
-			locBestRFBunchShifts.insert(locNumRFBucketsShifted);
+			locBestRFBunchShifts.insert(locNumBeamBucketsShifted);
 	}
 
 	return locHighestNumVotes;
 }
 
-bool DEventRFBunch_factory::Break_TieVote_BeamPhotons(vector<const DBeamPhoton*>& locBeamPhotons, double locRFTime, map<int, vector<const JObject*> >& locNumRFBucketsShiftedMap, set<int>& locBestRFBunchShifts, int locHighestNumVotes)
+bool DEventRFBunch_factory::Break_TieVote_BeamPhotons(vector<const DBeamPhoton*>& locBeamPhotons, double locRFTime, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts, int locHighestNumVotes)
 {
 	//locHighestNumVotes intentionally passed-in as value-type (non-reference)
 		//beam photons are only used to BREAK the tie, not count as equal votes
@@ -285,27 +285,27 @@ bool DEventRFBunch_factory::Break_TieVote_BeamPhotons(vector<const DBeamPhoton*>
 	for(size_t loc_i = 0; loc_i < locBeamPhotons.size(); ++loc_i)
 	{
 		double locDeltaT = locBeamPhotons[loc_i]->time() - locRFTime;
-		int locNumRFBucketsShifted = (locDeltaT > 0.0) ? int(locDeltaT/dRFBunchPeriod + 0.5) : int(locDeltaT/dRFBunchPeriod - 0.5);
-		if(locInputRFBunchShifts.find(locNumRFBucketsShifted) == locInputRFBunchShifts.end())
+		int locNumBeamBucketsShifted = (locDeltaT > 0.0) ? int(locDeltaT/dBeamBunchPeriod + 0.5) : int(locDeltaT/dBeamBunchPeriod - 0.5);
+		if(locInputRFBunchShifts.find(locNumBeamBucketsShifted) == locInputRFBunchShifts.end())
 			continue; //only use beam votes to break input tie, not contribute to other beam buckets
 
-		locNumRFBucketsShiftedMap[locNumRFBucketsShifted].push_back(locBeamPhotons[loc_i]);
+		locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted].push_back(locBeamPhotons[loc_i]);
 
-		int locNumVotesThisShift = locNumRFBucketsShiftedMap[locNumRFBucketsShifted].size();
+		int locNumVotesThisShift = locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted].size();
 		if(locNumVotesThisShift > locHighestNumVotes)
 		{
 			locHighestNumVotes = locNumVotesThisShift;
 			locBestRFBunchShifts.clear();
-			locBestRFBunchShifts.insert(locNumRFBucketsShifted);
+			locBestRFBunchShifts.insert(locNumBeamBucketsShifted);
 		}
 		else if(locNumVotesThisShift == locHighestNumVotes)
-			locBestRFBunchShifts.insert(locNumRFBucketsShifted);
+			locBestRFBunchShifts.insert(locNumBeamBucketsShifted);
 	}
 
 	return (locBestRFBunchShifts.size() == 1);
 }
 
-int DEventRFBunch_factory::Break_TieVote_Tracks(map<int, vector<const JObject*> >& locNumRFBucketsShiftedMap, set<int>& locBestRFBunchShifts)
+int DEventRFBunch_factory::Break_TieVote_Tracks(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts)
 {
 	//Select the bunch with the most total track hits (highest total tracking NDF)
 	//If still a tie: 
@@ -321,7 +321,7 @@ int DEventRFBunch_factory::Break_TieVote_Tracks(map<int, vector<const JObject*> 
 		int locTotalTrackingNDF = 0;
 		double locTotalTrackingChiSq = 0.0;
 
-		const vector<const JObject*>& locVoters = locNumRFBucketsShiftedMap[locRFBunchShift];
+		const vector<const JObject*>& locVoters = locNumBeamBucketsShiftedMap[locRFBunchShift];
 		for(size_t loc_i = 0; loc_i < locVoters.size(); ++loc_i)
 		{
 			const DTrackTimeBased* locTrackTimeBased = dynamic_cast<const DTrackTimeBased*>(locVoters[loc_i]);
@@ -346,7 +346,7 @@ int DEventRFBunch_factory::Break_TieVote_Tracks(map<int, vector<const JObject*> 
 	return locBestRFBunchShift;
 }
 
-int DEventRFBunch_factory::Break_TieVote_Neutrals(map<int, vector<const JObject*> >& locNumRFBucketsShiftedMap, set<int>& locBestRFBunchShifts)
+int DEventRFBunch_factory::Break_TieVote_Neutrals(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts)
 {
 	//Break tie with highest total shower energy
 
@@ -359,7 +359,7 @@ int DEventRFBunch_factory::Break_TieVote_Neutrals(map<int, vector<const JObject*
 		int locRFBunchShift = *locSetIterator;
 		double locTotalEnergy = 0.0;
 
-		const vector<const JObject*>& locVoters = locNumRFBucketsShiftedMap[locRFBunchShift];
+		const vector<const JObject*>& locVoters = locNumBeamBucketsShiftedMap[locRFBunchShift];
 		for(size_t loc_i = 0; loc_i < locVoters.size(); ++loc_i)
 		{
 			const DNeutralShower* locNeutralShower = dynamic_cast<const DNeutralShower*>(locVoters[loc_i]);
@@ -403,7 +403,7 @@ jerror_t DEventRFBunch_factory::Select_RFBunch_NoRFTime(JEventLoop* locEventLoop
 	int locBestRFBunchShift = Conduct_Vote(locEventLoop, locRFTimeGuess, locTimes, true, locHighestNumVotes);
 
 	DEventRFBunch *locEventRFBunch = new DEventRFBunch;
-	locEventRFBunch->dTime = locRFTimeGuess + dRFBunchPeriod*double(locBestRFBunchShift);
+	locEventRFBunch->dTime = locRFTimeGuess + dBeamBunchPeriod*double(locBestRFBunchShift);
 	locEventRFBunch->dTimeVariance = locTimeVariance;
 	locEventRFBunch->dNumParticleVotes = locHighestNumVotes;
 	locEventRFBunch->dTimeSource = locTimeSource;
@@ -446,8 +446,8 @@ void DEventRFBunch_factory::Get_RFTimeGuess(vector<pair<double, const JObject*> 
 	for(size_t loc_i = 1; loc_i < locTimes.size(); ++loc_i)
 	{
 		double locDeltaT = locTimes[loc_i].first - locTimes[0].first;
-		double locNumRFBucketsShifted = (locDeltaT > 0.0) ? floor(locDeltaT/dRFBunchPeriod + 0.5) : floor(locDeltaT/dRFBunchPeriod - 0.5);
-		locRFTimeGuess += locTimes[loc_i].first - locNumRFBucketsShifted*dRFBunchPeriod;
+		double locNumBeamBucketsShifted = (locDeltaT > 0.0) ? floor(locDeltaT/dBeamBunchPeriod + 0.5) : floor(locDeltaT/dBeamBunchPeriod - 0.5);
+		locRFTimeGuess += locTimes[loc_i].first - locNumBeamBucketsShifted*dBeamBunchPeriod;
 	}
 	locRFTimeGuess /= double(locTimes.size());
 

--- a/src/libraries/PID/DEventRFBunch_factory.h
+++ b/src/libraries/PID/DEventRFBunch_factory.h
@@ -58,11 +58,11 @@ class DEventRFBunch_factory : public jana::JFactory<DEventRFBunch>
 		bool Find_TrackTimes_NonSC(const DDetectorMatches* locDetectorMatches, const vector<const DTrackTimeBased*>& locTrackTimeBasedVector, vector<pair<double, const JObject*> >& locTimes);
 		bool Find_NeutralTimes(JEventLoop* locEventLoop, vector<pair<double, const JObject*> >& locTimes);
 
-		int Find_BestRFBunchShifts(double locRFHitTime, const vector<pair<double, const JObject*> >& locTimes, map<int, vector<const JObject*> >& locNumRFBucketsShiftedMap, set<int>& locBestRFBunchShifts);
+		int Find_BestRFBunchShifts(double locRFHitTime, const vector<pair<double, const JObject*> >& locTimes, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts);
 
-		bool Break_TieVote_BeamPhotons(vector<const DBeamPhoton*>& locBeamPhotons, double locRFTime, map<int, vector<const JObject*> >& locNumRFBucketsShiftedMap, set<int>& locBestRFBunchShifts, int locHighestNumVotes);
-		int Break_TieVote_Tracks(map<int, vector<const JObject*> >& locNumRFBucketsShiftedMap, set<int>& locBestRFBunchShifts);
-		int Break_TieVote_Neutrals(map<int, vector<const JObject*> >& locNumRFBucketsShiftedMap, set<int>& locBestRFBunchShifts);
+		bool Break_TieVote_BeamPhotons(vector<const DBeamPhoton*>& locBeamPhotons, double locRFTime, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts, int locHighestNumVotes);
+		int Break_TieVote_Tracks(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts);
+		int Break_TieVote_Neutrals(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts);
 
 		jerror_t Select_RFBunch_NoRFTime(JEventLoop* locEventLoop, vector<const DTrackTimeBased*>& locTrackTimeBasedVector);
 
@@ -72,7 +72,7 @@ class DEventRFBunch_factory : public jana::JFactory<DEventRFBunch>
 
 		const DParticleID* dParticleID;
 
-		double dRFBunchPeriod;
+		double dBeamBunchPeriod;
 		DVector3 dTargetCenter;
 
 		double dMinTrackingFOM;

--- a/src/libraries/PID/DEventRFBunch_factory_Calibrations.h
+++ b/src/libraries/PID/DEventRFBunch_factory_Calibrations.h
@@ -54,14 +54,14 @@ class DEventRFBunch_factory_Calibrations : public jana::JFactory<DEventRFBunch>
 		bool Find_TrackTimes_SC(const DDetectorMatches* locDetectorMatches, const vector<const DTrackWireBased*>& locTrackWireBasedVector, vector<pair<double, const JObject*> >& locTimes) const;
 		int Conduct_Vote(JEventLoop* locEventLoop, double locRFTime, vector<pair<double, const JObject*> >& locTimes, int& locHighestNumVotes);
 
-		int Find_BestRFBunchShifts(double locRFHitTime, const vector<pair<double, const JObject*> >& locTimes, map<int, vector<const JObject*> >& locNumRFBucketsShiftedMap, set<int>& locBestRFBunchShifts);
-		int Break_TieVote_Tracks(map<int, vector<const JObject*> >& locNumRFBucketsShiftedMap, set<int>& locBestRFBunchShifts);
+		int Find_BestRFBunchShifts(double locRFHitTime, const vector<pair<double, const JObject*> >& locTimes, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts);
+		int Break_TieVote_Tracks(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts);
 
 		jerror_t Create_NaNRFBunch(void);
 
 		const DParticleID* dParticleID;
 
-		double dRFBunchPeriod;
+		double dBeamBunchPeriod;
 		DVector3 dTargetCenter;
 
 		DetectorSystem_t dRFTDCSourceSystem;

--- a/src/libraries/RF/DRFTime_factory.cc
+++ b/src/libraries/RF/DRFTime_factory.cc
@@ -22,9 +22,9 @@ jerror_t DRFTime_factory::init(void)
 jerror_t DRFTime_factory::brun(jana::JEventLoop *locEventLoop, int runnumber)
 {
 	//RF Period
-	vector<double> locRFPeriodVector;
-	locEventLoop->GetCalib("PHOTON_BEAM/RF/rf_period", locRFPeriodVector);
-	dRFBunchPeriod = locRFPeriodVector[0];
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
 	
 	//Time Offsets
 	map<string, double> locCCDBMap;
@@ -144,14 +144,14 @@ jerror_t DRFTime_factory::evnt(JEventLoop *locEventLoop, int eventnumber)
 
 double DRFTime_factory::Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo) const
 {
-	return Step_TimeToNearInputTime(locTimeToStep, locTimeToStepTo, dRFBunchPeriod);
+	return Step_TimeToNearInputTime(locTimeToStep, locTimeToStepTo, dBeamBunchPeriod);
 }
 
-double DRFTime_factory::Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo, double locRFPeriod) const
+double DRFTime_factory::Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo, double locPeriod) const
 {
 	double locDeltaT = locTimeToStepTo - locTimeToStep;
-	int locNumRFBucketsToShift = (locDeltaT > 0.0) ? int(locDeltaT/locRFPeriod + 0.5) : int(locDeltaT/locRFPeriod - 0.5);
-	return (locTimeToStep + locRFPeriod*double(locNumRFBucketsToShift));
+	int locNumBucketsToShift = (locDeltaT > 0.0) ? int(locDeltaT/locPeriod + 0.5) : int(locDeltaT/locPeriod - 0.5);
+	return (locTimeToStep + locPeriod*double(locNumBucketsToShift));
 }
 
 double DRFTime_factory::Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigiTime, const DTTabUtilities* locTTabUtilities) const
@@ -173,8 +173,8 @@ double DRFTime_factory::Calc_WeightedAverageRFTime(map<DetectorSystem_t, vector<
 	//returns the average (and the variance by reference)
 
 	//will line up the first time near zero, then line up subsequent times to the first time
-		//cannot line up all times to zero: if first time is near +/- rf_period/2 (e.g. +/- 1.002 ns),
-		//may end up with some times near 1.002 and some near -1.002!
+		//cannot line up all times to zero: if first time is near +/- beam_period/2 (e.g. +/- 2.004 ns),
+		//may end up with some times near 2.004 and some near -2.004!
 
 	map<DetectorSystem_t, vector<double> >::iterator locTimeIterator = locRFTimesMap.begin();
 	double locFirstTime = (locTimeIterator->second)[0];

--- a/src/libraries/RF/DRFTime_factory.h
+++ b/src/libraries/RF/DRFTime_factory.h
@@ -28,7 +28,7 @@ class DRFTime_factory : public jana::JFactory<DRFTime>
 		~DRFTime_factory(){};
 
 		double Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo) const;
-		double Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo, double locRFPeriod) const;
+		double Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo, double locPeriod) const;
 
 		double Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigiTime, const DTTabUtilities* locTTabUtilities) const;
 		double Convert_ADCToTime(const DRFDigiTime* locRFDigiTime) const;
@@ -44,7 +44,7 @@ class DRFTime_factory : public jana::JFactory<DRFTime>
 		double Calc_WeightedAverageRFTime(map<DetectorSystem_t, vector<double> >& locRFTimesMap, double& locRFTimeVariance) const;
 
 		DetectorSystem_t dOverrideRFSourceSystem; //Choose this system over the best-resolution system if data is present (default SYS_NULL (disabled))
-		double dRFBunchPeriod;
+		double dBeamBunchPeriod;
 
 		map<DetectorSystem_t, double> dTimeOffsetMap;
 		map<DetectorSystem_t, double> dTimeOffsetVarianceMap;

--- a/src/libraries/TAGGER/DTAGHHit_factory.cc
+++ b/src/libraries/TAGGER/DTAGHHit_factory.cc
@@ -231,10 +231,10 @@ jerror_t DTAGHHit_factory::evnt(JEventLoop *loop, int eventnumber)
               hit->pulse_peak = numeric_limits<double>::quiet_NaN();
               hit->npe_fadc = numeric_limits<double>::quiet_NaN();
               hit->has_fADC = false;
-              hit->time_tdc = T;
-              hit->has_TDC = true;
               _data.push_back(hit);
           }
+          hit->time_tdc = T;
+          hit->has_TDC = true;
           // apply time-walk corrections
           double c0 = tdc_twalk_c0[counter]; double c1 = tdc_twalk_c1[counter];
           double c2 = tdc_twalk_c2[counter]; double c3 = tdc_twalk_c3[counter];

--- a/src/libraries/TAGGER/DTAGHHit_factory.cc
+++ b/src/libraries/TAGGER/DTAGHHit_factory.cc
@@ -231,10 +231,10 @@ jerror_t DTAGHHit_factory::evnt(JEventLoop *loop, int eventnumber)
               hit->pulse_peak = numeric_limits<double>::quiet_NaN();
               hit->npe_fadc = numeric_limits<double>::quiet_NaN();
               hit->has_fADC = false;
+              hit->time_tdc = T;
+              hit->has_TDC = true;
               _data.push_back(hit);
           }
-          hit->time_tdc = T;
-          hit->has_TDC = true;
           // apply time-walk corrections
           double c0 = tdc_twalk_c0[counter]; double c1 = tdc_twalk_c1[counter];
           double c2 = tdc_twalk_c2[counter]; double c3 = tdc_twalk_c3[counter];

--- a/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.cc
+++ b/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.cc
@@ -16,27 +16,7 @@ extern "C"
 	}
 }
 
-/*
-	TI-TIME UNIFORMITY CHECK:
-	1) Confirm that the copies of the global system clock present on each ROC are consistent with each other: "ROCTIs" directory
-
-	TDC->TIME CHECK:
-	1) Confirm that the tdc->time conversion is accurate for each system: "DeltaT_RF_FirstTime" directory
-
-	RF TIME CALIBRATION:
-	1) Confirm that the RF signal is arriving at approximately 499 MHz: "RF_SignalPeriod" directory
-	2) Study the resolution of each source of the RF signal: "DeltaT_RF_Itself" directory. Check in these constants. 
-	3) Do a rough alignment of each RF system with respect to the TOF signal: "AbsoluteDeltaT_RF_OtherRFs" directory & FitMacro_RF_CoarseOffsets.C Macro. Check in these constants.
-		- This is important in case the RF signal period is not exactly 499 MHz. If it's slightly wrong, add the time offsets are huge, then propagating across several micro-s will result in a many-ps error in the time. 
-	4) Study the resolution when taking the difference between RF times at different sources: "DeltaT_RF_OtherRFs" directory. 
-		- If these resolutions are much larger than the individual system uncertainties, then do not average the system times together.
-		- This is the default behavior of the DRFTime factory (for the signals in the data stream, only uses the system with the best time resolution)
-	5) Do a detailed alignment of each RF system with respect to the TOF signal: "AverageDeltaT_RF_OtherRFs" directory. Update these constants (and the uncertainties). 
-
-	CONFIRM ALIGNMENT TO TAGGER HODOSCOPE:
-	1) Once the tagger hodoscope has been aligned to the RF, confirm the alignment: "DeltaT_RF_TAGH" directory. 
-      - If it is out-of-line, realign the tagger to the RF (outside the scope of this plugin)
-*/
+//DOCUMENTATION: https://halldweb.jlab.org/wiki/index.php/RF_Calibration
 
 jerror_t JEventProcessor_RF_online::init(void)
 {

--- a/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.cc
+++ b/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.cc
@@ -22,8 +22,6 @@ extern "C"
 
 	TDC->TIME CHECK:
 	1) Confirm that the tdc->time conversion is accurate for each system: "DeltaT_RF_FirstTime" directory
-		- TOF & TAGH RF signals read out 1/128 times: expect first delta-t peak at 128*1000/499 ns
-		- PSC & FDC RF signals read out 1/64 times: expect first delta-t peak at 64*1000/499 ns
 
 	RF TIME CALIBRATION:
 	1) Confirm that the RF signal is arriving at approximately 499 MHz: "RF_SignalPeriod" directory
@@ -42,27 +40,15 @@ extern "C"
 
 jerror_t JEventProcessor_RF_online::init(void)
 {
+	//This constant should be fixed for the lifetime of GlueX.  If it ever changes, move it into the CCDB.
 	dRFSignalPeriod = 1000.0/499.0; //2.004008016
 
 	//pick a combination such that there is a bin edge at +/- 1.002 and +/- 2.004
-	double locDeltaTRangeMax = 1.1; //should be a little more than expected-RF-period / 2
+	double locDeltaTRangeMax = 1.1; //should be a little more than expected-RF-period / 2 //choose 2.2 for run <= 2438
 	unsigned int locNumDeltaTBins = 1100;
 
 	dRFSignalSystems.push_back(SYS_FDC);  dRFSignalSystems.push_back(SYS_PSC);
 	dRFSignalSystems.push_back(SYS_TAGH);  dRFSignalSystems.push_back(SYS_TOF);
-
-	dRFSamplingRateMap[SYS_TOF] = 1.0/128.0;
-	dRFSamplingRateMap[SYS_TAGH] = 1.0/128.0;
-	dRFSamplingRateMap[SYS_FDC] = 1.0/64.0;
-	dRFSamplingRateMap[SYS_PSC] = 1.0/64.0;
-
-/*
-	//SUBTRACT this number to the measured RF time
-	dTimeOffsetMap[SYS_PSC] = 0.0;
-	dTimeOffsetMap[SYS_TAGH] = 33.93; //from TAGH - PSC
-	dTimeOffsetMap[SYS_TOF] = -30.59; //from TOF - PSC
-	dTimeOffsetMap[SYS_FDC] = 2347.0; //from FDC - PSC
-*/
 
 	string locHistName, locHistTitle;
 
@@ -293,6 +279,32 @@ jerror_t JEventProcessor_RF_online::evnt(JEventLoop* locEventLoop, int eventnumb
 			locTAGHDeltaTs.push_back(*locSetIterator - *locPreviousSetIterator);
 	}
 
+	//CALC RF SIGNAL SAMPLING RATES
+		//Set by EPICS guis, but can back-compute rather than carry around more data
+		//Compute for each event, so don't need to acquire locks for accessing/modifying member variable (processor member variables are NOT thread-local)
+	map<DetectorSystem_t, double> locRFSamplingRateMap;
+	for(locTDCIterator = locRFTimes.begin(); locTDCIterator != locRFTimes.end(); ++locTDCIterator)
+	{
+		DetectorSystem_t locSystem = locTDCIterator->first;
+		set<double>& locRFTimeSet = locTDCIterator->second;
+		if(locRFTimeSet.size() < 2)
+			continue;
+
+		double locFirstDeltaT = *(++locRFTimeSet.begin()) - *(locRFTimeSet.begin());
+		double locRFSamplingRate = locFirstDeltaT/dRFSignalPeriod; //is a number like "128.0" so is actually an inverse rate (rate = 1/128)
+
+		//get the nearest even integer
+		int locRFSamplingRateInt = int(locRFSamplingRate); //round down
+		if(locRFSamplingRateInt % 2 == 1) //if true: rounded to odd: wrong direction
+			locRFSamplingRateInt += (locRFSamplingRate > double(locRFSamplingRateInt)) ? 1 : -1; //if rounded down/up, increase/decrease (was wrong direction)
+		//else rounded down to even number: OK (rounding up would have been to an odd number, so rounding down was closest int)
+
+		locRFSamplingRateMap[locSystem] = 1.0/double(locRFSamplingRateInt); //convert from int -> double, then from inverse-rate to rate (i.e. is now something like 1/128.0)
+		set<double>::iterator locSetIterator = locRFTimeSet.begin();
+		for(++locSetIterator; locSetIterator != locRFTimeSet.end(); ++locSetIterator)
+			dHistMap_RFFirstTimeDeltaT[locTDCIterator->first]->Fill(*locSetIterator - *(locRFTimeSet.begin()));
+	}
+
 	//FILL HISTOGRAMS
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
@@ -314,7 +326,8 @@ jerror_t JEventProcessor_RF_online::evnt(JEventLoop* locEventLoop, int eventnumb
 			if(locRFTimeSet.size() < 2)
 				continue;
 			DetectorSystem_t locSystem = locTDCIterator->first;
-			double locRFSignalFrequency = (*(locRFTimeSet.rbegin()) - *(locRFTimeSet.begin()))*dRFSamplingRateMap[locSystem]/(double(locRFTimeSet.size() - 1));
+			double locDeltaT = *(locRFTimeSet.rbegin()) - *(locRFTimeSet.begin());
+			double locRFSignalFrequency = locDeltaT*locRFSamplingRateMap[locSystem]/(double(locRFTimeSet.size() - 1));
 			dHistMap_RFSignalPeriod[locSystem]->Fill(locRFSignalFrequency);
 		}
 

--- a/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.h
+++ b/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.h
@@ -42,7 +42,6 @@ class JEventProcessor_RF_online : public jana::JEventProcessor
 		TDirectoryFile* dROCTIDirectory;
 
 		double dRFSignalPeriod; //not the same as the period of the beam //before multiplexing
-		map<DetectorSystem_t, double> dRFSamplingRateMap;
 		vector<DetectorSystem_t> dRFSignalSystems;
 
 		map<uint32_t, TH1I*> dHistMap_ROCInfoDeltaT; //key is rocid

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_BeamBunchPeriod.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_BeamBunchPeriod.C
@@ -1,8 +1,8 @@
 // hnamepath: /RF/RF_BeamBunchPeriod/RFBeamBunchPeriod
 
-int main(void)
+int RFMacro_BeamBunchPeriod(void)
 {
-	TDirectory *locTopDirectory = gDirectory;
+	gDirectory->cd("/"); //return to file base directory
 
 	//Goto Beam Path
 	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("RF");
@@ -34,4 +34,3 @@ int main(void)
 		locHist->Draw();
 	}
 }
-

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_CoarseTimeOffsets.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_CoarseTimeOffsets.C
@@ -5,9 +5,6 @@
 // hnamepath: /RF/AbsoluteDeltaT_RF_OtherRFs/RFDeltaT_PSC_TOF
 // hnamepath: /RF/AbsoluteDeltaT_RF_OtherRFs/RFDeltaT_TAGH_TOF
 
-//Commit constants with:
-//ccdb add PHOTON_BEAM/RF/time_offset -r <run_min>-<run_max> rf_coarse_time_offsets.txt #"coarse time offsets"
-
 double Calc_Mean(TH1I* locHist)
 {
         double locTotal = 0.0;
@@ -23,10 +20,10 @@ double Calc_Mean(TH1I* locHist)
         return (locTotal / double(locEntries));
 }
 
-int main(int locRunNumber)
+int RFMacro_CoarseTimeOffsets(int locRunNumber, string locVariation = "default")
 {
 	//INPUT RUN NUMBER MUST BE A RUN NUMBER IN THE RUN RANGE YOU ARE TRYING TO COMMIT CONSTANTS TO
-	TDirectory *locTopDirectory = gDirectory;
+	gDirectory->cd("/"); //return to file base directory
 
 	//Goto Beam Path
 	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("RF");
@@ -55,7 +52,7 @@ int main(int locRunNumber)
 	//Pipe the current constants into this macro
 		//NOTE: This dumps the "LATEST" values. If you need something else, modify this script.
 	ostringstream locCommandStream;
-	locCommandStream << "ccdb dump PHOTON_BEAM/RF/time_offset -r " << locRunNumber;
+	locCommandStream << "ccdb -v " << locVariation << " dump PHOTON_BEAM/RF/time_offset -r " << locRunNumber;
 	FILE* locInputFile = gSystem->OpenPipe(locCommandStream.str().c_str(), "r");
 	if(locInputFile == NULL)
 		return 0;

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_FineTimeOffsets.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_FineTimeOffsets.C
@@ -9,10 +9,6 @@ double gRFSignalPeriod = 1000.0/499.0;
 int gRebinF1sAmount = 25;
 int gRebinTOFAmount = 2;
 
-//Commit constants with:
-//ccdb add PHOTON_BEAM/RF/time_offset -r <run_min>-<run_max> rf_fine_time_offsets.txt #"fine time offsets"
-//ccdb add PHOTON_BEAM/RF/time_offset_var -r <run_min>-<run_max> rf_time_offset_vars.txt #"time offset variances"
-
 Double_t Periodic_Gaussian_Func(Double_t* locXArray, Double_t* locParamArray)
 {
 	Double_t locValue = locParamArray[0]*TMath::Gaus(locXArray[0], locParamArray[1], locParamArray[2]);
@@ -37,10 +33,10 @@ TF1* Create_FitFunc(TH1I* locHist)
 	return locFunc;
 }
 
-int main(int locRunNumber)
+int RFMacro_FineTimeOffsets(int locRunNumber, string locVariation = "default")
 {
 	//INPUT RUN NUMBER MUST BE A RUN NUMBER IN THE RUN RANGE YOU ARE TRYING TO COMMIT CONSTANTS TO
-	TDirectory *locTopDirectory = gDirectory;
+	gDirectory->cd("/"); //return to file base directory
 
 	//Goto Beam Path
 	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("RF");
@@ -198,7 +194,7 @@ int main(int locRunNumber)
 	//Pipe the current constants into this macro
 		//NOTE: This dumps the "LATEST" values. If you need something else, modify this script.
 	ostringstream locCommandStream;
-	locCommandStream << "ccdb dump PHOTON_BEAM/RF/time_offset -r " << locRunNumber;
+	locCommandStream << "ccdb -v " << locVariation << " dump PHOTON_BEAM/RF/time_offset -r " << locRunNumber;
 	FILE* locInputFile = gSystem->OpenPipe(locCommandStream.str().c_str(), "r");
 	if(locInputFile == NULL)
 		return 0;

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_ROCTITimes.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_ROCTITimes.C
@@ -1,10 +1,10 @@
-int main(void)
+int RFMacro_ROCTITimes(void)
 {
 	//Each tdc-tick of the TI-time corresponds to 4 ns, so max deviation from average allowed is 3.9
 		//3.9 instead of 0: is average of all other ROCs. If a ROC is out of time, it will throw off the average when analyzing the other ROCs
 	double locMaxDeviation = 3.9;
 
-	TDirectory *locTopDirectory = gDirectory;
+	gDirectory->cd("/"); //return to file base directory
 
 	//Goto Beam Path
 	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("RF");

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_SelfResolution.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_SelfResolution.C
@@ -3,12 +3,10 @@
 // hnamepath: /RF/DeltaT_RF_Itself/TAGHRF_SelfDeltaT
 // hnamepath: /RF/DeltaT_RF_Itself/PSCRF_SelfDeltaT
 
-//ccdb add PHOTON_BEAM/RF/time_resolution_sq -r <run_min>-<run_max> rf_time_resolution_sq.txt #"time resolution squared"
-
-int main(void)
+int RFMacro_SelfResolution(void)
 {
 	gStyle->SetOptStat(1111);
-	TDirectory *locTopDirectory = gDirectory;
+	gDirectory->cd("/"); //return to file base directory
 
 	//Goto Beam Path
 	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("RF");
@@ -103,4 +101,3 @@ int main(void)
 		locHist->Draw();
 	}
 }
-

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_SignalPeriod.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_SignalPeriod.C
@@ -3,10 +3,10 @@
 // hnamepath: /RF/RF_SignalPeriod/TAGHRF_SignalPeriod
 // hnamepath: /RF/RF_SignalPeriod/PSCRF_SignalPeriod
 
-int main(void)
+int RFMacro_SignalPeriod(void)
 {
 	gStyle->SetOptStat(1111);
-	TDirectory *locTopDirectory = gDirectory;
+	gDirectory->cd("/"); //return to file base directory
 
 	//Goto Beam Path
 	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("RF");

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_TDCConversion.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_TDCConversion.C
@@ -3,9 +3,9 @@
 // hnamepath: /RF/DeltaT_RF_FirstTime/TAGHRF_FirstTimeDeltaT
 // hnamepath: /RF/DeltaT_RF_FirstTime/PSCRF_FirstTimeDeltaT
 
-int main(void)
+int RFMacro_TDCConversion(void)
 {
-	TDirectory *locTopDirectory = gDirectory;
+	gDirectory->cd("/"); //return to file base directory
 
 	//Goto Beam Path
 	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("RF");

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_TaggerComparison.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_TaggerComparison.C
@@ -3,10 +3,10 @@
 // hnamepath: /RF/DeltaT_RF_TAGH/TAGHRF_TaggerDeltaT
 // hnamepath: /RF/DeltaT_RF_TAGH/PSCRF_TaggerDeltaT
 
-int main(void)
+int RFMacro_TaggerComparison(void)
 {
 	gStyle->SetOptStat(1111);
-	TDirectory *locTopDirectory = gDirectory;
+	gDirectory->cd("/"); //return to file base directory
 
 	//Goto Beam Path
 	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("RF");

--- a/src/programs/Simulation/HDGeant/hitTag.c
+++ b/src/programs/Simulation/HDGeant/hitTag.c
@@ -65,7 +65,7 @@ binTree_t* hodoTree = 0;
 static int microCount = 0;
 static int hodoCount = 0;
 static int printDone = 0;
-static float rf_period = -1.0;
+static float beam_period = -1.0;
 
 /* register hits during event initialization (from gukine) */
 
@@ -74,12 +74,12 @@ void hitTagger (float xin[4], float xout[4],
                 int track, int stack, int history)
 {
 
-   /* read rf_period from calibdb */
-   if(rf_period < 0.0)
+   /* read beam_period from calibdb */
+   if(beam_period < 0.0)
    {
-	  char dbname[] = "/PHOTON_BEAM/RF/rf_period::mc";
+	  char dbname[] = "/PHOTON_BEAM/RF/beam_period::mc";
 	  unsigned int ndata = 1;
-	  if (GetCalib(dbname, &ndata, &rf_period)) {
+	  if (GetCalib(dbname, &ndata, &beam_period)) {
 		 fprintf(stderr,"HDGeant error in hitTagger: %s %s\n",
 				 "failed to read RF period ",
 				 "from calibdb, cannot continue.");
@@ -92,7 +92,7 @@ void hitTagger (float xin[4], float xout[4],
    double Etag = 0;
    double E = pin[3];
    double t = xin[3]*1e9-(xin[2]-REF_TIME_Z_CM)/C_CM_PER_NS;
-   t = floor(t/rf_period+0.5)*rf_period;
+   t = floor(t/beam_period+0.5)*beam_period;
 
    /* read tagger set endpoint energy from calibdb */
    if (endpoint_energy_GeV == 0) {

--- a/src/programs/Simulation/HDGeant/settofg.F
+++ b/src/programs/Simulation/HDGeant/settofg.F
@@ -28,7 +28,7 @@
       integer GetCalib
       external GetCalib
       if (beam_bucket_period_ns .lt. 0) then
-        dbpath = "/PHOTON_BEAM/RF/rf_period"
+        dbpath = "/PHOTON_BEAM/RF/beam_period"
         ndata = 1
         if (GetCalib(dbpath, ndata, beam_bucket_period_ns) .ne. 0) then
           write (6,*) "HDGeant error in settofg: ",


### PR DESCRIPTION
Rename CCDB constant from "rf_period" to "beam_period"

DTAGHHit: Still set time_tdc if no matching ADC hit (wasn't before).
This is essential for confirming the beam bunch timing (which is done
before ALL calibrations).

RF factory: Protect against divide-by-0 in case the resolution constants are zero.

RF Plugin: No longer rely on hard-coded rf sampling rates.  Instead
calculate them event-by-event from the data.

Macros: Make callable via .x
Macros: Can now specify variation when running.
