### PR TITLE
* DTAGMHit_factory.cc [rtj]

### DIFF
--- a/src/libraries/TAGGER/DTAGMHit_factory.cc
+++ b/src/libraries/TAGGER/DTAGMHit_factory.cc
@@ -238,7 +238,8 @@ jerror_t DTAGMHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 
         // apply time-walk corrections
         double P = hit->pulse_peak;
-        double c0 = tw_c0[row][column];
+        // c0 is not used, should it be??
+        //double c0 = tw_c0[row][column];
         double c1 = tw_c1[row][column];
         double c2 = tw_c2[row][column];
         double TH = thresh[row][column];

--- a/src/programs/Simulation/genr8/genr8.c
+++ b/src/programs/Simulation/genr8/genr8.c
@@ -171,6 +171,7 @@ int main(int argc,char **argv)
   X= &(particle[1]);
   X->parent = &CM;
   X->nchildren = 0;
+  X->bookmass = 0;
   //  recoil.parent = &CM;
   CM.child[0]= X;
   CM.child[1]= Y;


### PR DESCRIPTION
- fix warnings about unused variables from the code analyzer.
  - genr8.c [rtj]
- fix warnings about garbage assignment from the code analyzer
