### PR TITLE
Fix neutrons.

### DIFF
--- a/src/libraries/ANALYSIS/ANALYSIS_init.cc
+++ b/src/libraries/ANALYSIS/ANALYSIS_init.cc
@@ -112,6 +112,7 @@ jerror_t ANALYSIS_init(JEventLoop *loop)
 	DCutAction_BeamEnergy(NULL, false, 0.0, 0.0);
 	DCutAction_TrackFCALShowerEOverP(NULL, false, 0.0);
 	DCutAction_PIDDeltaT(NULL, false, 0.0);
+	DCutAction_PIDTimingBeta(NULL, 0.0, 0.0);
 	DCutAction_OneVertexKinFit(NULL);
 
 	return NOERROR;

--- a/src/libraries/ANALYSIS/DCutActions.cc
+++ b/src/libraries/ANALYSIS/DCutActions.cc
@@ -968,6 +968,36 @@ bool DCutAction_PIDDeltaT::Perform_Action(JEventLoop* locEventLoop, const DParti
 	return true;
 }
 
+string DCutAction_PIDTimingBeta::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dPID << "_" << dSystem << "_" << dMinBeta << "_" << dMaxBeta;
+	return locStream.str();
+}
+
+bool DCutAction_PIDTimingBeta::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+{
+	//if dPID = Unknown, apply cut to all PIDs
+	//if dSystem = SYS_NULL, apply cut to all systems
+
+	deque<const DKinematicData*> locParticles;
+	locParticleCombo->Get_DetectedFinalParticles_Measured(locParticles);
+
+	for(size_t loc_i = 0; loc_i < locParticles.size(); ++loc_i)
+	{
+		if((dPID != Unknown) && (locParticles[loc_i]->PID() != dPID))
+			continue;
+		if((dSystem != SYS_NULL) && (locParticles[loc_i]->t1_detector() != dSystem))
+			continue;
+
+		double locBeta = locParticles[loc_i]->measuredBeta();
+		if((locBeta < dMinBeta) || (locBeta > dMaxBeta))
+			return false;
+	}
+
+	return true;
+}
+
 void DCutAction_OneVertexKinFit::Initialize(JEventLoop* locEventLoop)
 {
 	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());

--- a/src/libraries/ANALYSIS/DCutActions.h
+++ b/src/libraries/ANALYSIS/DCutActions.h
@@ -58,6 +58,7 @@ DCutAction_ProtonPiPlusdEdx
 DCutAction_BeamEnergy
 DCutAction_TrackFCALShowerEOverP
 DCutAction_PIDDeltaT
+DCutAction_PIDTimingBeta
 
 DCutAction_OneVertexKinFit
 */
@@ -605,6 +606,31 @@ class DCutAction_PIDDeltaT : public DAnalysisAction
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 
 		double dDeltaTCut;
+		Particle_t dPID;
+		DetectorSystem_t dSystem;
+};
+
+class DCutAction_PIDTimingBeta : public DAnalysisAction
+{
+	//if dPID = Unknown, apply cut to all PIDs
+	//if dSystem = SYS_NULL, apply cut to all systems
+	//RECOMMENDED ONLY FOR CUTTING ON NEUTRALS (e.g. separating photons and neutrons)
+
+	public:
+
+		DCutAction_PIDTimingBeta(const DReaction* locReaction, double locMinBeta, double locMaxBeta, Particle_t locPID = Unknown, DetectorSystem_t locSystem = SYS_NULL, string locActionUniqueString = "") :
+		DAnalysisAction(locReaction, "Cut_PIDTimingBeta", false, locActionUniqueString),
+		dMinBeta(locMinBeta), dMaxBeta(locMaxBeta), dPID(locPID), dSystem(locSystem){}
+
+		void Initialize(JEventLoop* locEventLoop){};
+		string Get_ActionName(void) const;
+
+	private:
+
+		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
+
+		double dMinBeta;
+		double dMaxBeta;
 		Particle_t dPID;
 		DetectorSystem_t dSystem;
 };

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -77,7 +77,7 @@ class DHistogramAction_PID : public DAnalysisAction
 
 		DHistogramAction_PID(const DReaction* locReaction, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Hist_PID", false, locActionUniqueString), 
-		dNum2DPBins(250), dNum2DdEdxBins(400), dNum2DBetaBins(400), dNum2DBCALThetaBins(260), dNum2DFCALThetaBins(120), dNum2DThetaBins(280), 
+		dNum2DPBins(250), dNum2DdEdxBins(400), dNum2DBetaBins(400), dNum2DBCALThetaBins(260), dNum2DFCALThetaBins(120), dNum2DThetaBins(280), dNumBetaBins(700),
 		dNum2DEOverPBins(300), dNum2DDeltaBetaBins(400), dNum2DDeltadEdxBins(300), dNum2DDeltaTBins(400), dNum2DPullBins(200), dNumFOMBins(400), 
 		dNum2DFOMBins(200), dMinP(0.0), dMaxP(10.0), dMaxBCALP(3.0), dMindEdX(0.0), dMaxdEdX(25.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinBCALTheta(10.0), 
 		dMaxBCALTheta(140.0), dMinFCALTheta(0.0), dMaxFCALTheta(12.0), dMinTheta(0.0), dMaxTheta(140.0), dMinEOverP(0.0), dMaxEOverP(4.0), dMinDeltaBeta(-1.0), 
@@ -94,7 +94,7 @@ class DHistogramAction_PID : public DAnalysisAction
 
 		void Initialize(JEventLoop* locEventLoop);
 
-		unsigned int dNum2DPBins, dNum2DdEdxBins, dNum2DBetaBins, dNum2DBCALThetaBins, dNum2DFCALThetaBins, dNum2DThetaBins;
+		unsigned int dNum2DPBins, dNum2DdEdxBins, dNum2DBetaBins, dNum2DBCALThetaBins, dNum2DFCALThetaBins, dNum2DThetaBins, dNumBetaBins;
 		unsigned int dNum2DEOverPBins, dNum2DDeltaBetaBins, dNum2DDeltadEdxBins, dNum2DDeltaTBins, dNum2DPullBins, dNumFOMBins, dNum2DFOMBins;
 		double dMinP, dMaxP, dMaxBCALP, dMindEdX, dMaxdEdX, dMinBeta, dMaxBeta, dMinBCALTheta, dMaxBCALTheta, dMinFCALTheta, dMaxFCALTheta, dMinTheta, dMaxTheta;
 		double dMinEOverP, dMaxEOverP, dMinDeltaBeta, dMaxDeltaBeta, dMinDeltadEdx, dMaxDeltadEdx, dMinDeltaT, dMaxDeltaT, dMinPull, dMaxPull;
@@ -124,6 +124,8 @@ class DHistogramAction_PID : public DAnalysisAction
 		map<Particle_t, map<DetectorSystem_t, TH2I*> > dHistMap_DeltaTVsP;
 		map<Particle_t, map<DetectorSystem_t, TH2I*> > dHistMap_TimePullVsP;
 		map<Particle_t, map<DetectorSystem_t, TH2I*> > dHistMap_TimeFOMVsP;
+
+		map<Particle_t, map<DetectorSystem_t, TH1I*> > dHistMap_Beta; //for BCAL/FCAL neutrals only
 
 		map<Particle_t, TH1I*> dHistMap_PIDFOM; //overall
 


### PR DESCRIPTION
Fix bug that caused crash DHistogramAction_PID.
Add new action: DCutAction_PIDTimingBeta. Can be used to cut on the beta
derived from the timing. Since photons have beta = 1, this can be used
to separate photons from massive neutrals / junk.
