### PR TITLE
Tagm online plugin fix

### DIFF
--- a/src/plugins/monitoring/TAGM_online/JEventProcessor_TAGM_online.cc
+++ b/src/plugins/monitoring/TAGM_online/JEventProcessor_TAGM_online.cc
@@ -25,7 +25,7 @@ using namespace jana;
 
 // Define some constants
 const uint32_t NROWS = 5;
-const uint32_t NCOLUMNS = 100;
+const uint32_t NCOLUMNS = 102;
 const uint32_t NSINGLES = 20;
 
 const float MIN_ADC_PINT_LOG10 = 0.;


### PR DESCRIPTION
Change the number of columns from 100 to 102 to support monitoring simulated data.
