### PR TITLE
Comment out unused variables to avoid compiler warnings.

### DIFF
--- a/src/libraries/CDC/DCDCHit_factory.cc
+++ b/src/libraries/CDC/DCDCHit_factory.cc
@@ -210,7 +210,7 @@ jerror_t DCDCHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 
         // There are a few values from the new data type that are critical for the interpretation of the data
         uint16_t IBIT = 0; // 2^{IBIT} Scale factor for integral
-        uint16_t ABIT = 0; // 2^{ABIT} Scale factor for amplitude
+//        uint16_t ABIT = 0; // 2^{ABIT} Scale factor for amplitude
         uint16_t PBIT = 0; // 2^{PBIT} Scale factor for pedestal
 
         // This is the place to make quality cuts on the data. 
@@ -223,7 +223,7 @@ jerror_t DCDCHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 
             // Set some constants to defaults until they appear correctly in the config words in the future
             IBIT = config->IBIT == 0xffff ? 4 : config->IBIT;
-            ABIT = config->ABIT == 0xffff ? 3 : config->ABIT;
+//            ABIT = config->ABIT == 0xffff ? 3 : config->ABIT;
             PBIT = config->PBIT == 0xffff ? 0 : config->PBIT;
             uint16_t NW   = config->NW   == 0xffff ? 200 : config->NW;
             

--- a/src/libraries/DAQ/JEventSource_EVIO.cc
+++ b/src/libraries/DAQ/JEventSource_EVIO.cc
@@ -4687,7 +4687,6 @@ void JEventSource_EVIO::ParseCAEN1190(int32_t rocid, const uint32_t* &iptr, cons
 	uint32_t tdc_num = 0;
 	uint32_t event_id = 0;
 	uint32_t bunch_id = 0;
-	uint32_t last_event_id = event_id - 1;
 
 	// We need to accomodate multi-event blocks where
 	// events are entangled (i.e. hits from event 1
@@ -4743,8 +4742,6 @@ void JEventSource_EVIO::ParseCAEN1190(int32_t rocid, const uint32_t* &iptr, cons
 				if( find(event_id_order.begin(), event_id_order.end(), event_id) == event_id_order.end()){
 					event_id_order.push_back(event_id);
 				}
-				//if(event_id != last_event_id) event_id_order.push_back(event_id);
-				last_event_id = event_id;
 				if(VERBOSE>7) evioout << "         CAEN TDC TDC Header (tdc=" << tdc_num <<" , event id=" << event_id <<" , bunch id=" << bunch_id << ")" << endl;
 				break;
 			case 0b00000:  // TDC Measurement


### PR DESCRIPTION
Comment out unused variables to avoid compiler warnings.
