### PR TITLE
Add -pthread when linking HDDM tools using the clang compiler

### DIFF
--- a/src/programs/Utilities/hddm/SConscript
+++ b/src/programs/Utilities/hddm/SConscript
@@ -22,6 +22,11 @@ env.Replace(CFLAGS=cflags, CXXFLAGS=cxxflags)
 sbms.AddXERCES(env)
 sbms.Add_xstream(env)
 
+# The llvm_clan_3.7.0 compiler on Linux_CentOS6-x86_64 needs
+# -pthread on the link command to work. 
+if env['COMPILER']=='clang':
+	env.AppendUnique(LINKFLAGS=['-pthread'])
+
 progs = []
 
 commonsrc = ['XString.cpp', 'XParsers.cpp', 'md5.c']


### PR DESCRIPTION
Builds with a newly installed clang 3.7.0 file were failing due to linking problems in programs/Utilities/hddm. (hddm-xml specifically, but that was probably just the first one).

Added "-pthread" to LINKFLAGS, but only when using the clang compiler and only in the hddm tools since this seems to be the only place it is needed.
