### PR TITLE
St calib work

### DIFF
--- a/src/libraries/START_COUNTER/DSCHit_factory.cc
+++ b/src/libraries/START_COUNTER/DSCHit_factory.cc
@@ -55,6 +55,10 @@ jerror_t DSCHit_factory::init(void)
     gPARMS->SetDefaultParameter("SC:ADC_THRESHOLD", ADC_THRESHOLD,
             "Software pulse integral threshold");
 
+    USE_TIMEWALK_CORRECTION = 1.;
+    gPARMS->SetDefaultParameter("SC:USE_TIMEWALK_CORRECTION", USE_TIMEWALK_CORRECTION,
+                                "Flag to decide if timewalk corrections should be applied.");
+
     /// set the base conversion scales
     a_scale    = 0.0001; 
     t_scale    = 0.0625;   // 62.5 ps/count
@@ -305,7 +309,7 @@ jerror_t DSCHit_factory::evnt(JEventLoop *loop, int eventnumber)
 		//jout << "t_tDC = " << hit->t_TDC << endl;
 
 
-		if (hit->dE > 0.0)
+		if (USE_TIMEWALK_CORRECTION && (hit->dE > 0.0) )
 		  {
 		    // // Correct for time walk
 		    // // The correction is the form t=t_tdc- C1 (A^C2 - A0^C2)

--- a/src/libraries/START_COUNTER/DSCHit_factory.h
+++ b/src/libraries/START_COUNTER/DSCHit_factory.h
@@ -37,6 +37,7 @@ class DSCHit_factory:public jana::JFactory<DSCHit>{
 		double DELTA_T_ADC_TDC_MAX;
 		double HIT_TIME_WINDOW;
 		double ADC_THRESHOLD;
+        double USE_TIMEWALK_CORRECTION;
 
 		// geometry information
 		static const int MAX_SECTORS = 30.;

--- a/src/plugins/Calibration/st_tw_corr_auto/JEventProcessor_st_tw_corr_auto.cc
+++ b/src/plugins/Calibration/st_tw_corr_auto/JEventProcessor_st_tw_corr_auto.cc
@@ -1,0 +1,199 @@
+// $Id$
+//
+//    File: JEventProcessor_st_tw_corr_auto.cc
+// Created: Mon Oct 26 10:35:45 EDT 2015
+// Creator: mkamel (on Linux ifarm1401 2.6.32-431.el6.x86_64 x86_64)
+//
+#include "JEventProcessor_st_tw_corr_auto.h"
+
+// Routine used to create our JEventProcessor
+#include <JANA/JApplication.h>
+#include <JANA/JFactory.h>
+
+extern "C"{
+void InitPlugin(JApplication *app){
+	InitJANAPlugin(app);
+	app->AddProcessor(new JEventProcessor_st_tw_corr_auto());
+}
+} // "C"
+
+//------------------
+// JEventProcessor_st_tw_corr_auto (Constructor)
+//------------------
+JEventProcessor_st_tw_corr_auto::JEventProcessor_st_tw_corr_auto()
+{
+
+}
+
+//------------------
+// ~JEventProcessor_st_tw_corr_auto (Destructor)
+//------------------
+JEventProcessor_st_tw_corr_auto::~JEventProcessor_st_tw_corr_auto()
+{
+
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_st_tw_corr_auto::init(void)
+{
+	// This is called once at program startup. If you are creating
+	// and filling historgrams in this plugin, you should lock the
+	// ROOT mutex like this:
+	//
+	// japp->RootWriteLock();
+	//  ... fill historgrams or trees ...
+	// japp->RootUnLock();
+	//
+  USE_TIMEWALK_CORRECTION = 1.;
+  gPARMS->SetDefaultParameter("SC:USE_TIMEWALK_CORRECTION", USE_TIMEWALK_CORRECTION,
+			      "Flag to decide if timewalk corrections should be applied.");
+  // ***************** define constants*************************
+  NCHANNELS          = 30;
+  tdc_thresh_mV   = 50.0;
+  tdc_gain_factor = 5.0;
+  adc_max_chan    = 4096.0;
+  adc_max_mV      = 2000.0;
+  adc_thresh_calc = (tdc_thresh_mV/tdc_gain_factor)*(adc_max_chan/adc_max_mV);
+  // **************** define histograms *************************
+  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+  
+  h_pp_chan = new TH1I*[NCHANNELS];
+  h_stt_chan = new TH1I*[NCHANNELS];
+  h2_stt_vs_pp_chan = new TH2I*[NCHANNELS];
+  h1_st_corr_time = new TH1I*[NCHANNELS];
+  h2_st_corr_vs_pp = new TH2I*[NCHANNELS];
+  // Book Histos
+  for (Int_t i = 0; i < NCHANNELS; i++)
+    { 
+      h2_stt_vs_pp_chan[i] = new TH2I(Form("stt_vs_pp_chan_%i", i+1), "Hit Time vs. Pulse Peak; Pulse Peak (channels); #delta_{t} (ns)", 4096,0.0,4095.0, 160, -5.0, 5.0);
+      
+      h_pp_chan[i]  = new TH1I(Form("pp_chan_%i", i+1), "Pulse Peak; Pulse Peak (channels); Counts",  4096,0.0,4095.0);
+      
+      h_stt_chan[i] = new TH1I(Form("h_stt_chan_%i",i+1), "ST Time; ST Time (ns); Counts", 160, -5.0, 5.0);
+
+      h1_st_corr_time[i] = new TH1I(Form("h1_st_corr_time_%i",i+1), "ST Time; ST Time (ns); Counts", 160, -5.0, 5.0);
+      
+      h2_st_corr_vs_pp[i]= new TH2I(Form("h2_st_corr_vs_pp_%i", i+1), "Hit Time vs. Pulse Peak; Pulse Peak (channels); #delta_{t} (ns)", 4096,0.0,4095.0, 160, -5.0, 5.0);
+    }
+  japp->RootUnLock();
+ 
+  return NOERROR;
+}
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_st_tw_corr_auto::brun(JEventLoop *eventLoop, int runnumber)
+{
+  // This is called whenever the run number changes
+  // load constant tables
+  // timewalk_parameters (timewalk_parms)
+  if(eventLoop->GetCalib("START_COUNTER/timewalk_parms_v2", timewalk_parameters))
+    jout << "Error loading /START_COUNTER/timewalk_parms_v2 !" << endl;
+  
+  return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_st_tw_corr_auto::evnt(JEventLoop *loop, int eventnumber)
+{
+	// This is called for every event. Use of common resources like writing
+	// to a file or filling a histogram should be mutex protected. Using
+	// loop->Get(...) to get reconstructed objects (and thereby activating the
+	// reconstruction algorithm) should be done outside of any mutex lock
+	// since multiple threads may call this method at the same time.
+	// Here's an example:
+	//
+	// vector<const MyDataClass*> mydataclasses;
+	// loop->Get(mydataclasses);
+	//
+	// japp->RootWriteLock();
+	//  ... fill historgrams or trees ...
+	// japp->RootUnLock();
+  vector<const DSCHit*>      st_hits; 
+  loop->Get(st_hits); 
+  
+  for (unsigned int k = 0; k < st_hits.size(); k++)
+    {
+      if(!st_hits[k]->has_fADC || !st_hits[k]->has_TDC)
+	continue;
+      // get the associated digihit so that we can access the
+      // pulse peak and pedestal information
+      const DSCDigiHit* the_digihit = NULL;
+      st_hits[k]->GetSingle(the_digihit);
+      if(the_digihit == NULL)
+	continue;
+      
+      // There is a slight difference between Mode 7 and 8 data
+      // The following condition signals an error state in the flash algorithm
+      // Do not make hits out of these
+      const Df250PulsePedestal* PPobj = NULL;
+      the_digihit->GetSingle(PPobj);
+      if (PPobj != NULL)
+	{
+	  if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
+	}
+      // Extract the information we're interested in 
+      double adc_pp;
+      if(PPobj != NULL)
+	adc_pp   = (double)PPobj->pulse_peak - (double)PPobj->pedestal;
+      else
+	adc_pp =0.;
+      
+      double T   = st_hits[k]->t;             // this is always set to the TDC time
+      // timewalk corrections are controlled by command line flag
+      double adc_t   = st_hits[k]->t_fADC;
+      int sector     = st_hits[k]->sector;
+      // Lock ROOT mutex so other threads won't interfere 
+      japp->RootWriteLock();
+      {
+	double	st_time = T - adc_t;
+	h_stt_chan[sector-1]->Fill(st_time);
+	if (USE_TIMEWALK_CORRECTION==0)
+	  {
+	    h_pp_chan[sector-1]->Fill(adc_pp);
+	    h2_stt_vs_pp_chan[sector-1]->Fill(adc_pp,st_time);
+	  }
+	//  Correct for the time walk
+	else if (USE_TIMEWALK_CORRECTION==1)
+	  { 
+	    double C0       = timewalk_parameters[sector -1][0];
+	    double C1       = timewalk_parameters[sector -1][1];
+	    double C2       = timewalk_parameters[sector -1][2];
+	    double A_THRESH = timewalk_parameters[sector -1][3];
+	    double A0       = timewalk_parameters[sector -1][4];
+	    // cout<<  C1 << "\t" << C2 << "\t" << A_THRESH << "\t" << A0  <<endl;
+	    
+	    st_time -= C0 + C1 *(TMath::Power(A0/A_THRESH, C2));
+	    // cout << "st_time =" << st_time << endl;
+	    h1_st_corr_time[sector-1]->Fill(st_time);
+	    h2_st_corr_vs_pp[sector-1]->Fill(adc_pp,st_time);
+	  }
+      }
+      japp->RootUnLock();
+    }
+  return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_st_tw_corr_auto::erun(void)
+{
+	// This is called whenever the run number changes, before it is
+	// changed to give you a chance to clean up before processing
+	// events from the next run number.
+	return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t JEventProcessor_st_tw_corr_auto::fini(void)
+{
+  return NOERROR;
+}
+

--- a/src/plugins/Calibration/st_tw_corr_auto/JEventProcessor_st_tw_corr_auto.cc
+++ b/src/plugins/Calibration/st_tw_corr_auto/JEventProcessor_st_tw_corr_auto.cc
@@ -136,6 +136,7 @@ jerror_t JEventProcessor_st_tw_corr_auto::evnt(JEventLoop *loop, int eventnumber
 	{
 	  if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
 	}
+	else continue;
       // Extract the information we're interested in 
       double adc_pp;
       if(PPobj != NULL)

--- a/src/plugins/Calibration/st_tw_corr_auto/JEventProcessor_st_tw_corr_auto.h
+++ b/src/plugins/Calibration/st_tw_corr_auto/JEventProcessor_st_tw_corr_auto.h
@@ -1,0 +1,69 @@
+// $Id$
+//
+//    File: JEventProcessor_st_tw_corr_auto.h
+// Created: Mon Oct 26 10:35:45 EDT 2015
+// Creator: mkamel (on Linux ifarm1401 2.6.32-431.el6.x86_64 x86_64)
+//
+
+#ifndef _JEventProcessor_st_tw_corr_auto_
+#define _JEventProcessor_st_tw_corr_auto_
+
+#include <JANA/JEventProcessor.h>
+using namespace jana;
+using namespace std;
+using std::vector;
+using std::string;
+// ***************** C++ header files******************
+//*****************************************************
+#include <stdint.h>
+#include <vector>
+#include <stdio.h>
+#include <fstream>
+// ***************** ST header files*******************************
+#include "START_COUNTER/DSCHit.h"
+#include "START_COUNTER/DSCDigiHit.h"
+// ***************** ROOT header files*****************************
+#include <TH1.h>
+#include <TH2.h>
+#include <TDirectory.h>
+#include <TF1.h>
+#include <TMath.h>
+#include <TFile.h>
+// ******************* DAQ libraries******************************
+#include <DAQ/Df250PulsePedestal.h>
+
+class JEventProcessor_st_tw_corr_auto:public jana::JEventProcessor{
+	public:
+		JEventProcessor_st_tw_corr_auto();
+		~JEventProcessor_st_tw_corr_auto();
+		const char* className(void){return "JEventProcessor_st_tw_corr_auto";}
+
+	private:
+		jerror_t init(void);						///< Called once at program start.
+		jerror_t brun(jana::JEventLoop *eventLoop, int runnumber);	///< Called everytime a new run number is detected.
+		jerror_t evnt(jana::JEventLoop *eventLoop, int eventnumber);	///< Called every event.
+		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+        
+        // ***************** define constants*************************
+        Int_t NCHANNELS;
+        Double_t tdc_thresh_mV;
+        Double_t tdc_gain_factor;
+        Double_t adc_max_chan;
+        Double_t adc_max_mV;
+        Double_t adc_thresh_calc ;
+        // ******************* 2D histos **************
+        TH2I **h2_stt_vs_pp_chan;
+	TH2I ** h2_st_corr_vs_pp;
+        // ******************** 1D histos *******************
+        TH1I **h_pp_chan;
+        TH1I **h_stt_chan;
+	TH1I **h1_st_corr_time;
+	//Define Calibration parameters variable called from CCDB
+	vector<vector<double> >timewalk_parameters;
+	double USE_TIMEWALK_CORRECTION;
+};
+
+#endif // _JEventProcessor_st_tw_corr_auto_
+

--- a/src/plugins/Calibration/st_tw_corr_auto/SConstruct
+++ b/src/plugins/Calibration/st_tw_corr_auto/SConstruct
@@ -1,0 +1,126 @@
+
+#
+#  Jan. 31, 2014  David Lawrence
+#
+# This SConstruct file can be copied into a directory containing
+# the source for a plugin and used to compile it. It will use and
+# install into the directory specified by the HALLD_MY environment
+# variable if defined. Otherwise, it will install in the HALLD_HOME
+# directory.
+#
+# This file should not need modification. It will be copied in by
+# the mkplugin or mkfactory_plugin scripts or you can just copy it
+# by hand.
+#
+# To use this, just type "scons install" to build and install.
+# Just type "scons" if you want to build, but not install it.
+#
+# > scons install
+#
+# Note that unlike the rest of the SBMS system, this does not
+# use a separate build directory and builds everything in the
+# source directory. This is due to technical details and will hopefully
+# be fixed in the future. For now it means, that you must be
+# diligent of building for multiple platforms using the same source.
+#
+
+import os
+import sys
+import subprocess
+import glob
+
+# Get HALLD_HOME environment variable, verifying it is set
+halld_home = os.getenv('HALLD_HOME')
+if(halld_home == None):
+	print 'HALLD_HOME environment variable not set!'
+	exit(-1)
+
+# Get HALLD_MY if it exists. Otherwise use HALLD_HOME
+halld_my = os.getenv('HALLD_MY', halld_home)
+
+# Add SBMS directory to PYTHONPATH
+sbmsdir = "%s/src/SBMS" % halld_home
+sys.path.append(sbmsdir)
+
+import sbms
+
+# Get command-line options
+SHOWBUILD = ARGUMENTS.get('SHOWBUILD', 0)
+
+# Get platform-specific name
+osname = os.getenv('BMS_OSNAME', 'build')
+
+# Get architecture name
+arch = subprocess.Popen(["uname"], stdout=subprocess.PIPE).communicate()[0].strip()
+
+# Setup initial environment
+installdir = "%s/%s" %(halld_my, osname)
+include = "%s/include" % (installdir)
+bin = "%s/bin" % (installdir)
+lib = "%s/lib" % (installdir)
+plugins = "%s/plugins" % (installdir)
+env = Environment(    CPPPATH = [include],
+                      LIBPATH = ["%s/%s/lib" %(halld_home, osname)],  # n.b. add HALLD_HOME here and prepend HALLD_MY below
+                  variant_dir = ".%s" % (osname))
+
+# Only add HALLD_MY library search path if it already exists
+# since we'll get a warning otherwise
+if (os.path.exists(lib)): env.PrependUnique(lib)
+
+# These are SBMS-specific variables (i.e. not default scons ones)
+env.Replace(INSTALLDIR    = installdir,
+				OSNAME        = osname,
+				INCDIR        = include,
+				BINDIR        = bin,
+				LIBDIR        = lib,
+				PLUGINSDIR    = plugins,
+				ALL_SOURCES   = [],        # used so we can add generated sources
+				SHOWBUILD     = SHOWBUILD,
+		 COMMAND_LINE_TARGETS = COMMAND_LINE_TARGETS)
+
+# Use terse output unless otherwise specified
+if SHOWBUILD==0:
+	env.Replace(   CCCOMSTR       = "Compiling  [$SOURCE]",
+				  CXXCOMSTR       = "Compiling  [$SOURCE]",
+				  FORTRANPPCOMSTR = "Compiling  [$SOURCE]",
+				  FORTRANCOMSTR   = "Compiling  [$SOURCE]",
+				  SHCCCOMSTR      = "Compiling  [$SOURCE]",
+				  SHCXXCOMSTR     = "Compiling  [$SOURCE]",
+				  LINKCOMSTR      = "Linking    [$TARGET]",
+				  SHLINKCOMSTR    = "Linking    [$TARGET]",
+				  INSTALLSTR      = "Installing [$TARGET]",
+				  ARCOMSTR        = "Archiving  [$TARGET]",
+				  RANLIBCOMSTR    = "Ranlib     [$TARGET]")
+
+
+# Get compiler from environment variables (if set)
+env.Replace( CXX = os.getenv('CXX', 'g++'),
+             CC  = os.getenv('CC' , 'gcc'),
+             FC  = os.getenv('FC' , 'gfortran') )
+
+# Add local directory, directories from HALLD_MY and HALLD_HOME to include search path
+#env.PrependUnique(CPPPATH = ['#'])
+env.PrependUnique(CPPPATH = ['%s/src' % halld_my, '%s/src/libraries' % halld_my, '%s/src/libraries/include' % halld_my])
+env.PrependUnique(CPPPATH = ['%s/src' % halld_home, '%s/src/libraries' % halld_home, '%s/src/libraries/include' % halld_home])
+
+env.PrependUnique(CPPPATH = ['%s/%s/include' % (halld_my,osname)])
+env.PrependUnique(CPPPATH = ['%s/%s/include' % (halld_home,osname)])
+
+# Turn on debug symbols and warnings
+env.PrependUnique(      CFLAGS = ['-g', '-fPIC', '-Wall'])
+env.PrependUnique(    CXXFLAGS = ['-g', '-fPIC', '-Wall'])
+env.PrependUnique(FORTRANFLAGS = ['-g', '-fPIC', '-Wall'])
+
+# Apply any platform/architecture specific settings
+sbms.ApplyPlatformSpecificSettings(env, arch)
+sbms.ApplyPlatformSpecificSettings(env, osname)
+
+# Make plugin from source in this directory
+sbms.AddDANA(env)
+sbms.AddROOT(env)
+sbms.plugin(env)
+
+# Make install target
+env.Alias('install', installdir)
+
+

--- a/src/plugins/Calibration/st_tw_corr_auto/macros/st_tw_fits.C
+++ b/src/plugins/Calibration/st_tw_corr_auto/macros/st_tw_fits.C
@@ -1,0 +1,119 @@
+// File: st_tw_fits.C
+// Last Modified: 11/10/2015
+// Creator: Mahmoud Kamel mkame006@fiu.edu
+// Purpose: Displaying histograms and tw automatic process.
+#include "TH1.h"
+#include <TH2I.h>
+#include "TF1.h"
+#include "TROOT.h"
+#include "TStyle.h"
+#include "TMath.h"
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TAxis.h"
+#include <TDirectory.h>
+#include <TLine.h>
+#include <TPaveLabel.h>
+#include <TPaletteAxis.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <fstream>
+using namespace std;
+using std::string;
+// ***************** define constants and varibles*************************
+const Int_t NCHANNELS          = 30;
+const Double_t tdc_thresh_mV   = 50.0;
+const Double_t tdc_gain_factor = 5.0;
+const Double_t adc_max_chan    = 4096.0;
+const Double_t adc_max_mV      = 2000.0;
+const Double_t adc_thresh_calc = (tdc_thresh_mV/tdc_gain_factor)*(adc_max_chan/adc_max_mV);
+Double_t sudo_mpv_chan[NCHANNELS];
+Double_t t_pp_fit_params[NCHANNELS][3];
+Double_t t_pp_fit_params_err[NCHANNELS][3];
+//****   Declare fits *****************************
+TF1 *t_vs_pp_fit_chan[NCHANNELS];
+// Declare canvas
+TCanvas *TW_can[30];
+
+Double_t fitf_pp(Double_t *x, Double_t *par)
+{
+  Double_t fitval_pp = par[0] + par[1]*(TMath::Power(x[0]/adc_thresh_calc, par[2]));
+  return fitval_pp;
+}
+
+void st_tw_fits(char*input_filename)
+//void st_tw_fits()
+{
+  // df = new TFile("/lustre/expphy/work/halld/home/mkamel/st_tw_corr_auto/hd_root_pass0.root");
+  // df = new TFile("/lustre/expphy/work/halld/home/mkamel/st_tw_corr_auto/hd_root.root");
+   TFile *df = new TFile(input_filename);
+  std::ofstream results;
+  results.open ("results.txt", std::ofstream::out);
+  //*****************************************************************
+  //*********** Grab the histograms from the root file **************
+  //*****************************************************************
+  for (unsigned int j = 0; j < 30; j++)
+    {
+      //Create the canvas
+      TW_can[j] = new TCanvas( Form("TW_can_%i",j+1), "TW_can", 800, 450);
+      TW_can[j]->Divide(2, 1);
+	  
+      // Grab the histograms 
+      char* sttpp = Form("stt_vs_pp_chan_%i",j+1);
+      TH2I* h2_tpp = (TH2I*) df->Get(sttpp);
+      char* pp = Form("pp_chan_%i",j+1);
+      TH1I* h_pp = (TH1I*) df->Get(pp);
+      //*****************************************************************
+      //***********      Plot stt vs pp                ******************
+      //*****************************************************************
+      TW_can[j]->cd(1);
+      gStyle->SetOptStat(10);
+      gPad->SetTicks();
+      gPad->SetGrid();
+    
+      h2_tpp->Draw("colz"); 
+      h2_tpp->GetZaxis()->SetRangeUser(0,300);
+      h2_tpp->GetXaxis()->SetRangeUser(120.,3500.);
+      h2_tpp->GetYaxis()->SetRangeUser(-2.0,2.0);
+      TPaletteAxis *palette = new TPaletteAxis(3501.0,-2.0,3599.0,2.0,h2_tpp);
+      palette->SetLabelOffset(0.002);
+      palette->SetLabelSize(0.05);
+      h2_tpp->GetListOfFunctions()->Add(palette,"br");
+      //*****************************************************************
+      //***********          Do the fit                ******************
+      //*****************************************************************
+      cout << "==================================================" << endl;
+      cout << "Processing Channel " << j+1 << endl;
+      cout << "==================================================" << endl;
+      t_vs_pp_fit_chan[j] = new TF1(Form("t_vs_pp_fit_chan_%i", j+1), fitf_pp, 120.0,3500.0, 3);   
+      t_vs_pp_fit_chan[j]->SetParameters(-1.0, 7.0, -0.5);
+     
+      h2_tpp->Fit(Form("t_vs_pp_fit_chan_%i", j+1));
+      
+      t_pp_fit_params[j][0] =  t_vs_pp_fit_chan[j]->GetParameter(0);
+      t_pp_fit_params_err[j][0] =  t_vs_pp_fit_chan[j]->GetParError(0);
+      t_pp_fit_params[j][1] =  t_vs_pp_fit_chan[j]->GetParameter(1);
+      t_pp_fit_params_err[j][1] =  t_vs_pp_fit_chan[j]->GetParError(1);
+      t_pp_fit_params[j][2] =  t_vs_pp_fit_chan[j]->GetParameter(2);
+      t_pp_fit_params_err[j][2] =  t_vs_pp_fit_chan[j]->GetParError(2);
+      gPad->Update();
+      //*****************************************************************
+      //*********** Plot 1D pp histos                  ******************
+      //*****************************************************************
+      TW_can[j]->cd(2);
+      gStyle->SetOptStat(10);
+      gStyle->SetErrorX(0); 
+      gPad->SetTicks();
+      gPad->SetGrid();
+      h_pp->Draw(); 
+      h_pp->GetXaxis()->SetRangeUser(120.0,3500.);
+      sudo_mpv_chan[j] = (Double_t) h_pp->GetMaximumBin();
+      //*****************************************************************
+      //*********** Write the Results                  ******************
+      //*****************************************************************
+      results << t_pp_fit_params[j][0] << "\t" << t_pp_fit_params[j][1] << "\t" << "\t" << t_pp_fit_params[j][2] << "\t" << adc_thresh_calc  << "000" << "\t"  <<  sudo_mpv_chan[j] << ".0000"<< endl;
+      TW_can[j]->Print(Form("stt_tw_plot_%i.png",j+1));
+    }
+  results.close();
+}
+

--- a/src/plugins/Calibration/st_tw_corr_auto/macros/st_tw_resols.C
+++ b/src/plugins/Calibration/st_tw_corr_auto/macros/st_tw_resols.C
@@ -1,0 +1,147 @@
+// File: st_tw_fits.C
+// Last Modified: 11/10/2015
+// Creator: Mahmoud Kamel mkame006@fiu.edu
+// Purpose: Displaying histograms and tw automatic process.
+#include "TH1.h"
+#include <TH2I.h>
+#include "TF1.h"
+#include "TROOT.h"
+#include "TStyle.h"
+#include "TMath.h"
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TAxis.h"
+#include <TDirectory.h>
+#include <TLine.h>
+#include <TGraph.h>
+#include <TPaveLabel.h>
+#include <TPaletteAxis.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <fstream>
+
+using namespace std;
+using std::string;
+// ***************** define constants and varibles*************************
+const Int_t NCHANNELS          = 30;
+const Double_t tdc_thresh_mV   = 50.0;
+const Double_t tdc_gain_factor = 5.0;
+const Double_t adc_max_chan    = 4096.0;
+const Double_t adc_max_mV      = 2000.0;
+const Double_t adc_thresh_calc = (tdc_thresh_mV/tdc_gain_factor)*(adc_max_chan/adc_max_mV);
+Double_t sudo_mpv_chan[NCHANNELS];
+Double_t t_pp_fit_params[NCHANNELS][3];
+Double_t t_pp_fit_params_err[NCHANNELS][3];
+Double_t stt_fit_params[NCHANNELS][3];
+Double_t stt_fit_params_err[NCHANNELS][3];
+Double_t sigma[NCHANNELS];
+Double_t Err[NCHANNELS];
+Double_t x[NCHANNELS];
+Double_t ex[NCHANNELS];
+//****   Declare fits *****************************
+TF1 *t_fit_chan[NCHANNELS];
+TGraph *gr[NCHANNELS];
+// Declare canvas
+TCanvas *TW_can[30];
+TCanvas *Time_can;
+Double_t fitf_pp(Double_t *x, Double_t *par)
+{
+  Double_t fitval_pp = par[0] + par[1]*(TMath::Power(x[0]/adc_thresh_calc, par[2]));
+  return fitval_pp;
+}
+
+void st_tw_resols(char*input_filename)
+
+{
+  TFile *df = new TFile(input_filename);
+  std::ofstream Time_resol;
+  Time_resol.open ("Time_resol.txt", std::ofstream::out);
+
+  //*****************************************************************
+  //*********** Grab the histograms from the root file **************
+  //*****************************************************************
+  for (unsigned int j = 0; j < 30; j++)
+    {
+        t_fit_chan[j] = new TF1(Form("t_fit_chan_%i", j+1), "gaus", -2.0,2.0);
+        //t_fit_chan[j] = new TF1(Form("t_fit_chan_%i", j), "[0]*exp(-0.5*((x-[1])/[2])**2)", -2.0,2.0);
+        t_fit_chan[j]->SetParameters(1000,0.,0.3);
+	x[j]=j+1;
+	ex[j]=0.0;
+      //Create the canvas
+      TW_can[j] = new TCanvas( Form("TW_can_%i",j+1), "TW_can", 800, 600);
+      TW_can[j]->Divide(2, 2);
+	  
+      // Grab the histograms 
+      char* stt = Form("h_stt_chan_%i",j+1);
+      TH1I* h_st = (TH1I*) df->Get(stt);
+      char* stt_corr = Form("h1_st_corr_time_%i",j+1);
+      TH1I* h_st_cr = (TH1I*) df->Get(stt_corr);
+      char* h2_st_corr_vs_pp = Form("h2_st_corr_vs_pp_%i",j+1);
+      TH2I* h2_st_cr_pp = (TH2I*) df->Get(h2_st_corr_vs_pp);
+
+      //*****************************************************************
+      //*********** Plot 1D stt histos                 ******************
+      //*****************************************************************
+      TW_can[j]->cd(1);
+      gStyle->SetOptStat(10);
+      gStyle->SetErrorX(0); 
+      gPad->SetTicks();
+      gPad->SetGrid();
+      h_st->Draw();
+      h_st->GetXaxis()->SetRangeUser(-2.,2.);
+      //*****************************************************************
+      //*********** Plot 1D  histos for the Corrected stt ***************
+      //*****************************************************************
+      TW_can[j]->cd(2);
+      gStyle->SetOptStat(10);
+      gStyle->SetErrorX(0); 
+      gPad->SetTicks();
+      gPad->SetGrid();
+      h_st_cr->Draw();
+      h_st_cr->GetXaxis()->SetRangeUser(-2.,2.);
+      h_st_cr->Fit(t_fit_chan[j]);
+      sigma[j] =  t_fit_chan[j]->GetParameter(2);
+      Err[j] =  t_fit_chan[j]->GetParError(2);
+      Time_resol << x[j] << "\t" <<sigma[j]*1000 << "\t" << ex[j] << "\t" << Err[j]*1000 << endl;
+
+      //*****************************************************************
+      //*********** Plot 2D  histos the Corrected stt vs pp *************
+      //*****************************************************************
+      TW_can[j]->cd(3);
+      gStyle->SetOptStat(10);
+      gStyle->SetErrorX(0); 
+      gPad->SetTicks();
+      gPad->SetGrid();
+      h2_st_cr_pp->Draw("colz");
+      h2_st_cr_pp->GetXaxis()->SetRangeUser(120.,3500.);
+      h2_st_cr_pp->GetYaxis()->SetRangeUser(-2.0,2.0);
+    }
+  //*****************************************************************
+  //*********** Plot 1D  histos of the time resolution  *************
+  //*****************************************************************
+  Time_resol.close();
+  ifstream in;
+  in.open(Form("Time_resol.txt"));
+  float sector, t, es ,e;
+  TNtuple *ntuple = new TNtuple("ntuple","data from text file","sector:t:es:e");
+  ntuple->ReadFile("Time_resol.txt");
+  ntuple->Write();
+  in.close();
+  //Create the canvas
+  Time_can = new TCanvas( "Time_can", "Time_can", 800, 600);
+  Time_can->SetFillColor(41);
+  gStyle->SetOptFit(0111);
+  ntuple->Draw("sector:t:es:e");
+  TGraphErrors *gr=new TGraphErrors(ntuple->GetSelectedRows(),ntuple->GetV1(),ntuple->GetV2(),ntuple->GetV3(),ntuple->GetV4());
+  gr->Draw("AP");
+  gr->SetTitle("Time Resolution Vs Sector Number");
+  gr->GetXaxis()->SetTitle("Sector Number");
+  gr->GetYaxis()->SetTitle("Time Resolution (ps)");
+  gr->SetMarkerStyle(21);
+  gr->SetMarkerSize(3);
+  gr->SetMarkerColor(4);
+  gr->Fit("pol0");
+ 
+  
+}
+


### PR DESCRIPTION
ST time walk corrections for callibration challenge. The plugin uses USE_TIMEWALK_CORRECTION flag that is created in the hit factory to turn the corrections off for pass0. After pass0 the macro st_tw_fits.C will fit the histograms and creats the calibration constants. In pass1, these corrections will be applied to the data. the macro st_tw_resols.C will calculate the corrected time resolution.
