### PR TITLE
Fix bug in histogramming neutral shower kinematics.

### DIFF
--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -2656,7 +2656,7 @@ bool DHistogramAction_DetectedParticleKinematics::Perform_Action(JEventLoop* loc
 		}
 		if(locNeutralParticle == NULL)
 			continue;
-		const DNeutralParticleHypothesis* locNeutralParticleHypothesis = locNeutralParticles[loc_i]->Get_Hypothesis(Gamma);
+		const DNeutralParticleHypothesis* locNeutralParticleHypothesis = locNeutralParticle->Get_Hypothesis(Gamma);
 		if(locNeutralParticleHypothesis->dFOM < dMinPIDFOM)
 			continue;
 

--- a/src/libraries/ANALYSIS/DHistogramActions_Thrown.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Thrown.cc
@@ -1125,7 +1125,7 @@ void DHistogramAction_GenReconTrackComparison::Initialize(JEventLoop* locEventLo
 				//Pull vs Theta
 				locHistName = locPullNames[loc_j] + string("PullVsTheta");
 				locHistTitle = locParticleROOTName + string(";#theta#circ;#Delta") + locPullTitles[loc_j] + string("/#sigma_{") + locPullTitles[loc_j] + string("} (Reconstructed - Thrown)");
-				dHistMap_PullsVsTheta[locPID][dPullTypes[loc_j]] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DPullBins, -10.0, 10.0);
+				dHistMap_PullsVsTheta[locPID][dPullTypes[loc_j]] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, dMaxTheta, dNum2DPullBins, -10.0, 10.0);
 			}
 
 			//Delta-t Pulls - CDC & ST


### PR DESCRIPTION
This is what was causing the apparent hole in the reconstructed FCAL beam photon distribution.
The photons are all there, just a bug in the histogramming.
Also, fix a histogram axis range.
