### PR TITLE
SC timewalks update

### DIFF
--- a/src/libraries/START_COUNTER/DSCHit_factory.cc
+++ b/src/libraries/START_COUNTER/DSCHit_factory.cc
@@ -133,8 +133,8 @@ jerror_t DSCHit_factory::brun(jana::JEventLoop *eventLoop, int runnumber)
     if (eventLoop->GetCalib("/START_COUNTER/tdc_timing_offsets", tdc_time_offsets))
         jout << "Error loading /START_COUNTER/tdc_timing_offsets !" << endl;
     // timewalk_parameters (timewalk_parms)
-    if(eventLoop->GetCalib("START_COUNTER/timewalk_parms", timewalk_parameters))
-        jout << "Error loading /START_COUNTER/timewalk_parms !" << endl;
+    if(eventLoop->GetCalib("START_COUNTER/timewalk_parms_v2", timewalk_parameters))
+        jout << "Error loading /START_COUNTER/timewalk_parms_v2 !" << endl;
 
 
     /* 
@@ -321,10 +321,12 @@ jerror_t DSCHit_factory::evnt(JEventLoop *loop, int eventnumber)
 
 		    // Correct for timewalk using pulse peak instead of pulse integral
 		    double A        = hit->pulse_height;
-		    double C1       = timewalk_parameters[id][0];
-		    double C2       = timewalk_parameters[id][1];
-		    double A_THRESH = timewalk_parameters[id][2];
-		    double A0       = timewalk_parameters[id][3];
+		    double C0       = timewalk_parameters[id][0];
+		    double C1       = timewalk_parameters[id][1];
+		    double C2       = timewalk_parameters[id][2];
+		    double A_THRESH = timewalk_parameters[id][3];
+		    double A0       = timewalk_parameters[id][4];
+            // do correction
 		    T -= C1*(pow(A/A_THRESH, C2) - pow(A0/A_THRESH, C2));
 		  }
 		hit->t=T;

--- a/src/plugins/Calibration/st_tw_corr_auto/macros/st_tw_fits.C
+++ b/src/plugins/Calibration/st_tw_corr_auto/macros/st_tw_fits.C
@@ -48,7 +48,7 @@ void st_tw_fits(char*input_filename)
   // df = new TFile("/lustre/expphy/work/halld/home/mkamel/st_tw_corr_auto/hd_root.root");
    TFile *df = new TFile(input_filename);
   std::ofstream results;
-  results.open ("results.txt", std::ofstream::out);
+  results.open ("st_timewalks.txt", std::ofstream::out);
   //*****************************************************************
   //*********** Grab the histograms from the root file **************
   //*****************************************************************

--- a/src/plugins/Calibration/st_tw_corr_auto/macros/st_tw_resols.C
+++ b/src/plugins/Calibration/st_tw_corr_auto/macros/st_tw_resols.C
@@ -55,7 +55,7 @@ void st_tw_resols(char*input_filename)
 {
   TFile *df = new TFile(input_filename);
   std::ofstream Time_resol;
-  Time_resol.open ("Time_resol.txt", std::ofstream::out);
+  Time_resol.open ("SC_time_resol.txt", std::ofstream::out);
 
   //*****************************************************************
   //*********** Grab the histograms from the root file **************


### PR DESCRIPTION
Apply latest timewalk corrections, which are stored in a new table, to the start counter hits.
