### PR TITLE
* gukine.F [rtj]

### DIFF
--- a/src/programs/Simulation/HDGeant/gukine.F
+++ b/src/programs/Simulation/HDGeant/gukine.F
@@ -179,6 +179,7 @@
 *
         PLAB(4) = get_beam_momentum(0)
         if (PLAB(4) .gt. 0) then
+          call GFVERT(1,VERT,NTBEAM,NTTARG,TOFG,ubuf,nubuf)
           PLAB(1) = get_beam_momentum(1)
           PLAB(2) = get_beam_momentum(2)
           PLAB(3) = get_beam_momentum(3)


### PR DESCRIPTION
- Fix bug in how the t0 for the event is set based on the beam
   rf timing and the vertex position. My recent update to remove
   the assumption of a proton target also removed the setting of
   the vertex position (was happening as a by-product of another
   operation). Added a line to restore the correct functionality.
