### PR TITLE
* hitUPV.c [rtj]

### DIFF
--- a/src/programs/Simulation/HDGeant/hitUPV.c
+++ b/src/programs/Simulation/HDGeant/hitUPV.c
@@ -71,7 +71,6 @@ void hitUpstreamEMveto (float xin[4], float xout[4],
   
   int layer = getlayer_wrapper_();
   int row = getrow_wrapper_();
-  int column = getcolumn_wrapper_();
   /*
     'column' is not used in the current code. It distinguishes long 
     paddles (column=0) from short paddles to the left(column=1) or 
@@ -81,8 +80,9 @@ void hitUpstreamEMveto (float xin[4], float xout[4],
     right pair of short paddles form a long paddle which just happens 
     to have an insensitive to hits area in the middle but otherwise is identical
     to a normal long paddle. If we later change our minds and start treating 3 
-    types of paddles differently, then 'column' is available for use.
+    types of paddles differently, then 'column' can be made available for use.
   */
+  //int column = getcolumn_wrapper_();
 
   float dxleft = xlocal[0];
   float dxright = -xlocal[0];

--- a/src/programs/Simulation/mcsmear/mcsmear.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear.cc
@@ -256,7 +256,7 @@ void ParseCommandLineArguments(int narg, char* argv[])
       char str[256];
       sprintf(str, "%s_%ssmeared.hddm", path_stripped, ADD_NOISE ? "n":"");
       OUTFILENAME = strdup(str);
-      delete pdup;
+      free(pdup);
    }
    
    cout << "BCAL values will " <<  (SMEAR_BCAL ? "":"not")  << " be smeared"


### PR DESCRIPTION
- remove unused variable to avoid code analyzer warnings
  - mcsmear.cc [rtj]
- memory released by "delete" should use "free" instead, fixed.
