### PR TITLE
Make code templates compatible with JANA 0.7.4+

### DIFF
--- a/src/programs/Utilities/mkfactory_plugin/mkfactory_plugin
+++ b/src/programs/Utilities/mkfactory_plugin/mkfactory_plugin
@@ -152,8 +152,8 @@ class ${classname}_factory${tag_suffix}:public jana::JFactory<${classname}>{
 
 	private:
 		jerror_t init(void);						///< Called once at program start.
-		jerror_t brun(jana::JEventLoop *eventLoop, int runnumber);	///< Called everytime a new run number is detected.
-		jerror_t evnt(jana::JEventLoop *eventLoop, int eventnumber);	///< Called every event.
+		jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 };
@@ -200,7 +200,7 @@ jerror_t ${classname}_factory${tag_suffix}::init(void)
 //------------------
 // brun
 //------------------
-jerror_t ${classname}_factory${tag_suffix}::brun(jana::JEventLoop *eventLoop, int runnumber)
+jerror_t ${classname}_factory${tag_suffix}::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 {
 	return NOERROR;
 }
@@ -208,7 +208,7 @@ jerror_t ${classname}_factory${tag_suffix}::brun(jana::JEventLoop *eventLoop, in
 //------------------
 // evnt
 //------------------
-jerror_t ${classname}_factory${tag_suffix}::evnt(JEventLoop *loop, int eventnumber)
+jerror_t ${classname}_factory${tag_suffix}::evnt(JEventLoop *loop, uint64_t eventnumber)
 {
 
 	// Code to generate factory data goes here. Add it like:

--- a/src/programs/Utilities/mkplugin/mkplugin
+++ b/src/programs/Utilities/mkplugin/mkplugin
@@ -104,8 +104,8 @@ class JEventProcessor_${pluginname}:public jana::JEventProcessor{
 
 	private:
 		jerror_t init(void);						///< Called once at program start.
-		jerror_t brun(jana::JEventLoop *eventLoop, int runnumber);	///< Called everytime a new run number is detected.
-		jerror_t evnt(jana::JEventLoop *eventLoop, int eventnumber);	///< Called every event.
+		jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 };
@@ -174,7 +174,7 @@ jerror_t JEventProcessor_${pluginname}::init(void)
 //------------------
 // brun
 //------------------
-jerror_t JEventProcessor_${pluginname}::brun(JEventLoop *eventLoop, int runnumber)
+jerror_t JEventProcessor_${pluginname}::brun(JEventLoop *eventLoop, int32_t runnumber)
 {
 	// This is called whenever the run number changes
 	return NOERROR;
@@ -183,7 +183,7 @@ jerror_t JEventProcessor_${pluginname}::brun(JEventLoop *eventLoop, int runnumbe
 //------------------
 // evnt
 //------------------
-jerror_t JEventProcessor_${pluginname}::evnt(JEventLoop *loop, int eventnumber)
+jerror_t JEventProcessor_${pluginname}::evnt(JEventLoop *loop, uint64_t eventnumber)
 {
 	// This is called for every event. Use of common resources like writing
 	// to a file or filling a histogram should be mutex protected. Using


### PR DESCRIPTION
Update the data types of run/event-number arguments of brun() and
evnt() in the plugin and factory_plugin code templates.
