### PR TITLE
Hd geant run number fix

### DIFF
--- a/src/programs/Simulation/HDGeant/controlparams.inc
+++ b/src/programs/Simulation/HDGeant/controlparams.inc
@@ -3,7 +3,8 @@
       integer get_next_evt
       real trigger_time_sigma_ns
       integer event_count
+      integer override_run_number
       common /controlparams/ writenohits, showersincol, driftclusters
      +                       ,tgtwidth(2),runtime_geom,get_next_evt
      +                       ,trigger_time_sigma_ns
-     +                       ,event_count
+     +                       ,event_count,override_run_number

--- a/src/programs/Simulation/HDGeant/gukine.F
+++ b/src/programs/Simulation/HDGeant/gukine.F
@@ -164,7 +164,7 @@
         get_next_evt=1
       endif
       if (itry .eq. 0) then
-        itry = loadInput()
+        itry = loadInput(override_run_number,IDRUN)
 *
 *       Check for random number seeds in the input file. If they are
 *       there, then the values of iseed1 and iseed2 will be overwritten

--- a/src/programs/Simulation/HDGeant/guout.F
+++ b/src/programs/Simulation/HDGeant/guout.F
@@ -64,13 +64,14 @@ C.
 C.
 #include "geant321/gcomis.inc"
 #include "geant321/gcphys.inc"
+#include "geant321/gcflag.inc"
 #include "controlparams.inc"
 C.    ------------------------------------------------------------------
 C.
       integer iskip
       integer iseen
       call gelh_outp(iskip)
-      iseen = loadOutput()
+      iseen = loadOutput(IDRUN)
 
 C     #define WRITE_ONLY_IF_SOMETHING_WAS_SEEN 1
 C     #if WRITE_ONLY_IF_SOMETHING_WAS_SEEN

--- a/src/programs/Simulation/HDGeant/hddmInput.c
+++ b/src/programs/Simulation/HDGeant/hddmInput.c
@@ -136,7 +136,7 @@ int nextInput ()
  * loadInput
  *-------------------------
  */
-int loadInput ()
+int loadInput (int override_run_number, int myInputRunNo)
 {
 	/* Extracts the "thrown" particle 4-vectors and types from the
 	 * current HDDM buffer "thisInputEvent" and creates a vertex for
@@ -144,7 +144,7 @@ int loadInput ()
 	 */
    s_Reactions_t* reacts;
    int reactCount, ir;
-   int runNo = thisInputEvent->physicsEvents->in[0].runNo;
+   int runNo = (override_run_number>0)?(myInputRunNo):thisInputEvent->physicsEvents->in[0].runNo;
    int eventNo = thisInputEvent->physicsEvents->in[0].eventNo;
    seteventid_(&runNo,&eventNo);
    reacts = thisInputEvent ->physicsEvents->in[0].reactions;
@@ -357,6 +357,8 @@ int storeInput (int runNo, int eventNo, int ntracks)
                                           +plab[2]*plab[2]+amass*amass);
       ps->mult++;
    }
+   printf(">>>>>>>>>>>>>>>> here %d\n",runNo);
+
    pes->in[0].runNo = runNo;
    pes->in[0].eventNo = eventNo;
    return 0;
@@ -456,9 +458,9 @@ int nextinput_ ()
    return nextInput();
 }
 
-int loadinput_ ()
+int loadinput_ (int *override_run_number,int *myInputRunNo)
 {
-   return loadInput();
+  return loadInput(*override_run_number,*myInputRunNo);
 }
 
 int storeinput_ (int* runNo, int* eventNo, int* ntracks)

--- a/src/programs/Simulation/HDGeant/hddmInput.c
+++ b/src/programs/Simulation/HDGeant/hddmInput.c
@@ -357,8 +357,6 @@ int storeInput (int runNo, int eventNo, int ntracks)
                                           +plab[2]*plab[2]+amass*amass);
       ps->mult++;
    }
-   printf(">>>>>>>>>>>>>>>> here %d\n",runNo);
-
    pes->in[0].runNo = runNo;
    pes->in[0].eventNo = eventNo;
    return 0;

--- a/src/programs/Simulation/HDGeant/hddmOutput.c
+++ b/src/programs/Simulation/HDGeant/hddmOutput.c
@@ -63,7 +63,7 @@ int closeOutput ()
    return 0;
 }
 
-int loadOutput ()
+int loadOutput (int runNo)
 {
    int packages_hit=0;
    s_HitView_t *hitView;
@@ -85,7 +85,7 @@ int loadOutput ()
       thisOutputEvent->physicsEvents->mult = 1;
       thisOutputEvent->physicsEvents->in[0].eventNo = ++eventNo;
    }
-	
+   thisOutputEvent->physicsEvents->in[0].runNo=runNo;
 	if (Nevents == 1) {
 		if (thisOutputEvent->geometry == HDDM_NULL) {
 			thisOutputEvent->geometry = make_s_Geometry();
@@ -164,9 +164,9 @@ int flushoutput_ ()
    return flushOutput();
 }
 
-int loadoutput_ ()
+int loadoutput_ (int *runNo)
 {
-   return loadOutput();
+   return loadOutput(*runNo);
 }
 
 int closeoutput_ ()

--- a/src/programs/Simulation/HDGeant/uginit.F
+++ b/src/programs/Simulation/HDGeant/uginit.F
@@ -129,6 +129,7 @@
 *                                                                      *
 ************************************************************************
 *
+#include "geant321/gcflag.inc"
 #include "geant321/gckine.inc"
 #include "geant321/gcunit.inc"
 #include "geant321/gcphys.inc"
@@ -156,9 +157,6 @@
       data bfield_map/20*0/
       data PS_bfield_type/20*0/
       data PS_bfield_map/20*0/
-
-      integer myrunno
-      data myrunno/1/
 
       integer postsmear
       integer mcsmearopts(64)
@@ -219,6 +217,7 @@ C..geant..
 *             PKINE(1)=particle energy
 *             IKINE and PKINE can be changed with the data card KINE
 *
+      IDRUN=1
       PKINE(1)=10.
       PKINE(5)=4.
       IKINE=1
@@ -289,7 +288,7 @@ C..geant..
 *
 *             Open the input stream
 *
-      nevent = 0
+c      nevent = 0
       if (infile(1) .gt. 0) then
         ifail = openInput(infile)
         if (ifail .ne. 0) then
@@ -298,15 +297,15 @@ C..geant..
            stop
         endif
         get_next_evt=0
-        call extractRunNumber(myrunno)
+        call extractRunNumber(IDRUN)
 
-        write(6,*) 'run number ',myrunno
+        write(6,*) 'run number ',IDRUN
         if (iskip .gt. 0) then
           ifail = skipInput(iskip)
         endif
-        if (nevent .eq. 0) then
-          nevent = 999999999
-        endif
+c        if (nevent .eq. 0) then
+c          nevent = 999999999
+c        endif
       endif
 *
 *             Open the output stream
@@ -396,7 +395,7 @@ C..geant..
 *      endif
       call Goptimize
       call initcalibdb(bfield_type, bfield_map, PS_bfield_type, 
-     +     PS_bfield_map, myrunno)
+     +     PS_bfield_map, IDRUN)
       call copytocplusplus(infile,outfile,postsmear,mcsmearopts
      +,deleteunsmeared)
       call copygatetocplusplus(bggate(1), bggate(2))

--- a/src/programs/Simulation/HDGeant/uginit.F
+++ b/src/programs/Simulation/HDGeant/uginit.F
@@ -165,6 +165,9 @@
       data mcsmearopts/64*0/
       data postsmear/0/
       data deleteunsmeared/0/
+      
+      integer myrunno
+      data myrunno/1/
 
       integer openInput, skipInput, openOutput
       external openInput, skipInput, openOutput
@@ -194,6 +197,7 @@ c The following parameters are declared in controlparams.inc above.
       data get_next_evt/1/
       data trigger_time_sigma_ns/10./
       data event_count/0/
+      data override_run_number/0/
 
 C  Use this parameter to set up a minimum photon energy 
 C  for the coherent bremsstrahlung beam generator - see beamgen.F
@@ -217,7 +221,7 @@ C..geant..
 *             PKINE(1)=particle energy
 *             IKINE and PKINE can be changed with the data card KINE
 *
-      IDRUN=1
+      IDRUN=-1
       PKINE(1)=10.
       PKINE(5)=4.
       IKINE=1
@@ -297,9 +301,16 @@ c      nevent = 0
            stop
         endif
         get_next_evt=0
-        call extractRunNumber(IDRUN)
+*            Get the run number from the input file 
+        call extractRunNumber(myrunno)
+*           .. but override it with the RUNG card if IDRUN>0        
+        if (IDRUN.lt.0) then
+           IDRUN=myrunno
+        else 
+           override_run_number=1
+        endif
 
-        write(6,*) 'run number ',IDRUN
+        write(6,*) 'run number ',IDRUN,override_run_number
         if (iskip .gt. 0) then
           ifail = skipInput(iskip)
         endif
@@ -394,6 +405,8 @@ c        endif
 *        call HDDSgeant3_runtime
 *      endif
       call Goptimize
+*         Set some default value for run number if not set otherwise
+      if (IDRUN.lt.0) IDRUN=1 
       call initcalibdb(bfield_type, bfield_map, PS_bfield_type, 
      +     PS_bfield_map, IDRUN)
       call copytocplusplus(infile,outfile,postsmear,mcsmearopts


### PR DESCRIPTION
This modifies the code to enable use of the geant RUNG ffread card to specify the run number in the control.in in file (e.g.  RUNG 3185).    For  an hddm input file,  if the RUNG card is set in the control.in file, the value set will override the run number in the file.   If the card is not set and the particle gun is chosen, the run number defaults to 1.
