### PR TITLE
Update to HLDetectorTiming scripts

### DIFF
--- a/src/plugins/Calibration/HLDetectorTiming/FitScripts/ExtractTDCADCTiming.C
+++ b/src/plugins/Calibration/HLDetectorTiming/FitScripts/ExtractTDCADCTiming.C
@@ -22,6 +22,54 @@ TH2I * Get2DHistogram(const char * plugin, const char * directoryName, const cha
     return histogram;
 }
 
+void GetCCDBConstants(TString path, Int_t run, TString variation, vector<double>& container, Int_t column = 1){
+    char command[256];
+    sprintf(command, "ccdb dump %s:%i:%s", path.Data(), run, variation.Data());
+    FILE* inputPipe = gSystem->OpenPipe(command, "r");
+    if(inputPipe == NULL)
+        return 0;
+    //get the first (comment) line
+    char buff[1024];
+    if(fgets(buff, sizeof(buff), inputPipe) == NULL)
+        return 0;
+    //get the remaining lines
+    double entry;
+    int counter = 0;
+    while(fgets(buff, sizeof(buff), inputPipe) != NULL){
+        istringstream locConstantsStream(buff);
+        while (locConstantsStream >> entry){
+            counter++;
+            if (counter % column == 0) container.push_back(entry);
+        }
+    }
+    //Close the pipe
+    gSystem->ClosePipe(inputPipe);
+}
+//Overload this function to handle the base time offsets
+void GetCCDBConstants(TString path, Int_t run, TString variation, double& constant1, double& constant2 = NULL){
+    char command[256];
+    sprintf(command, "ccdb dump %s:%i:%s", path.Data(), run, variation.Data());
+    FILE* inputPipe = gSystem->OpenPipe(command, "r");
+    if(inputPipe == NULL)
+        return 0;
+    //get the first (comment) line
+    char buff[1024];
+    if(fgets(buff, sizeof(buff), inputPipe) == NULL)
+        return 0;
+    //get the line containing the values
+    while(fgets(buff, sizeof(buff), inputPipe) != NULL){
+        istringstream locConstantsStream(buff);
+        if(constant2 != NULL){
+            locConstantsStream >> constant1 >> constant2;
+        }
+        else{
+            locConstantsStream >> constant1;
+        }
+    }
+    //Close the pipe
+    gSystem->ClosePipe(inputPipe);
+}
+
 int GetCCDBIndexTAGM(int column, int row){
     int CCDBIndex = column + row;
     if (column > 9) CCDBIndex += 5;
@@ -46,10 +94,10 @@ Double_t FitFunctionRight(Double_t *x, Double_t *par)
     return f;
 }
 
-void ExtractTDCADCTiming(int runNumber){
+void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 2931, TString variation = "default", TString prefix = ""){
 
-    TString fileName = Form ("Run%i/TDCADCTiming.root", runNumber);
-    TString prefix = Form ("Run%i/constants/TDCADCTiming/",runNumber);
+    // set "prefix" in case you want to think about thowing the text files into another directory
+    cout << "Performing TDC/ADC timing fits for File: " << fileName.Data() << " Run: " << runNumber << " Variation: " << variation.Data() << endl;
 
     thisFile = TFile::Open( fileName , "UPDATE");
     if (thisFile == 0) {
@@ -58,109 +106,46 @@ void ExtractTDCADCTiming(int runNumber){
     }
     ofstream outFile;
 
-    //All the existing constants have been zero'd out already, But we should make copies in case one of the methods below fails
+    // We need to grab the existing values from the CCDB so that we know what was used in the creation of the ROOT file
+    cout << "Grabbing CCDB constants..." << endl;
 
-    outFile.open(prefix + "bcal_base_time.txt");
-    outFile << "0.0 0.0" << endl;
-    outFile.close();
+    // First are the base times for all of the detectors
+    double cdc_base_time,      fcal_base_time;
+    double sc_base_time_tdc,   sc_base_time_adc;
+    double fdc_base_time_tdc,  fdc_base_time_adc;
+    double bcal_base_time_tdc, bcal_base_time_adc;
+    double tagm_base_time_tdc, tagm_base_time_adc;
+    double tagh_base_time_tdc, tagh_base_time_adc;
+    double tof_base_time_tdc,  tof_base_time_adc;
 
-    outFile.open(prefix + "cdc_base_time.txt");
-    outFile << "0.0" << endl;
-    outFile.close();
+    GetCCDBConstants("/CDC/base_time_offset" ,runNumber, variation, cdc_base_time);
+    GetCCDBConstants("/FCAL/base_time_offset",runNumber, variation, fcal_base_time);
+    GetCCDBConstants("/FDC/base_time_offset" ,runNumber, variation, fdc_base_time_adc, fdc_base_time_tdc);
+    GetCCDBConstants("/BCAL/base_time_offset" ,runNumber, variation, bcal_base_time_adc, bcal_base_time_tdc);
+    GetCCDBConstants("/PHOTON_BEAM/microscope/base_time_offset" ,runNumber, variation, tagm_base_time_adc, tagm_base_time_tdc);
+    GetCCDBConstants("/PHOTON_BEAM/hodoscope/base_time_offset" ,runNumber, variation, tagh_base_time_adc, tagh_base_time_tdc);
+    GetCCDBConstants("/START_COUNTER/base_time_offset" ,runNumber, variation, sc_base_time_adc, sc_base_time_tdc);
+    GetCCDBConstants("/TOF/base_time_offset" ,runNumber, variation, tof_base_time_adc, tof_base_time_tdc);
 
-    outFile.open(prefix + "fdc_base_time.txt");
-    outFile << "0.0 0.0" << endl;
-    outFile.close();
+    // Then the channel by channel ADC and TDC times for those that need the calibration
+    vector<double> bcal_tdc_offsets;
+    vector<double> fcal_adc_offsets;
+    vector<double> sc_adc_offsets, sc_tdc_offsets;
+    vector<double> tagm_adc_offsets, tagm_tdc_offsets;
+    vector<double> tagh_adc_offsets, tagh_tdc_offsets;
+    vector<double> tof_adc_offsets, tof_tdc_offsets;
+    GetCCDBConstants("/BCAL/TDC_offsets"    ,runNumber, variation, bcal_tdc_offsets);
+    GetCCDBConstants("/FCAL/timing_offsets" ,runNumber, variation, fcal_adc_offsets);
+    GetCCDBConstants("/START_COUNTER/adc_timing_offsets" ,runNumber, variation, sc_adc_offsets);
+    GetCCDBConstants("/START_COUNTER/tdc_timing_offsets" ,runNumber, variation, sc_tdc_offsets);
+    GetCCDBConstants("/PHOTON_BEAM/microscope/fadc_time_offsets" ,runNumber, variation, tagm_adc_offsets,3);// Interested in 3rd column
+    GetCCDBConstants("/PHOTON_BEAM/microscope/tdc_time_offsets"  ,runNumber, variation, tagm_tdc_offsets,3);
+    GetCCDBConstants("/PHOTON_BEAM/hodoscope/fadc_time_offsets"  ,runNumber, variation, tagh_adc_offsets,2);// Interested in 2nd column
+    GetCCDBConstants("/PHOTON_BEAM/hodoscope/tdc_time_offsets"   ,runNumber, variation, tagh_tdc_offsets,2);
+    GetCCDBConstants("/TOF/adc_timing_offsets",runNumber, variation, tof_adc_offsets);
+    GetCCDBConstants("/TOF/timing_offsets",runNumber, variation, tof_tdc_offsets);
 
-    outFile.open(prefix + "fcal_base_time.txt");
-    outFile << "0.0" << endl;
-    outFile.close();
-
-    outFile.open(prefix + "sc_base_time.txt");
-    outFile << "0.0 0.0" << endl;
-    outFile.close();
-
-    outFile.open(prefix + "tagh_base_time.txt");
-    outFile << "0.0 0.0" << endl;
-    outFile.close();
-
-    outFile.open(prefix + "tagm_base_time.txt");
-    outFile << "0.0 0.0" << endl;
-    outFile.close();
-
-    outFile.open(prefix + "tof_base_time.txt");
-    outFile << "0.0 0.0" << endl;
-    outFile.close();
-
-    outFile.open(prefix + "bcal_adc_timing_offsets.txt");
-    for (int i = 1; i <= 1536; i++){
-        outFile << "0.0" << endl;
-    }
-    outFile.close();
-
-    outFile.open(prefix + "bcal_tdc_timing_offsets.txt");
-    for (int i = 1; i <= 1152; i++){
-        outFile << "0.0" << endl;
-    }
-    outFile.close();
-
-    outFile.open(prefix + "fcal_adc_timing_offsets.txt");
-    for (int i = 1; i <= 2800; i++){
-        outFile << "0.0" << endl;
-    }
-    outFile.close();
-
-    outFile.open(prefix + "sc_adc_timing_offsets.txt");
-    for (int i = 1; i <= 30; i++){
-        outFile << "0.0" << endl;
-    }
-    outFile.close();
-
-    outFile.open(prefix + "sc_tdc_timing_offsets.txt");
-    for (int i = 1; i <= 30; i++){
-        outFile << "0.0" << endl;
-    }
-    outFile.close();
-
-    outFile.open(prefix + "tagm_adc_timing_offsets.txt");
-    for (int i = 1; i <= 102; i++){
-        outFile << "0 " << i << " 0.0" << endl;
-        if ( i == 7 || i == 25 || i == 79 || i == 97){
-            for(int j = 1; j <= 5; j++){
-                outFile << j << " " << i << " 0.0" << endl;
-            }
-        }
-    }
-    outFile.close();
-
-    outFile.open(prefix + "tagm_tdc_timing_offsets.txt");
-    for (int i = 1; i <= 102; i++){
-        outFile << "0 " << i << " 0.0" << endl;
-        if ( i == 7 || i == 25 || i == 79 || i == 97){
-            for(int j = 1; j <= 5; j++){
-                outFile << j << " " << i << " 0.0" << endl;
-            }
-        }
-    }
-    outFile.close();
-
-    outFile.open(prefix + "tagh_adc_timing_offsets.txt");
-    for (int i = 1; i <= 274; i++){
-        outFile << i << " 0.0" << endl;
-    }
-    outFile.close();
-
-    outFile.open(prefix + "tagh_tdc_timing_offsets.txt");
-    for (int i = 1; i <= 274; i++){
-        outFile << i << " 0.0" << endl;
-    }
-    outFile.close();
-
-    outFile.open(prefix + "tof_adc_timing_offsets.txt");
-    for (int i = 1; i <= 176; i++){
-        outFile << "0.0" << endl;
-    }
-    outFile.close();
+    cout << "Done grabbing CCDB constants...Entering fits..." << endl;
 
     //Move the base times just for the tracking
 
@@ -185,7 +170,7 @@ void ExtractTDCADCTiming(int runNumber){
 
     CDC_ADC_Offset *= -1;
     outFile.open(prefix + "cdc_base_time.txt");
-    outFile << CDC_ADC_Offset << endl;
+    outFile << cdc_base_time + CDC_ADC_Offset << endl;
     outFile.close();
 
     float FDC_ADC_Offset = 0.0, FDC_TDC_Offset = 0.0;
@@ -209,7 +194,7 @@ void ExtractTDCADCTiming(int runNumber){
 
     FDC_ADC_Offset *= -1;
     outFile.open(prefix + "fdc_base_time.txt");
-    outFile << FDC_ADC_Offset << " " << FDC_TDC_Offset << endl;
+    outFile << fdc_base_time_adc + FDC_ADC_Offset << " " << fdc_base_time_tdc + FDC_TDC_Offset << endl;
     outFile.close();
 
     // Now that we have the file open, do all of the fits and write the output
@@ -287,7 +272,7 @@ void ExtractTDCADCTiming(int runNumber){
     }
 
     outFile.open(prefix + "sc_base_time.txt", ios::out);
-    outFile << -1*(sc_tdc_base_time + meanDiff) << " " << -1*sc_tdc_base_time << endl;
+    outFile << sc_base_time_adc - (sc_tdc_base_time + meanDiff) << " " << sc_base_time_tdc - sc_tdc_base_time << endl;
     outFile.close();
 
     thisHist = Get2DHistogram("HLDetectorTiming", "TOF", "TOFHit TDC_ADC Difference");
@@ -335,11 +320,11 @@ void ExtractTDCADCTiming(int runNumber){
         for (int i = 1 ; i <= nBinsX; i++){
             double valueToUse = selected_TOF_TDCADCOffset->GetBinContent(i);
             if (valueToUse == 0) valueToUse = meanOffset;
-            outFile << valueToUse - meanOffset << endl;
+            outFile << tof_adc_offsets[i-1] + valueToUse - meanOffset << endl;
         }
         outFile.close();
         outFile.open(prefix + "tof_base_time.txt", ios::out);
-        outFile << -1 * meanOffset << " 0.0" << endl;
+        outFile << tof_base_time_adc - meanOffset << " " << tof_base_time_tdc << endl;
         outFile.close();
 
     }
@@ -420,14 +405,14 @@ void ExtractTDCADCTiming(int runNumber){
             int index = GetCCDBIndexTAGM(column, 0);
             double valueToUse = selectedTAGMOffset->GetBinContent(index);
             if (valueToUse == 0) valueToUse = meanOffset;
-            outFile << "0 " << column << " " << valueToUse - meanOffset + tdcRFOffset[index-1] << endl;
+            outFile << "0 " << column << " " << tagm_adc_offsets[index-1] + valueToUse - meanOffset + tdcRFOffset[index-1] << endl;
             if (column == 9 || column == 27 || column == 81 || column == 99){
                 for (unsigned int row = 1; row <= 5; row++){
                     index = GetCCDBIndexTAGM(column, row);
                     valueToUse = selectedTAGMOffset->GetBinContent(index);
                     double valueToUse = selectedTAGMOffset->GetBinContent(index);
                     if (valueToUse == 0) valueToUse = meanOffset; 
-                    outFile << row << " " << column << " " << valueToUse - meanOffset + tdcRFOffset[index-1] << endl;
+                    outFile << row << " " << column << " " << tagm_adc_offsets[index-1] + valueToUse - meanOffset + tdcRFOffset[index-1] << endl;
                 }
             }
         }
@@ -438,18 +423,18 @@ void ExtractTDCADCTiming(int runNumber){
         // Loop over rows
         for (unsigned int column = 1; column <= 102; column++){
             int index = GetCCDBIndexTAGM(column, 0);
-            outFile << "0 " << column << " " << tdcRFOffset[index-1] << endl;
+            outFile << "0 " << column << " " << tagm_tdc_offsets[index-1] + tdcRFOffset[index-1] << endl;
             if (column == 9 || column == 27 || column == 81 || column == 99){
                 for (unsigned int row = 1; row <= 5; row++){
                     index = GetCCDBIndexTAGM(column, row);
-                    outFile << row << " " << column << " " << tdcRFOffset[index-1] << endl;
+                    outFile << row << " " << column << " " << tagm_tdc_offsets[index-1] + tdcRFOffset[index-1] << endl;
                 }
             }
         }
         outFile.close();
 
         outFile.open(prefix + "tagm_base_time.txt", ios::out);
-        outFile << -1 * meanOffset << " 0.0" << endl;
+        outFile << tagm_base_time_adc - meanOffset << " " << tagm_base_time_tdc << endl;
         outFile.close();
     }
 
@@ -526,18 +511,18 @@ void ExtractTDCADCTiming(int runNumber){
         for (int i = 1; i <= nBinsX; i++){
             double mean = selectedTAGHOffset->GetBinContent(i);
             if (mean == 0) mean = meanOffset;
-            outFile << i << " " << mean - meanOffset + tdcRFOffsetTAGH[i-1] << endl;
+            outFile << i << " " << tagh_adc_offsets[i-1] + mean - meanOffset + tdcRFOffsetTAGH[i-1] << endl;
         }
         outFile.close();
 
         outFile.open(prefix + "tagh_tdc_timing_offsets.txt");
         for (int i = 1; i <= nBinsX; i++){
-            outFile << i << " " << tdcRFOffsetTAGH[i-1] << endl;
+            outFile << i << " " << tagh_tdc_offsets[i-1] + tdcRFOffsetTAGH[i-1] << endl;
         }
         outFile.close();
 
         outFile.open(prefix + "tagh_base_time.txt", ios::out);
-        outFile << -1 * meanOffset << " 0.0" << endl;
+        outFile << tagh_base_time_adc - meanOffset << " " << tagh_base_time_tdc << endl;
         outFile.close();
     }
 
@@ -622,14 +607,14 @@ void ExtractTDCADCTiming(int runNumber){
 
     // One is added, the other subtracted @_@
     outFile.open(prefix + "bcal_base_time.txt", ios::out);
-    outFile << "0.0 " << -1*meanTDCOffset << endl;
+    outFile << bcal_base_time_adc << " " << bcal_base_time_tdc - meanTDCOffset << endl;
     outFile.close();
 
     for (int i = 1 ; i <= selectedBCALOffset->GetNbinsX(); i++){
         double valueToUse = selectedBCALOffset->GetBinContent(i);
         if (valueToUse == 0) valueToUse = meanTDCOffset;
         outFile.open(prefix + "bcal_tdc_timing_offsets.txt", ios::out | ios::app);
-        outFile << valueToUse - meanTDCOffset << endl;
+        outFile << bcal_tdc_offsets[i-1] + valueToUse - meanTDCOffset << endl;
         outFile.close();
     }
 


### PR DESCRIPTION
Update to scripts used in HLDetectorTiming. Grab values from CCDB according to run number and variation passed to the script.  
