### PR TITLE
Re-enable f125 emulation for old data.

### DIFF
--- a/src/libraries/DAQ/JEventSource_EVIO.cc
+++ b/src/libraries/DAQ/JEventSource_EVIO.cc
@@ -2413,10 +2413,15 @@ void JEventSource_EVIO::EmulateDf125PulseTime(vector<JObject*> &wrd_objs, vector
 		const vector<uint16_t> &samplesvector = f125WindowRawData->samples;
 		uint32_t Nsamples_all = samplesvector.size(); // (was NADCBUFFER in Naomi's code)
 		if(Nsamples_all < (Nped_samples+Nsamples)){
-			char str[256];
-			sprintf(str, "Too few samples in Df125WindowRawData for pulse time extraction! Nsamples_all=%d, (Nped_samples+Nsamples)=%d", Nsamples_all, (Nped_samples+Nsamples));
-			jerr << str << endl;
-			throw JException(str);
+			static int Nwarn=0;
+			if(Nwarn<10){
+				char str[256];
+				sprintf(str, "Too few samples in Df125WindowRawData for pulse time extraction! Nsamples_all=%d, (Nped_samples+Nsamples)=%d", Nsamples_all, (Nped_samples+Nsamples));
+				jerr << str << endl;
+				if(++Nwarn==10) jerr << "--- Last Warning! ---" <<endl;
+			}
+			return;
+//			throw JException(str);
 		}
 		
 		bool found_hit = false;

--- a/src/libraries/DAQ/JEventSource_EVIO.h
+++ b/src/libraries/DAQ/JEventSource_EVIO.h
@@ -344,9 +344,10 @@ class JEventSource_EVIO: public jana::JEventSource{
 		void AddSourceObjectsToCallStack(JEventLoop *loop, string className);
 		void AddEmulatedObjectsToCallStack(JEventLoop *loop, string caller, string callee);
 		void EmulateDf250PulseIntegral(vector<JObject*> &wrd_objs, vector<JObject*> &pi_objs);
-		void EmulateDf125PulseIntegral(vector<JObject*> &wrd_objs, vector<JObject*> &pi_objs, vector<JObject*> &pt_objs);
+		void EmulateDf125PulseIntegral(vector<JObject*> &wrd_objs, vector<JObject*> &pi_objs, vector<JObject*> &pt_objs, vector<JObject*> &cp_objs, vector<JObject*> &fp_objs);
 		void EmulateDf250PulseTime(vector<JObject*> &wrd_objs, vector<JObject*> &pt_objs, vector<JObject*> &pp_objs);
-		void EmulateDf125PulseTime(vector<JObject*> &wrd_objs, vector<JObject*> &pt_objs, vector<JObject*> &pp_objs);
+		void EmulateDf125PulseTime(vector<JObject*> &wrd_objs, vector<JObject*> &pt_objs, vector<JObject*> &pp_objs, vector<JObject*> &cp_objs, vector<JObject*> &fp_objs);
+
 		jerror_t ParseEvents(ObjList *objs_ptr);
 		int32_t FindRunNumber(uint32_t *iptr);
 		uint64_t FindEventNumber(uint32_t *iptr);

--- a/src/libraries/DAQ/fa125algo.cc
+++ b/src/libraries/DAQ/fa125algo.cc
@@ -99,22 +99,34 @@ void fa125_algos(int rocid, vector<uint16_t> samples, fa125_algos_data_t &fa125_
 
 
 	if (samples.size()<=(uint32_t)d.WINDOW_END + 20) {
-        cout << "The number of samples passed into the fa125_algos routine (" << samples.size() << ") is less than the" << endl;
-		cout << "minimum required by the parameters in use (" << d.WINDOW_END+21 << "). " << endl;
-		cout << "Parameter WE (" << d.WINDOW_END << ") should be decreased to " << samples.size()-21 << " or less." << endl;
-		exit(-1);
+		static int Nwarn=0;
+		if(Nwarn<10){
+        	cout << "The number of samples passed into the fa125_algos routine (" << samples.size() << ") is less than the" << endl;
+			cout << "minimum required by the parameters in use (" << d.WINDOW_END+21 << "). " << endl;
+			cout << "Parameter WE (" << d.WINDOW_END << ") should be decreased to " << samples.size()-21 << " or less." << endl;
+			if(++Nwarn==10) cout <<" --- LAST WARNING! ---" << endl;
+		}
+		return;
 	}
 
 	if (d.NPED2 > d.NPED) {
-       cout << "Parameter NPED is too small or NPED2 is too large. " << endl;
-       cout << "NPED (" << d.NPED << ") should be increased or NPED2 (" << d.NPED2 << ") decreased until NPED >= NPED2." << endl;
-		exit(-1);
+		static int Nwarn=0;
+		if(Nwarn<10){
+			cout << "Parameter NPED is too small or NPED2 is too large. " << endl;
+			cout << "NPED (" << d.NPED << ") should be increased or NPED2 (" << d.NPED2 << ") decreased until NPED >= NPED2." << endl;
+			if(++Nwarn==10) cout <<" --- LAST WARNING! ---" << endl;
+		}
+		return;
 	}
 
     if (d.WINDOW_START < d.NPED) {
-      cout << "Parameter WS (" << d.WINDOW_START << ") is too small or NPED (" << d.NPED << ") too large." << endl;
-      cout << "WS should be >= NPED." << endl;
-      exit(-1);
+		static int Nwarn=0;
+		if(Nwarn<10){
+			cout << "Parameter WS (" << d.WINDOW_START << ") is too small or NPED (" << d.NPED << ") too large." << endl;
+			cout << "WS should be >= NPED." << endl;
+			if(++Nwarn==10) cout <<" --- LAST WARNING! ---" << endl;
+		}
+		return;
     }
 	
 	// Copy uint16_t samples into Int_t type array so we can pass it into the cdc_algos2


### PR DESCRIPTION
Re-enable f125 emulation for old data. Most of the changes were a fix by Naomi. I modified it to attempt to continue processing, even when an error is encountered. Limit warning messages to 10 of each kind.
