### PR TITLE
Select tags

### DIFF
--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -1400,8 +1400,22 @@ void DHistogramAction_DetectorPID::Initialize(JEventLoop* locEventLoop)
 
 	string locHistName, locHistTitle, locParticleROOTName;
 
+	string locTrackSelectionTag = "NotATag", locShowerSelectionTag = "NotATag";
+	if(gPARMS->Exists("COMBO:TRACK_SELECT_TAG"))
+		gPARMS->GetParameter("COMBO:TRACK_SELECT_TAG", locTrackSelectionTag);
+	if(gPARMS->Exists("COMBO:SHOWER_SELECT_TAG"))
+		gPARMS->GetParameter("COMBO:SHOWER_SELECT_TAG", locShowerSelectionTag);
+
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
+		//So: Default tag is "", User can set it to something else
+		//In here, if tag is "", get from gparms, if not, leave it alone
+			//If gparms value does not exist, set it to (and use) "PreSelect"
+		if(dTrackSelectionTag == "NotATag")
+			dTrackSelectionTag = (locTrackSelectionTag == "NotATag") ? "PreSelect" : locTrackSelectionTag;
+		if(dShowerSelectionTag == "NotATag")
+			dShowerSelectionTag = (locShowerSelectionTag == "NotATag") ? "PreSelect" : locShowerSelectionTag;
+
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
 			//If another thread has already created the folder, it just changes to it.
 		CreateAndChangeTo_ActionDirectory();
@@ -1700,10 +1714,10 @@ bool DHistogramAction_DetectorPID::Perform_Action(JEventLoop* locEventLoop, cons
 		return true;
 
 	vector<const DChargedTrack*> locChargedTracks;
-	locEventLoop->Get(locChargedTracks, "PreSelect");
+	locEventLoop->Get(locChargedTracks, dTrackSelectionTag.c_str());
 
 	vector<const DNeutralParticle*> locNeutralParticles;
-	locEventLoop->Get(locNeutralParticles, "PreSelect");
+	locEventLoop->Get(locNeutralParticles, dShowerSelectionTag.c_str());
 
 	const DDetectorMatches* locDetectorMatches = NULL;
 	locEventLoop->GetSingle(locDetectorMatches);
@@ -2018,8 +2032,18 @@ void DHistogramAction_DetectorMatchParams::Initialize(JEventLoop* locEventLoop)
 	double locTargetZCenter = 0.0;
 	locGeometry->GetTargetZ(locTargetZCenter);
 
+	string locTrackSelectionTag = "NotATag";
+	if(gPARMS->Exists("COMBO:TRACK_SELECT_TAG"))
+		gPARMS->GetParameter("COMBO:TRACK_SELECT_TAG", locTrackSelectionTag);
+
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
+		//So: Default tag is "", User can set it to something else
+		//In here, if tag is "", get from gparms, if not, leave it alone
+			//If gparms value does not exist, set it to (and use) "PreSelect"
+		if(dTrackSelectionTag == "NotATag")
+			dTrackSelectionTag = (locTrackSelectionTag == "NotATag") ? "PreSelect" : locTrackSelectionTag;
+
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
 			//If another thread has already created the folder, it just changes to it.
 		CreateAndChangeTo_ActionDirectory();
@@ -2127,7 +2151,7 @@ bool DHistogramAction_DetectorMatchParams::Perform_Action(JEventLoop* locEventLo
 void DHistogramAction_DetectorMatchParams::Fill_Hists(JEventLoop* locEventLoop, bool locUseTruePIDFlag)
 {
 	vector<const DChargedTrack*> locChargedTracks;
-	locEventLoop->Get(locChargedTracks, "PreSelect");
+	locEventLoop->Get(locChargedTracks, dTrackSelectionTag.c_str());
 
 	vector<const DMCThrownMatching*> locMCThrownMatchingVector;
 	locEventLoop->Get(locMCThrownMatchingVector);
@@ -2215,9 +2239,18 @@ void DHistogramAction_EventVertex::Initialize(JEventLoop* locEventLoop)
 {
 	string locHistName, locHistTitle;
 
-	//CREATE THE HISTOGRAMS
+	string locTrackSelectionTag = "NotATag";
+	if(gPARMS->Exists("COMBO:TRACK_SELECT_TAG"))
+		gPARMS->GetParameter("COMBO:TRACK_SELECT_TAG", locTrackSelectionTag);
+
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
+		//So: Default tag is "", User can set it to something else
+		//In here, if tag is "", get from gparms, if not, leave it alone
+			//If gparms value does not exist, set it to (and use) "PreSelect"
+		if(dTrackSelectionTag == "NotATag")
+			dTrackSelectionTag = (locTrackSelectionTag == "NotATag") ? "PreSelect" : locTrackSelectionTag;
+
 		CreateAndChangeTo_ActionDirectory();
 
 		// Event RF Bunch Time
@@ -2326,7 +2359,7 @@ bool DHistogramAction_EventVertex::Perform_Action(JEventLoop* locEventLoop, cons
 	locEventLoop->GetSingle(locVertex);
 
 	vector<const DChargedTrack*> locChargedTracks;
-	locEventLoop->Get(locChargedTracks, "PreSelect");
+	locEventLoop->Get(locChargedTracks, dTrackSelectionTag.c_str());
 
 	const DDetectorMatches* locDetectorMatches = NULL;
 	locEventLoop->GetSingle(locDetectorMatches);
@@ -2424,9 +2457,22 @@ void DHistogramAction_DetectedParticleKinematics::Initialize(JEventLoop* locEven
 	string locHistName, locHistTitle, locParticleName, locParticleROOTName;
 	Particle_t locPID;
 
-	//CREATE THE HISTOGRAMS
+	string locTrackSelectionTag = "NotATag", locShowerSelectionTag = "NotATag";
+	if(gPARMS->Exists("COMBO:TRACK_SELECT_TAG"))
+		gPARMS->GetParameter("COMBO:TRACK_SELECT_TAG", locTrackSelectionTag);
+	if(gPARMS->Exists("COMBO:SHOWER_SELECT_TAG"))
+		gPARMS->GetParameter("COMBO:SHOWER_SELECT_TAG", locShowerSelectionTag);
+
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
+		//So: Default tag is "", User can set it to something else
+		//In here, if tag is "", get from gparms, if not, leave it alone
+			//If gparms value does not exist, set it to (and use) "PreSelect"
+		if(dTrackSelectionTag == "NotATag")
+			dTrackSelectionTag = (locTrackSelectionTag == "NotATag") ? "PreSelect" : locTrackSelectionTag;
+		if(dShowerSelectionTag == "NotATag")
+			dShowerSelectionTag = (locShowerSelectionTag == "NotATag") ? "PreSelect" : locShowerSelectionTag;
+
 		CreateAndChangeTo_ActionDirectory();
 
 		// Beam Particle
@@ -2539,7 +2585,7 @@ bool DHistogramAction_DetectedParticleKinematics::Perform_Action(JEventLoop* loc
 	japp->RootUnLock();
 
 	vector<const DChargedTrack*> locPreSelectChargedTracks;
-	locEventLoop->Get(locPreSelectChargedTracks, "PreSelect");
+	locEventLoop->Get(locPreSelectChargedTracks, dTrackSelectionTag.c_str());
 
 	for(size_t loc_i = 0; loc_i < locPreSelectChargedTracks.size(); ++loc_i)
 	{
@@ -2596,7 +2642,7 @@ bool DHistogramAction_DetectedParticleKinematics::Perform_Action(JEventLoop* loc
 	locEventLoop->Get(locNeutralParticles);
 
 	vector<const DNeutralShower*> locNeutralShowers;
-	locEventLoop->Get(locNeutralShowers, "PreSelect");
+	locEventLoop->Get(locNeutralShowers, dShowerSelectionTag.c_str());
 
 	for(size_t loc_i = 0; loc_i < locNeutralShowers.size(); ++loc_i)
 	{
@@ -3004,9 +3050,22 @@ bool DHistogramAction_NumReconstructedObjects::Perform_Action(JEventLoop* locEve
 
 void DHistogramAction_TrackMultiplicity::Initialize(JEventLoop* locEventLoop)
 {
-	//CREATE THE HISTOGRAMS
+	string locTrackSelectionTag = "NotATag", locShowerSelectionTag = "NotATag";
+	if(gPARMS->Exists("COMBO:TRACK_SELECT_TAG"))
+		gPARMS->GetParameter("COMBO:TRACK_SELECT_TAG", locTrackSelectionTag);
+	if(gPARMS->Exists("COMBO:SHOWER_SELECT_TAG"))
+		gPARMS->GetParameter("COMBO:SHOWER_SELECT_TAG", locShowerSelectionTag);
+
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
+		//So: Default tag is "", User can set it to something else
+		//In here, if tag is "", get from gparms, if not, leave it alone
+			//If gparms value does not exist, set it to (and use) "PreSelect"
+		if(dTrackSelectionTag == "NotATag")
+			dTrackSelectionTag = (locTrackSelectionTag == "NotATag") ? "PreSelect" : locTrackSelectionTag;
+		if(dShowerSelectionTag == "NotATag")
+			dShowerSelectionTag = (locShowerSelectionTag == "NotATag") ? "PreSelect" : locShowerSelectionTag;
+
 		CreateAndChangeTo_ActionDirectory();
 
 		string locHistName("NumReconstructedParticles");
@@ -3060,7 +3119,7 @@ bool DHistogramAction_TrackMultiplicity::Perform_Action(JEventLoop* locEventLoop
 	locEventLoop->Get(locChargedTracks);
 
 	vector<const DChargedTrack*> locGoodChargedTracks;
-	locEventLoop->Get(locGoodChargedTracks, "PreSelect");
+	locEventLoop->Get(locGoodChargedTracks, dTrackSelectionTag.c_str());
 
 	// get #tracks by PID/q type 
 	size_t locNumPositiveTracks = 0, locNumNegativeTracks = 0; 
@@ -3109,7 +3168,7 @@ bool DHistogramAction_TrackMultiplicity::Perform_Action(JEventLoop* locEventLoop
 	locEventLoop->Get(locNeutralParticles);
 
 	vector<const DNeutralShower*> locGoodNeutralShowers;
-	locEventLoop->Get(locGoodNeutralShowers, "PreSelect");
+	locEventLoop->Get(locGoodNeutralShowers, dShowerSelectionTag.c_str());
 
 	// neutrals by pid
 	for(size_t loc_i = 0; loc_i < locNeutralParticles.size(); ++loc_i)

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.h
@@ -449,7 +449,7 @@ class DHistogramAction_DetectorMatchParams : public DAnalysisAction
 		dNumShowerEnergyBins(800), dNumShowerDepthBins(400), dNum2DPBins(250), dNum2DThetaBins(280), dNum2DHitEnergyBins(250),
 		dMinShowerEnergy(0.0), dMaxShowerEnergy(8.0), dMaxBCALP(1.5), dMinShowerDepth(0.0), dMaxShowerDepth(20.0), dMinP(0.0), dMaxP(10.0), 
 		dMinTheta(0.0), dMaxTheta(140.0), dMinHitEnergy(0.0), dMaxHitEnergy(50.0), dNum2DPhiBins(360), dMinPhi(-180.0), dMaxPhi(180.0),
-		dTrackSelectionTag("")
+		dTrackSelectionTag("NotATag")
 		{
 			dTrackingPIDs.push_back(PiPlus);  dTrackingPIDs.push_back(KPlus);  dTrackingPIDs.push_back(Proton);
 			dTrackingPIDs.push_back(PiMinus);  dTrackingPIDs.push_back(KMinus);
@@ -461,7 +461,7 @@ class DHistogramAction_DetectorMatchParams : public DAnalysisAction
 		dNumShowerEnergyBins(800), dNumShowerDepthBins(400), dNum2DPBins(250), dNum2DThetaBins(280), dNum2DHitEnergyBins(250),
 		dMinShowerEnergy(0.0), dMaxShowerEnergy(8.0), dMaxBCALP(1.5), dMinShowerDepth(0.0), dMaxShowerDepth(20.0), dMinP(0.0), dMaxP(10.0), 
 		dMinTheta(0.0), dMaxTheta(140.0), dMinHitEnergy(0.0), dMaxHitEnergy(50.0), dNum2DPhiBins(360), dMinPhi(-180.0), dMaxPhi(180.0),
-		dTrackSelectionTag("")
+		dTrackSelectionTag("NotATag")
 		{
 			dTrackingPIDs.push_back(PiPlus);  dTrackingPIDs.push_back(KPlus);  dTrackingPIDs.push_back(Proton);
 			dTrackingPIDs.push_back(PiMinus);  dTrackingPIDs.push_back(KMinus);
@@ -473,7 +473,7 @@ class DHistogramAction_DetectorMatchParams : public DAnalysisAction
 		dNumShowerEnergyBins(800), dNumShowerDepthBins(400), dNum2DPBins(250), dNum2DThetaBins(280), dNum2DHitEnergyBins(250),
 		dMinShowerEnergy(0.0), dMaxShowerEnergy(8.0), dMaxBCALP(1.5), dMinShowerDepth(0.0), dMaxShowerDepth(20.0), dMinP(0.0), dMaxP(10.0), 
 		dMinTheta(0.0), dMaxTheta(140.0), dMinHitEnergy(0.0), dMaxHitEnergy(50.0), dNum2DPhiBins(360), dMinPhi(-180.0), dMaxPhi(180.0),
-		dTrackSelectionTag("")
+		dTrackSelectionTag("NotATag")
 		{
 			dTrackingPIDs.push_back(PiPlus);  dTrackingPIDs.push_back(KPlus);  dTrackingPIDs.push_back(Proton);
 			dTrackingPIDs.push_back(PiMinus);  dTrackingPIDs.push_back(KMinus);
@@ -518,7 +518,7 @@ class DHistogramAction_EventVertex : public DAnalysisAction
 		DAnalysisAction(locReaction, "Hist_EventVertex", false, locActionUniqueString), 
 		dNumConfidenceLevelBins(400), dNumPullBins(200), dNumVertexZBins(600), dNumTBins(400), dNumRFTBins(300), dNumVertexXYBins(400),
 		dMinVertexZ(0.0), dMaxVertexZ(200.0), dMinT(-20.0), dMaxT(20.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0), 
-		dMinPull(-4.0), dMaxPull(4.0), dPullHistConfidenceLevelCut(0.05), dTrackSelectionTag("")
+		dMinPull(-4.0), dMaxPull(4.0), dPullHistConfidenceLevelCut(0.05), dTrackSelectionTag("NotATag")
 		{
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(Proton);  dFinalStatePIDs.push_back(PiMinus);
 		}
@@ -527,7 +527,7 @@ class DHistogramAction_EventVertex : public DAnalysisAction
 		DAnalysisAction(NULL, "Hist_EventVertex", false, locActionUniqueString), 
 		dNumConfidenceLevelBins(400), dNumPullBins(200), dNumVertexZBins(600), dNumTBins(400), dNumRFTBins(300), dNumVertexXYBins(400),
 		dMinVertexZ(0.0), dMaxVertexZ(200.0), dMinT(-20.0), dMaxT(20.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0), 
-		dMinPull(-4.0), dMaxPull(4.0), dPullHistConfidenceLevelCut(0.05), dTrackSelectionTag("")
+		dMinPull(-4.0), dMaxPull(4.0), dPullHistConfidenceLevelCut(0.05), dTrackSelectionTag("NotATag")
 		{
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(Proton);  dFinalStatePIDs.push_back(PiMinus);
 		}
@@ -536,7 +536,7 @@ class DHistogramAction_EventVertex : public DAnalysisAction
 		DAnalysisAction(NULL, "Hist_EventVertex", false, ""), 
 		dNumConfidenceLevelBins(400), dNumPullBins(200), dNumVertexZBins(600), dNumTBins(400), dNumRFTBins(300), dNumVertexXYBins(400),
 		dMinVertexZ(0.0), dMaxVertexZ(200.0), dMinT(-20.0), dMaxT(20.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0), 
-		dMinPull(-4.0), dMaxPull(4.0), dPullHistConfidenceLevelCut(0.05), dTrackSelectionTag("")
+		dMinPull(-4.0), dMaxPull(4.0), dPullHistConfidenceLevelCut(0.05), dTrackSelectionTag("NotATag")
 		{
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(Proton);  dFinalStatePIDs.push_back(PiMinus);
 		}

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.h
@@ -316,7 +316,7 @@ class DHistogramAction_DetectorPID : public DAnalysisAction
 		dNum2DDeltaBetaBins(400), dNum2DDeltadEdxBins(300), dNum2DDeltaTBins(400), dNum2DPullBins(200), dNum2DFOMBins(200), dMinP(0.0), dMaxP(10.0), dMaxBCALP(3.0), 
 		dMindEdX(0.0), dMaxdEdX(25.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinBCALTheta(10.0), dMaxBCALTheta(140.0), dMinFCALTheta(0.0), dMaxFCALTheta(12.0), 
 		dMinEOverP(0.0), dMaxEOverP(4.0), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0), dMinDeltadEdx(-30.0), dMaxDeltadEdx(30.0), dMinDeltaT(-10.0), dMaxDeltaT(10.0), 
-		dMinPull(-10.0), dMaxPull(10.0)
+		dMinPull(-10.0), dMaxPull(10.0), dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
 			dFinalStatePIDs.push_back(PiMinus);  dFinalStatePIDs.push_back(KMinus);
@@ -328,7 +328,7 @@ class DHistogramAction_DetectorPID : public DAnalysisAction
 		dNum2DDeltaBetaBins(400), dNum2DDeltadEdxBins(300), dNum2DDeltaTBins(400), dNum2DPullBins(200), dNum2DFOMBins(200), dMinP(0.0), dMaxP(10.0), dMaxBCALP(3.0), 
 		dMindEdX(0.0), dMaxdEdX(25.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinBCALTheta(10.0), dMaxBCALTheta(140.0), dMinFCALTheta(0.0), dMaxFCALTheta(12.0), 
 		dMinEOverP(0.0), dMaxEOverP(4.0), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0), dMinDeltadEdx(-30.0), dMaxDeltadEdx(30.0), dMinDeltaT(-10.0), dMaxDeltaT(10.0), 
-		dMinPull(-10.0), dMaxPull(10.0)
+		dMinPull(-10.0), dMaxPull(10.0), dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
 			dFinalStatePIDs.push_back(PiMinus);  dFinalStatePIDs.push_back(KMinus);
@@ -340,7 +340,7 @@ class DHistogramAction_DetectorPID : public DAnalysisAction
 		dNum2DDeltaBetaBins(400), dNum2DDeltadEdxBins(300), dNum2DDeltaTBins(400), dNum2DPullBins(200), dNum2DFOMBins(200), dMinP(0.0), dMaxP(10.0), dMaxBCALP(3.0), 
 		dMindEdX(0.0), dMaxdEdX(25.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinBCALTheta(10.0), dMaxBCALTheta(140.0), dMinFCALTheta(0.0), dMaxFCALTheta(12.0), 
 		dMinEOverP(0.0), dMaxEOverP(4.0), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0), dMinDeltadEdx(-30.0), dMaxDeltadEdx(30.0), dMinDeltaT(-10.0), dMaxDeltaT(10.0), 
-		dMinPull(-10.0), dMaxPull(10.0)
+		dMinPull(-10.0), dMaxPull(10.0), dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
 			dFinalStatePIDs.push_back(PiMinus);  dFinalStatePIDs.push_back(KMinus);
@@ -352,6 +352,7 @@ class DHistogramAction_DetectorPID : public DAnalysisAction
 		unsigned int dNum2DEOverPBins, dNum2DDeltaBetaBins, dNum2DDeltadEdxBins, dNum2DDeltaTBins, dNum2DPullBins, dNum2DFOMBins;
 		double dMinP, dMaxP, dMaxBCALP, dMindEdX, dMaxdEdX, dMinBeta, dMaxBeta, dMinBCALTheta, dMaxBCALTheta, dMinFCALTheta, dMaxFCALTheta;
 		double dMinEOverP, dMaxEOverP, dMinDeltaBeta, dMaxDeltaBeta, dMinDeltadEdx, dMaxDeltadEdx, dMinDeltaT, dMaxDeltaT, dMinPull, dMaxPull;
+		string dTrackSelectionTag, dShowerSelectionTag; //In Initialize, will default to "PreSelect" unless otherwise specified
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo = NULL);
@@ -447,7 +448,8 @@ class DHistogramAction_DetectorMatchParams : public DAnalysisAction
 		DAnalysisAction(locReaction, "Hist_DetectorMatchParams", false, locActionUniqueString),
 		dNumShowerEnergyBins(800), dNumShowerDepthBins(400), dNum2DPBins(250), dNum2DThetaBins(280), dNum2DHitEnergyBins(250),
 		dMinShowerEnergy(0.0), dMaxShowerEnergy(8.0), dMaxBCALP(1.5), dMinShowerDepth(0.0), dMaxShowerDepth(20.0), dMinP(0.0), dMaxP(10.0), 
-		dMinTheta(0.0), dMaxTheta(140.0), dMinHitEnergy(0.0), dMaxHitEnergy(50.0), dNum2DPhiBins(360), dMinPhi(-180.0), dMaxPhi(180.0)
+		dMinTheta(0.0), dMaxTheta(140.0), dMinHitEnergy(0.0), dMaxHitEnergy(50.0), dNum2DPhiBins(360), dMinPhi(-180.0), dMaxPhi(180.0),
+		dTrackSelectionTag("")
 		{
 			dTrackingPIDs.push_back(PiPlus);  dTrackingPIDs.push_back(KPlus);  dTrackingPIDs.push_back(Proton);
 			dTrackingPIDs.push_back(PiMinus);  dTrackingPIDs.push_back(KMinus);
@@ -458,7 +460,8 @@ class DHistogramAction_DetectorMatchParams : public DAnalysisAction
 		DAnalysisAction(NULL, "Hist_DetectorMatchParams", false, locActionUniqueString),
 		dNumShowerEnergyBins(800), dNumShowerDepthBins(400), dNum2DPBins(250), dNum2DThetaBins(280), dNum2DHitEnergyBins(250),
 		dMinShowerEnergy(0.0), dMaxShowerEnergy(8.0), dMaxBCALP(1.5), dMinShowerDepth(0.0), dMaxShowerDepth(20.0), dMinP(0.0), dMaxP(10.0), 
-		dMinTheta(0.0), dMaxTheta(140.0), dMinHitEnergy(0.0), dMaxHitEnergy(50.0), dNum2DPhiBins(360), dMinPhi(-180.0), dMaxPhi(180.0)
+		dMinTheta(0.0), dMaxTheta(140.0), dMinHitEnergy(0.0), dMaxHitEnergy(50.0), dNum2DPhiBins(360), dMinPhi(-180.0), dMaxPhi(180.0),
+		dTrackSelectionTag("")
 		{
 			dTrackingPIDs.push_back(PiPlus);  dTrackingPIDs.push_back(KPlus);  dTrackingPIDs.push_back(Proton);
 			dTrackingPIDs.push_back(PiMinus);  dTrackingPIDs.push_back(KMinus);
@@ -469,7 +472,8 @@ class DHistogramAction_DetectorMatchParams : public DAnalysisAction
 		DAnalysisAction(NULL, "Hist_DetectorMatchParams", false, ""),
 		dNumShowerEnergyBins(800), dNumShowerDepthBins(400), dNum2DPBins(250), dNum2DThetaBins(280), dNum2DHitEnergyBins(250),
 		dMinShowerEnergy(0.0), dMaxShowerEnergy(8.0), dMaxBCALP(1.5), dMinShowerDepth(0.0), dMaxShowerDepth(20.0), dMinP(0.0), dMaxP(10.0), 
-		dMinTheta(0.0), dMaxTheta(140.0), dMinHitEnergy(0.0), dMaxHitEnergy(50.0), dNum2DPhiBins(360), dMinPhi(-180.0), dMaxPhi(180.0)
+		dMinTheta(0.0), dMaxTheta(140.0), dMinHitEnergy(0.0), dMaxHitEnergy(50.0), dNum2DPhiBins(360), dMinPhi(-180.0), dMaxPhi(180.0),
+		dTrackSelectionTag("")
 		{
 			dTrackingPIDs.push_back(PiPlus);  dTrackingPIDs.push_back(KPlus);  dTrackingPIDs.push_back(Proton);
 			dTrackingPIDs.push_back(PiMinus);  dTrackingPIDs.push_back(KMinus);
@@ -481,6 +485,7 @@ class DHistogramAction_DetectorMatchParams : public DAnalysisAction
 		unsigned int dNumShowerEnergyBins, dNumShowerDepthBins, dNum2DPBins, dNum2DThetaBins, dNum2DHitEnergyBins;
 		double dMinShowerEnergy, dMaxShowerEnergy, dMaxBCALP, dMinShowerDepth, dMaxShowerDepth, dMinP, dMaxP;
 		double dMinTheta, dMaxTheta, dMinHitEnergy, dMaxHitEnergy, dNum2DPhiBins, dMinPhi, dMaxPhi;
+		string dTrackSelectionTag; //In Initialize, will default to "PreSelect" unless otherwise specified
 
 		vector<Particle_t> dTrackingPIDs;
 
@@ -513,7 +518,7 @@ class DHistogramAction_EventVertex : public DAnalysisAction
 		DAnalysisAction(locReaction, "Hist_EventVertex", false, locActionUniqueString), 
 		dNumConfidenceLevelBins(400), dNumPullBins(200), dNumVertexZBins(600), dNumTBins(400), dNumRFTBins(300), dNumVertexXYBins(400),
 		dMinVertexZ(0.0), dMaxVertexZ(200.0), dMinT(-20.0), dMaxT(20.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0), 
-		dMinPull(-4.0), dMaxPull(4.0), dPullHistConfidenceLevelCut(0.05)
+		dMinPull(-4.0), dMaxPull(4.0), dPullHistConfidenceLevelCut(0.05), dTrackSelectionTag("")
 		{
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(Proton);  dFinalStatePIDs.push_back(PiMinus);
 		}
@@ -522,7 +527,7 @@ class DHistogramAction_EventVertex : public DAnalysisAction
 		DAnalysisAction(NULL, "Hist_EventVertex", false, locActionUniqueString), 
 		dNumConfidenceLevelBins(400), dNumPullBins(200), dNumVertexZBins(600), dNumTBins(400), dNumRFTBins(300), dNumVertexXYBins(400),
 		dMinVertexZ(0.0), dMaxVertexZ(200.0), dMinT(-20.0), dMaxT(20.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0), 
-		dMinPull(-4.0), dMaxPull(4.0), dPullHistConfidenceLevelCut(0.05)
+		dMinPull(-4.0), dMaxPull(4.0), dPullHistConfidenceLevelCut(0.05), dTrackSelectionTag("")
 		{
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(Proton);  dFinalStatePIDs.push_back(PiMinus);
 		}
@@ -531,7 +536,7 @@ class DHistogramAction_EventVertex : public DAnalysisAction
 		DAnalysisAction(NULL, "Hist_EventVertex", false, ""), 
 		dNumConfidenceLevelBins(400), dNumPullBins(200), dNumVertexZBins(600), dNumTBins(400), dNumRFTBins(300), dNumVertexXYBins(400),
 		dMinVertexZ(0.0), dMaxVertexZ(200.0), dMinT(-20.0), dMaxT(20.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0), 
-		dMinPull(-4.0), dMaxPull(4.0), dPullHistConfidenceLevelCut(0.05)
+		dMinPull(-4.0), dMaxPull(4.0), dPullHistConfidenceLevelCut(0.05), dTrackSelectionTag("")
 		{
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(Proton);  dFinalStatePIDs.push_back(PiMinus);
 		}
@@ -540,6 +545,7 @@ class DHistogramAction_EventVertex : public DAnalysisAction
 		double dMinVertexZ, dMaxVertexZ, dMinT, dMaxT, dMinVertexXY, dMaxVertexXY, dMinPull, dMaxPull;
 
 		double dPullHistConfidenceLevelCut;
+		string dTrackSelectionTag; //In Initialize, will default to "PreSelect" unless otherwise specified
 
 		deque<Particle_t> dFinalStatePIDs;
 
@@ -569,7 +575,8 @@ class DHistogramAction_DetectedParticleKinematics : public DAnalysisAction
 		dMinPIDFOM(5.73303E-7), dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400),
 		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180),
 		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
-		dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0)
+		dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0),
+		dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
 			dFinalStatePIDs.push_back(Gamma);
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
@@ -581,7 +588,8 @@ class DHistogramAction_DetectedParticleKinematics : public DAnalysisAction
 		dMinPIDFOM(5.73303E-7), dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400),
 		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180),
 		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
-		dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0)
+		dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0),
+		dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
 			dFinalStatePIDs.push_back(Gamma);
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
@@ -593,7 +601,8 @@ class DHistogramAction_DetectedParticleKinematics : public DAnalysisAction
 		dMinPIDFOM(5.73303E-7), dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400),
 		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180),
 		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
-		dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0)
+		dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0),
+		dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
 			dFinalStatePIDs.push_back(Gamma);
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
@@ -605,6 +614,7 @@ class DHistogramAction_DetectedParticleKinematics : public DAnalysisAction
 		unsigned int dNum2DThetaBins, dNum2DPhiBins;
 		double dMinT, dMaxT, dMinP, dMaxP, dMinTheta, dMaxTheta, dMinPhi, dMaxPhi, dMinVertexZ, dMaxVertexZ, dMinVertexXY, dMaxVertexXY, dMinBeta;
 		double dMaxBeta, dMinDeltaBeta, dMaxDeltaBeta;
+		string dTrackSelectionTag, dShowerSelectionTag; //In Initialize, will default to "PreSelect" unless otherwise specified
 
 		deque<Particle_t> dFinalStatePIDs;
 
@@ -705,7 +715,8 @@ class DHistogramAction_TrackMultiplicity : public DAnalysisAction
 	public:
 		DHistogramAction_TrackMultiplicity(const DReaction* locReaction, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Hist_TrackMultiplicity", false, locActionUniqueString),
-		dMaxNumTracks(40), dMinTrackingFOM(0.0027), dMinPIDFOM(5.73303E-7), dRequireDetectorMatchFlag(true)
+		dMaxNumTracks(40), dMinTrackingFOM(0.0027), dMinPIDFOM(5.73303E-7), dRequireDetectorMatchFlag(true),
+		dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
 			dFinalStatePIDs.push_back(Gamma);
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
@@ -714,7 +725,8 @@ class DHistogramAction_TrackMultiplicity : public DAnalysisAction
 
 		DHistogramAction_TrackMultiplicity(string locActionUniqueString) : 
 		DAnalysisAction(NULL, "Hist_TrackMultiplicity", false, ""),
-		dMaxNumTracks(40), dMinTrackingFOM(0.0027), dMinPIDFOM(5.73303E-7), dRequireDetectorMatchFlag(true)
+		dMaxNumTracks(40), dMinTrackingFOM(0.0027), dMinPIDFOM(5.73303E-7), dRequireDetectorMatchFlag(true),
+		dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
 			dFinalStatePIDs.push_back(Gamma);
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
@@ -723,7 +735,8 @@ class DHistogramAction_TrackMultiplicity : public DAnalysisAction
 
 		DHistogramAction_TrackMultiplicity(void) : 
 		DAnalysisAction(NULL, "Hist_TrackMultiplicity", false, ""),
-		dMaxNumTracks(40), dMinTrackingFOM(0.0027), dMinPIDFOM(5.73303E-7), dRequireDetectorMatchFlag(true)
+		dMaxNumTracks(40), dMinTrackingFOM(0.0027), dMinPIDFOM(5.73303E-7), dRequireDetectorMatchFlag(true),
+		dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
 			dFinalStatePIDs.push_back(Gamma);
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
@@ -734,6 +747,7 @@ class DHistogramAction_TrackMultiplicity : public DAnalysisAction
 		double dMinTrackingFOM;
 		double dMinPIDFOM;
 		bool dRequireDetectorMatchFlag;
+		string dTrackSelectionTag, dShowerSelectionTag; //In Initialize, will default to "PreSelect" unless otherwise specified
 
 		deque<Particle_t> dFinalStatePIDs;
 

--- a/src/libraries/PID/DMCReaction.h
+++ b/src/libraries/PID/DMCReaction.h
@@ -28,7 +28,7 @@ class DMCReaction:public JObject{
 			AddString(items, "type", "%2d", type);
 			AddString(items, "weight", "%3.1f", weight);
 			AddString(items, "mass target(GeV)", "%3.1f", target.mass());
-			AddString(items, "mass beam(GeV)", "%3.1f", beam.mass());
+			AddString(items, "energy beam(GeV/c^2)", "%3.1f", beam.energy());
 		}
 
 	protected:


### PR DESCRIPTION
 Can now preselect factory tags in the independent analysis actions (e.g. monitoring). They also respect the command line arguments for the factory tags.

In DMCReaction, print beam energy rather than beam mass in toStrings function (hd_dump).
