### PR TITLE
* hddmInput.c [rtj]

### DIFF
--- a/src/programs/Simulation/HDGeant/gukine.F
+++ b/src/programs/Simulation/HDGeant/gukine.F
@@ -175,22 +175,34 @@
         call GRNDMQ(iseed1,iseed2,0,'S')
 
 *
-*       Fake a tagger hit of the correct energy by adding up the energy
-*       of all generated tracks and assigning them to the trigger time.
+*       Try to read the beam photon energy from the input MC record.
 *
-        PLAB(1) = 0
-        PLAB(2) = 0
-        PLAB(3) = 0
-        PLAB(4) = REAL(-PMASS)
-        do nt=1,NTRACK
-          call GFKINE(nt,VERT,PVERT,IPART,IVERT,ubuf,nubuf)
-          call GFPART(IPART,pname,ITRTYP,AMASS,CHARGE,TLIFE,ubuf,nubuf)
-          PLAB(1) = PLAB(1) + PVERT(1)
-          PLAB(2) = PLAB(2) + PVERT(2)
-          PLAB(3) = PLAB(3) + PVERT(3)
-          PLAB(4) = PLAB(4)
-     +            + sqrt(AMASS**2+PVERT(1)**2+PVERT(2)**2+PVERT(3)**2)
-        enddo
+        PLAB(4) = get_beam_momentum(0)
+        if (PLAB(4) .gt. 0) then
+          PLAB(1) = get_beam_momentum(1)
+          PLAB(2) = get_beam_momentum(2)
+          PLAB(3) = get_beam_momentum(3)
+        else
+*
+*         Fake a tagger hit of the correct energy by adding up the energy
+*         of all generated tracks minus the rest mass of the (assumed
+*         proton) target, and assigning it to the trigger time.
+*
+          PLAB(1) = 0
+          PLAB(2) = 0
+          PLAB(3) = 0
+          PLAB(4) = REAL(-PMASS)
+          do nt=1,NTRACK
+            call GFKINE(nt,VERT,PVERT,IPART,IVERT,ubuf,nubuf)
+            call GFPART(IPART,pname,ITRTYP,AMASS,CHARGE,TLIFE,
+     +                                            ubuf,nubuf)
+            PLAB(1) = PLAB(1) + PVERT(1)
+            PLAB(2) = PLAB(2) + PVERT(2)
+            PLAB(3) = PLAB(3) + PVERT(3)
+            PLAB(4) = PLAB(4) +
+     +                sqrt(AMASS**2+PVERT(1)**2+PVERT(2)**2+PVERT(3)**2)
+          enddo
+        endif
         PLAB(5) = PLAB(4)
         VERTEX(1) = VERT(1)
         VERTEX(2) = VERT(2)

--- a/src/programs/Simulation/HDGeant/hddmInput.c
+++ b/src/programs/Simulation/HDGeant/hddmInput.c
@@ -72,7 +72,18 @@ float settofg_(float origin[3], float *time0);
 s_iostream_t* thisInputStream = 0;
 s_HDDM_t* thisInputEvent = 0;
 
-int extractRunNumber(int *runNo){
+float beam_momentum[4];
+float target_momentum[4];
+
+float get_beam_momentum_(const int *comp) {
+   return beam_momentum[*comp];
+}
+
+float get_target_momentum_(const int *comp) {
+   return target_momentum[*comp];
+}
+
+int extractRunNumber(int *runNo) {
   thisInputEvent = read_s_HDDM(thisInputStream);
   return *runNo = thisInputEvent->physicsEvents->in[0].runNo;
 }
@@ -143,6 +154,39 @@ int loadInput ()
       s_Vertices_t* verts;
       int vertCount, iv;
       s_Reaction_t* react = &reacts->in[ir];
+      s_Beam_t* beam = react->beam;
+      s_Target_t* target = react->target;
+
+      if (beam)
+      {
+         beam_momentum[0] = beam->momentum->E;
+         beam_momentum[1] = beam->momentum->px;
+         beam_momentum[2] = beam->momentum->py;
+         beam_momentum[3] = beam->momentum->pz;
+      }
+      else
+      {
+         beam_momentum[0] = 0;
+         beam_momentum[1] = 0;
+         beam_momentum[2] = 0;
+         beam_momentum[3] = 0;
+      }
+
+      if (target)
+      {
+         target_momentum[0] = target->momentum->E;
+         target_momentum[1] = target->momentum->px;
+         target_momentum[2] = target->momentum->py;
+         target_momentum[3] = target->momentum->pz;
+      }
+      else
+      {
+         target_momentum[0] = 0;
+         target_momentum[1] = 0;
+         target_momentum[2] = 0;
+         target_momentum[3] = 0;
+      }
+
       verts = react->vertices;
       vertCount = verts->mult;
       for (iv = 0; iv < vertCount; iv++)


### PR DESCRIPTION
- add new code in loadInput() to unpack the beam and target
   momenta from the input Monte Carlo record
- allocate global arrays to hold the beam and target momenta
- create fortran-callable functions to fetch the values of the
   four-momentum components for beam and target particles, as
   read from the input hddm record at the last call to loadInput()
      *) get_beam_momentum(i)
      *) get_target_momentum(i)
   returns momentum component i=0(E), 1..3(p) in GeV.
  - gukine.F [rtj]
- modified to use get_beam_momentum(0) to set the (fake) tagger
   hit channel in the output event record according to the value of
   the beam energy in the input hddm record, if available, otherwise
   fall back to the old method for guessing the tagger energy
   assuming a fixed proton target and energy conservation.
