### PR TITLE
Bcal timing format

### DIFF
--- a/src/libraries/BCAL/DBCALHit_factory.cc
+++ b/src/libraries/BCAL/DBCALHit_factory.cc
@@ -262,10 +262,10 @@ void DBCALHit_factory::FillCalibTableShort( bcal_digi_constants_t &table,
     for (int module=1; module<=BCAL_NUM_MODULES; module++) {
         for (int layer=1; layer<=BCAL_NUM_LAYERS; layer++) {
             for (int sector=1; sector<=BCAL_NUM_SECTORS; sector++) {
-                if (channel > BCAL_MAX_CHANNELS) {  // sanity check
+                if (channel > BCAL_MAX_CHANNELS/2) {  // sanity check
                     sprintf(str, "Too many channels for BCAL table!"
                             " channel=%d (should be %d)",
-                            channel, BCAL_MAX_CHANNELS);
+                            channel, BCAL_MAX_CHANNELS/2);
                     cerr << str << endl;
                     throw JException(str);
                 }
@@ -282,10 +282,10 @@ void DBCALHit_factory::FillCalibTableShort( bcal_digi_constants_t &table,
     }
 
     // check to make sure that we loaded enough channels
-    if (channel != BCAL_MAX_CHANNELS) {
+    if (channel != BCAL_MAX_CHANNELS/2) {
         sprintf(str, "Not enough channels for BCAL table!"
                 " channel=%d (should be %d)",
-                channel, BCAL_MAX_CHANNELS);
+                channel, BCAL_MAX_CHANNELS/2);
         cerr << str << endl;
         throw JException(str);
     }

--- a/src/libraries/BCAL/DBCALHit_factory.cc
+++ b/src/libraries/BCAL/DBCALHit_factory.cc
@@ -49,6 +49,8 @@ jerror_t DBCALHit_factory::brun(jana::JEventLoop *eventLoop, int runnumber)
    vector<double> raw_gains;
    vector<double> raw_pedestals;
    vector<double> raw_time_offsets;
+   vector<double> raw_channel_global_offset;
+   vector<double> raw_tdiff_u_d;
 
     if(print_messages) jout << "In DBCALHit_factory, loading constants..." << endl;
    
@@ -89,6 +91,10 @@ jerror_t DBCALHit_factory::brun(jana::JEventLoop *eventLoop, int runnumber)
        jout << "Error loading /BCAL/ADC_pedestals !" << endl;
    if (eventLoop->GetCalib("/BCAL/ADC_timing_offsets", raw_time_offsets))
        jout << "Error loading /BCAL/ADC_timing_offsets !" << endl;
+   if(eventLoop->GetCalib("/BCAL/channel_global_offset", raw_channel_global_offset))
+       jout << "Error loading /BCAL/channel_global_offset !" << endl;
+   if(eventLoop->GetCalib("/BCAL/tdiff_u_d", raw_tdiff_u_d))
+       jout << "Error loading /BCAL/tdiff_u_d !" << endl;
 
    if (PRINTCALIBRATION) jout << "DBCALHit_factory >> raw_gains" << endl;
    FillCalibTable(gains, raw_gains);
@@ -96,6 +102,10 @@ jerror_t DBCALHit_factory::brun(jana::JEventLoop *eventLoop, int runnumber)
    FillCalibTable(pedestals, raw_pedestals);
    if (PRINTCALIBRATION) jout << "DBCALHit_factory >> raw_time_offsets" << endl;
    FillCalibTable(time_offsets, raw_time_offsets);
+   if (PRINTCALIBRATION) jout << "DBCALHit_factory >> raw_channel_global_offset" << endl;
+   FillCalibTableShort(channel_global_offset, raw_channel_global_offset);
+   if (PRINTCALIBRATION) jout << "DBCALHit_factory >> raw_tdiff_u_d" << endl;
+   FillCalibTableShort(tdiff_u_d, raw_tdiff_u_d);
 
    return NOERROR;
 }
@@ -154,7 +164,9 @@ jerror_t DBCALHit_factory::evnt(JEventLoop *loop, int eventnumber)
       int pulse_peak_pedsub = digihit->pulse_peak - digihit->pedestal / digihit->nsamples_pedestal;
       // Calculate time for channel
       double pulse_time        = (double)digihit->pulse_time;
-      double hit_t             = t_scale * pulse_time - GetConstant(time_offsets,digihit) + t_base;
+      double end_sign          = digihit->end ? -1.0 : 1.0; // Upstream = 0 -> Positive (then subtracted)
+      double hit_t             = t_scale * pulse_time + t_base - GetConstant(channel_global_offset,digihit) 
+                                    - (0.5 * end_sign) * GetConstant(tdiff_u_d,digihit);
 
       DBCALHit *hit = new DBCALHit;
       hit->module = digihit->module;
@@ -229,6 +241,50 @@ void DBCALHit_factory::FillCalibTable( bcal_digi_constants_t &table,
     if (channel != BCAL_MAX_CHANNELS) { 
         sprintf(str, "Not enough channels for BCAL table!"
                 " channel=%d (should be %d)", 
+                channel, BCAL_MAX_CHANNELS);
+        cerr << str << endl;
+        throw JException(str);
+    }
+}
+
+//------------------
+// FillCalibTableShort
+//------------------
+void DBCALHit_factory::FillCalibTableShort( bcal_digi_constants_t &table,
+        const vector<double> &raw_table)
+{
+    char str[256];
+    int channel = 0;
+
+    // reset the table before filling it
+    table.clear();
+
+    for (int module=1; module<=BCAL_NUM_MODULES; module++) {
+        for (int layer=1; layer<=BCAL_NUM_LAYERS; layer++) {
+            for (int sector=1; sector<=BCAL_NUM_SECTORS; sector++) {
+                if (channel > BCAL_MAX_CHANNELS) {  // sanity check
+                    sprintf(str, "Too many channels for BCAL table!"
+                            " channel=%d (should be %d)",
+                            channel, BCAL_MAX_CHANNELS);
+                    cerr << str << endl;
+                    throw JException(str);
+                }
+
+                table.push_back( cell_calib_t(raw_table[channel],raw_table[channel]) );
+
+                if (PRINTCALIBRATION) {
+                    printf("%2i  %2i  %2i   %.10f\n",module,layer,sector,raw_table[channel]);
+                }
+
+                channel += 1;
+            }
+        }
+    }
+
+    // check to make sure that we loaded enough channels
+    if (channel != BCAL_MAX_CHANNELS) {
+        sprintf(str, "Not enough channels for BCAL table!"
+                " channel=%d (should be %d)",
                 channel, BCAL_MAX_CHANNELS);
         cerr << str << endl;
         throw JException(str);

--- a/src/libraries/BCAL/DBCALHit_factory.h
+++ b/src/libraries/BCAL/DBCALHit_factory.h
@@ -50,7 +50,8 @@ class DBCALHit_factory:public jana::JFactory<DBCALHit>{
 		bcal_digi_constants_t gains;
 		bcal_digi_constants_t pedestals;
 		bcal_digi_constants_t time_offsets;
-
+        bcal_digi_constants_t channel_global_offset;
+        bcal_digi_constants_t tdiff_u_d;
 		
 		const int GetCalibIndex( int module, int layer, int sector ) const {
 			return BCAL_NUM_LAYERS*BCAL_NUM_SECTORS*(module-1) + BCAL_NUM_SECTORS*(layer-1) + (sector-1);
@@ -76,6 +77,8 @@ class DBCALHit_factory:public jana::JFactory<DBCALHit>{
 		
 		void FillCalibTable( bcal_digi_constants_t &table, 
 				     const vector<double> &raw_table);
+        void FillCalibTableShort( bcal_digi_constants_t &table,
+                    const vector<double> &raw_table);
 		    
 };
 

--- a/src/libraries/BCAL/DBCALTDCHit_factory.cc
+++ b/src/libraries/BCAL/DBCALTDCHit_factory.cc
@@ -220,13 +220,17 @@ void DBCALTDCHit_factory::FillCalibTableShort( bcal_digi_constants_t &table,
 
     // reset the table before filling it
     table.clear();
-
+    // These short tables have 768 values
     for(int module=1; module<=BCAL_NUM_MODULES; module++) {
-        for(int layer=1; layer<=BCAL_NUM_TDC_LAYERS; layer++) {
+        for(int layer=1; layer<=BCAL_NUM_LAYERS; layer++) {
             for(int sector=1; sector<=BCAL_NUM_SECTORS; sector++) {
-                if( channel > BCAL_MAX_TDC_CHANNELS ) {  // sanity check
+                if (layer == 4) {
+                    channel += 1;
+                    continue;
+                }
+                if( channel > BCAL_MAX_CHANNELS/2 ) {  // sanity check
                     sprintf(str, "Too many channels for BCAL table! channel=%d (should be %d)",
-                            channel, BCAL_MAX_TDC_CHANNELS);
+                            channel, BCAL_MAX_CHANNELS/2);
                     cerr << str << endl;
                     throw JException(str);
                 }
@@ -239,9 +243,9 @@ void DBCALTDCHit_factory::FillCalibTableShort( bcal_digi_constants_t &table,
     }
 
     // check to make sure that we loaded enough channels
-    if(channel != BCAL_MAX_TDC_CHANNELS) {
+    if(channel != BCAL_MAX_CHANNELS/2) {
         sprintf(str, "Not enough channels for BCAL table! channel=%d (should be %d)",
-                channel, BCAL_MAX_TDC_CHANNELS);
+                channel, BCAL_MAX_CHANNELS/2);
         cerr << str << endl;
         throw JException(str);
     }

--- a/src/libraries/BCAL/DBCALTDCHit_factory.h
+++ b/src/libraries/BCAL/DBCALTDCHit_factory.h
@@ -35,6 +35,8 @@ class DBCALTDCHit_factory:public jana::JFactory<DBCALTDCHit>{
 		int t_rollover;
 
 		bcal_digi_constants_t time_offsets;
+        bcal_digi_constants_t channel_global_offset;
+        bcal_digi_constants_t tdiff_u_d;
 
 		const int GetCalibIndex( int module, int layer, int sector ) const {
 			return BCAL_NUM_TDC_LAYERS*BCAL_NUM_SECTORS*(module-1) + BCAL_NUM_SECTORS*(layer-1) + (sector-1);
@@ -61,6 +63,8 @@ class DBCALTDCHit_factory:public jana::JFactory<DBCALTDCHit>{
 
 		void FillCalibTable( bcal_digi_constants_t &table, 
 				     const vector<double> &raw_table);
+        void FillCalibTableShort( bcal_digi_constants_t &table,
+                     const vector<double> &raw_table);
 };
 
 #endif // _DBCALTDCHit_factory_

--- a/src/libraries/BCAL/DBCALTDCHit_factory.h
+++ b/src/libraries/BCAL/DBCALTDCHit_factory.h
@@ -24,10 +24,12 @@ class DBCALTDCHit_factory:public jana::JFactory<DBCALTDCHit>{
 		// shortcut geometry factors
 		// these should really be taken from
 		// DBCALGeometry/DGeometry objects
-		static const int BCAL_NUM_MODULES  = 48;
-		static const int BCAL_NUM_TDC_LAYERS =  3;
-		static const int BCAL_NUM_SECTORS    =  4;
+		static const int BCAL_NUM_MODULES      =    48;
+		static const int BCAL_NUM_TDC_LAYERS   =     3;
+        static const int BCAL_NUM_LAYERS       =     4;
+        static const int BCAL_NUM_SECTORS      =     4;
 		static const int BCAL_MAX_TDC_CHANNELS =  1152;
+        static const int BCAL_MAX_CHANNELS     =  1536;
 
 		// overall scale factors
 		double t_scale;

--- a/src/plugins/Calibration/BCAL_TDC_Timing/FitScripts/ExtractTimeOffsetsAndCEff.C
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/FitScripts/ExtractTimeOffsetsAndCEff.C
@@ -47,13 +47,13 @@ void ExtractTimeOffsetsAndCEff(int run = 2931, TString filename = "hd_root.root"
 
     // Since we are updating existing constants we will need their current values. We can pipe them in from the CCDB...
     // We need a place to store them...
-    double tdc_offsets[1152];
-    double adc_offsets[1536];
+    double tdiff_u_d[768];
+    double channel_global_offset[768];
 
     //Pipe the current constants into this macro
     //NOTE: This dumps the "LATEST" values. If you need something else, modify this script.
     char command[100];
-    sprintf(command, "ccdb dump /BCAL/TDC_offsets:%i:default", run);
+    sprintf(command, "ccdb dump /BCAL/tdiff_u_d:%i:default", run);
     FILE* locInputFile = gSystem->OpenPipe(command, "r");
     if(locInputFile == NULL)
         return 0;
@@ -67,15 +67,15 @@ void ExtractTimeOffsetsAndCEff(int run = 2931, TString filename = "hd_root.root"
     while(fgets(buff, sizeof(buff), locInputFile) != NULL){
         istringstream locConstantsStream(buff);
         locConstantsStream >> time;
-        cout << "TDC Time Offset = " << time << endl;
-        tdc_offsets[counter] = time;
+        cout << "t_up - t_down = " << time << endl;
+        tdiff_u_d[counter] = time;
         counter++;
     }
-    if (counter != 1152) cout << "Wrong number of TDC entries (" << counter << " != 1152)?" << endl;
+    if (counter != 768) cout << "Wrong number of tdiff_u_d entries (" << counter << " != 768)?" << endl;
     //Close the pipe
     gSystem->ClosePipe(locInputFile);
 
-    sprintf(command, "ccdb dump /BCAL/ADC_timing_offsets:%i:default", run);
+    sprintf(command, "ccdb dump /BCAL/channel_global_offset:%i:default", run);
     locInputFile = gSystem->OpenPipe(command, "r");
     if(locInputFile == NULL)
         return 0;
@@ -88,19 +88,19 @@ void ExtractTimeOffsetsAndCEff(int run = 2931, TString filename = "hd_root.root"
     while(fgets(buff, sizeof(buff), locInputFile) != NULL){
         istringstream locConstantsStream(buff);
         locConstantsStream >> time;
-        cout << "ADC Time Offset = " << time << endl;
-        adc_offsets[counter] = time;
+        cout << "Channel Global Offset = " << time << endl;
+        channel_global_offset[counter] = time;
         counter++;
     }
-    if (counter != 1536) cout << "Wrong number of ADC entries (" << counter << " != 1536)?" << endl;
+    if (counter != 768) cout << "Wrong number of channel global offsets (" << counter << " != 768)?" << endl;
     //Close the pipe
     gSystem->ClosePipe(locInputFile);
 
     // This stream will be for outputting the results in a format suitable for the CCDB
     // Will wait to open until needed
-    ofstream adcOffsetFile, tdcOffsetFile;
-    adcOffsetFile.open("ADCOffsetsBCAL.txt");
-    tdcOffsetFile.open("TDCOffsetsBCAL.txt");
+    ofstream channel_global_offset_File, tdiff_u_d_File;
+    channel_global_offset_File.open("channel_global_offset_BCAL.txt");
+    tdiff_u_d_File.open("tdiff_u_d_BCAL.txt");
 
     // Declaration of the fit funtion
     TF1 *f1 = new TF1("f1", "[0]+[1]*x", -200, 200);
@@ -115,7 +115,6 @@ void ExtractTimeOffsetsAndCEff(int run = 2931, TString filename = "hd_root.root"
     TH2I *h2_c0_c1 = new TH2I("h2_c0_c1", "c_{1} Vs. c_{0}; c_{0}; c_{1}", 100, -15, 15, 100, 0.85, 1.15);
 
     // Fit the global offset histogram to get the per channel global offset
-    double globalOffset[768]; 
     TH1D * selectedBCALOffset = new TH1D("selectedBCALOffset", "Selected Global BCAL Offset; CCDB Index; Offset [ns]", 768, 0.5, 768 + 0.5);
     TH1I * BCALOffsetDistribution = new TH1I("BCALOffsetDistribution", "Global BCAL Offset; Global Offset [ns]; Entries", 100, -10, 10);
 
@@ -146,7 +145,7 @@ void ExtractTimeOffsetsAndCEff(int run = 2931, TString filename = "hd_root.root"
                     }
                 }
             }
-            globalOffset[i-1] = maxMean;
+            channel_global_offset_File <<  maxMean + channel_global_offset[i-1] << endl;;
             selectedBCALOffset->SetBinContent(i, maxMean);
             BCALOffsetDistribution->Fill(maxMean);
         }
@@ -187,36 +186,21 @@ void ExtractTimeOffsetsAndCEff(int run = 2931, TString filename = "hd_root.root"
                         h1_c0->Fill(c0); h1_c1->Fill(c1); h2_c0_c1->Fill(c0,c1); 
                         h1_c0_all->SetBinContent(the_cell, c0); h1_c0_all->SetBinError(the_cell, c0_err);
                         h1_c1_all->SetBinContent(the_cell, c1); h1_c1_all->SetBinError(the_cell, c1_err);
-                        adcOffsetFile << adc_offsets[(the_cell - 1) * 2] + 0.5 * c0 / C_eff + globalOffset[the_cell] << endl;
-                        adcOffsetFile << adc_offsets[ the_cell*2 - 1] - 0.5 * c0 / C_eff + globalOffset[the_cell] << endl;
-                        if (iLayer != 4){
-                            tdcOffsetFile << tdc_offsets[(the_tdc_cell - 1) * 2] + 0.5 * c0 / C_eff + globalOffset[the_cell] << endl;
-                            tdcOffsetFile << tdc_offsets[the_tdc_cell*2 - 1] - 0.5 * c0 / C_eff + globalOffset[the_cell] << endl;
-                        }
+                        tdiff_u_d_File << tdiff_u_d[the_cell - 1] + c0 / C_eff << endl;
                     }
                     else {
                         cout << "WARNING: Fit Status "<< fitStatus << " for Upstream " << name << endl;
-                        adcOffsetFile << adc_offsets[(the_cell - 1) * 2] + globalOffset[the_cell] << endl;
-                        adcOffsetFile << adc_offsets[the_cell*2 - 1] + globalOffset[the_cell] << endl;
-                        if (iLayer != 4){
-                            tdcOffsetFile << tdc_offsets[(the_tdc_cell - 1) * 2] + globalOffset[the_cell] << endl;
-                            tdcOffsetFile << tdc_offsets[the_tdc_cell*2 - 1] + globalOffset[the_cell] << endl;
-                        }
+                        tdiff_u_d_File << tdiff_u_d[the_cell - 1] << endl;
                     }
                 }
                 else{
-                    adcOffsetFile << adc_offsets[ (the_cell-1) * 2] + globalOffset[the_cell] << endl;
-                    adcOffsetFile << adc_offsets[  the_cell*2  - 1] + globalOffset[the_cell] << endl;
-                    if (iLayer != 4){
-                        tdcOffsetFile << tdc_offsets[(the_tdc_cell -1) * 2] + globalOffset[the_cell] << endl;
-                        tdcOffsetFile << tdc_offsets[ the_tdc_cell*2 - 1] + globalOffset[the_cell] << endl;
-                    }
+                    tdiff_u_d_File << tdiff_u_d[the_cell - 1] << endl;
                 }
             }
         }
     }
-    adcOffsetFile.close();
-    tdcOffsetFile.close();
+    channel_global_offset_File.close();
+    tdiff_u_d_File.close();
     outputFile->Write();
     thisFile->Close();
     return;


### PR DESCRIPTION
Refactor the BCAL timing to separate t_up-t_down and the global offset relative to the RF from the previous constant that contained all of the shifts. Necessary tables have been added to the CCDB.

Changed the code for extracting these constants in BCAL_TDC_Timing plugin to match the new format.
