### PR TITLE
Updates to support MC trigger studies

### DIFF
--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -967,6 +967,28 @@ jerror_t DEventSourceREST::Extract_DMCTrigger(hddm_r::HDDM *record,
       trigger->L1a_fired = iter->getL1a();
       trigger->L1b_fired = iter->getL1b();
       trigger->L1c_fired = iter->getL1c();
+
+      const hddm_r::TriggerDataList& locTriggerDataList = iter->getTriggerDatas();
+	   hddm_r::TriggerDataList::iterator locTriggerDataIterator = locTriggerDataList.begin();
+		if(locTriggerDataIterator == locTriggerDataList.end())
+		{
+			trigger->Ebcal = 0.;
+			trigger->Efcal = 0.;
+			trigger->Nschits = 0;
+			trigger->Ntofhits = 0;
+			
+		}
+		else //should only be 1
+		{
+			for(; locTriggerDataIterator != locTriggerDataList.end(); ++locTriggerDataIterator)
+			{
+				trigger->Ebcal = locTriggerDataIterator->getEbcal();
+				trigger->Efcal = locTriggerDataIterator->getEfcal();
+				trigger->Nschits = locTriggerDataIterator->getNschits();
+				trigger->Ntofhits = locTriggerDataIterator->getNtofhits();
+			}
+		}
+
       data.push_back(trigger);
    }
 

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -279,14 +279,16 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 	locEventLoop->Get(triggers);
 	for (size_t i=0; i < triggers.size(); i++)
 	{
-		hddm_r::Trigger_v2List trigger = res().addTrigger_v2s(1);
+		hddm_r::TriggerList trigger = res().addTriggers(1);
 		trigger().setL1a(triggers[i]->L1a_fired);
 		trigger().setL1b(triggers[i]->L1b_fired);
 		trigger().setL1c(triggers[i]->L1c_fired);
-		trigger().setEbcal(triggers[i]->Ebcal);
-		trigger().setEfcal(triggers[i]->Efcal);
-		trigger().setNschits(triggers[i]->Nschits);
-		trigger().setNtofhits(triggers[i]->Ntofhits);
+
+        hddm_r::TriggerDataList data = trigger().addTriggerDatas(1);
+	    data().setEbcal(triggers[i]->Ebcal);
+		data().setEfcal(triggers[i]->Efcal);
+		data().setNschits(triggers[i]->Nschits);
+		data().setNtofhits(triggers[i]->Ntofhits);
 	}
 
 	// push any DDetectorMatches objects to the output record

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -279,10 +279,14 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 	locEventLoop->Get(triggers);
 	for (size_t i=0; i < triggers.size(); i++)
 	{
-		hddm_r::TriggerList trigger = res().addTriggers(1);
+		hddm_r::Trigger_v2List trigger = res().addTrigger_v2s(1);
 		trigger().setL1a(triggers[i]->L1a_fired);
 		trigger().setL1b(triggers[i]->L1b_fired);
 		trigger().setL1c(triggers[i]->L1c_fired);
+		trigger().setEbcal(triggers[i]->Ebcal);
+		trigger().setEfcal(triggers[i]->Efcal);
+		trigger().setNschits(triggers[i]->Nschits);
+		trigger().setNtofhits(triggers[i]->Ntofhits);
 	}
 
 	// push any DDetectorMatches objects to the output record

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -71,8 +71,12 @@
     </tofPoint>
     <RFtime minOccurs="0" jtag="string"
             tsync="float" tunit="ns"/>
+    <!-- trigger for backwards compatibility only (replaced by trigger_v2) -->
     <trigger minOccurs="0" jtag="string"
 			L1a="boolean" L1b="boolean" L1c="boolean"/>
+    <trigger_v2 minOccurs="0" jtag="string"
+			    L1a="boolean" L1b="boolean" L1c="boolean"
+                Ebcal="float" Efcal="float" Nschits="int" Ntofhits="int" />
 
     <detectorMatches minOccurs="1" maxOccurs="1" jtag="string">
       <!-- 

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -71,12 +71,10 @@
     </tofPoint>
     <RFtime minOccurs="0" jtag="string"
             tsync="float" tunit="ns"/>
-    <!-- trigger for backwards compatibility only (replaced by trigger_v2) -->
     <trigger minOccurs="0" jtag="string"
-			L1a="boolean" L1b="boolean" L1c="boolean"/>
-    <trigger_v2 minOccurs="0" jtag="string"
-			    L1a="boolean" L1b="boolean" L1c="boolean"
-                Ebcal="float" Efcal="float" Nschits="int" Ntofhits="int" />
+			 L1a="boolean" L1b="boolean" L1c="boolean">
+      <triggerData  Ebcal="float" Efcal="float" Nschits="int" Ntofhits="int" />
+    </trigger>
 
     <detectorMatches minOccurs="1" maxOccurs="1" jtag="string">
       <!-- 

--- a/src/libraries/TRIGGER/DMCTrigger.h
+++ b/src/libraries/TRIGGER/DMCTrigger.h
@@ -19,10 +19,16 @@ class DMCTrigger:public jana::JObject{
 		bool L1b_fired; // BCAL + 4FCAL >2 GeV && BCAL > 30 MeV && FCAL > 30 MeV && NSC>0
 		bool L1c_fired; // FCAL > 250MeV
 
+        // energy sums with per-channel thresholds applied
 		double Ebcal;
-		double Efcal;
+		double Efcal;		
+        // energy sums without per-channel thresholds
+		double Ebcal_all;   
+		double Efcal_all;		
+        // number of hits in fast sub-detectors
 		unsigned int Nschits;
-		
+		unsigned int Ntofhits;
+
 		// This method is used primarily for pretty printing
 		// the second argument to AddString is printf style format
 		void toStrings(vector<pair<string,string> > &items)const{
@@ -30,7 +36,10 @@ class DMCTrigger:public jana::JObject{
 			AddString(items, "L1b_fired", "%d", L1b_fired ? 1:0);
 			AddString(items, "Ebcal", "%5.3f", Ebcal);
 			AddString(items, "Efcal", "%5.3f", Efcal);
+			AddString(items, "Ebcal_all", "%5.3f", Ebcal_all);
+			AddString(items, "Efcal_all", "%5.3f", Efcal_all);
 			AddString(items, "Nschits", "%2d", Nschits);
+			AddString(items, "Ntofhits", "%2d", Ntofhits);
 		}
 		
 };

--- a/src/libraries/TRIGGER/DMCTrigger_factory.cc
+++ b/src/libraries/TRIGGER/DMCTrigger_factory.cc
@@ -16,9 +16,13 @@ using namespace std;
 using namespace jana;
 
 #include <BCAL/DBCALHit.h>
+#include <BCAL/DBCALDigiHit.h>
 #include <FCAL/DFCALHit.h>
 #include <START_COUNTER/DSCHit.h>
+#include <TOF/DTOFHit.h>
 
+// constant stolen from mcsmear - this should be put in the CCDB
+static double BCAL_MEV_PER_ADC_COUNT    = 0.029;
 
 //------------------
 // init
@@ -38,6 +42,25 @@ jerror_t DMCTrigger_factory::brun(jana::JEventLoop *eventLoop, int runnumber)
 	double Xo = DBCALGeometry::ATTEN_LENGTH;
 	unattenuate_to_center = exp(+L_over_2/Xo);
 
+    USE_OLD_BCAL_HITS = 0;
+    gPARMS->SetDefaultParameter("TRIGGER:USE_OLD_BCAL_HITS", USE_OLD_BCAL_HITS,
+                                "Use old DBCALHit calculation for BCAL energy sum.");
+
+    // Per-channel trigger thresholds
+    // Defaults in data according to A. Somov for Spring 2015 run (as of 11/13/15):
+    // FCAL: 130 MeV (65 adc counts)
+    // BCAL: 13.2 MeV (20 adc counts)
+    // Added 11/17/15 (sdobbs):
+    // Caveat: BCAL simulations use an adc count -> MeV conversion factor of 0.029, 
+    // so for the BCAL use a threshold of  
+    BCAL_CHANNEL_THRESHOLD = 455.;     // in adc counts
+    FCAL_CHANNEL_THRESHOLD = 0.130;    // in MeV
+    gPARMS->SetDefaultParameter("TRIGGER:BCAL_CHANNEL_THRESHOLD", BCAL_CHANNEL_THRESHOLD,
+                                "Threshold for BCAL energy sum (units of adc counts)");
+    gPARMS->SetDefaultParameter("TRIGGER:FCAL_CHANNEL_THRESHOLD", FCAL_CHANNEL_THRESHOLD,
+                                "Threshold for FCAL energy sum (units of MeV)");
+
+
 	return NOERROR;
 }
 
@@ -48,65 +71,105 @@ jerror_t DMCTrigger_factory::evnt(JEventLoop *loop, int eventnumber)
 {
 	// See comments in DMCTrigger_factory.h
 
-	vector<const DBCALHit*> bcalhits;
+    vector<const DBCALHit*> bcalhits;
 	vector<const DFCALHit*> fcalhits;
 	vector<const DSCHit*> schits;
-	loop->Get(bcalhits);
+	vector<const DTOFHit*> tofhits;
+    loop->Get(bcalhits);
 	loop->Get(fcalhits);
 	loop->Get(schits);
+	loop->Get(tofhits);
 
-	/// In GlueX-doc-1043, it appaears the energy deposited in the BCAL
-	/// is used. In reality, only the attenuated energy will be available
-	/// to the L1 trigger electronics. If an average of the sum of both
-	/// sides is used, it will be off by at most, 20% at the ends (excluding
-	/// any dark pulsing effects). This conclusion comes from assuming
-	/// we scale the values by e^(L/2/lambda) such that the value of the
-	/// threshold is in GeV for energy deposited at the center of the module.
-	/// The average of the two ends then is:
-	///
-	///   Eavg = (E*e^+x + E*e^-x)/2
-	///
-	/// or
-	///
-	///   Eavg = E * cosh(x)
-	///
-	/// where x = L/2/lambda 
-	///       L = 390 cm
-	///       lambda = 300 cm
-	///
-	/// The dark pulses should contribute at most about 10 MeV.
-	///
-	/// For the BCAL "energy" we therefore take the average of the
-	/// sums of the DBCALHits for each side knowing it is
-	/// overestimated by as much as 20%.
-	///
-	/// The FCAL energy is just a straight sum of the FCAL hits
+    double Ebcal = 0.0;
+    double Ebcal_all = 0.0;
+    double Efcal = 0.0;
+    double Efcal_all = 0.0;
+    double BCAL_Eupstream = 0.0;
+    double BCAL_Edownstream = 0.0;
+    // BCAL simulations now write out DBCALDigiHits, so we can directly sum the unattenuated energies
+    // Keep the old algorithm around for compatabilty
+    if(USE_OLD_BCAL_HITS) {
+        /// In GlueX-doc-1043, it appaears the energy deposited in the BCAL
+        /// is used. In reality, only the attenuated energy will be available
+        /// to the L1 trigger electronics. If an average of the sum of both
+        /// sides is used, it will be off by at most, 20% at the ends (excluding
+        /// any dark pulsing effects). This conclusion comes from assuming
+        /// we scale the values by e^(L/2/lambda) such that the value of the
+        /// threshold is in GeV for energy deposited at the center of the module.
+        /// The average of the two ends then is:
+        ///
+        ///   Eavg = (E*e^+x + E*e^-x)/2
+        ///
+        /// or
+        ///
+        ///   Eavg = E * cosh(x)
+        ///
+        /// where x = L/2/lambda 
+        ///       L = 390 cm
+        ///       lambda = 300 cm
+        ///
+        /// The dark pulses should contribute at most about 10 MeV.
+        ///
+        /// For the BCAL "energy" we therefore take the average of the
+        /// sums of the DBCALHits for each side knowing it is
+        /// overestimated by as much as 20%.
+        ///
+        /// The FCAL energy is just a straight sum of the FCAL hits
+        
+        for(unsigned int i=0; i< bcalhits.size(); i++){
+            const DBCALHit* bcalhit = bcalhits[i];
+            
+            if(bcalhit->end == DBCALGeometry::kUpstream){
+                Ebcal_all += bcalhit->E;
+                if(1000.*bcalhit->E > BCAL_CHANNEL_THRESHOLD*BCAL_MEV_PER_ADC_COUNT) 
+                    BCAL_Eupstream += bcalhit->E;
+            }else{
+                Ebcal_all += bcalhit->E;
+                if(1000.*bcalhit->E > BCAL_CHANNEL_THRESHOLD*BCAL_MEV_PER_ADC_COUNT) 
+                    BCAL_Edownstream += bcalhit->E;
+            }
+        }
 	
-	double BCAL_Eupstream = 0.0;
-	double BCAL_Edownstream = 0.0;
-	for(unsigned int i=0; i< bcalhits.size(); i++){
-		const DBCALHit* bcalhit = bcalhits[i];
-		
-		if(bcalhit->end == DBCALGeometry::kUpstream){
-			BCAL_Eupstream += bcalhit->E;
-		}else{
-			BCAL_Edownstream += bcalhit->E;
-		}
-	}
+        // Calculate "energy" sum for BCAL in GeV-ish units
+        Ebcal = unattenuate_to_center * (BCAL_Eupstream + BCAL_Edownstream)/2.0;
 	
-	// Calculate "energy" sum for BCAL in GeV-ish units
-	double Ebcal = unattenuate_to_center * (BCAL_Eupstream + BCAL_Edownstream)/2.0;
+        // Sum up FCAL energy
+        for(unsigned int i=0; i< fcalhits.size(); i++){
+            const DFCALHit* fcalhit = fcalhits[i];
+	   
+            Efcal_all += fcalhit->E;
+            if(fcalhit->E > FCAL_CHANNEL_THRESHOLD)
+                Efcal += fcalhit->E;
+        }
+    } else {
+        // Sum up BCAL energy
+        for(unsigned int i=0; i< bcalhits.size(); i++){
+            const DBCALHit* bcalhit = bcalhits[i];
+            const DBCALDigiHit* bcaldigihit = NULL;
+            bcalhit->GetSingle(bcaldigihit);
+            if(bcaldigihit == NULL)
+                continue;
+            
+            Ebcal_all += bcalhit->E;
+            if(bcaldigihit->pulse_integral > BCAL_CHANNEL_THRESHOLD)  
+                Ebcal += bcalhit->E;
+        }
+        
+        // Sum up FCAL energy
+        for(unsigned int i=0; i< fcalhits.size(); i++){
+            const DFCALHit* fcalhit = fcalhits[i];
 	
-	// Sum up FCAL energy
-	double Efcal = 0.0;
-	for(unsigned int i=0; i< fcalhits.size(); i++){
-		const DFCALHit* fcalhit = fcalhits[i];
-		
-		Efcal += fcalhit->E;
-	}
-	
+            Efcal_all += fcalhit->E;
+            if(fcalhit->E > FCAL_CHANNEL_THRESHOLD)
+                Efcal += fcalhit->E;
+        }
+    }
+        
 	// Number of start counter hits
 	unsigned int Nschits = schits.size();
+
+	// Number of TOF hits
+	unsigned int Ntofhits = tofhits.size();
 
 	DMCTrigger *trig = new DMCTrigger;
 
@@ -118,7 +181,10 @@ jerror_t DMCTrigger_factory::evnt(JEventLoop *loop, int eventnumber)
 
 	trig->Ebcal = Ebcal;
 	trig->Efcal = Efcal;
+	trig->Ebcal_all = Ebcal_all;
+	trig->Efcal_all = Efcal_all;
 	trig->Nschits = Nschits;
+	trig->Ntofhits = Ntofhits;
 	
 	_data.push_back(trig);
 

--- a/src/libraries/TRIGGER/DMCTrigger_factory.h
+++ b/src/libraries/TRIGGER/DMCTrigger_factory.h
@@ -44,6 +44,10 @@ class DMCTrigger_factory:public jana::JFactory<DMCTrigger>{
 
 		bool REQUIRE_START_COUNTER;
 		double unattenuate_to_center;
+
+        int USE_OLD_BCAL_HITS;
+        double BCAL_CHANNEL_THRESHOLD;
+        double FCAL_CHANNEL_THRESHOLD;
 };
 
 #endif // _DMCTrigger_factory_


### PR DESCRIPTION
- Updated MCTrigger factory to calculate trigger-style BCAL and FCAL hit energy sums with per-channel thresholds.  These are found to be different than the sum of all shower energies.
- BCAL & FCAL energy sums saved in REST format
