### PR TITLE
 add fitting for BCAL_inv_mass monitoring plugin

### DIFF
--- a/src/plugins/monitoring/BCAL_inv_mass/JEventProcessor_BCAL_inv_mass.cc
+++ b/src/plugins/monitoring/BCAL_inv_mass/JEventProcessor_BCAL_inv_mass.cc
@@ -33,12 +33,12 @@
 // Routine used to create our DEventProcessor
 
 
-static TH1F* bcal_diphoton_mass_500 = NULL;
 static TH1F* bcal_diphoton_mass_300 = NULL;
+static TH1F* bcal_diphoton_mass_500 = NULL;
 static TH1F* bcal_diphoton_mass_700 = NULL;
 static TH1F* bcal_diphoton_mass_900 = NULL;
-static TH1F* bcal_fcal_diphoton_mass_500 = NULL;
 static TH1F* bcal_fcal_diphoton_mass_300 = NULL;
+static TH1F* bcal_fcal_diphoton_mass_500 = NULL;
 static TH1F* bcal_fcal_diphoton_mass_700 = NULL;
 static TH1F* bcal_fcal_diphoton_mass_900 = NULL;
 
@@ -70,6 +70,10 @@ jerror_t JEventProcessor_BCAL_inv_mass::init(void)
 	TDirectory *main = gDirectory;
 	gDirectory->mkdir("bcal_inv_mass")->cd();
 
+        bcal_diphoton_mass_300 = new TH1F("bcal_diphoton_mass_300","bcal diphoton mass (Cluster E > 300 MeV)",100,0.0,1.0);
+        bcal_diphoton_mass_300->GetXaxis()->SetTitle("invariant mass [GeV]");
+        bcal_diphoton_mass_300->GetYaxis()->SetTitle("counts / 10 MeV");
+
 	bcal_diphoton_mass_500 = new TH1F("bcal_diphoton_mass_500","bcal diphoton mass (Cluster E > 500 MeV)",100,0.0,1.0);
 	bcal_diphoton_mass_500->GetXaxis()->SetTitle("invariant mass [GeV]");
 	bcal_diphoton_mass_500->GetYaxis()->SetTitle("counts / 10 MeV");	
@@ -78,14 +82,13 @@ jerror_t JEventProcessor_BCAL_inv_mass::init(void)
         bcal_diphoton_mass_700->GetXaxis()->SetTitle("invariant mass [GeV]");
         bcal_diphoton_mass_700->GetYaxis()->SetTitle("counts / 10 MeV");
 
-        bcal_diphoton_mass_300 = new TH1F("bcal_diphoton_mass_300","bcal diphoton mass (Cluster E > 300 MeV)",100,0.0,1.0);
-        bcal_diphoton_mass_300->GetXaxis()->SetTitle("invariant mass [GeV]");
-        bcal_diphoton_mass_300->GetYaxis()->SetTitle("counts / 10 MeV");
-
         bcal_diphoton_mass_900 = new TH1F("bcal_diphoton_mass_900","bcal diphoton mass (Cluster E > 900 MeV)",100,0.0,1.0);
         bcal_diphoton_mass_900->GetXaxis()->SetTitle("invariant mass [GeV]");
         bcal_diphoton_mass_900->GetYaxis()->SetTitle("counts / 10 MeV");
 
+        bcal_fcal_diphoton_mass_300 = new TH1F("bcal_fcal_diphoton_mass_300","bcal and fcal diphoton mass (Cluster E > 300 MeV)",100,0.0,1.0);
+        bcal_fcal_diphoton_mass_300->GetXaxis()->SetTitle("invariant mass [GeV]");
+        bcal_fcal_diphoton_mass_300->GetYaxis()->SetTitle("counts / 10 MeV");
 	
         bcal_fcal_diphoton_mass_500 = new TH1F("bcal_fcal_diphoton_mass_500","bcal and fcal diphoton mass (Cluster E > 500 MeV)",100,0.0,1.0);
         bcal_fcal_diphoton_mass_500->GetXaxis()->SetTitle("invariant mass [GeV]");
@@ -94,10 +97,6 @@ jerror_t JEventProcessor_BCAL_inv_mass::init(void)
         bcal_fcal_diphoton_mass_700 = new TH1F("bcal_fcal_diphoton_mass_700","bcal and fcal diphoton mass (Cluster E > 700 MeV)",100,0.0,1.0);
         bcal_fcal_diphoton_mass_700->GetXaxis()->SetTitle("invariant mass [GeV]");
         bcal_fcal_diphoton_mass_700->GetYaxis()->SetTitle("counts / 10 MeV");
-
-        bcal_fcal_diphoton_mass_300 = new TH1F("bcal_fcal_diphoton_mass_300","bcal and fcal diphoton mass (Cluster E > 300 MeV)",100,0.0,1.0);
-        bcal_fcal_diphoton_mass_300->GetXaxis()->SetTitle("invariant mass [GeV]");
-        bcal_fcal_diphoton_mass_300->GetYaxis()->SetTitle("counts / 10 MeV");
 
         bcal_fcal_diphoton_mass_900 = new TH1F("bcal_fcal_diphoton_mass_900","bcal and fcal diphoton mass (Cluster E > 900 MeV)",100,0.0,1.0);
         bcal_fcal_diphoton_mass_900->GetXaxis()->SetTitle("invariant mass [GeV]");
@@ -258,10 +257,10 @@ jerror_t JEventProcessor_BCAL_inv_mass::evnt(jana::JEventLoop* locEventLoop, uin
 				TLorentzVector ptot = sh1_p+sh2_p;
 				TLorentzVector ptot_raw = sh1_p_raw + sh2_p_raw ;
 				double inv_mass_raw = ptot_raw.M();
+				if(E1_raw>.3&&E2_raw>.3) bcal_diphoton_mass_300->Fill(inv_mass_raw);
 				if(E1_raw>.5&&E2_raw>.5) bcal_diphoton_mass_500->Fill(inv_mass_raw);
                	                if(E1_raw>.9&&E2_raw>.9) bcal_diphoton_mass_900->Fill(inv_mass_raw);
                		        if(E1_raw>.7&&E2_raw>.7) bcal_diphoton_mass_700->Fill(inv_mass_raw);
-               	       	        if(E1_raw>.3&&E2_raw>.3) bcal_diphoton_mass_300->Fill(inv_mass_raw);
 			}		
 			for(unsigned int j=0; j<locFCALClusters.size(); j++){
 				if (find(matchedFCALClusters.begin(), matchedFCALClusters.end(),locFCALClusters[j]) != matchedFCALClusters.end()) continue;
@@ -274,10 +273,10 @@ jerror_t JEventProcessor_BCAL_inv_mass::evnt(jana::JEventLoop* locEventLoop, uin
 				TLorentzVector cl2_p(fcal_E*dx2/R2, fcal_E*dy2/R2, fcal_E*dz2/R2, fcal_E);
 				TLorentzVector ptot_fcal_bcal = sh1_p_raw + cl2_p;
 				double inv_mass = ptot_fcal_bcal.M();
+                                if(E1_raw>.3&&fcal_E>.3) bcal_fcal_diphoton_mass_300->Fill(inv_mass);
 				if(E1_raw>.5&&fcal_E>.5) bcal_fcal_diphoton_mass_500->Fill(inv_mass);
 			        if(E1_raw>.7&&fcal_E>.7) bcal_fcal_diphoton_mass_700->Fill(inv_mass);
                                 if(E1_raw>.9&&fcal_E>.9) bcal_fcal_diphoton_mass_900->Fill(inv_mass);
-                                if(E1_raw>.3&&fcal_E>.3) bcal_fcal_diphoton_mass_300->Fill(inv_mass);
 			}
 	}   
 

--- a/src/plugins/monitoring/BCAL_inv_mass/bcal_fcal_inv_mass.C
+++ b/src/plugins/monitoring/BCAL_inv_mass/bcal_fcal_inv_mass.C
@@ -12,7 +12,15 @@
   TH1F* bcal_fcal_diphoton_mass_500 = (TH1F*)gDirectory->FindObjectAny("bcal_fcal_diphoton_mass_500");
   TH1F* bcal_fcal_diphoton_mass_700 = (TH1F*)gDirectory->FindObjectAny("bcal_fcal_diphoton_mass_700");
   TH1F* bcal_fcal_diphoton_mass_900 = (TH1F*)gDirectory->FindObjectAny("bcal_fcal_diphoton_mass_900");
- 
+
+  int polnumber = 3;
+  float fit_low = 0.04;
+  float fit_high = 0.20;
+  float par_300[15];
+  float par_500[15];
+  float par_700[15];
+  float par_900[15];
+
   if(gPad == NULL){
 
     TCanvas *c1 = new TCanvas( "c1", "BCAL_FCAL_inv_mass_plot", 800, 800 );
@@ -28,26 +36,123 @@
   if( bcal_fcal_diphoton_mass_300 ){
 
     bcal_fcal_diphoton_mass_300->SetStats(0);
+    double max_300 = bcal_diphoton_mass_300->GetMaximum();
     c1->cd(1);
     bcal_fcal_diphoton_mass_300->Draw();
+    bcal_fcal_diphoton_mass_300->SetLineWidth(2);
+    TF1 *fitfunc_300 = new TF1("fitfunc_300",Form("gaus(0)+pol%i(3)",polnumber),fit_low,fit_high);
+    fitfunc_300->SetParameters(max_300/2, 0.1, 0.009);
+    for (int i=0; i<=polnumber; i++) {
+         fitfunc_300->SetParameter(3+i,par_300[i]);
+    }
+    fitfunc_300->SetParNames("height","mean","sigma");
+    fitfunc_300->SetParLimits(0,max_300/5.,max_300+max_300/10.);
+    fitfunc_300->SetParLimits(1,0.06,0.18);
+    fitfunc_300->SetParLimits(2,0.006,0.03);
+    fitfunc_300->SetLineWidth(2);
+    bcal_fcal_diphoton_mass_300->Fit(fitfunc_300,"RQ");
+    for (int i=0; i<9; i++) {
+         par_300[i] = fitfunc_300->GetParameter(i);
+    }
+    fitfunc_300->Draw("same");
+
+    TPaveText *pt_300 = new TPaveText(0.6, 0.65, 0.99, 0.89, "NDC");
+    pt_300->SetFillColor(0);
+    pt_300->AddText(Form("M_{#pi^{0}} = %.3f MeV",par_300[1]*1000));
+    pt_300->AddText(Form("#sigma_{#pi^{0}} = %.3f MeV",par_300[2]*1000));
+    pt_300->AddText(Form("#sigma/M = %.3f %%",(par_300[2]/par_300[1])*100));
+    pt_300->Draw();
   }
   if( bcal_fcal_diphoton_mass_500 ){
 
     bcal_fcal_diphoton_mass_500->SetStats(0);
+    double max_500 = bcal_fcal_diphoton_mass_500->GetMaximum();
     c1->cd(2);
     bcal_fcal_diphoton_mass_500->Draw();
+    bcal_fcal_diphoton_mass_500->SetLineWidth(2);
+    TF1 *fitfunc_500 = new TF1("fitfunc_500",Form("gaus(0)+pol%i(3)",polnumber),fit_low,fit_high);
+    fitfunc_500->SetParameters(max_500/5, 0.135, 0.01);
+    for (int i=0; i<=polnumber; i++) {
+         fitfunc_500->SetParameter(3+i,par_500[i]);
+    }
+    fitfunc_500->SetParNames("height","mean","sigma");
+    fitfunc_500->SetParLimits(0,0.,max_500+max_500/10.);
+    fitfunc_500->SetParLimits(1,0.02,0.30);
+    fitfunc_500->SetParLimits(2,0.001,0.050);
+    fitfunc_500->SetLineWidth(2);
+    bcal_fcal_diphoton_mass_500->Fit(fitfunc_500,"RQ");
+    for (int i=0; i<9; i++) {
+         par_500[i] = fitfunc_500->GetParameter(i);
+    }
+    fitfunc_500->Draw("same");
+
+    TPaveText *pt_500 = new TPaveText(0.6, 0.65, 0.99, 0.89, "NDC");
+    pt_500->SetFillColor(0);
+    pt_500->AddText(Form("M_{#pi^{0}} = %.3f MeV",par_500[1]*1000));
+    pt_500->AddText(Form("#sigma_{#pi^{0}} = %.3f MeV",par_500[2]*1000));
+    pt_500->AddText(Form("#sigma/M = %.3f %%",(par_500[2]/par_500[1])*100));
+    pt_500->Draw();    
+
   }
    if( bcal_fcal_diphoton_mass_700 ){
-
+   
     bcal_fcal_diphoton_mass_700->SetStats(0);
+    double max_700 = bcal_fcal_diphoton_mass_700->GetMaximum();
     c1->cd(3);
     bcal_fcal_diphoton_mass_700->Draw();
+    bcal_fcal_diphoton_mass_700->SetLineWidth(2);
+    TF1 *fitfunc_700 = new TF1("fitfunc_700",Form("gaus(0)+pol%i(3)",polnumber),fit_low,fit_high);
+    fitfunc_700->SetParameters(max_700/5, 0.135, 0.01);
+    for (int i=0; i<=polnumber; i++) {
+         fitfunc_700->SetParameter(3+i,par_700[i]);
+    }
+    fitfunc_700->SetParNames("height","mean","sigma");
+    fitfunc_700->SetParLimits(0,0.,max_700+max_700/10.);
+    fitfunc_700->SetParLimits(1,0.02,0.30);
+    fitfunc_700->SetParLimits(2,0.001,0.050);
+    fitfunc_700->SetLineWidth(2);
+    bcal_fcal_diphoton_mass_700->Fit(fitfunc_700,"RQ");
+    for (int i=0; i<9; i++) {
+         par_700[i] = fitfunc_700->GetParameter(i);
+    }
+    fitfunc_700->Draw("same");
+
+    TPaveText *pt_700 = new TPaveText(0.6, 0.65, 0.99, 0.89, "NDC");
+    pt_700->SetFillColor(0);
+    pt_700->AddText(Form("M_{#pi^{0}} = %.3f MeV",par_700[1]*1000));
+    pt_700->AddText(Form("#sigma_{#pi^{0}} = %.3f MeV",par_700[2]*1000));
+    pt_700->AddText(Form("#sigma/M = %.3f %%",(par_700[2]/par_700[1])*100));
+    pt_700->Draw();
   }
    if( bcal_fcal_diphoton_mass_900 ){
 
     bcal_fcal_diphoton_mass_900->SetStats(0);
+    double max_900 = bcal_fcal_diphoton_mass_900->GetMaximum();
     c1->cd(4);
     bcal_fcal_diphoton_mass_900->Draw();
+    bcal_fcal_diphoton_mass_900->SetLineWidth(2);
+    TF1 *fitfunc_900 = new TF1("fitfunc_900",Form("gaus(0)+pol%i(3)",polnumber),fit_low,fit_high);
+    fitfunc_900->SetParameters(max_900/5, 0.135, 0.01);
+    for (int i=0; i<=polnumber; i++) {
+         fitfunc_900->SetParameter(3+i,par_900[i]);
+    }
+    fitfunc_900->SetParNames("height","mean","sigma");
+    fitfunc_900->SetParLimits(0,0.,max_900+max_900/10.);
+    fitfunc_900->SetParLimits(1,0.02,0.30);
+    fitfunc_900->SetParLimits(2,0.001,0.050);
+    fitfunc_900->SetLineWidth(2);
+    bcal_fcal_diphoton_mass_900->Fit(fitfunc_900,"RQ");
+    for (int i=0; i<9; i++) {
+         par_900[i] = fitfunc_900->GetParameter(i);
+    }
+    fitfunc_900->Draw("same");
+
+    TPaveText *pt_900 = new TPaveText(0.6, 0.65, 0.99, 0.89, "NDC");
+    pt_900->SetFillColor(0);
+    pt_900->AddText(Form("M_{#pi^{0}} = %.3f MeV",par_900[1]*1000));
+    pt_900->AddText(Form("#sigma_{#pi^{0}} = %.3f MeV",par_900[2]*1000));
+    pt_900->AddText(Form("#sigma/M = %.3f %%",(par_900[2]/par_900[1])*100));
+    pt_900->Draw();
   }
 
 

--- a/src/plugins/monitoring/BCAL_inv_mass/bcal_inv_mass.C
+++ b/src/plugins/monitoring/BCAL_inv_mass/bcal_inv_mass.C
@@ -12,7 +12,13 @@
   TH1F* bcal_diphoton_mass_500 = (TH1F*)gDirectory->FindObjectAny("bcal_diphoton_mass_500");
   TH1F* bcal_diphoton_mass_700 = (TH1F*)gDirectory->FindObjectAny("bcal_diphoton_mass_700");
   TH1F* bcal_diphoton_mass_900 = (TH1F*)gDirectory->FindObjectAny("bcal_diphoton_mass_900");
- 
+  int polnumber = 3;
+  float fit_low = 0.07;
+  float fit_high = 0.20;
+  float par_300[15]; 
+  float par_500[15];
+  float par_700[15];
+  float par_900[15];
   if(gPad == NULL){
 
     TCanvas *c1 = new TCanvas( "c1", "BCAL_inv_mass_plot", 800, 800 );
@@ -28,26 +34,120 @@
   if( bcal_diphoton_mass_300 ){
 
     bcal_diphoton_mass_300->SetStats(0);
+    double max_300 = bcal_diphoton_mass_300->GetMaximum();
     c1->cd(1);
     bcal_diphoton_mass_300->Draw();
+    bcal_diphoton_mass_300->SetLineWidth(2);
+    TF1 *fitfunc_300 = new TF1("fitfunc_300",Form("gaus(0)+pol%i(3)",polnumber),fit_low,fit_high);
+    fitfunc_300->SetParameters(max_300/2, 0.1, 0.009);
+    for (int i=0; i<=polnumber; i++) {
+         fitfunc_300->SetParameter(3+i,par_300[i]);
+    }
+    fitfunc_300->SetParNames("height","mean","sigma");
+    fitfunc_300->SetParLimits(0,max_300/5.,max_300+max_300/10.);
+    fitfunc_300->SetParLimits(1,0.06,0.18);
+    fitfunc_300->SetParLimits(2,0.006,0.02);
+    fitfunc_300->SetLineWidth(2);
+    bcal_diphoton_mass_300->Fit(fitfunc_300,"RQ");
+    for (int i=0; i<9; i++) {
+         par_300[i] = fitfunc_300->GetParameter(i);
+    }
+    fitfunc_300->Draw("same");
+    TPaveText *pt_300 = new TPaveText(0.6, 0.65, 0.99, 0.89, "NDC");
+    pt_300->SetFillColor(0);
+    pt_300->AddText(Form("M_{#pi^{0}} = %.3f MeV",par_300[1]*1000));
+    pt_300->AddText(Form("#sigma_{#pi^{0}} = %.3f MeV",par_300[2]*1000));
+    pt_300->AddText(Form("#sigma/M = %.3f %%",(par_300[2]/par_300[1])*100));
+    pt_300->Draw();
   }
   if( bcal_diphoton_mass_500 ){
-
     bcal_diphoton_mass_500->SetStats(0);
+    double max_500 = bcal_diphoton_mass_500->GetMaximum();
     c1->cd(2);
     bcal_diphoton_mass_500->Draw();
+    bcal_diphoton_mass_500->SetLineWidth(2);
+    TF1 *fitfunc_500 = new TF1("fitfunc_500",Form("gaus(0)+pol%i(3)",polnumber),fit_low,fit_high);
+    fitfunc_500->SetParameters(max_500/5, 0.135, 0.01);
+    for (int i=0; i<=polnumber; i++) { 
+         fitfunc_500->SetParameter(3+i,par_500[i]);
+    }
+    fitfunc_500->SetParNames("height","mean","sigma");
+    fitfunc_500->SetParLimits(0,0.,max_500+max_500/10.);
+    fitfunc_500->SetParLimits(1,0.02,0.30);
+    fitfunc_500->SetParLimits(2,0.001,0.050);
+    fitfunc_500->SetLineWidth(2);
+    bcal_diphoton_mass_500->Fit(fitfunc_500,"RQ");
+    for (int i=0; i<9; i++) {
+         par_500[i] = fitfunc_500->GetParameter(i);
+    }
+    fitfunc_500->Draw("same");
+
+    TPaveText *pt_500 = new TPaveText(0.6, 0.65, 0.99, 0.89, "NDC");
+    pt_500->SetFillColor(0);
+    pt_500->AddText(Form("M_{#pi^{0}} = %.3f MeV",par_500[1]*1000));
+    pt_500->AddText(Form("#sigma_{#pi^{0}} = %.3f MeV",par_500[2]*1000));
+    pt_500->AddText(Form("#sigma/M = %.3f %%",(par_500[2]/par_500[1])*100));
+    pt_500->Draw();
   }
    if( bcal_diphoton_mass_700 ){
 
     bcal_diphoton_mass_700->SetStats(0);
+    double max_700 = bcal_diphoton_mass_700->GetMaximum();
     c1->cd(3);
     bcal_diphoton_mass_700->Draw();
+    bcal_diphoton_mass_700->SetLineWidth(2);
+    TF1 *fitfunc_700 = new TF1("fitfunc_700",Form("gaus(0)+pol%i(3)",polnumber),fit_low,fit_high);
+    fitfunc_700->SetParameters(max_700/5, 0.135, 0.01);
+    for (int i=0; i<=polnumber; i++) {
+         fitfunc_700->SetParameter(3+i,par_700[i]);
+    }
+    fitfunc_700->SetParNames("height","mean","sigma");
+    fitfunc_700->SetParLimits(0,0.,max_700+max_700/10.);
+    fitfunc_700->SetParLimits(1,0.02,0.30);
+    fitfunc_700->SetParLimits(2,0.001,0.050);
+    fitfunc_700->SetLineWidth(2);
+    bcal_diphoton_mass_700->Fit(fitfunc_700,"RQ");
+    for (int i=0; i<9; i++) {
+         par_700[i] = fitfunc_700->GetParameter(i);
+    }
+    fitfunc_700->Draw("same");
+        
+    TPaveText *pt_700 = new TPaveText(0.6, 0.65, 0.99, 0.89, "NDC");
+    pt_700->SetFillColor(0);
+    pt_700->AddText(Form("M_{#pi^{0}} = %.3f MeV",par_700[1]*1000));
+    pt_700->AddText(Form("#sigma_{#pi^{0}} = %.3f MeV",par_700[2]*1000));
+    pt_700->AddText(Form("#sigma/M = %.3f %%",(par_700[2]/par_700[1])*100));
+    pt_700->Draw();
   }
    if( bcal_diphoton_mass_900 ){
 
     bcal_diphoton_mass_900->SetStats(0);
+    double max_900 = bcal_diphoton_mass_900->GetMaximum();
     c1->cd(4);
     bcal_diphoton_mass_900->Draw();
+    bcal_diphoton_mass_900->SetLineWidth(2);
+    TF1 *fitfunc_900 = new TF1("fitfunc_900",Form("gaus(0)+pol%i(3)",polnumber),fit_low,fit_high);
+    fitfunc_900->SetParameters(max_900/5, 0.135, 0.01);
+    for (int i=0; i<=polnumber; i++) {
+         fitfunc_900->SetParameter(3+i,par_900[i]);
+    }
+    fitfunc_900->SetParNames("height","mean","sigma");
+    fitfunc_900->SetParLimits(0,0.,max_900+max_900/10.);
+    fitfunc_900->SetParLimits(1,0.02,0.30);
+    fitfunc_900->SetParLimits(2,0.001,0.050);
+    fitfunc_900->SetLineWidth(2);
+    bcal_diphoton_mass_900->Fit(fitfunc_900,"RQ");
+    for (int i=0; i<9; i++) {
+         par_900[i] = fitfunc_900->GetParameter(i);
+    }
+    fitfunc_900->Draw("same");
+
+    TPaveText *pt_900 = new TPaveText(0.6, 0.65, 0.99, 0.89, "NDC");
+    pt_900->SetFillColor(0);
+    pt_900->AddText(Form("M_{#pi^{0}} = %.3f MeV",par_900[1]*1000));
+    pt_900->AddText(Form("#sigma_{#pi^{0}} = %.3f MeV",par_900[2]*1000));
+    pt_900->AddText(Form("#sigma/M = %.3f %%",(par_900[2]/par_900[1])*100));
+    pt_900->Draw();
   }
 
 


### PR DESCRIPTION
Included fitting to the BCAL_inv_mass monitoring plugin to fit pi0 peaks for 2 photons in the BCAL and 1 photon each in BCAL and FCAL.
