### PR TITLE
Use measured start counter resolutions in MatchToSC()

### DIFF
--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -6,6 +6,7 @@
 //
 
 #include "DParticleID.h"
+#include "START_COUNTER/DSCHit_factory.h"
 
 #ifndef M_TWO_PI
 #define M_TWO_PI 6.28318530717958647692
@@ -205,6 +206,16 @@ DParticleID::DParticleID(JEventLoop *loop)
 		sc_attn_C[SC_BENDNOSE_ATTN].push_back(row["SC_BENDNOSE_ATTENUATION_C"]); 
 	      }
 	  }
+
+    // Start counter individual paddle resolutions
+    if(loop->GetCalib("START_COUNTER/time_resol_paddle", sc_paddle_resols))
+        jout << "Error in loading START_COUNTER/time_resol_paddle !" << endl;
+	else {
+        if(sc_paddle_resols.size() != (unsigned int)DSCHit_factory::MAX_SECTORS)
+            jerr << "Start counter paddle resolutions table has wrong number of entries:" << endl
+                 << "  loaded = " << sc_paddle_resols.size() 
+                 << "  expexted = " << DSCHit_factory::MAX_SECTORS << endl;
+    }
 
 }
 
@@ -965,8 +976,8 @@ bool DParticleID::MatchToSC(const DReferenceTrajectory* rt, const vector<const D
 	Get_BestSCMatchParams(locSCHitMatchParamsVector, locBestMatchParams);
 
 	locStartTime = locBestMatchParams.dHitTime - locBestMatchParams.dFlightTime;
-//	locTimeVariance = locBestMatchParams.dFlightTimeVariance - locBestMatchParams.dHitTimeVariance; //uncomment when ready!
-	locTimeVariance = 0.3*0.3+locBestMatchParams.dFlightTimeVariance;
+	locTimeVariance = locBestMatchParams.dFlightTimeVariance + locBestMatchParams.dHitTimeVariance; 
+	//locTimeVariance = 0.3*0.3+locBestMatchParams.dFlightTimeVariance;
 
 	return true;
 }
@@ -1154,7 +1165,7 @@ bool DParticleID::MatchToSC(const DKinematicData* locTrack, const DReferenceTraj
 	locSCHitMatchParams.dHitEnergy = locCorrectedHitEnergy;
 	locSCHitMatchParams.dEdx = locSCHitMatchParams.dHitEnergy/ds;
 	locSCHitMatchParams.dHitTime = locCorrectedHitTime;
-	locSCHitMatchParams.dHitTimeVariance = 0.0; //SET ME!!!
+	locSCHitMatchParams.dHitTimeVariance = sc_paddle_resols[sc_index]*sc_paddle_resols[sc_index];
 	locSCHitMatchParams.dFlightTime = locFlightTime;
 	locSCHitMatchParams.dFlightTimeVariance = locFlightTimeVariance;
 	locSCHitMatchParams.dPathLength = locPathLength;

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -196,6 +196,8 @@ class DParticleID:public jana::JObject{
 	vector<double> sc_attn_B[2];
 	vector<double> sc_attn_C[2];
 
+    vector<double> sc_paddle_resols;
+
 	// FCAL geometry
 	double dFCALz;
 	const DFCALGeometry *dFCALGeometry;

--- a/src/libraries/START_COUNTER/DSCHit_factory.h
+++ b/src/libraries/START_COUNTER/DSCHit_factory.h
@@ -11,6 +11,7 @@
 #include <JANA/JFactory.h>
 #include "TTAB/DTTabUtilities.h"
 #include "DSCHit.h"
+#include "DSCDigiHit.h"
 
 
 class DSCHit_factory:public jana::JFactory<DSCHit>{


### PR DESCRIPTION
Small change to use measured start counter resolutions stored in CCDB when matching start counter hits to tracks.
