### PR TITLE
* external/xstream/src/base64.cpp [rtj]

### DIFF
--- a/src/external/xstream/src/base64.cpp
+++ b/src/external/xstream/src/base64.cpp
@@ -52,14 +52,14 @@ namespace xstream
             //XXX all these sputn calls need to be checked
             if (delim_w > 0 && rcol <= len) {
                 LOG("\t" << rcol << " columns to padding");
-                ret = _sb->sputn(buf, rcol);
-                ret = _sb->sputc(delim);
-                ret = _sb->sputn(buf + rcol, len - rcol);
+                ret += _sb->sputn(buf, rcol);
+                ret += (_sb->sputc(delim) == delim)? 1 : 0;
+                ret += _sb->sputn(buf + rcol, len - rcol);
                 col = len - rcol;
                 LOG("\tcol = " << col);
             }
             else {
-                ret = _sb->sputn(buf,len);
+                ret += _sb->sputn(buf,len);
                 col += len;
             }
 


### PR DESCRIPTION
- changed to have write method return actual number of bytes
   written instead of just the byte count of the last transaction,
   avoids warnings from code analyzer and better conforms to the
   streambuf standards, but does not fix any known problems.
