### PR TITLE
Run dependent beam energy

### DIFF
--- a/src/libraries/AMPTOOLS_MCGEN/GammaPToXYP.cc
+++ b/src/libraries/AMPTOOLS_MCGEN/GammaPToXYP.cc
@@ -16,8 +16,9 @@
 
 // FORTRAN routines
 extern "C"{
-void cobrems_(float* Emax, float* Epeak, float* Dist);
+void cobrems_(float* Emax, float* Epeak, float* emitmr, float* radt, float* Dist, float* collDiam, int* doPolFluxfloat);
 float dntdx_(float* x);
+float dnidx_(float* x);
 };
 
 // Wrapper function for total
@@ -25,6 +26,12 @@ double dNtdx(double x)
 {
         float xx = x;
         return (double)dntdx_(&xx);
+}
+
+double dNidx(double x)
+{
+        float xx = x;
+        return (double)dnidx_(&xx);
 }
 
 GammaPToXYP::GammaPToXYP( float lowMassXY, float highMassXY, 
@@ -44,18 +51,24 @@ m_childMass( 0 ) {
   float Epeak = beamPeakE;
   float Elow = beamLowE;
   float Ehigh = beamHighE;
-  float Dist = 76.0;
-  cobrems_(&Emax, &Epeak, &Dist);
+  
+  int doPolFlux=0;  // want total flux (1 for polarized flux)
+  float emitmr=10.e-9; // electron beam emittance
+  float radt=20.e-6; // radiator thickness in m
+  float collDiam=0.0034; // meters
+  float Dist = 76.0; // meters
+  cobrems_(&Emax, &Epeak, &emitmr, &radt, &Dist, &collDiam, &doPolFlux);
 
   // Create histogram
-  cobrem_vs_E = new TH1D("cobrem_vs_E", "Coherent Bremstrahlung vs. E_{#gamma}", (int)(100*Emax), 0.0, Emax);
+  cobrem_vs_E = new TH1D("cobrem_vs_E", "Coherent Bremstrahlung vs. E_{#gamma}", 1000, Elow, Ehigh);
   
   // Fill histogram
   for(int i=1; i<=cobrem_vs_E->GetNbinsX(); i++){
 	  double x = cobrem_vs_E->GetBinCenter(i)/Emax;
-	  double y = dNtdx(x);
-	  if(cobrem_vs_E->GetBinCenter(i) > Elow && cobrem_vs_E->GetBinCenter(i) < Ehigh) 
-		  cobrem_vs_E->SetBinContent(i, y);
+	  double y = 0;
+	  if(Epeak<Elow) y = dNidx(x);
+	  else y = dNtdx(x);
+	  cobrem_vs_E->SetBinContent(i, y);
   }
 
 }

--- a/src/libraries/AMPTOOLS_MCGEN/SConscript
+++ b/src/libraries/AMPTOOLS_MCGEN/SConscript
@@ -6,7 +6,7 @@ import sbms
 Import('*')
 env = env.Clone()
 
-
+sbms.AddCERNLIB(env)
 sbms.AddAmpTools(env)
 sbms.AddROOT(env)
 sbms.library(env)

--- a/src/libraries/AMPTOOLS_MCGEN/cobrems.F
+++ b/src/libraries/AMPTOOLS_MCGEN/cobrems.F
@@ -8,12 +8,11 @@ C    no 3 (1975) pp. 478-494.
 C
 C Author: Richard Jones    8-July-1997
 C
-C #define vector real
+#define vector real
 
-      Subroutine cobrems(Emax,Epeak,Dist)
-      real Emax,Epeak,Dist
+      Subroutine cobrems(Emax,Epeak,emitmr,radt,dist,coldiam,polar)
+      real Emax,Epeak,emitmr,radt,dist,coldiam
       include 'cobrems.inc'
-c      REAL inputs(10)
       integer i
       real c
       dpi=acos(-1d0)
@@ -24,24 +23,25 @@ c      REAL inputs(10)
       a=3.56e-10        !dimension of diamond unit cell (m)
       Aphonon=0.5e9     !phonon-free recoil constant (GeV**-2)
       betaFF=111*Z**(-1/3.)/me !cutoff for atomic form-factor (/GeV)
-      mospread=50e-6    !crystal r.m.s. mosaic spread
+      mospread=20e-6    !crystal r.m.s. mosaic spread
       E=Emax            !electron beam energy (GeV)
-      Erms=6.0e-3       !electron beam energy rms spread (GeV)
-      emitx=1.0e-8      !electron beam emittance in x (m r)
-      emity=0.5e-8      !electron beam emittance in y (m r)
-      spot=0.0005       !electron beam spot size at collimator
-      D=Dist            !distance from radiator to collimator
-      t=20.0e-6         !thickness of radiator (m)
-      collim=0.0034     !collimator diameter (m)
+      Erms=6.0e-4       !electron beam energy rms spread (GeV)
+      emit=emitmr       !electron beam emittance (m r)
+      spot=0.0005       !electron beam spot size at collimator (m)
+      D=dist            !distance from radiator to collimator (m)
+      t=radt            !thickness of radiator (m)
+      collim=coldiam    !collimator diameter (m)
       thx=-0.0300/E     !rotation of crystal about x (first)
-      thy=0.100         !rotation of crystal about y (second)
+      thy=0.050         !rotation of crystal about y (second)
 C-- require Epeak < Emax
       if (Epeak.ge.Emax) then
         return
       endif
+C-- decide if you want total or polarized flux
+      unpolar=(polar.eq.0)
 C-- approximate calculation of angle from primary edge energy
-      edge=Epeak !desired position of primary edge
-      qtotal=9.8e-6 !Qtot for dominant lattice vector
+      edge=Epeak        !desired position of primary edge
+      qtotal=9.8e-6     !Qtot for dominant lattice vector
       qlong=edge/(E-edge)*me**2/(2*E)
       thx=-qlong/qtotal
 C-- PDG formula for radiation length, converted to meters
@@ -51,21 +51,31 @@ C-- PDG formula for radiation length, converted to meters
      +                -(c**2)*(1/(1+c**2) + 0.20206 - 0.0369*(c**2)
      +                        + 0.0083*(c**4) - 0.002*(c**6)))
      +        + Z*log(1194*Z**(-2/3)))
+C-- Schiff formula for radiation length, converted to meters
+c     zeta=log(1440*Z**(-2/3.))/log(183*Z**(-1/3.))
+c     radlen=4*nsites*alpha**3*(hbarc/(a*me))**2/a
+c    +      *Z*(Z+zeta)*log(183*Z**(-1/3.))
+C-- use either one formula or the other from above
       radlen=1/radlen
       write(6,*)
       write(6,1000)
-1000  format('Initialization for coherent bremsstralung calculation')
+ 1000 format('Initialization for coherent bremsstralung calculation')
       write(6,1010) E
-1010  format(' electron beam energy:',f12.3,'GeV')
+ 1010 format(' electron beam energy:',f12.3,'GeV')
+      write(6,1012) emit*1e9
+ 1012 format(' electron beam emittance:',f12.3,'mm.urad')
       write(6,1020) 'diamond',t*1e6
-1020  format(' radiator crystal: ',a10,', thickness',f8.0,'um')
+ 1020 format(' radiator crystal: ',a10,', thickness',f8.0,'um')
       write(6,1030) radlen*1e2,mospread*1e6
-1030  format(' radiation length:',f8.1,'cm, mosaic spread:',f8.1,'ur')
+ 1030 format(' radiation length:',f8.1,'cm, mosaic spread:',f8.1,'urad')
       write(6,1040) collim/(2*D)*(E/me)
-1040  format(' photon beam collimator half-angle:',f12.3,'(m/E)')
+ 1040 format(' photon beam collimator half-angle:',f12.3,'(m/E)')
+      write(6,1045) colDiam*1e2
+ 1045 format(' Collimator diameter:',f8.3,'cm')
       write(6,1050) thx*1e3,thy*1e3
-1050  format(' crystal orientation: theta-x',f10.3,'mr',
-     +      /'                      theta-y',f10.3,'mr')
+ 1050 format(' crystal orientation: theta-x',f10.3,'mrad',
+     +      /'                      theta-y',f10.3,'mrad')
+
 C  define the unit cell of the radiator crystal
       ucell(1,1)=0
       ucell(2,1)=0
@@ -95,10 +105,10 @@ C  define the crystal->lab rotation matrix
       rotate(3,1)=0
       rotate(3,2)=0
       rotate(3,3)=1
-      call rotmat(rotate,0d0,dpi/2,0d0) !point (1,0,0) along beam
-      call rotmat(rotate,0d0,0d0,dpi/4) !point (0,1,1) vertically
-      call rotmat(rotate,-thx,0d0,0d0) !the goniometer-x rotation
-      call rotmat(rotate,0d0,-thy,0d0) !the goniometer-y rotation
+      call rotmat(rotate,0d0,dpi/2,0d0)       !point (1,0,0) along beam
+      call rotmat(rotate,0d0,0d0,dpi/4)       !point (0,1,1) vertically
+      call rotmat(rotate,-thx,0d0,0d0)        !the goniometer-x rotation
+      call rotmat(rotate,0d0,-thy,0d0)        !the goniometer-y rotation
       write(6,2000) (rotate(1,j),j=1,3)
       write(6,2000) (rotate(2,j),j=1,3)
       write(6,2000) (rotate(3,j),j=1,3)
@@ -139,8 +149,8 @@ C  define the crystal->lab rotation matrix
       real x
       include 'cobrems.inc'
       real phi
-      phi=dpi/4
-      dNcdx=2*dpi*dNcdxdp(x,phi)
+      phi=REAL(dpi/4)
+      dNcdx=REAL(2*dpi*dNcdxdp(x,phi))
       end
 
       real function dNcdx3(x,dRadCol,diamCol)
@@ -150,8 +160,8 @@ C  define the crystal->lab rotation matrix
       if (dRadCol.gt.0) D=dRadCol
       if (diamCol.gt.0) collim=diamCol
       if (diamCol.lt.0) collim=-2*D*diamCol*me/E
-      phi=dpi/4
-      dNcdx3=2*dpi*dNcdxdp(x,phi)
+      phi=REAL(dpi/4)
+      dNcdx3=REAL(2*dpi*dNcdxdp(x,phi))
       end
 
       real function dNcdxdp(x,phi)
@@ -165,11 +175,11 @@ C  define the crystal->lab rotation matrix
       real q3min
       integer i
       real sigma0
-      sigma0=16*dpi*t*Z**2*alpha**3*E*(hbarc/a**2)*(hbarc/a/me)**4
+      sigma0=REAL(16*dpi*t*Z**2*alpha**3*E*(hbarc/a**2)*(hbarc/a/me)**4)
       q2points=0
       q3min=1
       sum=0
-      do h=0,0
+      do h=-4,4  ! can replace with 0,0 for cpu speed-up if crystal alignment is "reasonable"
         do k=-10,10
           do l=-10,10
 c       do k=-2,-2
@@ -198,13 +208,13 @@ c         do l=-2,-2
             if (S2.lt.1e-4) then
               goto 10
             endif
-            qnorm=2*dpi*hbarc/a
+            qnorm=REAL(2*dpi*hbarc/a)
             q(1)=qnorm*(rotate(1,1)*h + rotate(1,2)*k + rotate(1,3)*l)
             q(2)=qnorm*(rotate(2,1)*h + rotate(2,2)*k + rotate(2,3)*l)
             q(3)=qnorm*(rotate(3,1)*h + rotate(3,2)*k + rotate(3,3)*l)
             q2=q(1)**2+q(2)**2+q(3)**2
             qT2=q(1)**2+q(2)**2
-            xmax=2*E*q(3)
+            xmax=REAL(2*E*q(3))
             xmax=xmax/(xmax+me**2)
             if ((x.gt.xmax).or.(xmax.gt.1)) then
               goto 10
@@ -213,19 +223,19 @@ c             write(6,*) h,k,l,S2
 c             write(6,*) q2,xmax
             endif
             if (q(3).lt.q3min) then
-              q3min=q(3)
+              q3min=REAL(q(3))
               hmin=h
               kmin=k
               lmin=l
             endif
             theta2=(1-x)*xmax/(x*(1-xmax)) - 1
-            FF=1/(1+q2*betaFF**2)
-            sum=sum+sigma0*qT2*S2*exp(-Aphonon*q2)*(FF*betaFF**2)**2
+            FF=REAL(1/(1+q2*betaFF**2))
+            sum=REAL(sum+sigma0*qT2*S2*exp(-Aphonon*q2)*(FF*betaFF**2)**2
      +         * ((1-x)/(x*(1+theta2))**2)
      +         * ((1+(1-x)**2)
      +               - 8*(theta2/(1+theta2)**2)*(1-x)*cos(phi)**2)
      +         * acceptance(theta2)
-c    +         * polarization(x,theta2)
+     +         * polarization(x,theta2))
 C comment out the preceding line to disable polarization -RTJ
             q2points=q2points+1
             q2theta2(q2points)=theta2
@@ -336,21 +346,37 @@ c     write(6,*) dNidxdt2
       real function polarization(x,theta2)
       real x,theta2
       include 'cobrems.inc'
+      if (unpolar) then
+        polarization=1
+        return
+      endif
       polarization=2*(1-x)/((1+theta2)**2*((1-x)**2+1) - 4*theta2*(1-x))
+      end
+
+      real function acceptance2(theta2,phi)
+      real theta2,phi
+      include 'cobrems.inc'
+      real xc,yc
+      real xshift,yshift
+      parameter (xshift=1.7e-3,yshift=0)
+      real theta
+      theta=sqrt(theta2)*me/E
+      xc=D*sin(theta)*cos(phi)+xshift
+      yc=D*sin(theta)*sin(phi)+yshift
+      acceptance2 = acceptance((atan2(sqrt(xc**2+yc**2),D)*(E/me))**2)
       end
 
       real function acceptance(theta2)
       real theta2
       include 'cobrems.inc'
-      REAL sig(4)
+      vector sig(4)
       real u,var0,varMS,thetaC
       real pu,du2,u0,u1,u2
       integer iter,niter
       real theta
 Comment out the following lines to enable collimation -RTJ
-         acceptance=1
-C        write(6,*) sqrt(theta2)
-C       return
+c      acceptance=1
+c      return
 Comment out the preceding lines to enable collimation -RTJ
       acceptance=0
       niter=50
@@ -391,9 +417,9 @@ Comment out the preceding lines to enable collimation -RTJ
         else
           pu=exp(-u2/(2*var0))/(2*var0)
         endif
-        acceptance=acceptance + pu*du2/dpi
+        acceptance=REAL(acceptance + pu*du2/dpi
      +    * atan2(sqrt((theta2-(thetaC-u)**2)*((thetaC+u)**2-theta2)),
-     +            theta2-thetaC**2+u2)
+     +            theta2-thetaC**2+u2))
       enddo
       end
 
@@ -439,7 +465,7 @@ C   with rotations understood in the passive sense
       subroutine convol(nbins)
       integer nbins
       include 'cobrems.inc'
-      REAL hisx(10000),hisy(10000),sig(4)
+      vector hisx(10000),hisy(10000),sig(4)
       real norm(10000),result(10000)
       real x,x0,x1,dx
       real alph,dalph
@@ -448,7 +474,7 @@ C   with rotations understood in the passive sense
       integer i,ii,j
       x0=hisx(1)
       x1=hisx(nbins)
-      var0=(mospread**2+(emitx/spot)**2)
+      var0=(mospread**2+(emit/spot)**2)
       varMS=sigma2MS(t)
       sig(3)=sqrt(var0)*E/me
       sig(4)=sqrt(varMS)*E/me
@@ -457,9 +483,9 @@ C  is dominantly responsible for the coherent photons in this bin in x.
 C  I just use the smallest of the two angles, but this does not work when
 C  both angles are small, and you have to be more clever -- BEWARE!!!
 C--In any case, fine-tuning below the mosaic spread limit makes no sense.
-      alph=min(abs(thx),abs(thy))
+      alph=REAL(min(abs(thx),abs(thy)))
       if (alph.eq.0) then
-        alph=max(abs(thx),abs(thy))
+        alph=REAL(max(abs(thx),abs(thy)))
       else
         alph=max(alph,mospread)
       endif
@@ -472,13 +498,13 @@ C--In any case, fine-tuning below the mosaic spread limit makes no sense.
           x=x0+(x1-x0)*(j-0.5)/nbins
           dalph=dx*alph/(x*(1-x))
           if (varMS/var0.gt.1e-4) then
-            term=dalph/varMS
+            term=REAL(dalph/varMS
      +      *(ERF(dalph/sqrt(2*(var0+varMS))) - ERF(dalph/sqrt(2*var0)))
      +         + sqrt(2/dpi)/varMS
      +      *(exp(-dalph**2/(2*(var0+varMS)))*sqrt(var0+varMS)
-     +       -exp(-dalph**2/(2*var0))*sqrt(var0))
+     +       -exp(-dalph**2/(2*var0))*sqrt(var0)))
           else
-            term=exp(-dalph**2/(2*var0))/sqrt(2*dpi*var0)
+            term=REAL(exp(-dalph**2/(2*var0))/sqrt(2*dpi*var0))
           endif
           term=term*alph/x
           norm(j)=norm(j)+term
@@ -498,13 +524,13 @@ c     write(6,*) norm
           x=x0+(x1-x0)*(j-0.5)/nbins
           dalph=dx*alph/(x*(1-x))
           if (varMS/var0.gt.1e-4) then
-            term=dalph/varMS
+            term=REAL(dalph/varMS
      +      *(ERF(dalph/sqrt(2*(var0+varMS))) - ERF(dalph/sqrt(2*var0)))
      +         + sqrt(2/dpi)/varMS
      +      *(exp(-dalph**2/(2*(var0+varMS)))*sqrt(var0+varMS)
-     +       -exp(-dalph**2/(2*var0))*sqrt(var0))
+     +       -exp(-dalph**2/(2*var0))*sqrt(var0)))
           else
-            term=exp(-dalph**2/(2*var0))/sqrt(2*dpi*var0)
+            term=REAL(exp(-dalph**2/(2*var0))/sqrt(2*dpi*var0))
           endif
           term=term*alph/x
           result(ii)=result(ii)+term*hisy(j)/norm(j)
@@ -522,12 +548,103 @@ c     write(6,*) norm
 
       real function sigma2MS(tt)
       real tt
-      include 'cobrems.inc'
-C--Multiple scattering formula of Kaune et.al. is a bit off
-c     sigma2MS=8*dpi*nsites*alpha**2*Z**2*tt*(hbarc/(me*a))**2/a
-c    +         *log(183*Z**(-1/3.))
-C--Use the PDG formula instead (with beta=1, charge=1)
-      sigma2MS=(13.6e-3/E)**2*(tt/radlen)*(1+0.038*log(tt/radlen))**2
+C--Chose one of the available implementations of this function below.
+c  Some formulas, although valid for a reasonable range of target thickness,
+c  can go negative for extremely small target thicknesses.  Here I protect
+c  against these unusual cases by taking the absolute value. [rtj]
+      sigma2MS=abs(sigma2MS_Geant(tt))
       end
-C
-C      include 'expint.f'
+
+      real function sigma2MS_Kaune(tt)
+      real tt
+      include 'cobrems.inc'
+C--Multiple scattering formula of Kaune et.al. 
+c  with a correction factor from a multiple-scattering calculation
+c  taking into account the atomic and nuclear form factors for carbon.
+
+c--Note by RTJ, Oct. 13, 2008:
+c  I think this formula overestimates multiple scattering in thin targets
+c  like these diamond radiators, because it scales simply like sqrt(tt).
+c  Although the leading behavior is sqrt(tt/radlen), it should increase
+c  faster than that because of the 1/theta**2 tail of the Rutherford
+c  distribution that makes the central gaussian region swell with increasing
+c  number of scattering events.  For comparison, I include below the PDG
+c  formula (sigma2MS), the Moliere formula used in the Geant3 simulation
+c  of gaussian multiple scattering (sigma2MS_Geant), and a Moliere fit for
+c  thin targets taken from reference Phys.Rev. vol.3 no.2, (1958), p.647
+c  (sigma2MS_Hanson).  The latter two separate the gaussian part from the
+c  tails in different ways, but both agree that the central part is much
+c  more narrow than the formulation by Kaune et.al. below.
+
+      carboncor=4.2/4.6
+      sigma2MS_Kaune=REAL(8*dpi*nsites*alpha**2*Z**2*tt*(hbarc/(E*a))**2/a
+     +              *log(183*Z**(-1/3.))
+     +              *carboncor)
+      end
+
+      real function sigma2MS_pdg(tt)
+      real tt
+      include 'cobrems.inc'
+C--The PDG formula instead (with beta=1, charge=1)
+c  This formula is said to be within 11% for t > 1e-3 rad.len.
+      sigma2MS_pdg=(13.6e-3/E)**2*(tt/radlen)
+     +            *(1+0.038*log(tt/radlen))**2
+      end
+
+      real function sigma2MS_Geant(tt)
+      real tt
+      include 'cobrems.inc'
+C--Geant3 formula for the rms multiple-scattering angle
+c  This formula is based on the theory of Moliere scattering.  It contains
+c  a cutoff parameter F that is used for the fractional integral of the
+c  scattering probability distribution that is included in computing the
+c  rms.  This is needed because the complete distribution of scattering
+c  angles connects smoothly from a central gaussian (small-angle
+c  multiple-scattering regime) to a 1/theta^2 tail (large-angle Rutherford
+c  scattering regime) through the so-called plural scattering region.
+      F=0.98 ! probability cutoff in definition of sigma2MS
+      density=3.534 ! g/cm^3
+      chi2cc=(0.39612e-2)**2*(Z*(Z+1))*(density/12) ! GeV^2/m
+      chi2c=chi2cc*(tt/E**2)
+      rBohr=0.52917721e-10 ! m
+      chi2alpha=1.13*(hbarc/(E*rBohr*0.885))**2
+     +         *Z**(2/3.)*(1+3.34*(alpha*Z)**2)
+      omega0=chi2c/(1.167*chi2alpha) ! mean number of scatters
+      gnu=omega0/(2*(1-F))
+      sigma2MS_Geant=chi2c/(1+F**2)*((1+gnu)/gnu*log(1+gnu)-1)
+      end
+
+      real function sigma2MS_Hanson(tt)
+      real tt
+      include 'cobrems.inc'
+C--Formulation of the rms projected angle attributed to Hanson et.al.
+c  in reference Phys.Rev. vol.3 no.2, (1958), p.647.  This is just Moliere
+c  theory used to give the 1/e angular width of the scattering distribution.
+c  In the paper, though, they compare it with experiment for a variety of
+c  metal foils down to 1e-4 rad.len. in thickness, and show excellent
+c  agreement with the gaussian approximation out to 4 sigma or so.  I
+c  like this paper because of the excellent agreement between the theory
+c  and experimental data.
+      density=3.534 ! g/cm^3
+      ttingcm=tt*100*density
+      Atomicweight=12
+      EinMeV=E*1000
+      theta2max=0.157*Z*(Z+1)/Atomicweight*(ttingcm/EinMeV**2)
+      theta2screen=theta2max*Atomicweight*(1+3.35*(Z*alpha)**2)
+     +            /(7800*(Z+1)*Z**(1/3.)*ttingcm)
+      BminuslogB=log(theta2max/theta2screen)-0.154
+      Blast=1
+      do i=1,999
+        B=BminuslogB+log(Blast)
+        if (B.lt.1.2) then
+          B=1.21
+          goto 10
+        elseif (abs(B-Blast).gt.1e-6) then
+          Blast=B
+        else
+          goto 10
+        endif
+      enddo
+   10 continue
+      sigma2MS_Hanson=theta2max*(B-1.2)/2
+      end

--- a/src/libraries/AMPTOOLS_MCGEN/cobrems.inc
+++ b/src/libraries/AMPTOOLS_MCGEN/cobrems.inc
@@ -6,10 +6,11 @@ C units: length in m; energy,momentum,mass in GeV; angles in radians
       parameter (nsites=8)
       common /cotarg/Z,a,radlen,Aphonon,mospread,betaFF,ucell(3,nsites)
       real Z,a,radlen,Aphonon,mospread,betaFF,ucell
-      common /cosetup/thx,thy,rotate(3,3),E,emitx,emity,spot,Erms,
-     +                D,t,collim
+      common /cosetup/thx,thy,rotate(3,3),E,Erms,emit,spot,D,t,collim
       double precision thx,thy,rotate
-      real E,emitx,emity,Erms,spot,D,t,collim
+      real E,Erms,emit,spot,D,t,collim
       common /coQ2list/q2points,q2theta2(1000),q2weight(1000)
       integer q2points
       real q2theta2,q2weight
+      common /coselect/unpolar
+      logical unpolar

--- a/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_hists.h
+++ b/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_hists.h
@@ -37,8 +37,13 @@ class DCustomAction_p2gamma_hists : public DAnalysisAction
 
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 
+		// Parameters for event selection to fill histograms
+		int endpoint_energy_bins;
+		double cohmin_energy, cohedge_energy, endpoint_energy;
+		double dEdxCut, minMM2Cut, maxMM2Cut, missingEnergyCut, min2gMassCut, max2gMassCut;
+
 		// Optional: Useful utility functions.
-//		const DAnalysisUtilities* dAnalysisUtilities;
+		//const DAnalysisUtilities* dAnalysisUtilities;
 		
 		set<set<pair<const JObject*, Particle_t> > > dPreviousSourceObjects;
 

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.cc
@@ -9,6 +9,34 @@
 
 void DCustomAction_p2pi_hists::Initialize(JEventLoop* locEventLoop)
 {
+	DApplication* dapp=dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	JCalibration *jcalib = dapp->GetJCalibration((locEventLoop->GetJEvent()).GetRunNumber());
+
+	// Parameters for event selection to fill histograms
+	endpoint_energy = 12.;
+	map<string, double> photon_endpoint_energy;
+	if(jcalib->Get("/PHOTON_BEAM/endpoint_energy", photon_endpoint_energy) == false) {
+		endpoint_energy = photon_endpoint_energy["PHOTON_BEAM_ENDPOINT_ENERGY"];
+	}
+	endpoint_energy_bins = (int)(20*endpoint_energy);
+
+	cohmin_energy = 0.;
+	cohedge_energy = 12.;
+	map<string, double> photon_beam_param;
+	if(jcalib->Get("test/PHOTON_BEAM/coherent_energy", photon_beam_param) == false) {
+		cohmin_energy = photon_beam_param["cohmin_energy"];
+		cohedge_energy = photon_beam_param["cohedge_energy"];
+	}
+
+	dEdxCut = 2.2;
+	minMMCut = 0.8;
+	maxMMCut = 1.05;
+	minMM2Cut = -0.005;
+	maxMM2Cut = 0.005;
+	missingEnergyCut = 1.0;
+	minRhoMassCut = 0.6;
+	maxRhoMassCut = 0.88;
+
 	// get PID algos
         const DParticleID* locParticleID = NULL;
         locEventLoop->GetSingle(locParticleID);
@@ -25,7 +53,7 @@ void DCustomAction_p2pi_hists::Initialize(JEventLoop* locEventLoop)
 			//If another thread has already created the folder, it just changes to it. 
 		CreateAndChangeTo_ActionDirectory();
 		
-		dEgamma = GetOrCreate_Histogram<TH1I>("Egamma", "TAGGER photon energy; E_{#gamma}", 400, 0., 12.);
+		dEgamma = GetOrCreate_Histogram<TH1I>("Egamma", "TAGGER photon energy; E_{#gamma}", endpoint_energy_bins, 0., endpoint_energy);
 		
 		if(dMissingPID == Proton) {
 			dMM_M2pi = GetOrCreate_Histogram<TH2I>("MM_M2pi", "MM off #pi^{+}#pi^{-} vs M_{#pi^{+}#pi^{-}}; M_{#pi^{+}#pi^{-}}; MM", 200, 0.0, 2.0, 200, 0., 4.);
@@ -35,7 +63,7 @@ void DCustomAction_p2pi_hists::Initialize(JEventLoop* locEventLoop)
 		}
 		else {
 			dMM2_M2pi = GetOrCreate_Histogram<TH2I>("MM2_M2pi", "MM^{2} off #pi^{+}#pi^{-} vs M_{#pi^{+}#pi^{-}}; M_{#pi^{+}#pi^{-}}; MM^{2}", 200, 0.0, 2.0, 200, -1., 1.);
-			dProton_dEdx_P = GetOrCreate_Histogram<TH2I>("Proton_dEdx_P","dE/dx vs p; p; dE/dx",200,0,2,500,0,5);
+			dProton_dEdx_P = GetOrCreate_Histogram<TH2I>("Proton_dEdx_P","dE/dx vs p; p; dE/dx",200,0,2,500,0,25);
 			dProton_P_Theta = GetOrCreate_Histogram<TH2I>("Proton_P_Theta","p vs #theta; #theta; p (GeV/c)",180,0,180,120,0,12);
 			dDeltaE_M2pi = GetOrCreate_Histogram<TH2I>("DeltaE_M2pi", "#DeltaE vs M_{#pi^{+}#pi^{-}}; M_{#pi^{+}#pi^{-}}; #DeltaE (tagger - tracks)", 200, 0.0, 2.0, 200, -5., 5.);
 			dDeltaE_M2pi_ProtonTag = GetOrCreate_Histogram<TH2I>("DeltaE_M2pi_ProtonTag", "#DeltaE vs M_{#pi^{+}#pi^{-}}; M_{#pi^{+}#pi^{-}}; #DeltaE (tagger - tracks)", 200, 0.0, 2.0, 200, -5., 5.);
@@ -44,11 +72,11 @@ void DCustomAction_p2pi_hists::Initialize(JEventLoop* locEventLoop)
 			dMppiplus_M2pi = GetOrCreate_Histogram<TH2I>("Mppiplus_M2pi", "Psuedo-Dalitz p#pi^{+}#pi^{-}; M_{#pi^{+}#pi^{-}}; M_{p#pi^{+}}", 200, 0.0, 2.0, 200, 1.0, 3.0);
 			dMppiminus_M2pi = GetOrCreate_Histogram<TH2I>("Mppiminus_M2pi", "Psuedo-Dalitz p#pi^{+}#pi^{-}; M_{#pi^{+}#pi^{-}}; M_{p#pi^{-}}", 200, 0.0, 2.0, 200, 1.0, 3.0);
 
-			dProtonPhi_Egamma = GetOrCreate_Histogram<TH2I>("ProtonPhi_Egamma","#phi vs E_{#gamma}; E_{#gamma}; proton #phi",240,0,6,360,-180,180);	
-			dPiPlusPsi_Egamma = GetOrCreate_Histogram<TH2I>("PiPlusPsi_Egamma","#psi vs E_{#gamma}; E_{#gamma}; #pi^{+} #phi",240,0,6,360,-180,180);
+			dProtonPhi_Egamma = GetOrCreate_Histogram<TH2I>("ProtonPhi_Egamma","#phi vs E_{#gamma}; E_{#gamma}; proton #phi",endpoint_energy_bins,0,endpoint_energy,360,-180,180);	
+			dPiPlusPsi_Egamma = GetOrCreate_Histogram<TH2I>("PiPlusPsi_Egamma","#psi vs E_{#gamma}; E_{#gamma}; #pi^{+} #phi",endpoint_energy_bins,0,endpoint_energy,360,-180,180);
 			dPiPlusPsi_t = GetOrCreate_Histogram<TH2I>("PiPlusPsi_t","#psi vs |t|; |t|; #pi^{+} #psi",1000,0.,5.,360,-180,180);
 
-			dEgamma_M2pi = GetOrCreate_Histogram<TH2I>("Egamma_M2pi", "E_{#gamma} vs M_{#pi^{+}#pi^{-}}; M_{#pi^{+}#pi^{-}}; E_{#gamma}", 200, 0.0, 2.0, 240, 0., 6.);		
+			dEgamma_M2pi = GetOrCreate_Histogram<TH2I>("Egamma_M2pi", "E_{#gamma} vs M_{#pi^{+}#pi^{-}}; M_{#pi^{+}#pi^{-}}; E_{#gamma}", 200, 0.0, 2.0, endpoint_energy_bins,0,endpoint_energy);		
 
 			dBaryonM_CosTheta_Egamma1 = GetOrCreate_Histogram<TH2I>("BaryonM_CosTheta_Egamma1", "Baryon M_{p#pi^{+}} vs cos#theta: E_{#gamma} < 2.5; cos#theta; M_{p#pi^{+}}", 100, -1, 1, 100, 1.0, 2.5);
 			dBaryonM_CosTheta_Egamma2 = GetOrCreate_Histogram<TH2I>("BaryonM_CosTheta_Egamma2", "Baryon M_{p#pi^{+}} vs cos#theta: 2.5 < E_{#gamma} < 3.0; cos#theta; M_{p#pi^{+}}", 100, -1, 1, 100, 1.0, 2.5);
@@ -103,8 +131,6 @@ bool DCustomAction_p2pi_hists::Perform_Action(JEventLoop* locEventLoop, const DP
 	}
 	else locProtonP4 = locMissingP4;
 
-	double dEdxCut = 2.2;
-
 	// production kinematics
 	DLorentzVector locSumInitP4; 
 	DLorentzVector locProtonP4Init(0,0,0,0.938);
@@ -113,10 +139,7 @@ bool DCustomAction_p2pi_hists::Perform_Action(JEventLoop* locEventLoop, const DP
 	TLorentzVector locDelta = (locProtonP4 - locProtonP4Init);
 	double t = locDelta.M2();
 
-	TVector3 locBoostVector = -1.*locP4_2pi.BoostVector();
 	TLorentzVector locPiPlus_P4 = locParticles[1]->lorentzMomentum();
-	locPiPlus_P4.Boost(locBoostVector);
-	double locPsi = locPiPlus_P4.Phi();
 
 	// copied from TwoPiAngles
 	TLorentzRotation resonanceBoost( -locP4_2pi.BoostVector() );
@@ -135,19 +158,28 @@ bool DCustomAction_p2pi_hists::Perform_Action(JEventLoop* locEventLoop, const DP
 
 	double cosTheta = angles.CosTheta();
 
+	double phi = angles.Phi();
+        double Phi = locProtonP4.Vect().Phi();
+	double locPsi = phi - Phi;
+	if(locPsi < -1*TMath::Pi()) locPsi += 2*TMath::Pi();
+        if(locPsi > TMath::Pi()) locPsi -= 2*TMath::Pi();
+
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		// Fill histograms here
 		dEgamma->Fill(locBeamPhotonEnergy);
 
 		if(dMissingPID == Proton) {
-			if(locBeamPhotonEnergy > 2.5 && locBeamPhotonEnergy < 3.0) {
+			if(locBeamPhotonEnergy > cohmin_energy && locBeamPhotonEnergy < cohedge_energy) {
 				dMM_M2pi->Fill(locP4_2pi.M(), locMissingP4.M());
+				
 				if(locParticles[1]->lorentzMomentum().Theta()*180/PI > 2. && locParticles[2]->lorentzMomentum().Theta()*180/PI > 2.) {
 					dMM_M2pi_noEle->Fill(locP4_2pi.M(), locMissingP4.M());
-					if(locMissingP4.M() > 0.8 && locMissingP4.M() < 1.05) {
+					
+					if(locMissingP4.M() > minMMCut && locMissingP4.M() < maxMMCut) {
 						dt_M2pi_noEle->Fill(locP4_2pi.M(), fabs(t));
-						if(locP4_2pi.M() > 0.6 && locP4_2pi.M() < 0.88){
+						
+						if(locP4_2pi.M() > minRhoMassCut && locP4_2pi.M() < maxRhoMassCut){
 							dPiPlusPsi_t->Fill(fabs(t), locPsi*180/TMath::Pi());
 						}	
 					}
@@ -158,7 +190,7 @@ bool DCustomAction_p2pi_hists::Perform_Action(JEventLoop* locEventLoop, const DP
 			dMM2_M2pi->Fill(locP4_2pi.M(), locMissingP4.M2());
 			dDeltaE_M2pi->Fill(locP4_2pi.M(),locMissingP4.E());
 
-			if(fabs(locMissingP4.M2()) < 0.02 && fabs(locMissingP4.E()) < 0.2){
+			if(locMissingP4.M2() > minMM2Cut && locMissingP4.M2() < maxMM2Cut && fabs(locMissingP4.E()) < missingEnergyCut){
 				dProton_dEdx_P->Fill(locProtonP4.Vect().Mag(), dEdx);
 				dProton_P_Theta->Fill(locProtonP4.Vect().Theta()*180/TMath::Pi(), locProtonP4.Vect().Mag());
 
@@ -171,26 +203,26 @@ bool DCustomAction_p2pi_hists::Perform_Action(JEventLoop* locEventLoop, const DP
 					DLorentzVector locP4_ppiminus = locProtonP4;
 					locP4_ppiplus += locParticles[1]->lorentzMomentum();
 					locP4_ppiminus += locParticles[2]->lorentzMomentum();
-					if(locBeamPhotonEnergy > 2.5 && locBeamPhotonEnergy < 3.0){
+					if(locBeamPhotonEnergy > cohmin_energy && locBeamPhotonEnergy < cohedge_energy){
 						dDalitz_p2pi->Fill(locP4_2pi.M2(), locP4_ppiplus.M2());
 						dMppiplus_M2pi->Fill(locP4_2pi.M(), locP4_ppiplus.M());
 						dMppiminus_M2pi->Fill(locP4_2pi.M(), locP4_ppiminus.M());
 					}
 					
 					// some p pi+ mass distributions (hunt for Delta++...)
-					if(locBeamPhotonEnergy < 2.5)
+					if(locBeamPhotonEnergy < cohmin_energy)
 						dBaryonM_CosTheta_Egamma1->Fill(cosTheta,locP4_ppiplus.M());
-					else if(locBeamPhotonEnergy < 3.0)
+					else if(locBeamPhotonEnergy < cohedge_energy)
 						dBaryonM_CosTheta_Egamma2->Fill(cosTheta,locP4_ppiplus.M());
 					else 
 						dBaryonM_CosTheta_Egamma3->Fill(cosTheta,locP4_ppiplus.M());
 
 
-					if(locP4_2pi.M() > 0.6 && locP4_2pi.M() < 0.9){
+					if(locP4_2pi.M() > minRhoMassCut && locP4_2pi.M() < maxRhoMassCut){
 						dProtonPhi_Egamma->Fill(locBeamPhotonEnergy, locProtonP4.Phi()*180/TMath::Pi());
 						dPiPlusPsi_Egamma->Fill(locBeamPhotonEnergy, locPsi*180/TMath::Pi());
 						
-						if(locBeamPhotonEnergy > 2.5 && locBeamPhotonEnergy < 3.0){
+						if(locBeamPhotonEnergy > cohmin_energy && locBeamPhotonEnergy < cohedge_energy){
 							dPiPlusPsi_t->Fill(fabs(t), locPsi*180/TMath::Pi());	
 						}
 					}	

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.h
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.h
@@ -38,6 +38,11 @@ class DCustomAction_p2pi_hists : public DAnalysisAction
 
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 
+		// Parameters for event selection to fill histograms
+		int endpoint_energy_bins;
+		double cohmin_energy, cohedge_energy, endpoint_energy;
+		double dEdxCut, minMMCut, maxMMCut, minMM2Cut, maxMM2Cut, missingEnergyCut, minRhoMassCut, maxRhoMassCut;
+
 		// Optional: Useful utility functions.
 		const DAnalysisUtilities* dAnalysisUtilities;
 

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.cc
@@ -15,6 +15,10 @@ void DCustomAction_p2pi_unusedHists::Initialize(JEventLoop* locEventLoop)
         locEventLoop->GetSingle(locParticleID);
 	dParticleID = locParticleID;
 
+	vector<const DFCALGeometry*> locFCALGeometry;
+	locEventLoop->Get(locFCALGeometry);
+	dFCALGeometry = locFCALGeometry[0];
+	
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
@@ -33,6 +37,38 @@ void DCustomAction_p2pi_unusedHists::Initialize(JEventLoop* locEventLoop)
 		dHistMap_BCALShowerDeltaPhi_Theta = GetOrCreate_Histogram<TH2I>("BCALShowerDeltaPhi_Theta", "Unused BCAL showers #Delta#phi vs #theta; #theta; #Delta#phi", 150, 0, 150, 360, -180, 180);
 		dHistMap_BCALShowerDeltaPhi_DeltaT = GetOrCreate_Histogram<TH2I>("BCALShowerDeltaPhi_DeltaT", "Unused BCAL showers #Delta#phi vs #Deltat; #Deltat; #Delta$phi", 200, -100., 100., 360, -180, 180);
 		dHistMap_BCALShowerDeltaZ_DeltaT = GetOrCreate_Histogram<TH2I>("BCALShowerDeltaZ_DeltaT", "Unused FCAL showers #DeltaZ vs #Deltat; #Deltat; #DeltaZ", 200, -100., 100., 200, -50, 50);
+
+		int nbins = 100;
+		h1_deltaX = GetOrCreate_Histogram<TH1I>("h1_deltaX", "Fcal X - Track X", nbins,-25,25);
+		h1_deltaY = GetOrCreate_Histogram<TH1I>("h1_deltaY", "Fcal Y - Track Y", nbins,-25,25);
+		h1_Efcal = GetOrCreate_Histogram<TH1I>("h1_Efcal", "Hit energy", nbins,0,4);
+		h1_tfcal = GetOrCreate_Histogram<TH1I>("h1_tfcal", "Hit time", 250,-25,225);
+	       
+		h1_N9 = GetOrCreate_Histogram<TH1I>("h1_N9", "Hit N9", 25, 0, 25);
+		h1_E9 = GetOrCreate_Histogram<TH1I>("h1_E9", "Energy E9 (GeV)", nbins, 0, 2);
+		h1_t9 = GetOrCreate_Histogram<TH1I>("h1_t9", "Time t9 (ns)", 250, -25, 225);
+		h1_t9sigma = GetOrCreate_Histogram<TH1I>("h1_t9sigma", "Time t9sigma",nbins,0,10);
+		
+		h1_N1 = GetOrCreate_Histogram<TH1I>("h1_N1", "Hit N1", 25, 0, 25);
+		h1_E1 = GetOrCreate_Histogram<TH1I>("h1_E1", "Energy E1 (GeV)", nbins, 0, 2);
+		h1_t1 = GetOrCreate_Histogram<TH1I>("h1_t1", "Time t1 (ns)", 250, -25, 225);
+		h1_t1sigma = GetOrCreate_Histogram<TH1I>("h1_t1sigma", "Time t1sigma",nbins,0,10);
+
+		h2_YvsX9 = GetOrCreate_Histogram<TH2I>("h2_YvsX9", "Hit position Y vs X, E9",240,-120,120,240,-120,120);
+		h2_dEdx9_vsp= GetOrCreate_Histogram<TH2I>("h2_dEdx9_vsp", "Track dEdx9 vs p",nbins,0,4,nbins,0,10);
+		h2_E9vsp= GetOrCreate_Histogram<TH2I>("h2_E9vsp", "E9 vs p",nbins,0,4,nbins,0,4);
+		h2_dEdxvsE9= GetOrCreate_Histogram<TH2I>("h2_dEdxvsE9", "dEdx vs E9 energy",nbins,0,4,nbins,0,4);
+		h2_E9_vsTheta= GetOrCreate_Histogram<TH2I>("h2_E9_vsTheta", "E9 vs Theta",90,0,30,nbins,0,4);
+		h2_E9_vsPhi= GetOrCreate_Histogram<TH2I>("h2_E9_vsPhi", "E9 vs Phi",90,-180,180,nbins,0,4);
+		
+		h2_YvsX1 = GetOrCreate_Histogram<TH2I>("h2_YvsX1", "Hit position Y vs X, E1",240,-120,120,240,-120,120);
+		h2_dEdx1_vsp = GetOrCreate_Histogram<TH2I>("h2_dEdx1_vsp", "Track dEdx1 vs p",nbins,0,4,nbins,0,10);
+		h2_E1vsp = GetOrCreate_Histogram<TH2I>("h2_E1vsp", "E1 vs p",nbins,0,4,nbins,0,4);
+		h2_dEdxvsE1 = GetOrCreate_Histogram<TH2I>("h2_dEdxvsE1", "dEdx vs E1 energy",nbins,0,4,nbins,0,4);
+		h2_E1_vsTheta = GetOrCreate_Histogram<TH2I>("h2_E1_vsTheta", "E1 vs Theta",90,0,30,nbins,0,4);
+		h2_E1_vsPhi = GetOrCreate_Histogram<TH2I>("h2_E1_vsPhi", "E1 vs Phi",90,-180,180,nbins,0,4);
+		h2_E1vsRlocal = GetOrCreate_Histogram<TH2I>("h2_E1vsRlocal", "E1 vs Rtrk rel to Block center (cm)",nbins,0,5,nbins,0,4);
+		h2_YvsXcheck = GetOrCreate_Histogram<TH2I>("h2_E1vsRlocal", "E1 vs Rtrk rel to Block center (cm)",nbins,0,5,nbins,0,4);
 
 		TString locHistName;
 		TString locHistTitle;
@@ -268,14 +304,14 @@ bool DCustomAction_p2pi_unusedHists::Perform_Action(JEventLoop* locEventLoop, co
                         const DChargedTrackHypothesis* locChargedTrackHypothesis = locChargedTrack->Get_BestFOM();
 			if(locChargedTracks[loc_j]->Get_BestFOM()->candidateid == locChargedTrackHypothesis->candidateid) {
                                 nMatched++;
-				FillTrack(locChargedTracks[loc_j], true, locMCThrown);
+				FillTrack(locEventLoop, locChargedTracks[loc_j], true, locMCThrown);
 			}
                 }
 		
 		// plot properties of unused charged tracks
                 if(nMatched==0) {
 			locUnusedChargedTracks.push_back(locChargedTracks[loc_j]);
-			FillTrack(locChargedTracks[loc_j], false, locMCThrown);
+			FillTrack(locEventLoop, locChargedTracks[loc_j], false, locMCThrown);
 		}
         }
 
@@ -429,7 +465,7 @@ bool DCustomAction_p2pi_unusedHists::Perform_Action(JEventLoop* locEventLoop, co
 }
 
 
-void DCustomAction_p2pi_unusedHists::FillTrack(const DChargedTrack* locChargedTrack, bool locMatch, const DMCThrown* locMCThrown)
+void DCustomAction_p2pi_unusedHists::FillTrack(JEventLoop* locEventLoop, const DChargedTrack* locChargedTrack, bool locMatch, const DMCThrown* locMCThrown)
 {
 
 	const DChargedTrackHypothesis* locChargedTrackHypothesis = locChargedTrack->Get_BestFOM();
@@ -495,6 +531,117 @@ void DCustomAction_p2pi_unusedHists::FillTrack(const DChargedTrack* locChargedTr
 		}
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+
+	if(!locMatch) return;
+
+	// do FCAL energy sums to compare with Elton's E9 and E25 in fcal_charged
+	Double_t zfcal=625;
+        DVector3 fcal_origin(0.0,0.0,zfcal);
+        DVector3 fcal_normal(0.0,0.0,1.0);
+	DVector3 trkpos(0.0,0.0,0.0);
+        DVector3 proj_mom(0.0,0.0,0.0);
+	double theta = locTrackTimeBased->momentum().Theta()*180./TMath::Pi();
+	double phi = locTrackTimeBased->momentum().Phi()*180./TMath::Pi();
+	double p = locTrackTimeBased->momentum().Mag();
+        double dEdx = locTrackTimeBased->dEdx()*1e6;
+
+	vector<const DFCALHit*> fcalhits;
+        locEventLoop->Get(fcalhits);
+	if(fcalhits.empty()) return;
+
+	if (locTrackTimeBased->rt->GetIntersectionWithPlane(fcal_origin,fcal_normal,trkpos,proj_mom,NULL,NULL,NULL,SYS_FCAL)==NOERROR){
+		double trkposX = trkpos.X();
+		double trkposY = trkpos.Y();
+		int trkrow = dFCALGeometry->row((float)trkposY);
+		int trkcol = dFCALGeometry->column((float)trkposX);
+		
+		// loop over fcal hits
+
+		double E9=0;  // energy, x, y of 9 blocks surrounding track
+		double E9peak=0;
+		double x9=0;
+		double y9=0;
+		double t9=0;
+		double t9sq=0;
+		double t9sigma=0;
+		int N9=0;
+		int Delta_block=1;   // =1 for 3x3, =2 for 5x5
+		double dX_E1=-1000;
+		double dY_E1=-1000;
+		
+		int row_offset = 0;   // offset actual row to look for randoms
+		int col_offset = 0;
+		trkrow += row_offset;
+		trkcol += col_offset;
+		
+		for (unsigned int j=0; j < fcalhits.size(); ++j) {
+			int row = fcalhits[j]->row;
+			int col = fcalhits[j]->column;
+			double x = fcalhits[j]->x;
+			double y = fcalhits[j]->y;
+			double Efcal = fcalhits[j]->E;
+			double tfcal= fcalhits[j]->t;
+			double intOverPeak = fcalhits[j]->intOverPeak;
+			
+			// fill histograms
+			int drow = abs(row - trkrow);
+			int dcol = abs(col - trkcol);
+			
+			h1_deltaX->Fill(x - trkposX);
+			h1_deltaY->Fill(y - trkposY);
+			h1_Efcal->Fill(Efcal);
+			h1_tfcal->Fill(tfcal);
+		
+			// select hits 
+			if (drow<=Delta_block && dcol<=Delta_block && (tfcal>-15 && tfcal<50) && (intOverPeak>2.5 && intOverPeak<9)) {
+				E9 += Efcal;
+				E9peak += Efcal*6/intOverPeak;   // factor of 6 so that E9peak ~ E9
+				x9 += x;
+				y9 += y;
+				t9 += tfcal;
+				t9sq += tfcal*tfcal;
+				N9 += 1;
+			}
+			
+		} // end loop over fcal hits
+
+		x9 = N9>0? x9/N9 : 0;
+		y9 = N9>0? y9/N9 : 0;
+		t9 = N9>0? t9/N9 : 0;
+		t9sigma = N9>0? sqrt(t9sq/N9 - t9*t9): 0;
+		
+		japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+		{
+			if (N9>0) {
+				h1_N9->Fill(N9);
+				h1_E9->Fill(E9);
+				h1_t9->Fill(t9);
+				h1_t9sigma->Fill(t9sigma);
+				h2_YvsX9->Fill(trkposX,trkposY);
+				h2_dEdx9_vsp->Fill(p,dEdx);
+				h2_E9vsp->Fill(p,E9);
+				h2_dEdxvsE9->Fill(E9,dEdx);
+				h2_E9_vsTheta->Fill(theta,E9);
+				h2_E9_vsPhi->Fill(phi,E9);
+			}
+			if (N9==1) {
+				h1_N1->Fill(N9);
+				h1_E1->Fill(E9);
+				h1_t1->Fill(t9);
+				h1_t1sigma->Fill(t9sigma);
+				h2_YvsX1->Fill(trkposX,trkposY);
+				h2_dEdx1_vsp->Fill(p,dEdx);
+				h2_E1vsp->Fill(p,E9);
+				h2_dEdxvsE1->Fill(E9,dEdx);
+				h2_E1_vsTheta->Fill(theta,E9);
+				h2_E1_vsPhi->Fill(phi,E9);
+				double Rlocal = sqrt(dX_E1*dX_E1 + dY_E1*dY_E1);
+				h2_E1vsRlocal->Fill(Rlocal,E9);
+				h2_YvsXcheck->Fill(dX_E1,dY_E1);
+			  }
+		}
+		japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	}
 
 	return;
 }

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.cc
@@ -601,6 +601,9 @@ void DCustomAction_p2pi_unusedHists::FillTrack(JEventLoop* locEventLoop, const D
 				t9 += tfcal;
 				t9sq += tfcal*tfcal;
 				N9 += 1;
+
+				dX_E1 = x - trkposX;
+				dY_E1 = y - trkposY;
 			}
 			
 		} // end loop over fcal hits

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.h
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.h
@@ -22,6 +22,7 @@
 
 #include <FCAL/DFCALCluster.h>
 #include <FCAL/DFCALHit.h>
+#include <FCAL/DFCALGeometry.h>
 #include <BCAL/DBCALCluster.h>
 #include <BCAL/DBCALPoint.h>
 
@@ -40,7 +41,7 @@ class DCustomAction_p2pi_unusedHists : public DAnalysisAction
 	private:
 
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
-		void FillTrack(const DChargedTrack* locChargedTrack, bool locMatch, const DMCThrown* locMCThrown);
+		void FillTrack(JEventLoop* locEventLoop, const DChargedTrack* locChargedTrack, bool locMatch, const DMCThrown* locMCThrown);
 		void FillShower(const DNeutralShower* locNeutralShower, bool locMatch, double locBeamPhotonTime, double locFlightTime);
 
 		// Optional: Useful utility functions.
@@ -48,6 +49,7 @@ class DCustomAction_p2pi_unusedHists : public DAnalysisAction
 
 		// need PID algos for SC matching
 		const DParticleID* dParticleID;
+		const DFCALGeometry* dFCALGeometry;
 
 		// maps of histograms by track charge and match flag
 		map<bool, map<int, TH2I*> > dHistMap_TrackNhits_Theta;
@@ -71,6 +73,11 @@ class DCustomAction_p2pi_unusedHists : public DAnalysisAction
 
 		// maps of histograms by detector system and match flag
 		TH2I *dNShowerBCAL_FCAL;
+		TH1I *h1_deltaX, *h1_deltaY, *h1_Efcal, *h1_tfcal;
+		TH1I *h1_N9, *h1_E9, *h1_t9, *h1_t9sigma;
+		TH2I *h2_YvsX9, *h2_dEdx9_vsp, *h2_E9vsp, *h2_dEdxvsE9, *h2_E9_vsTheta, *h2_E9_vsPhi;
+		TH1I *h1_N1, *h1_E1, *h1_t1, *h1_t1sigma;
+		TH2I *h2_YvsX1, *h2_dEdx1_vsp, *h2_E1vsp, *h2_dEdxvsE1, *h2_E1_vsTheta, *h2_E1_vsPhi, *h2_E1vsRlocal, *h2_YvsXcheck;
 		TH2I *dHistMap_FCALShowerDeltaR_P, *dHistMap_FCALShowerDeltaR_Theta, *dHistMap_FCALShowerDeltaD_P, *dHistMap_FCALShowerDeltaD_Theta;
 		TH2I *dHistMap_FCALShowerDeltaD_DeltaT;
 		TH2I *dHistMap_BCALShowerDeltaPhi_DeltaZ, *dHistMap_BCALShowerDeltaPhi_P, *dHistMap_BCALShowerDeltaPhi_Theta;


### PR DESCRIPTION
Add access to coherent peak beam energy range from test CCDB table, so the same plugin can be run on Spring 2015 data and simulation for Spring 2016 (sim1).  Also, update cobrems for coherent peak generation in AmpTools generators.
