### PR TITLE
Pass "jana-only" flag to jana-config in AddJANA()

### DIFF
--- a/src/SBMS/sbms.py
+++ b/src/SBMS/sbms.py
@@ -479,8 +479,8 @@ def IsNotSWIGWrapper(fileNode):
 ##################################
 def AddJANA(env):
 	jana_home = os.getenv('JANA_HOME', '/no/default/jana/path')
-	JANA_CFLAGS = subprocess.Popen(["%s/bin/jana-config" % jana_home, "--cflags"], stdout=subprocess.PIPE).communicate()[0]
-	JANA_LINKFLAGS = subprocess.Popen(["%s/bin/jana-config" % jana_home, "--libs"], stdout=subprocess.PIPE).communicate()[0]
+	JANA_CFLAGS = subprocess.Popen(["%s/bin/jana-config" % jana_home,"--jana-only","--cflags"], stdout=subprocess.PIPE).communicate()[0]
+	JANA_LINKFLAGS = subprocess.Popen(["%s/bin/jana-config" % jana_home,"--jana-only","--libs"], stdout=subprocess.PIPE).communicate()[0]
 
 	AddCompileFlags(env, JANA_CFLAGS)
 	AddLinkFlags(env, JANA_LINKFLAGS)


### PR DESCRIPTION
jana-config hardcodes the paths to JANA's dependencies based on the
original locations of those packages during installation of JANA. As
a result, if one tries to link against relocated libraries, one obtains
linking errors.

This commit removes the cflags and libs of JANA's dependencies from
AddJANA(); Those flags are not needed there anyways because they are
added separately by their own sbms functions.
