### PR TITLE
Rf factories

### DIFF
--- a/src/libraries/RF/DRFTime_factory_FDC.cc
+++ b/src/libraries/RF/DRFTime_factory_FDC.cc
@@ -1,0 +1,202 @@
+// $Id$
+//
+//    File: DRFTime_factory_FDC.cc
+// Created: Mon Mar 30 10:51:29 EDT 2015
+// Creator: pmatt (on Linux pmattdesktop.jlab.org 2.6.32-504.12.2.el6.x86_64 x86_64)
+//
+
+#include "DRFTime_factory_FDC.h"
+
+//------------------
+// init
+//------------------
+jerror_t DRFTime_factory_FDC::init(void)
+{
+	dSourceSystem = SYS_FDC;
+	dTimeOffset = 0.0;
+	dTimeOffsetVariance = 0.0;
+	dTimeResolutionSq = 0.0;
+	return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t DRFTime_factory_FDC::brun(jana::JEventLoop *locEventLoop, int runnumber)
+{
+	//RF Period
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
+	
+	//Time Offsets
+	map<string, double> locCCDBMap;
+	map<string, double>::iterator locIterator;
+	if(locEventLoop->GetCalib("/PHOTON_BEAM/RF/time_offset", locCCDBMap))
+		jout << "Error loading /PHOTON_BEAM/RF/time_offset !" << endl;
+	for(locIterator = locCCDBMap.begin(); locIterator != locCCDBMap.end(); ++locIterator)
+	{
+		DetectorSystem_t locSystem = NameToSystem(locIterator->first.c_str());
+		if(locSystem != dSourceSystem)
+			continue;
+		dTimeOffset = locIterator->second;
+		break;
+	}
+
+	//Time Offset Variances
+	if(locEventLoop->GetCalib("/PHOTON_BEAM/RF/time_offset_var", locCCDBMap))
+		jout << "Error loading /PHOTON_BEAM/RF/time_offset_var !" << endl;
+	for(locIterator = locCCDBMap.begin(); locIterator != locCCDBMap.end(); ++locIterator)
+	{
+		DetectorSystem_t locSystem = NameToSystem(locIterator->first.c_str());
+		if(locSystem != dSourceSystem)
+			continue;
+		dTimeOffsetVariance = locIterator->second;
+		break;
+	}
+
+	//Time Resolution Squared
+	if(locEventLoop->GetCalib("/PHOTON_BEAM/RF/time_resolution_sq", locCCDBMap))
+		jout << "Error loading /PHOTON_BEAM/RF/time_resolution_sq !" << endl;
+	for(locIterator = locCCDBMap.begin(); locIterator != locCCDBMap.end(); ++locIterator)
+	{
+		DetectorSystem_t locSystem = NameToSystem(locIterator->first.c_str());
+		if(locSystem != dSourceSystem)
+			continue;
+		dTimeResolutionSq = locIterator->second;
+		break;
+	}
+
+	return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t DRFTime_factory_FDC::evnt(JEventLoop *locEventLoop, int eventnumber)
+{
+	//The RF Time is defined at the center of the target
+	//The time offset needed to line it up to the center of the target is absorbed into the calibration constants.
+
+	vector<const DRFTDCDigiTime*> locRFTDCDigiTimes;
+	locEventLoop->Get(locRFTDCDigiTimes);
+
+	const DTTabUtilities* locTTabUtilities = NULL;
+	locEventLoop->GetSingle(locTTabUtilities);
+
+	//Get RF Times
+	vector<double> locRFTimes;
+
+	//F1TDC's
+	for(size_t loc_i = 0; loc_i < locRFTDCDigiTimes.size(); ++loc_i)
+	{
+		const DRFTDCDigiTime* locRFTDCDigiTime = locRFTDCDigiTimes[loc_i];
+		DetectorSystem_t locSystem = locRFTDCDigiTime->dSystem;
+		if(locSystem != dSourceSystem)
+			continue;
+		double locRFTime = Convert_TDCToTime(locRFTDCDigiTime, locTTabUtilities);
+		locRFTimes.push_back(locRFTime);
+	}
+
+	if(locRFTimes.empty())
+		return NOERROR;
+
+	//Calculate the average RF time
+	double locRFTimeVariance = 0.0;
+	double locAverageRFTime = Calc_WeightedAverageRFTime(locRFTimes, locRFTimeVariance);
+
+	DRFTime* locRFTime = new DRFTime();
+	locRFTime->dTime = locAverageRFTime; //This time is defined at the center of the target (offsets with other detectors center it)
+	locRFTime->dTimeVariance = locRFTimeVariance;
+	_data.push_back(locRFTime);
+
+	return NOERROR;
+}
+
+double DRFTime_factory_FDC::Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo) const
+{
+	return Step_TimeToNearInputTime(locTimeToStep, locTimeToStepTo, dBeamBunchPeriod);
+}
+
+double DRFTime_factory_FDC::Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo, double locPeriod) const
+{
+	double locDeltaT = locTimeToStepTo - locTimeToStep;
+	int locNumBucketsToShift = (locDeltaT > 0.0) ? int(locDeltaT/locPeriod + 0.5) : int(locDeltaT/locPeriod - 0.5);
+	return (locTimeToStep + locPeriod*double(locNumBucketsToShift));
+}
+
+double DRFTime_factory_FDC::Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigiTime, const DTTabUtilities* locTTabUtilities) const
+{
+	double locRFTime = 0.0;
+	if(locRFTDCDigiTime->dIsCAENTDCFlag)
+		locRFTime = locTTabUtilities->Convert_DigiTimeToNs_CAEN1290TDC(locRFTDCDigiTime);
+	else
+		locRFTime = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(locRFTDCDigiTime);
+
+	map<DetectorSystem_t, double>::const_iterator locIterator = dTimeOffsetMap.find(locRFTDCDigiTime->dSystem);
+	if(locIterator != dTimeOffsetMap.end())
+		locRFTime -= locIterator->second;
+	return locRFTime;
+}
+
+double DRFTime_factory_FDC::Calc_WeightedAverageRFTime(vector<double>& locRFTimes, double& locRFTimeVariance) const
+{
+	//returns the average (and the variance by reference)
+
+	//will line up the first time near zero, then line up subsequent times to the first time
+		//cannot line up all times to zero: if first time is near +/- beam_period/2 (e.g. +/- 2.004 ns),
+		//may end up with some times near 2.004 and some near -2.004!
+
+	double locFirstTime = locRFTimes[0];
+	locFirstTime = Step_TimeToNearInputTime(locFirstTime, 0.0);
+
+	//take weighted average of times
+		//avg = Sum(w_i * x_i) / Sum (w_i)
+			//w_i = 1/varx_i
+		//avg = Sum(x_i / varx_i) / Sum (1 / varx_i)
+			//var_avg = 1 / Sum (1 / varx_i)
+		//avg = Sum(x_i / varx_i) * var_avg
+
+	double locSumOneOverTimeVariance = 0.0;
+	double locSumTimeOverTimeVariance = 0.0;
+
+	double locSingleTimeVariance = dTimeResolutionSq + dTimeOffsetVariance;
+	if(!(locSingleTimeVariance > 0.0))
+	{
+		locRFTimeVariance = numeric_limits<double>::quiet_NaN();
+		return locFirstTime;
+	}
+	locSumOneOverTimeVariance += double(locRFTimes.size()) / locSingleTimeVariance;
+
+	for(size_t loc_i = 0; loc_i < locRFTimes.size(); ++loc_i)
+	{
+		double locShiftedRFTime = Step_TimeToNearInputTime(locRFTimes[loc_i], locFirstTime);
+		locSumTimeOverTimeVariance += locShiftedRFTime / locSingleTimeVariance;
+	}
+
+	if(!(locSumOneOverTimeVariance > 0.0))
+	{
+		locRFTimeVariance = numeric_limits<double>::quiet_NaN();
+		return locFirstTime;
+	}
+
+	locRFTimeVariance = 1.0 / locSumOneOverTimeVariance;
+	double locAverageRFTime = locSumTimeOverTimeVariance * locRFTimeVariance;
+	return locAverageRFTime;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t DRFTime_factory_FDC::erun(void)
+{
+	return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t DRFTime_factory_FDC::fini(void)
+{
+	return NOERROR;
+}

--- a/src/libraries/RF/DRFTime_factory_FDC.cc
+++ b/src/libraries/RF/DRFTime_factory_FDC.cc
@@ -133,9 +133,7 @@ double DRFTime_factory_FDC::Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigi
 	else
 		locRFTime = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(locRFTDCDigiTime);
 
-	map<DetectorSystem_t, double>::const_iterator locIterator = dTimeOffsetMap.find(locRFTDCDigiTime->dSystem);
-	if(locIterator != dTimeOffsetMap.end())
-		locRFTime -= locIterator->second;
+	locRFTime -= dTimeOffset;
 	return locRFTime;
 }
 

--- a/src/libraries/RF/DRFTime_factory_FDC.h
+++ b/src/libraries/RF/DRFTime_factory_FDC.h
@@ -1,0 +1,55 @@
+// $Id$
+//
+//    File: DRFTime_factory_FDC.h
+// Created: Mon Mar 30 10:51:29 EDT 2015
+// Creator: pmatt (on Linux pmattdesktop.jlab.org 2.6.32-504.12.2.el6.x86_64 x86_64)
+//
+
+#ifndef _DRFTime_factory_FDC_
+#define _DRFTime_factory_FDC_
+
+#include <limits>
+#include <iostream>
+
+#include <JANA/JFactory.h>
+#include "TTAB/DTTabUtilities.h"
+
+#include "DRFTime.h"
+#include "DRFDigiTime.h"
+#include "DRFTDCDigiTime.h"
+
+using namespace std;
+using namespace jana;
+
+class DRFTime_factory_FDC : public jana::JFactory<DRFTime>
+{
+	public:
+		DRFTime_factory_FDC(){};
+		~DRFTime_factory_FDC(){};
+		const char* Tag(void){return "FDC";}
+
+		double Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo) const;
+		double Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo, double locPeriod) const;
+
+		double Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigiTime, const DTTabUtilities* locTTabUtilities) const;
+
+		jerror_t brun(jana::JEventLoop *eventLoop, int runnumber);	///< Called everytime a new run number is detected.
+	
+	private:
+		jerror_t init(void);						///< Called once at program start.
+		jerror_t evnt(jana::JEventLoop *eventLoop, int eventnumber);	///< Called every event.
+		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+		double Calc_WeightedAverageRFTime(vector<double>& locRFTimes, double& locRFTimeVariance) const;
+
+		DetectorSystem_t dSourceSystem;
+		double dBeamBunchPeriod;
+
+		double dTimeOffset;
+		double dTimeOffsetVariance;
+		double dTimeResolutionSq;
+};
+
+#endif // _DRFTime_factory_FDC_
+

--- a/src/libraries/RF/DRFTime_factory_PSC.cc
+++ b/src/libraries/RF/DRFTime_factory_PSC.cc
@@ -133,9 +133,7 @@ double DRFTime_factory_PSC::Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigi
 	else
 		locRFTime = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(locRFTDCDigiTime);
 
-	map<DetectorSystem_t, double>::const_iterator locIterator = dTimeOffsetMap.find(locRFTDCDigiTime->dSystem);
-	if(locIterator != dTimeOffsetMap.end())
-		locRFTime -= locIterator->second;
+	locRFTime -= dTimeOffset;
 	return locRFTime;
 }
 

--- a/src/libraries/RF/DRFTime_factory_PSC.cc
+++ b/src/libraries/RF/DRFTime_factory_PSC.cc
@@ -1,0 +1,202 @@
+// $Id$
+//
+//    File: DRFTime_factory_PSC.cc
+// Created: Mon Mar 30 10:51:29 EDT 2015
+// Creator: pmatt (on Linux pmattdesktop.jlab.org 2.6.32-504.12.2.el6.x86_64 x86_64)
+//
+
+#include "DRFTime_factory_PSC.h"
+
+//------------------
+// init
+//------------------
+jerror_t DRFTime_factory_PSC::init(void)
+{
+	dSourceSystem = SYS_PSC;
+	dTimeOffset = 0.0;
+	dTimeOffsetVariance = 0.0;
+	dTimeResolutionSq = 0.0;
+	return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t DRFTime_factory_PSC::brun(jana::JEventLoop *locEventLoop, int runnumber)
+{
+	//RF Period
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
+	
+	//Time Offsets
+	map<string, double> locCCDBMap;
+	map<string, double>::iterator locIterator;
+	if(locEventLoop->GetCalib("/PHOTON_BEAM/RF/time_offset", locCCDBMap))
+		jout << "Error loading /PHOTON_BEAM/RF/time_offset !" << endl;
+	for(locIterator = locCCDBMap.begin(); locIterator != locCCDBMap.end(); ++locIterator)
+	{
+		DetectorSystem_t locSystem = NameToSystem(locIterator->first.c_str());
+		if(locSystem != dSourceSystem)
+			continue;
+		dTimeOffset = locIterator->second;
+		break;
+	}
+
+	//Time Offset Variances
+	if(locEventLoop->GetCalib("/PHOTON_BEAM/RF/time_offset_var", locCCDBMap))
+		jout << "Error loading /PHOTON_BEAM/RF/time_offset_var !" << endl;
+	for(locIterator = locCCDBMap.begin(); locIterator != locCCDBMap.end(); ++locIterator)
+	{
+		DetectorSystem_t locSystem = NameToSystem(locIterator->first.c_str());
+		if(locSystem != dSourceSystem)
+			continue;
+		dTimeOffsetVariance = locIterator->second;
+		break;
+	}
+
+	//Time Resolution Squared
+	if(locEventLoop->GetCalib("/PHOTON_BEAM/RF/time_resolution_sq", locCCDBMap))
+		jout << "Error loading /PHOTON_BEAM/RF/time_resolution_sq !" << endl;
+	for(locIterator = locCCDBMap.begin(); locIterator != locCCDBMap.end(); ++locIterator)
+	{
+		DetectorSystem_t locSystem = NameToSystem(locIterator->first.c_str());
+		if(locSystem != dSourceSystem)
+			continue;
+		dTimeResolutionSq = locIterator->second;
+		break;
+	}
+
+	return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t DRFTime_factory_PSC::evnt(JEventLoop *locEventLoop, int eventnumber)
+{
+	//The RF Time is defined at the center of the target
+	//The time offset needed to line it up to the center of the target is absorbed into the calibration constants.
+
+	vector<const DRFTDCDigiTime*> locRFTDCDigiTimes;
+	locEventLoop->Get(locRFTDCDigiTimes);
+
+	const DTTabUtilities* locTTabUtilities = NULL;
+	locEventLoop->GetSingle(locTTabUtilities);
+
+	//Get RF Times
+	vector<double> locRFTimes;
+
+	//F1TDC's
+	for(size_t loc_i = 0; loc_i < locRFTDCDigiTimes.size(); ++loc_i)
+	{
+		const DRFTDCDigiTime* locRFTDCDigiTime = locRFTDCDigiTimes[loc_i];
+		DetectorSystem_t locSystem = locRFTDCDigiTime->dSystem;
+		if(locSystem != dSourceSystem)
+			continue;
+		double locRFTime = Convert_TDCToTime(locRFTDCDigiTime, locTTabUtilities);
+		locRFTimes.push_back(locRFTime);
+	}
+
+	if(locRFTimes.empty())
+		return NOERROR;
+
+	//Calculate the average RF time
+	double locRFTimeVariance = 0.0;
+	double locAverageRFTime = Calc_WeightedAverageRFTime(locRFTimes, locRFTimeVariance);
+
+	DRFTime* locRFTime = new DRFTime();
+	locRFTime->dTime = locAverageRFTime; //This time is defined at the center of the target (offsets with other detectors center it)
+	locRFTime->dTimeVariance = locRFTimeVariance;
+	_data.push_back(locRFTime);
+
+	return NOERROR;
+}
+
+double DRFTime_factory_PSC::Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo) const
+{
+	return Step_TimeToNearInputTime(locTimeToStep, locTimeToStepTo, dBeamBunchPeriod);
+}
+
+double DRFTime_factory_PSC::Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo, double locPeriod) const
+{
+	double locDeltaT = locTimeToStepTo - locTimeToStep;
+	int locNumBucketsToShift = (locDeltaT > 0.0) ? int(locDeltaT/locPeriod + 0.5) : int(locDeltaT/locPeriod - 0.5);
+	return (locTimeToStep + locPeriod*double(locNumBucketsToShift));
+}
+
+double DRFTime_factory_PSC::Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigiTime, const DTTabUtilities* locTTabUtilities) const
+{
+	double locRFTime = 0.0;
+	if(locRFTDCDigiTime->dIsCAENTDCFlag)
+		locRFTime = locTTabUtilities->Convert_DigiTimeToNs_CAEN1290TDC(locRFTDCDigiTime);
+	else
+		locRFTime = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(locRFTDCDigiTime);
+
+	map<DetectorSystem_t, double>::const_iterator locIterator = dTimeOffsetMap.find(locRFTDCDigiTime->dSystem);
+	if(locIterator != dTimeOffsetMap.end())
+		locRFTime -= locIterator->second;
+	return locRFTime;
+}
+
+double DRFTime_factory_PSC::Calc_WeightedAverageRFTime(vector<double>& locRFTimes, double& locRFTimeVariance) const
+{
+	//returns the average (and the variance by reference)
+
+	//will line up the first time near zero, then line up subsequent times to the first time
+		//cannot line up all times to zero: if first time is near +/- beam_period/2 (e.g. +/- 2.004 ns),
+		//may end up with some times near 2.004 and some near -2.004!
+
+	double locFirstTime = locRFTimes[0];
+	locFirstTime = Step_TimeToNearInputTime(locFirstTime, 0.0);
+
+	//take weighted average of times
+		//avg = Sum(w_i * x_i) / Sum (w_i)
+			//w_i = 1/varx_i
+		//avg = Sum(x_i / varx_i) / Sum (1 / varx_i)
+			//var_avg = 1 / Sum (1 / varx_i)
+		//avg = Sum(x_i / varx_i) * var_avg
+
+	double locSumOneOverTimeVariance = 0.0;
+	double locSumTimeOverTimeVariance = 0.0;
+
+	double locSingleTimeVariance = dTimeResolutionSq + dTimeOffsetVariance;
+	if(!(locSingleTimeVariance > 0.0))
+	{
+		locRFTimeVariance = numeric_limits<double>::quiet_NaN();
+		return locFirstTime;
+	}
+	locSumOneOverTimeVariance += double(locRFTimes.size()) / locSingleTimeVariance;
+
+	for(size_t loc_i = 0; loc_i < locRFTimes.size(); ++loc_i)
+	{
+		double locShiftedRFTime = Step_TimeToNearInputTime(locRFTimes[loc_i], locFirstTime);
+		locSumTimeOverTimeVariance += locShiftedRFTime / locSingleTimeVariance;
+	}
+
+	if(!(locSumOneOverTimeVariance > 0.0))
+	{
+		locRFTimeVariance = numeric_limits<double>::quiet_NaN();
+		return locFirstTime;
+	}
+
+	locRFTimeVariance = 1.0 / locSumOneOverTimeVariance;
+	double locAverageRFTime = locSumTimeOverTimeVariance * locRFTimeVariance;
+	return locAverageRFTime;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t DRFTime_factory_PSC::erun(void)
+{
+	return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t DRFTime_factory_PSC::fini(void)
+{
+	return NOERROR;
+}

--- a/src/libraries/RF/DRFTime_factory_PSC.h
+++ b/src/libraries/RF/DRFTime_factory_PSC.h
@@ -1,0 +1,55 @@
+// $Id$
+//
+//    File: DRFTime_factory_PSC.h
+// Created: Mon Mar 30 10:51:29 EDT 2015
+// Creator: pmatt (on Linux pmattdesktop.jlab.org 2.6.32-504.12.2.el6.x86_64 x86_64)
+//
+
+#ifndef _DRFTime_factory_PSC_
+#define _DRFTime_factory_PSC_
+
+#include <limits>
+#include <iostream>
+
+#include <JANA/JFactory.h>
+#include "TTAB/DTTabUtilities.h"
+
+#include "DRFTime.h"
+#include "DRFDigiTime.h"
+#include "DRFTDCDigiTime.h"
+
+using namespace std;
+using namespace jana;
+
+class DRFTime_factory_PSC : public jana::JFactory<DRFTime>
+{
+	public:
+		DRFTime_factory_PSC(){};
+		~DRFTime_factory_PSC(){};
+		const char* Tag(void){return "PSC";}
+
+		double Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo) const;
+		double Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo, double locPeriod) const;
+
+		double Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigiTime, const DTTabUtilities* locTTabUtilities) const;
+
+		jerror_t brun(jana::JEventLoop *eventLoop, int runnumber);	///< Called everytime a new run number is detected.
+	
+	private:
+		jerror_t init(void);						///< Called once at program start.
+		jerror_t evnt(jana::JEventLoop *eventLoop, int eventnumber);	///< Called every event.
+		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+		double Calc_WeightedAverageRFTime(vector<double>& locRFTimes, double& locRFTimeVariance) const;
+
+		DetectorSystem_t dSourceSystem;
+		double dBeamBunchPeriod;
+
+		double dTimeOffset;
+		double dTimeOffsetVariance;
+		double dTimeResolutionSq;
+};
+
+#endif // _DRFTime_factory_PSC_
+

--- a/src/libraries/RF/DRFTime_factory_TAGH.cc
+++ b/src/libraries/RF/DRFTime_factory_TAGH.cc
@@ -133,9 +133,7 @@ double DRFTime_factory_TAGH::Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDig
 	else
 		locRFTime = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(locRFTDCDigiTime);
 
-	map<DetectorSystem_t, double>::const_iterator locIterator = dTimeOffsetMap.find(locRFTDCDigiTime->dSystem);
-	if(locIterator != dTimeOffsetMap.end())
-		locRFTime -= locIterator->second;
+	locRFTime -= dTimeOffset;
 	return locRFTime;
 }
 

--- a/src/libraries/RF/DRFTime_factory_TAGH.cc
+++ b/src/libraries/RF/DRFTime_factory_TAGH.cc
@@ -1,0 +1,202 @@
+// $Id$
+//
+//    File: DRFTime_factory_TAGH.cc
+// Created: Mon Mar 30 10:51:29 EDT 2015
+// Creator: pmatt (on Linux pmattdesktop.jlab.org 2.6.32-504.12.2.el6.x86_64 x86_64)
+//
+
+#include "DRFTime_factory_TAGH.h"
+
+//------------------
+// init
+//------------------
+jerror_t DRFTime_factory_TAGH::init(void)
+{
+	dSourceSystem = SYS_TAGH;
+	dTimeOffset = 0.0;
+	dTimeOffsetVariance = 0.0;
+	dTimeResolutionSq = 0.0;
+	return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t DRFTime_factory_TAGH::brun(jana::JEventLoop *locEventLoop, int runnumber)
+{
+	//RF Period
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
+	
+	//Time Offsets
+	map<string, double> locCCDBMap;
+	map<string, double>::iterator locIterator;
+	if(locEventLoop->GetCalib("/PHOTON_BEAM/RF/time_offset", locCCDBMap))
+		jout << "Error loading /PHOTON_BEAM/RF/time_offset !" << endl;
+	for(locIterator = locCCDBMap.begin(); locIterator != locCCDBMap.end(); ++locIterator)
+	{
+		DetectorSystem_t locSystem = NameToSystem(locIterator->first.c_str());
+		if(locSystem != dSourceSystem)
+			continue;
+		dTimeOffset = locIterator->second;
+		break;
+	}
+
+	//Time Offset Variances
+	if(locEventLoop->GetCalib("/PHOTON_BEAM/RF/time_offset_var", locCCDBMap))
+		jout << "Error loading /PHOTON_BEAM/RF/time_offset_var !" << endl;
+	for(locIterator = locCCDBMap.begin(); locIterator != locCCDBMap.end(); ++locIterator)
+	{
+		DetectorSystem_t locSystem = NameToSystem(locIterator->first.c_str());
+		if(locSystem != dSourceSystem)
+			continue;
+		dTimeOffsetVariance = locIterator->second;
+		break;
+	}
+
+	//Time Resolution Squared
+	if(locEventLoop->GetCalib("/PHOTON_BEAM/RF/time_resolution_sq", locCCDBMap))
+		jout << "Error loading /PHOTON_BEAM/RF/time_resolution_sq !" << endl;
+	for(locIterator = locCCDBMap.begin(); locIterator != locCCDBMap.end(); ++locIterator)
+	{
+		DetectorSystem_t locSystem = NameToSystem(locIterator->first.c_str());
+		if(locSystem != dSourceSystem)
+			continue;
+		dTimeResolutionSq = locIterator->second;
+		break;
+	}
+
+	return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t DRFTime_factory_TAGH::evnt(JEventLoop *locEventLoop, int eventnumber)
+{
+	//The RF Time is defined at the center of the target
+	//The time offset needed to line it up to the center of the target is absorbed into the calibration constants.
+
+	vector<const DRFTDCDigiTime*> locRFTDCDigiTimes;
+	locEventLoop->Get(locRFTDCDigiTimes);
+
+	const DTTabUtilities* locTTabUtilities = NULL;
+	locEventLoop->GetSingle(locTTabUtilities);
+
+	//Get RF Times
+	vector<double> locRFTimes;
+
+	//F1TDC's
+	for(size_t loc_i = 0; loc_i < locRFTDCDigiTimes.size(); ++loc_i)
+	{
+		const DRFTDCDigiTime* locRFTDCDigiTime = locRFTDCDigiTimes[loc_i];
+		DetectorSystem_t locSystem = locRFTDCDigiTime->dSystem;
+		if(locSystem != dSourceSystem)
+			continue;
+		double locRFTime = Convert_TDCToTime(locRFTDCDigiTime, locTTabUtilities);
+		locRFTimes.push_back(locRFTime);
+	}
+
+	if(locRFTimes.empty())
+		return NOERROR;
+
+	//Calculate the average RF time
+	double locRFTimeVariance = 0.0;
+	double locAverageRFTime = Calc_WeightedAverageRFTime(locRFTimes, locRFTimeVariance);
+
+	DRFTime* locRFTime = new DRFTime();
+	locRFTime->dTime = locAverageRFTime; //This time is defined at the center of the target (offsets with other detectors center it)
+	locRFTime->dTimeVariance = locRFTimeVariance;
+	_data.push_back(locRFTime);
+
+	return NOERROR;
+}
+
+double DRFTime_factory_TAGH::Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo) const
+{
+	return Step_TimeToNearInputTime(locTimeToStep, locTimeToStepTo, dBeamBunchPeriod);
+}
+
+double DRFTime_factory_TAGH::Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo, double locPeriod) const
+{
+	double locDeltaT = locTimeToStepTo - locTimeToStep;
+	int locNumBucketsToShift = (locDeltaT > 0.0) ? int(locDeltaT/locPeriod + 0.5) : int(locDeltaT/locPeriod - 0.5);
+	return (locTimeToStep + locPeriod*double(locNumBucketsToShift));
+}
+
+double DRFTime_factory_TAGH::Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigiTime, const DTTabUtilities* locTTabUtilities) const
+{
+	double locRFTime = 0.0;
+	if(locRFTDCDigiTime->dIsCAENTDCFlag)
+		locRFTime = locTTabUtilities->Convert_DigiTimeToNs_CAEN1290TDC(locRFTDCDigiTime);
+	else
+		locRFTime = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(locRFTDCDigiTime);
+
+	map<DetectorSystem_t, double>::const_iterator locIterator = dTimeOffsetMap.find(locRFTDCDigiTime->dSystem);
+	if(locIterator != dTimeOffsetMap.end())
+		locRFTime -= locIterator->second;
+	return locRFTime;
+}
+
+double DRFTime_factory_TAGH::Calc_WeightedAverageRFTime(vector<double>& locRFTimes, double& locRFTimeVariance) const
+{
+	//returns the average (and the variance by reference)
+
+	//will line up the first time near zero, then line up subsequent times to the first time
+		//cannot line up all times to zero: if first time is near +/- beam_period/2 (e.g. +/- 2.004 ns),
+		//may end up with some times near 2.004 and some near -2.004!
+
+	double locFirstTime = locRFTimes[0];
+	locFirstTime = Step_TimeToNearInputTime(locFirstTime, 0.0);
+
+	//take weighted average of times
+		//avg = Sum(w_i * x_i) / Sum (w_i)
+			//w_i = 1/varx_i
+		//avg = Sum(x_i / varx_i) / Sum (1 / varx_i)
+			//var_avg = 1 / Sum (1 / varx_i)
+		//avg = Sum(x_i / varx_i) * var_avg
+
+	double locSumOneOverTimeVariance = 0.0;
+	double locSumTimeOverTimeVariance = 0.0;
+
+	double locSingleTimeVariance = dTimeResolutionSq + dTimeOffsetVariance;
+	if(!(locSingleTimeVariance > 0.0))
+	{
+		locRFTimeVariance = numeric_limits<double>::quiet_NaN();
+		return locFirstTime;
+	}
+	locSumOneOverTimeVariance += double(locRFTimes.size()) / locSingleTimeVariance;
+
+	for(size_t loc_i = 0; loc_i < locRFTimes.size(); ++loc_i)
+	{
+		double locShiftedRFTime = Step_TimeToNearInputTime(locRFTimes[loc_i], locFirstTime);
+		locSumTimeOverTimeVariance += locShiftedRFTime / locSingleTimeVariance;
+	}
+
+	if(!(locSumOneOverTimeVariance > 0.0))
+	{
+		locRFTimeVariance = numeric_limits<double>::quiet_NaN();
+		return locFirstTime;
+	}
+
+	locRFTimeVariance = 1.0 / locSumOneOverTimeVariance;
+	double locAverageRFTime = locSumTimeOverTimeVariance * locRFTimeVariance;
+	return locAverageRFTime;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t DRFTime_factory_TAGH::erun(void)
+{
+	return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t DRFTime_factory_TAGH::fini(void)
+{
+	return NOERROR;
+}

--- a/src/libraries/RF/DRFTime_factory_TAGH.h
+++ b/src/libraries/RF/DRFTime_factory_TAGH.h
@@ -1,0 +1,55 @@
+// $Id$
+//
+//    File: DRFTime_factory_TAGH.h
+// Created: Mon Mar 30 10:51:29 EDT 2015
+// Creator: pmatt (on Linux pmattdesktop.jlab.org 2.6.32-504.12.2.el6.x86_64 x86_64)
+//
+
+#ifndef _DRFTime_factory_TAGH_
+#define _DRFTime_factory_TAGH_
+
+#include <limits>
+#include <iostream>
+
+#include <JANA/JFactory.h>
+#include "TTAB/DTTabUtilities.h"
+
+#include "DRFTime.h"
+#include "DRFDigiTime.h"
+#include "DRFTDCDigiTime.h"
+
+using namespace std;
+using namespace jana;
+
+class DRFTime_factory_TAGH : public jana::JFactory<DRFTime>
+{
+	public:
+		DRFTime_factory_TAGH(){};
+		~DRFTime_factory_TAGH(){};
+		const char* Tag(void){return "TAGH";}
+
+		double Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo) const;
+		double Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo, double locPeriod) const;
+
+		double Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigiTime, const DTTabUtilities* locTTabUtilities) const;
+
+		jerror_t brun(jana::JEventLoop *eventLoop, int runnumber);	///< Called everytime a new run number is detected.
+	
+	private:
+		jerror_t init(void);						///< Called once at program start.
+		jerror_t evnt(jana::JEventLoop *eventLoop, int eventnumber);	///< Called every event.
+		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+		double Calc_WeightedAverageRFTime(vector<double>& locRFTimes, double& locRFTimeVariance) const;
+
+		DetectorSystem_t dSourceSystem;
+		double dBeamBunchPeriod;
+
+		double dTimeOffset;
+		double dTimeOffsetVariance;
+		double dTimeResolutionSq;
+};
+
+#endif // _DRFTime_factory_TAGH_
+

--- a/src/libraries/RF/DRFTime_factory_TOF.cc
+++ b/src/libraries/RF/DRFTime_factory_TOF.cc
@@ -1,0 +1,202 @@
+// $Id$
+//
+//    File: DRFTime_factory_TOF.cc
+// Created: Mon Mar 30 10:51:29 EDT 2015
+// Creator: pmatt (on Linux pmattdesktop.jlab.org 2.6.32-504.12.2.el6.x86_64 x86_64)
+//
+
+#include "DRFTime_factory_TOF.h"
+
+//------------------
+// init
+//------------------
+jerror_t DRFTime_factory_TOF::init(void)
+{
+	dSourceSystem = SYS_TOF;
+	dTimeOffset = 0.0;
+	dTimeOffsetVariance = 0.0;
+	dTimeResolutionSq = 0.0;
+	return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t DRFTime_factory_TOF::brun(jana::JEventLoop *locEventLoop, int runnumber)
+{
+	//RF Period
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
+	
+	//Time Offsets
+	map<string, double> locCCDBMap;
+	map<string, double>::iterator locIterator;
+	if(locEventLoop->GetCalib("/PHOTON_BEAM/RF/time_offset", locCCDBMap))
+		jout << "Error loading /PHOTON_BEAM/RF/time_offset !" << endl;
+	for(locIterator = locCCDBMap.begin(); locIterator != locCCDBMap.end(); ++locIterator)
+	{
+		DetectorSystem_t locSystem = NameToSystem(locIterator->first.c_str());
+		if(locSystem != dSourceSystem)
+			continue;
+		dTimeOffset = locIterator->second;
+		break;
+	}
+
+	//Time Offset Variances
+	if(locEventLoop->GetCalib("/PHOTON_BEAM/RF/time_offset_var", locCCDBMap))
+		jout << "Error loading /PHOTON_BEAM/RF/time_offset_var !" << endl;
+	for(locIterator = locCCDBMap.begin(); locIterator != locCCDBMap.end(); ++locIterator)
+	{
+		DetectorSystem_t locSystem = NameToSystem(locIterator->first.c_str());
+		if(locSystem != dSourceSystem)
+			continue;
+		dTimeOffsetVariance = locIterator->second;
+		break;
+	}
+
+	//Time Resolution Squared
+	if(locEventLoop->GetCalib("/PHOTON_BEAM/RF/time_resolution_sq", locCCDBMap))
+		jout << "Error loading /PHOTON_BEAM/RF/time_resolution_sq !" << endl;
+	for(locIterator = locCCDBMap.begin(); locIterator != locCCDBMap.end(); ++locIterator)
+	{
+		DetectorSystem_t locSystem = NameToSystem(locIterator->first.c_str());
+		if(locSystem != dSourceSystem)
+			continue;
+		dTimeResolutionSq = locIterator->second;
+		break;
+	}
+
+	return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t DRFTime_factory_TOF::evnt(JEventLoop *locEventLoop, int eventnumber)
+{
+	//The RF Time is defined at the center of the target
+	//The time offset needed to line it up to the center of the target is absorbed into the calibration constants.
+
+	vector<const DRFTDCDigiTime*> locRFTDCDigiTimes;
+	locEventLoop->Get(locRFTDCDigiTimes);
+
+	const DTTabUtilities* locTTabUtilities = NULL;
+	locEventLoop->GetSingle(locTTabUtilities);
+
+	//Get RF Times
+	vector<double> locRFTimes;
+
+	//F1TDC's
+	for(size_t loc_i = 0; loc_i < locRFTDCDigiTimes.size(); ++loc_i)
+	{
+		const DRFTDCDigiTime* locRFTDCDigiTime = locRFTDCDigiTimes[loc_i];
+		DetectorSystem_t locSystem = locRFTDCDigiTime->dSystem;
+		if(locSystem != dSourceSystem)
+			continue;
+		double locRFTime = Convert_TDCToTime(locRFTDCDigiTime, locTTabUtilities);
+		locRFTimes.push_back(locRFTime);
+	}
+
+	if(locRFTimes.empty())
+		return NOERROR;
+
+	//Calculate the average RF time
+	double locRFTimeVariance = 0.0;
+	double locAverageRFTime = Calc_WeightedAverageRFTime(locRFTimes, locRFTimeVariance);
+
+	DRFTime* locRFTime = new DRFTime();
+	locRFTime->dTime = locAverageRFTime; //This time is defined at the center of the target (offsets with other detectors center it)
+	locRFTime->dTimeVariance = locRFTimeVariance;
+	_data.push_back(locRFTime);
+
+	return NOERROR;
+}
+
+double DRFTime_factory_TOF::Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo) const
+{
+	return Step_TimeToNearInputTime(locTimeToStep, locTimeToStepTo, dBeamBunchPeriod);
+}
+
+double DRFTime_factory_TOF::Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo, double locPeriod) const
+{
+	double locDeltaT = locTimeToStepTo - locTimeToStep;
+	int locNumBucketsToShift = (locDeltaT > 0.0) ? int(locDeltaT/locPeriod + 0.5) : int(locDeltaT/locPeriod - 0.5);
+	return (locTimeToStep + locPeriod*double(locNumBucketsToShift));
+}
+
+double DRFTime_factory_TOF::Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigiTime, const DTTabUtilities* locTTabUtilities) const
+{
+	double locRFTime = 0.0;
+	if(locRFTDCDigiTime->dIsCAENTDCFlag)
+		locRFTime = locTTabUtilities->Convert_DigiTimeToNs_CAEN1290TDC(locRFTDCDigiTime);
+	else
+		locRFTime = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(locRFTDCDigiTime);
+
+	map<DetectorSystem_t, double>::const_iterator locIterator = dTimeOffsetMap.find(locRFTDCDigiTime->dSystem);
+	if(locIterator != dTimeOffsetMap.end())
+		locRFTime -= locIterator->second;
+	return locRFTime;
+}
+
+double DRFTime_factory_TOF::Calc_WeightedAverageRFTime(vector<double>& locRFTimes, double& locRFTimeVariance) const
+{
+	//returns the average (and the variance by reference)
+
+	//will line up the first time near zero, then line up subsequent times to the first time
+		//cannot line up all times to zero: if first time is near +/- beam_period/2 (e.g. +/- 2.004 ns),
+		//may end up with some times near 2.004 and some near -2.004!
+
+	double locFirstTime = locRFTimes[0];
+	locFirstTime = Step_TimeToNearInputTime(locFirstTime, 0.0);
+
+	//take weighted average of times
+		//avg = Sum(w_i * x_i) / Sum (w_i)
+			//w_i = 1/varx_i
+		//avg = Sum(x_i / varx_i) / Sum (1 / varx_i)
+			//var_avg = 1 / Sum (1 / varx_i)
+		//avg = Sum(x_i / varx_i) * var_avg
+
+	double locSumOneOverTimeVariance = 0.0;
+	double locSumTimeOverTimeVariance = 0.0;
+
+	double locSingleTimeVariance = dTimeResolutionSq + dTimeOffsetVariance;
+	if(!(locSingleTimeVariance > 0.0))
+	{
+		locRFTimeVariance = numeric_limits<double>::quiet_NaN();
+		return locFirstTime;
+	}
+	locSumOneOverTimeVariance += double(locRFTimes.size()) / locSingleTimeVariance;
+
+	for(size_t loc_i = 0; loc_i < locRFTimes.size(); ++loc_i)
+	{
+		double locShiftedRFTime = Step_TimeToNearInputTime(locRFTimes[loc_i], locFirstTime);
+		locSumTimeOverTimeVariance += locShiftedRFTime / locSingleTimeVariance;
+	}
+
+	if(!(locSumOneOverTimeVariance > 0.0))
+	{
+		locRFTimeVariance = numeric_limits<double>::quiet_NaN();
+		return locFirstTime;
+	}
+
+	locRFTimeVariance = 1.0 / locSumOneOverTimeVariance;
+	double locAverageRFTime = locSumTimeOverTimeVariance * locRFTimeVariance;
+	return locAverageRFTime;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t DRFTime_factory_TOF::erun(void)
+{
+	return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t DRFTime_factory_TOF::fini(void)
+{
+	return NOERROR;
+}

--- a/src/libraries/RF/DRFTime_factory_TOF.cc
+++ b/src/libraries/RF/DRFTime_factory_TOF.cc
@@ -133,9 +133,7 @@ double DRFTime_factory_TOF::Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigi
 	else
 		locRFTime = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(locRFTDCDigiTime);
 
-	map<DetectorSystem_t, double>::const_iterator locIterator = dTimeOffsetMap.find(locRFTDCDigiTime->dSystem);
-	if(locIterator != dTimeOffsetMap.end())
-		locRFTime -= locIterator->second;
+	locRFTime -= dTimeOffset;
 	return locRFTime;
 }
 

--- a/src/libraries/RF/DRFTime_factory_TOF.h
+++ b/src/libraries/RF/DRFTime_factory_TOF.h
@@ -1,0 +1,55 @@
+// $Id$
+//
+//    File: DRFTime_factory_TOF.h
+// Created: Mon Mar 30 10:51:29 EDT 2015
+// Creator: pmatt (on Linux pmattdesktop.jlab.org 2.6.32-504.12.2.el6.x86_64 x86_64)
+//
+
+#ifndef _DRFTime_factory_TOF_
+#define _DRFTime_factory_TOF_
+
+#include <limits>
+#include <iostream>
+
+#include <JANA/JFactory.h>
+#include "TTAB/DTTabUtilities.h"
+
+#include "DRFTime.h"
+#include "DRFDigiTime.h"
+#include "DRFTDCDigiTime.h"
+
+using namespace std;
+using namespace jana;
+
+class DRFTime_factory_TOF : public jana::JFactory<DRFTime>
+{
+	public:
+		DRFTime_factory_TOF(){};
+		~DRFTime_factory_TOF(){};
+		const char* Tag(void){return "TOF";}
+
+		double Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo) const;
+		double Step_TimeToNearInputTime(double locTimeToStep, double locTimeToStepTo, double locPeriod) const;
+
+		double Convert_TDCToTime(const DRFTDCDigiTime* locRFTDCDigiTime, const DTTabUtilities* locTTabUtilities) const;
+
+		jerror_t brun(jana::JEventLoop *eventLoop, int runnumber);	///< Called everytime a new run number is detected.
+	
+	private:
+		jerror_t init(void);						///< Called once at program start.
+		jerror_t evnt(jana::JEventLoop *eventLoop, int eventnumber);	///< Called every event.
+		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+		double Calc_WeightedAverageRFTime(vector<double>& locRFTimes, double& locRFTimeVariance) const;
+
+		DetectorSystem_t dSourceSystem;
+		double dBeamBunchPeriod;
+
+		double dTimeOffset;
+		double dTimeOffsetVariance;
+		double dTimeResolutionSq;
+};
+
+#endif // _DRFTime_factory_TOF_
+

--- a/src/libraries/RF/RF_init.cc
+++ b/src/libraries/RF/RF_init.cc
@@ -6,6 +6,10 @@ using namespace jana;
 #include "DRFDigiTime.h"
 #include "DRFTDCDigiTime.h"
 #include "DRFTime_factory.h"
+#include "DRFTime_factory_FDC.h"
+#include "DRFTime_factory_PSC.h"
+#include "DRFTime_factory_TAGH.h"
+#include "DRFTime_factory_TOF.h"
 
 jerror_t RF_init(JEventLoop *loop)
 {
@@ -13,6 +17,10 @@ jerror_t RF_init(JEventLoop *loop)
 	loop->AddFactory(new JFactory<DRFDigiTime>());
 	loop->AddFactory(new JFactory<DRFTDCDigiTime>());
 	loop->AddFactory(new DRFTime_factory());
+	loop->AddFactory(new DRFTime_factory_FDC());
+	loop->AddFactory(new DRFTime_factory_PSC());
+	loop->AddFactory(new DRFTime_factory_TAGH());
+	loop->AddFactory(new DRFTime_factory_TOF());
 	loop->AddFactory(new JFactory<DRFTime>("TRUTH"));
 
 	return NOERROR;

--- a/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.cc
+++ b/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.cc
@@ -22,9 +22,7 @@ jerror_t JEventProcessor_RF_online::init(void)
 {
 	//This constant should be fixed for the lifetime of GlueX.  If it ever changes, move it into the CCDB.
 	dRFSignalPeriod = 1000.0/499.0; //2.004008016
-
-	//pick a combination such that there is a bin edge at +/- 1.002 and +/- 2.004
-	double locDeltaTRangeMax = 2.2; //should be a little more than expected-RF-period / 2 //choose 2.2 for run <= 2438
+	double locDeltaTRangeMax = 2.2;
 	unsigned int locNumDeltaTBins = 1100;
 
 	dRFSignalSystems.push_back(SYS_FDC);  dRFSignalSystems.push_back(SYS_PSC);

--- a/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.cc
+++ b/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.cc
@@ -24,7 +24,7 @@ jerror_t JEventProcessor_RF_online::init(void)
 	dRFSignalPeriod = 1000.0/499.0; //2.004008016
 
 	//pick a combination such that there is a bin edge at +/- 1.002 and +/- 2.004
-	double locDeltaTRangeMax = 1.1; //should be a little more than expected-RF-period / 2 //choose 2.2 for run <= 2438
+	double locDeltaTRangeMax = 2.2; //should be a little more than expected-RF-period / 2 //choose 2.2 for run <= 2438
 	unsigned int locNumDeltaTBins = 1100;
 
 	dRFSignalSystems.push_back(SYS_FDC);  dRFSignalSystems.push_back(SYS_PSC);
@@ -228,11 +228,11 @@ jerror_t JEventProcessor_RF_online::evnt(JEventLoop* locEventLoop, int eventnumb
 	{
 		set<double>& locRFTimeSet = locTDCIterator->second;
 
-		double locFirstTime = dRFTimeFactory->Step_TimeToNearInputTime(*(locRFTimeSet.begin()), 0.0, dRFSignalPeriod);
+		double locFirstTime = dRFTimeFactory->Step_TimeToNearInputTime(*(locRFTimeSet.begin()), 0.0);
 		double locAverageTime = locFirstTime;
 		set<double>::iterator locSetIterator = locRFTimeSet.begin();
 		for(++locSetIterator; locSetIterator != locRFTimeSet.end(); ++locSetIterator)
-			locAverageTime += dRFTimeFactory->Step_TimeToNearInputTime(*locSetIterator, locFirstTime, dRFSignalPeriod);
+			locAverageTime += dRFTimeFactory->Step_TimeToNearInputTime(*locSetIterator, locFirstTime);
 		locAverageTime /= double(locRFTimeSet.size());
 		locAverageRFTimes[locTDCIterator->first] = locAverageTime;
 	}
@@ -357,7 +357,7 @@ jerror_t JEventProcessor_RF_online::evnt(JEventLoop* locEventLoop, int eventnumb
 				continue;
 			set<double>::iterator locSetIterator = locRFTimeSet.begin();
 			++locSetIterator;
-			double locShiftedRFTime = dRFTimeFactory->Step_TimeToNearInputTime(*locSetIterator, *(locRFTimeSet.begin()), dRFSignalPeriod);
+			double locShiftedRFTime = dRFTimeFactory->Step_TimeToNearInputTime(*locSetIterator, *(locRFTimeSet.begin()));
 			dHistMap_SelfResolution[locTDCIterator->first]->Fill(locShiftedRFTime - *(locRFTimeSet.begin()));
 		}
 
@@ -374,7 +374,7 @@ jerror_t JEventProcessor_RF_online::evnt(JEventLoop* locEventLoop, int eventnumb
 				set<double>::iterator locSetIterator = locRFTimeSet.begin();
 				for(; locSetIterator != locRFTimeSet.end(); ++locSetIterator)
 				{
-					double locShiftedRFTime = dRFTimeFactory->Step_TimeToNearInputTime(*locSetIterator, locTAGHHits[loc_i]->time_tdc, dRFSignalPeriod);
+					double locShiftedRFTime = dRFTimeFactory->Step_TimeToNearInputTime(*locSetIterator, locTAGHHits[loc_i]->time_tdc);
 					dHistMap_RFTaggerDeltaT[locTDCIterator->first]->Fill(locShiftedRFTime - locTAGHHits[loc_i]->time_tdc);
 				}
 			}
@@ -401,7 +401,7 @@ jerror_t JEventProcessor_RF_online::evnt(JEventLoop* locEventLoop, int eventnumb
 					continue;
 				set<double>& locRFTimeSet2 = locTDCIterator2->second;
 
-				double locShiftedRFTime = dRFTimeFactory->Step_TimeToNearInputTime(*(locRFTimeSet.begin()), *(locRFTimeSet2.begin()), dRFSignalPeriod);
+				double locShiftedRFTime = dRFTimeFactory->Step_TimeToNearInputTime(*(locRFTimeSet.begin()), *(locRFTimeSet2.begin()));
 				double locDeltaT = locShiftedRFTime - *(locRFTimeSet2.begin());
 				dHistMap_RFRFDeltaTs[locSystemPair]->Fill(locDeltaT);
 			}
@@ -426,7 +426,7 @@ jerror_t JEventProcessor_RF_online::evnt(JEventLoop* locEventLoop, int eventnumb
 				if(dHistMap_AverageRFRFDeltaTs.find(locSystemPair) == dHistMap_AverageRFRFDeltaTs.end())
 					continue;
 
-				double locShiftedAverageRFTime = dRFTimeFactory->Step_TimeToNearInputTime(locAverageRFTimes[locTDCIterator->first], locAverageRFTimes[locTDCIterator2->first], dRFSignalPeriod);
+				double locShiftedAverageRFTime = dRFTimeFactory->Step_TimeToNearInputTime(locAverageRFTimes[locTDCIterator->first], locAverageRFTimes[locTDCIterator2->first]);
 				double locDeltaT = locShiftedAverageRFTime - locAverageRFTimes[locTDCIterator2->first];
 				dHistMap_AverageRFRFDeltaTs[locSystemPair]->Fill(locDeltaT);
 			}

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_FineTimeOffsets.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_FineTimeOffsets.C
@@ -5,7 +5,7 @@
 // hnamepath: /RF/AverageDeltaT_RF_OtherRFs/RFDeltaT_PSC_TOF
 // hnamepath: /RF/AverageDeltaT_RF_OtherRFs/RFDeltaT_TAGH_TOF
 
-double gRFSignalPeriod = 1000.0/499.0;
+double gBeamSignalPeriod = 2000.0/499.0;
 int gRebinF1sAmount = 25;
 int gRebinTOFAmount = 2;
 
@@ -13,9 +13,9 @@ Double_t Periodic_Gaussian_Func(Double_t* locXArray, Double_t* locParamArray)
 {
 	Double_t locValue = locParamArray[0]*TMath::Gaus(locXArray[0], locParamArray[1], locParamArray[2]);
 	if(locParamArray[1] < 0.0)
-		locValue += locParamArray[0]*TMath::Gaus(locXArray[0], locParamArray[1] + gRFSignalPeriod, locParamArray[2]);
+		locValue += locParamArray[0]*TMath::Gaus(locXArray[0], locParamArray[1] + gBeamSignalPeriod, locParamArray[2]);
 	else
-		locValue += locParamArray[0]*TMath::Gaus(locXArray[0], locParamArray[1] - gRFSignalPeriod, locParamArray[2]);
+		locValue += locParamArray[0]*TMath::Gaus(locXArray[0], locParamArray[1] - gBeamSignalPeriod, locParamArray[2]);
 
 	return locValue;
 }
@@ -26,7 +26,7 @@ TF1* Create_FitFunc(TH1I* locHist)
 	double locMean = locHist->GetBinCenter(locMaxBin);
 
 	string locFuncName = string(locHist->GetName()) + string("_Func");
-	TF1 *locFunc = new TF1(locFuncName.c_str(), Periodic_Gaussian_Func, -0.5*gRFSignalPeriod, 0.5*gRFSignalPeriod, 3);
+	TF1 *locFunc = new TF1(locFuncName.c_str(), Periodic_Gaussian_Func, -0.5*gBeamSignalPeriod, 0.5*gBeamSignalPeriod, 3);
 	locFunc->SetParameters(locHist->GetBinContent(locMaxBin), locMean, 0.1);
 	locFunc->SetParNames("Gaussian Height", "Gaussian #mu", "Gaussian #sigma");
 


### PR DESCRIPTION
Add individual factories for getting the RF time from a given system. To use, just request the DRFTime object from JANA as before, but now with tag = "TOF," "PSC," "TAGH," or "FDC."

This is necessary because different calibration plugins want different RF times, and with this, you can run them simultaneously.

Also, fix problem where after timing alignment, times could still be offset by 2ns (because was using different periods when aligning (rf period = 2ns) and using (beam period = 4ns)). 
