### PR TITLE
Adding the ST time resolution to the online monitoring. Separate the …

### DIFF
--- a/src/plugins/Calibration/st_tw_corr_auto/macros/st_tw_resols.C
+++ b/src/plugins/Calibration/st_tw_corr_auto/macros/st_tw_resols.C
@@ -121,10 +121,10 @@ void st_tw_resols(char*input_filename)
   //*****************************************************************
   Time_resol.close();
   ifstream in;
-  in.open(Form("Time_resol.txt"));
+  in.open(Form("SC_time_resol.txt"));
   float sector, t, es ,e;
   TNtuple *ntuple = new TNtuple("ntuple","data from text file","sector:t:es:e");
-  ntuple->ReadFile("Time_resol.txt");
+  ntuple->ReadFile("SC_time_resol.txt");
   ntuple->Write();
   in.close();
   //Create the canvas
@@ -134,9 +134,9 @@ void st_tw_resols(char*input_filename)
   ntuple->Draw("sector:t:es:e");
   TGraphErrors *gr=new TGraphErrors(ntuple->GetSelectedRows(),ntuple->GetV1(),ntuple->GetV2(),ntuple->GetV3(),ntuple->GetV4());
   gr->Draw("AP");
-  gr->SetTitle("Time Resolution Vs Sector Number");
+  gr->SetTitle("ST Self Time Resolution Vs Sector Number");
   gr->GetXaxis()->SetTitle("Sector Number");
-  gr->GetYaxis()->SetTitle("Time Resolution (ps)");
+  gr->GetYaxis()->SetTitle("ST Self Time Resolution (ps)");
   gr->SetMarkerStyle(21);
   gr->SetMarkerSize(3);
   gr->SetMarkerColor(4);

--- a/src/plugins/monitoring/SConscript
+++ b/src/plugins/monitoring/SConscript
@@ -13,6 +13,8 @@ subdirs = [
 'PSPair_online',
 'ST_online_lowlevel',
 'ST_online_tracking',
+'ST_online_Tresolution',
+'ST_online_efficiency',
 'TAGH_online',
 'TAGM_online',
 'TOF_online',
@@ -23,7 +25,7 @@ subdirs = [
 'BCAL_Eff',
 'BCAL_inv_mass',
 'CDC_drift',
-'CDC_Cosmics' ]
+'CDC_Cosmics']
 
 #'L3_online',
 #'CODA_online',

--- a/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.cc
+++ b/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.cc
@@ -1,0 +1,282 @@
+// $Id$
+//
+//    File: JEventProcessor_ST_online_Tresolution.cc
+// Created: Fri Jan  8 09:07:34 EST 2016
+// Creator: mkamel (on Linux ifarm1401 2.6.32-431.el6.x86_64 x86_64)
+//
+
+#include "JEventProcessor_ST_online_Tresolution.h"
+using namespace jana;
+
+
+// Routine used to create our JEventProcessor
+#include <JANA/JApplication.h>
+#include <JANA/JFactory.h>
+extern "C"{
+void InitPlugin(JApplication *app){
+	InitJANAPlugin(app);
+	app->AddProcessor(new JEventProcessor_ST_online_Tresolution());
+}
+} // "C"
+
+
+//------------------
+// JEventProcessor_ST_online_Tresolution (Constructor)
+//------------------
+JEventProcessor_ST_online_Tresolution::JEventProcessor_ST_online_Tresolution()
+{
+
+}
+
+//------------------
+// ~JEventProcessor_ST_online_Tresolution (Destructor)
+//------------------
+JEventProcessor_ST_online_Tresolution::~JEventProcessor_ST_online_Tresolution()
+{
+
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_ST_online_Tresolution::init(void)
+{
+	// This is called once at program startup. If you are creating
+	// and filling historgrams in this plugin, you should lock the
+	// ROOT mutex like this:
+	//
+	// japp->RootWriteLock();
+	//  ... fill historgrams or trees ...
+	// japp->RootUnLock();
+	//
+  // **************** define histograms *************************
+  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+  h2_CorrectedTime_z = new TH2I*[NCHANNELS];
+  // All my Calculations in 2015 were using the binning below
+  NoBins_time = 80;
+  NoBins_z = 1300;
+  time_lower_limit = -4.0;      
+  time_upper_limit = 4.0;
+  z_lower_limit = 35.0;
+  z_upper_limit = 100.0;
+  for (Int_t i = 0; i < NCHANNELS; i++)
+    { 
+      h2_CorrectedTime_z[i] = new TH2I(Form("h2_CorrectedTime_z_%i", i+1), "Corrected Time vs. Z; Z (cm); Propagation Time (ns)", NoBins_z,z_lower_limit,z_upper_limit, NoBins_time, time_lower_limit, time_upper_limit);
+    }
+  japp->RootUnLock();
+  return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_ST_online_Tresolution::brun(JEventLoop *eventLoop, int runnumber)
+{
+	// This is called whenever the run number changes
+  // Get the particleID object for each run
+  vector<const DParticleID *> dParticleID_algos;
+  eventLoop->Get(dParticleID_algos);
+  if(dParticleID_algos.size() < 1)
+    {
+      _DBG_<<"Unable to get a DParticleID object! NO PID will be done!"<<endl;
+      return RESOURCE_UNAVAILABLE;
+    }
+  dParticleID = dParticleID_algos[0];
+  
+  // We want to be use some of the tools available in the RFTime factory 
+  // Specifically steping the RF back to a chosen time
+  dRFTimeFactory = static_cast<DRFTime_factory*>(eventLoop->GetFactory("DRFTime"));
+  
+  // Be sure that DRFTime_factory::init() and brun() are called
+  vector<const DRFTime*> locRFTimes;
+  eventLoop->Get(locRFTimes);
+  
+  //RF Period
+  vector<double> locRFPeriodVector;
+  eventLoop->GetCalib("PHOTON_BEAM/RF/rf_period", locRFPeriodVector);
+  dRFBunchPeriod = locRFPeriodVector[0];
+  
+  // Obtain the target center along z;
+  map<string,double> target_params;
+  if (eventLoop->GetCalib("/TARGET/target_parms", target_params))
+    jout << "Error loading /TARGET/target_parms/ !" << endl;
+  if (target_params.find("TARGET_Z_POSITION") != target_params.end())
+    z_target_center = target_params["TARGET_Z_POSITION"];
+  else
+    jerr << "Unable to get TARGET_Z_POSITION from /TARGET/target_parms !" << endl;
+  
+  // Obtain the Start Counter geometry
+  DApplication* dapp = dynamic_cast<DApplication*>(eventLoop->GetJApplication());
+  if(!dapp)
+    _DBG_<<"Cannot get DApplication from JEventLoop! (are you using a JApplication based program?)"<<endl; 
+  DGeometry* locGeometry = dapp->GetDGeometry(eventLoop->GetJEvent().GetRunNumber());
+  locGeometry->GetStartCounterGeom(sc_pos, sc_norm);
+  // Propagation Time constant
+  if(eventLoop->GetCalib("START_COUNTER/propagation_time_corr", propagation_time_corr))
+    jout << "Error loading /START_COUNTER/propagation_time_corr !" << endl;
+  return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_ST_online_Tresolution::evnt(JEventLoop *loop, int eventnumber)
+{
+	// This is called for every event. Use of common resources like writing
+	// to a file or filling a histogram should be mutex protected. Using
+	// loop->Get(...) to get reconstructed objects (and thereby activating the
+	// reconstruction algorithm) should be done outside of any mutex lock
+	// since multiple threads may call this method at the same time.
+	// Here's an example:
+	//
+	// vector<const MyDataClass*> mydataclasses;
+	// loop->Get(mydataclasses);
+	//
+	// japp->RootWriteLock();
+	//  ... fill historgrams or trees ...
+	// japp->RootUnLock();
+  double speed_light = 29.9792458;
+  // SC hits
+  vector<const DSCHit *> scHitVector;
+  loop->Get(scHitVector);
+  
+  // RF time object
+  const DRFTime* thisRFTime = NULL;
+  vector <const DRFTime*> RFTimeVector;
+  loop->Get(RFTimeVector);
+  if (RFTimeVector.size() != 0)
+    thisRFTime = RFTimeVector[0];
+
+  // Grab charged tracks
+  vector<const DChargedTrack *> chargedTrackVector;
+  loop->Get(chargedTrackVector);
+
+  // Grab the associated detector matches object
+  const DDetectorMatches* locDetectorMatches = NULL;
+  loop->GetSingle(locDetectorMatches);
+  
+  // Grab the associated RF bunch object
+  const DEventRFBunch *thisRFBunch = NULL;
+  loop->GetSingle(thisRFBunch, "Calibrations");
+  
+
+  japp->RootWriteLock();
+  for (uint32_t i = 0; i < chargedTrackVector.size(); i++)
+    {   
+      // Grab the charged track and declare time based track object
+      const DChargedTrack   *thisChargedTrack = chargedTrackVector[i];
+      const DTrackTimeBased *timeBasedTrack;
+      // Grab associated time based track object by selecting charged track with best FOM
+      thisChargedTrack->Get_BestTrackingFOM()->GetSingle(timeBasedTrack);
+      // Implement quality cuts for the time based tracks 
+      trackingFOMCut = 0.0027;  // 3 sigma cut
+      //trackingFOMCut = 0.0001;  // 5 sigma cut
+      if(timeBasedTrack->FOM  < trackingFOMCut) continue;
+
+      // Grab the ST hit match params object and cut on only tracks matched to the ST
+      DSCHitMatchParams locSCHitMatchParams;
+      foundSC = dParticleID->Get_BestSCMatchParams(timeBasedTrack, locDetectorMatches, locSCHitMatchParams);
+      if (!foundSC) continue;
+      
+      // Define vertex vector and cut on target/scattering chamber geometry
+      vertex = timeBasedTrack->position();
+      z_v = vertex.z();
+      r_v = vertex.Perp();
+      
+      z_vertex_cut = fabs(z_target_center - z_v) <= 15.0;
+      r_vertex_cut = r_v < 0.5;
+      // Apply  vertex cut
+      if (!z_vertex_cut) continue;
+      if (!r_vertex_cut) continue;
+      bool st_match = locDetectorMatches->Get_SCMatchParams(timeBasedTrack, st_params); 
+      // If st_match = true, there is a match between this track and the ST
+      if (!st_match) continue;
+     
+      sc_match_pid = dParticleID->MatchToSC(timeBasedTrack, 
+					    timeBasedTrack->rt, 
+					    st_params[0].dSCHit, 
+					    st_params[0].dSCHit->t, 
+					    locSCHitMatchParams, 
+					    true,
+					    &IntersectionPoint, &IntersectionDir); 
+      if(!sc_match_pid) continue; 
+      // Cut on the number of particle votes to find the best RF time
+      if (thisRFBunch->dNumParticleVotes < 2) continue;
+      // Calculate the TOF estimate of the target time
+
+      // Calculate the RF estimate of the target time
+      locCenteredRFTime       = thisRFTime->dTime;
+      // RF time at center of target
+      locCenterToVertexRFTime = (timeBasedTrack->z() - z_target_center)*(1.0/speed_light);  // Time correction for photon from target center to vertex of track
+      locVertexRFTime         = locCenteredRFTime + locCenterToVertexRFTime;
+      sc_index= locSCHitMatchParams.dSCHit->sector - 1;
+      // Start Counter geometry in hall coordinates 
+      sc_pos_soss = sc_pos[sc_index][0].z();   // Start of straight section
+      sc_pos_eoss = sc_pos[sc_index][1].z();   // End of straight section
+      sc_pos_eobs = sc_pos[sc_index][11].z();  // End of bend section
+      sc_pos_eons = sc_pos[sc_index][12].z();  // End of nose section
+      //Get the ST time walk corrected time
+      st_time = st_params[0].dSCHit->t;
+      // Get the Flight time 
+      FlightTime = locSCHitMatchParams.dFlightTime; 
+      //St time corrected for the flight time
+      st_corr_FlightTime =  st_time - FlightTime;
+      // SC_RFShiftedTime = dRFTimeFactory->Step_TimeToNearInputTime(locVertexRFTime,  st_corr_FlightTime);
+      // Z intersection of charged track and SC 
+      locSCzIntersection = IntersectionPoint.z();
+      ////////////////////////////////////////////////////////////////////
+      /// Fill the sc time histograms corrected for walk and propagation//
+      ////////////////////////////////////////////////////////////////////
+      // Read the constants from CCDB
+      double incpt_ss   = propagation_time_corr[sc_index][0];
+      double slope_ss   = propagation_time_corr[sc_index][1];
+      double incpt_bs   = propagation_time_corr[sc_index][2];
+      double slope_bs   = propagation_time_corr[sc_index][3];
+      double incpt_ns   = propagation_time_corr[sc_index][4];
+      double slope_ns   = propagation_time_corr[sc_index][5];
+      // Straight Sections
+      if (locSCzIntersection > sc_pos_soss && locSCzIntersection <= sc_pos_eoss)
+	{
+	  Corr_Time_ss = st_corr_FlightTime  - (incpt_ss + (slope_ss *  locSCzIntersection));
+	  SC_RFShiftedTime = dRFTimeFactory->Step_TimeToNearInputTime(locVertexRFTime,  Corr_Time_ss);
+	  h2_CorrectedTime_z[sc_index]->Fill(locSCzIntersection,Corr_Time_ss -SC_RFShiftedTime);
+	}
+      // Bend Sections
+      if(locSCzIntersection > sc_pos_eoss && locSCzIntersection <= sc_pos_eobs)
+	{
+	  Corr_Time_bs =  st_corr_FlightTime  - (incpt_bs + (slope_bs *  locSCzIntersection));
+	  SC_RFShiftedTime = dRFTimeFactory->Step_TimeToNearInputTime(locVertexRFTime,  Corr_Time_bs);
+	  h2_CorrectedTime_z[sc_index]->Fill(locSCzIntersection,Corr_Time_bs - SC_RFShiftedTime);
+	}
+      // Nose Sections
+      if(locSCzIntersection > sc_pos_eobs && locSCzIntersection <= sc_pos_eons)
+	{ 
+	  Corr_Time_ns =  st_corr_FlightTime  - (incpt_ns + (slope_ns *  locSCzIntersection));
+	  SC_RFShiftedTime = dRFTimeFactory->Step_TimeToNearInputTime(locVertexRFTime,  Corr_Time_ns);
+	  h2_CorrectedTime_z[sc_index]->Fill(locSCzIntersection,Corr_Time_ns - SC_RFShiftedTime);
+	}
+    } // sc charged tracks
+  japp->RootUnLock();
+  return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_ST_online_Tresolution::erun(void)
+{
+	// This is called whenever the run number changes, before it is
+	// changed to give you a chance to clean up before processing
+	// events from the next run number.
+	return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t JEventProcessor_ST_online_Tresolution::fini(void)
+{
+	// Called before program exit after event processing is finished.
+	return NOERROR;
+}
+

--- a/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.h
+++ b/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.h
@@ -1,0 +1,108 @@
+// $Id$
+//
+//    File: JEventProcessor_ST_online_Tresolution.h
+// Created: Fri Jan  8 09:07:34 EST 2016
+// Creator: mkamel (on Linux ifarm1401 2.6.32-431.el6.x86_64 x86_64)
+//
+
+#ifndef _JEventProcessor_ST_online_Tresolution_
+#define _JEventProcessor_ST_online_Tresolution_
+
+#include <JANA/JEventProcessor.h>
+// ROOT header files
+#include <TMath.h>
+#include <TDirectory.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TTree.h>
+// C++ header files
+#include <stdint.h>
+#include <vector>
+#include <stdio.h>
+// PID libraries
+#include <PID/DEventRFBunch.h>
+#include <PID/DParticleID.h>
+#include <PID/DDetectorMatches.h>
+#include <PID/DParticleID.h>
+#include <PID/DChargedTrack.h>
+// Tracking libraries
+#include <TRACKING/DTrackTimeBased.h>
+// RF libraries
+#include <RF/DRFTDCDigiTime.h>
+#include <RF/DRFTime_factory.h>
+// ST libraries
+#include <START_COUNTER/DSCHit.h>
+#include <START_COUNTER/DSCDigiHit.h>
+#include <START_COUNTER/DSCTDCDigiHit.h>
+#include <START_COUNTER/DSCTruthHit.h>
+// TOF libraries
+#include <TOF/DTOFHit.h>
+// DAQ/EPICS libraries
+#include <DAQ/DEPICSvalue.h>
+// Translation table libraries
+#include <TTAB/DTTabUtilities.h>
+#include <TTAB/DTranslationTable.h>
+//
+const Int_t NCHANNELS = 30;
+class JEventProcessor_ST_online_Tresolution:public jana::JEventProcessor{
+	public:
+		JEventProcessor_ST_online_Tresolution();
+		~JEventProcessor_ST_online_Tresolution();
+		const char* className(void){return "JEventProcessor_ST_online_Tresolution";}
+
+	private:
+		jerror_t init(void);						///< Called once at program start.
+		jerror_t brun(jana::JEventLoop *eventLoop, int runnumber);	///< Called everytime a new run number is detected.
+		jerror_t evnt(jana::JEventLoop *eventLoop, int eventnumber);	///< Called every event.
+		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+		const DParticleID* dParticleID;
+		DRFTime_factory *dRFTimeFactory;
+		double z_target_center;  // Target center along z
+		double dRFBunchPeriod;   // RF bunch period from CCDBr
+		//////////////////////////////////
+		double locSCHitTime,       locSCTrackFlightTime,   locFlightTimeCorrectedSCTime;
+		double locTOFHitTime,      locTOFTrackFlightTime,  locFlightTimeCorrectedTOFTime;
+		double locCenteredRFTime,  locCenterToVertexRFTime,  locVertexRFTime, locPeriod;
+		double SC_RFShiftedTime;
+		double locSCzIntersection;
+		double locSCPropTime;
+		double sc_pos_soss, sc_pos_eoss, sc_pos_eobs, sc_pos_eons;
+		double  Corr_Time,Corr_Time_ss,Corr_Time_bs,Corr_Time_ns, Corr_Time_bn;
+		double time_lower_limit, time_upper_limit, z_lower_limit, z_upper_limit;
+		int NoBins_time, NoBins_z;
+		double st_time, FlightTime, st_corr_FlightTime; 
+		vector<vector<DVector3> >sc_pos;   // SC geometry vector
+		vector<vector<DVector3> >sc_norm;  
+		// Grab match track detector parameters
+		DTOFHitMatchParams locTOFHitMatchParams;  // TOF
+		DSCHitMatchParams  locSCHitMatchParams;   // SC
+		// Declare event vertex vector
+		DVector3 vertex;
+		// Declare a vector which quantizes the point of the intersection of a charged particle 
+		//   with a plane in the middle of the scintillator 
+		DVector3 IntersectionPoint;
+		// Declare a vector which quantizes the unit vector of the charged particle track traversing
+	//   through the scintillator with its origin at the intersection point
+		DVector3 IntersectionDir;
+		// Grab the paramteres associated to a track matched to the ST
+		vector<DSCHitMatchParams> st_params;
+		// Declare r and z coord. of track vertex, sc array index
+		double z_v, r_v;
+		int sc_index;
+		// Cuts
+		double trackingFOMCut;
+		double pim_pmag_cut;
+		bool z_vertex_cut, r_vertex_cut;
+		bool foundTOF, foundSC, foundSCandTOF;
+		bool sc_match, sc_match_pid;
+		// ******************* 2D histos **************
+		TH2I **h2_CorrectedTime_z;
+		//Define Calibration parameters variable called from CCDB
+		vector<vector<double> >propagation_time_corr;
+
+
+};
+
+#endif // _JEventProcessor_ST_online_Tresolution_
+

--- a/src/plugins/monitoring/ST_online_Tresolution/SConscript
+++ b/src/plugins/monitoring/ST_online_Tresolution/SConscript
@@ -1,0 +1,12 @@
+
+
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddDANA(env)
+sbms.plugin(env)
+
+

--- a/src/plugins/monitoring/ST_online_Tresolution/st_time_resolution.C
+++ b/src/plugins/monitoring/ST_online_Tresolution/st_time_resolution.C
@@ -1,5 +1,5 @@
 // File: st_tw_fits.C
-// Last Modified: 11/10/2015
+// Last Modified: 01/26/2016
 // Creator: Mahmoud Kamel mkame006@fiu.edu
 // Purpose: Displaying histograms and tw automatic process.
 #include "TH1.h"
@@ -138,7 +138,7 @@ void st_time_resolution(char*input_filename)
       	}
       pytotal->Fit("gaus");
       gPad->Update();
-       PT_can[j]->Print(Form("ST_Sector_%i.png",j+1));
+      
       t_total_fit[j][2] = gaus->GetParameter(2)*1000;
       t_total_fit_err[j][2] = gaus->GetParError(2)*1000;
       
@@ -175,6 +175,5 @@ void st_time_resolution(char*input_filename)
   line->SetLineStyle(9);
 
   line->Draw();
-  Time_can->Print(Form("ST_Tresolution.png"));
 }
 

--- a/src/plugins/monitoring/ST_online_efficiency/JEventProcessor_ST_online_efficiency.cc
+++ b/src/plugins/monitoring/ST_online_efficiency/JEventProcessor_ST_online_efficiency.cc
@@ -1,0 +1,299 @@
+// $Id$
+//
+//    File: JEventProcessor_ST_online_efficiency.cc
+// Created: Wed Jan 20 10:35:58 EST 2016
+// Creator: mkamel (on Linux ifarm1102 2.6.32-431.el6.x86_64 x86_64)
+//
+
+#include "JEventProcessor_ST_online_efficiency.h"
+using namespace jana;
+using namespace std;
+
+// Routine used to create our JEventProcessor
+#include <JANA/JApplication.h>
+#include <JANA/JFactory.h>
+extern "C"{
+void InitPlugin(JApplication *app){
+	InitJANAPlugin(app);
+	app->AddProcessor(new JEventProcessor_ST_online_efficiency());
+}
+} // "C"
+
+
+//------------------
+// JEventProcessor_ST_online_efficiency (Constructor)
+//------------------
+JEventProcessor_ST_online_efficiency::JEventProcessor_ST_online_efficiency()
+{
+
+}
+
+//------------------
+// ~JEventProcessor_ST_online_efficiency (Destructor)
+//------------------
+JEventProcessor_ST_online_efficiency::~JEventProcessor_ST_online_efficiency()
+{
+
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_ST_online_efficiency::init(void)
+{
+	// This is called once at program startup. If you are creating
+	// and filling historgrams in this plugin, you should lock the
+	// ROOT mutex like this:
+	//
+	// japp->RootWriteLock();
+	//  ... fill historgrams or trees ...
+	// japp->RootUnLock();
+	//
+  // USE_SC_TIME = 0 in order to Not reconstruct tracks with start counter time
+  gPARMS->SetParameter("TRKFIT:USE_SC_TIME",false);
+  
+  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+  // Create root folder for ST and cd to it, store main dir
+  TDirectory *main = gDirectory;
+  gDirectory->mkdir("st_efficiency")->cd();
+  //eff histos
+  h_N_trck_prd_All = new TH1D("h_N_trck_prd_All", "h_N_trck_prd_All; Sector; Predicted Hit Counts", 31, -0.5, 30.5);
+  h_N_recd_hit_All = new TH1D("h_N_recd_hit_All", "h_N_recd_hit_All; Sector; Recorded Hit Counts", 31, -0.5, 30.5);
+  
+  h_N_trck_prd_ss = new TH1D("h_N_trck_prd_ss", "h_N_trck_prd_ss; Sector; Predicted Hit Counts", 31, -0.5, 30.5);
+  h_N_recd_hit_ss = new TH1D("h_N_recd_hit_ss", "h_N_recd_hit_ss; Sector; Recorded Hit Counts", 31, -0.5, 30.5);
+
+  h_N_trck_prd_bs = new TH1D("h_N_trck_prd_bs", "h_N_trck_prd_bs; Sector; Predicted Hit Counts", 31, -0.5, 30.5);
+  h_N_recd_hit_bs = new TH1D("h_N_recd_hit_bs", "h_N_recd_hit_bs; Sector; Recorded Hit Counts", 31, -0.5, 30.5);
+
+  h_N_trck_prd_ns = new TH1D("h_N_trck_prd_ns", "h_N_trck_prd_ns; Sector; Predicted Hit Counts", 31, -0.5, 30.5);
+  h_N_recd_hit_ns = new TH1D("h_N_recd_hit_ns", "h_N_recd_hit_ns; Sector; Recorded Hit Counts", 31, -0.5, 30.5);
+
+  h_ST_Eff_All= new TH1D("h_ST_Eff_All", " Efficiency; Sector; N_{RECD}/N_{TRCK}", 31, -0.5, 30.5);
+  h_ST_Eff_ss = new TH1D("h_ST_Eff_ss", " SS Efficiency; Sector; N_{RECD}/N_{TRCK}", 31, -0.5, 30.5);
+  h_ST_Eff_bs = new TH1D("h_ST_Eff_bs", " BS Efficiency; Sector; N_{RECD}/N_{TRCK}", 31, -0.5, 30.5);
+  h_ST_Eff_ns = new TH1D("h_ST_Eff_ns", " NS Efficiency; Sector; N_{RECD}/N_{TRCK}", 31, -0.5, 30.5);
+ 
+  gDirectory->cd("../");
+  main->cd();
+  japp->RootUnLock(); //RELEASE ROOT LOCK!!
+  // Initialize counters
+  memset(N_trck_prd_All, 0, sizeof(N_trck_prd_All));
+  memset(N_recd_hit_All, 0, sizeof(N_recd_hit_All));
+  memset(N_trck_prd_ss, 0, sizeof(N_trck_prd_ss));
+  memset(N_recd_hit_ss, 0, sizeof(N_recd_hit_ss));
+  memset(N_trck_prd_bs, 0, sizeof(N_trck_prd_bs));
+  memset(N_recd_hit_bs, 0, sizeof(N_recd_hit_bs));
+  memset(N_trck_prd_ns, 0, sizeof(N_trck_prd_ns));
+  memset(N_recd_hit_ns, 0, sizeof(N_recd_hit_ns));
+  
+  return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_ST_online_efficiency::brun(JEventLoop *eventLoop, int32_t runnumber)
+{
+	// This is called whenever the run number changes
+  // Obtain the target center along z;
+  map<string,double> target_params;
+  if (eventLoop->GetCalib("/TARGET/target_parms", target_params))
+    jout << "Error loading /TARGET/target_parms/ !" << endl;
+  if (target_params.find("TARGET_Z_POSITION") != target_params.end())
+    z_target_center = target_params["TARGET_Z_POSITION"];
+  else
+    jerr << "Unable to get TARGET_Z_POSITION from /TARGET/target_parms !" << endl;
+  // Obtain the Start Counter geometry
+  DApplication* dapp = dynamic_cast<DApplication*>(eventLoop->GetJApplication());
+  if(!dapp)
+    _DBG_<<"Cannot get DApplication from JEventLoop! (are you using a JApplication based program?)"<<endl; 
+  DGeometry* locGeometry = dapp->GetDGeometry(eventLoop->GetJEvent().GetRunNumber());
+  locGeometry->GetStartCounterGeom(sc_pos, sc_norm);
+  return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_ST_online_efficiency::evnt(JEventLoop *eventLoop, uint64_t eventnumber)
+{
+	// This is called for every event. Use of common resources like writing
+	// to a file or filling a histogram should be mutex protected. Using
+	// loop->Get(...) to get reconstructed objects (and thereby activating the
+	// reconstruction algorithm) should be done outside of any mutex lock
+	// since multiple threads may call this method at the same time.
+	// Here's an example:
+	//
+	// vector<const MyDataClass*> mydataclasses;
+	// loop->Get(mydataclasses);
+	//
+	// japp->RootWriteLock();
+	//  ... fill historgrams or trees ...
+	// japp->RootUnLock();
+  vector<const DSCDigiHit*>       st_adc_digi_hits;
+  vector<const DParticleID*>      pid_algorithm;
+  vector<const DSCHit*>           st_hits;
+  vector<const DChargedTrack*> chargedTrackVector;
+  eventLoop->Get(st_adc_digi_hits);
+  eventLoop->Get(pid_algorithm);
+  eventLoop->Get(st_hits);
+  eventLoop->Get(chargedTrackVector);
+  // Grab the associated detector matches object
+  const DDetectorMatches* locDetectorMatches = NULL;
+  eventLoop->GetSingle(locDetectorMatches);
+  
+  // Lock ROOT mutex so other threads won't interfere 
+  japp->RootWriteLock();
+  
+  // Loop over charged tracks
+  for (uint32_t i = 0; i < chargedTrackVector.size(); i++)
+    {
+      // Grab the charged track
+      const DChargedTrack *thisChargedTrack = chargedTrackVector[i];
+      // Declare the time based track object
+      const DTrackTimeBased *timeBasedTrack;
+      // Grab associated time based track object by selecting charged track with best FOM
+      thisChargedTrack->Get_BestTrackingFOM()->GetSingle(timeBasedTrack);
+      float trackingFOMCut = 0.0027;  // 3 sigma cut
+      if(timeBasedTrack->FOM  < trackingFOMCut)  continue;
+      // Define vertex vector
+      DVector3 vertex;
+      // Vertex info
+      vertex = timeBasedTrack->position();
+      // Cartesian Coordinates
+      double z_v = vertex.z();
+      double r_v = vertex.Perp();
+      bool z_vertex_cut = fabs(z_target_center - z_v) <= 15.0;
+      bool r_vertex_cut = r_v < 0.3;
+      // applied vertex cut
+      if (!z_vertex_cut) continue;
+      if (!r_vertex_cut) continue;
+      int st_pred_id = pid_algorithm[0]->PredictSCSector(timeBasedTrack->rt,0.05235,&locProjPos,&Barrel);
+      int st_pred_id_index = st_pred_id - 1;
+      // Z intersection of charged track and SC 
+      locSCzIntersection = locProjPos.z();
+      locSCrIntersection = locProjPos.Perp();
+      // Get the direction of the track momentum
+      // Momentum of the track
+      DVector3 Momentum;
+      Momentum = timeBasedTrack->momentum();
+      if (st_pred_id != 0) 
+	{ 
+	  // Define sector array index
+	  sc_index =  st_pred_id_index;
+	  // Start Counter geometry in hall coordinates 
+	  sc_pos_soss = sc_pos[sc_index][0].z();   // Start of straight section
+	  sc_pos_eoss = sc_pos[sc_index][1].z();   // End of straight section
+	  sc_pos_eobs = sc_pos[sc_index][11].z();  // End of bend section
+	  sc_pos_eons = sc_pos[sc_index][12].z();  // End of nose section
+	  ss_interval = (sc_pos_eoss - sc_pos_soss)/Nof_ss_intervals;
+	  bs_interval = (sc_pos_eobs - sc_pos_eoss)/Nof_bs_intervals;
+	  ns_interval = (sc_pos_eons - sc_pos_eobs)/Nof_ns_intervals;
+	  
+	  //****************************
+	  // Efficiency for the whole ST
+	  //****************************
+	  N_trck_prd_All[st_pred_id_index] += 1;
+	  //loop over the Hit object and get the real sector hit at ST
+	  for (uint32_t j = 0; j < st_hits.size(); j++)
+	    {
+	      int phi_sec_hit_sector       = st_hits[j]->sector;
+	      //********************************************************
+	      //total efficiency of the ST
+	      //********************************************************
+	      if (st_pred_id == phi_sec_hit_sector){
+		N_recd_hit_All[st_pred_id_index] += 1;
+		break;
+	      }
+	    }
+	  // ********************************
+	  // Efficiency for Straight Section
+	  // ********************************
+	  if ( sc_pos_soss <= locSCzIntersection  && locSCzIntersection <= sc_pos_eoss)
+	    {
+	      N_trck_prd_ss[st_pred_id_index] += 1;
+	      //loop over the Hit object and get the real sector hit at ST
+	      for (uint32_t j = 0; j < st_hits.size(); j++)
+		{
+		  int phi_sec_hit_sector       = st_hits[j]->sector;
+		  if (st_pred_id == phi_sec_hit_sector)
+		    {
+		      N_recd_hit_ss[st_pred_id_index] += 1;
+		      break;
+		    }
+		}
+	    }// end of straight section loop
+	  //********************************
+	  // Efficiency for Bend Section
+	  //********************************
+	  if ( sc_pos_eoss < locSCzIntersection  && locSCzIntersection <= sc_pos_eobs)
+	    {
+	      N_trck_prd_bs[st_pred_id_index] += 1;
+	      //loop over the Hit object and get the real sector hit at ST
+	      for (uint32_t j = 0; j < st_hits.size(); j++)
+		{
+		  int phi_sec_hit_sector       = st_hits[j]->sector;
+		  if (st_pred_id == phi_sec_hit_sector)
+		    {
+		      N_recd_hit_bs[st_pred_id_index] += 1;
+		      break;
+		    }
+		}
+	    }// end of bend section loop
+	  //********************************
+	  // Efficiency for Nose Section
+	  //********************************
+	  if ( sc_pos_eobs < locSCzIntersection  && locSCzIntersection <= sc_pos_eons)
+	    {
+	      N_trck_prd_ns[st_pred_id_index] += 1;
+	      
+	      //loop over the Hit object and get the real sector hit at ST
+	      for (uint32_t j = 0; j < st_hits.size(); j++)
+		{
+		  int phi_sec_hit_sector       = st_hits[j]->sector;
+		  if (st_pred_id == phi_sec_hit_sector)
+		    {
+		      N_recd_hit_ns[st_pred_id_index] += 1;
+		      break;
+		    }
+		}
+	    }// end of nose section loop
+	} // end if (st_pred_id != 0) 
+    }// end of charged track loop
+  japp->RootUnLock();	
+  return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_ST_online_efficiency::erun(void)
+{
+	// This is called whenever the run number changes, before it is
+	// changed to give you a chance to clean up before processing
+	// events from the next run number.
+	return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t JEventProcessor_ST_online_efficiency::fini(void)
+{
+	// Called before program exit after event processing is finished.
+  for (uint32_t i = 0; i < NCHANNELS; i++)
+    {
+      //hit object
+      h_N_trck_prd_All->Fill(i+1,double(N_trck_prd_All[i]));
+      h_N_recd_hit_All->Fill(i+1,double(N_recd_hit_All[i]));
+      h_N_trck_prd_ss->Fill(i+1,double(N_trck_prd_ss[i]));
+      h_N_recd_hit_ss->Fill(i+1,double(N_recd_hit_ss[i]));
+      h_N_trck_prd_bs->Fill(i+1,double(N_trck_prd_bs[i]));
+      h_N_recd_hit_bs->Fill(i+1,double(N_recd_hit_bs[i]));
+      h_N_trck_prd_ns->Fill(i+1,double(N_trck_prd_ns[i]));
+      h_N_recd_hit_ns->Fill(i+1,double(N_recd_hit_ns[i]));
+    }
+  return NOERROR;
+}
+

--- a/src/plugins/monitoring/ST_online_efficiency/JEventProcessor_ST_online_efficiency.h
+++ b/src/plugins/monitoring/ST_online_efficiency/JEventProcessor_ST_online_efficiency.h
@@ -1,0 +1,136 @@
+// $Id$
+//
+//    File: JEventProcessor_ST_online_efficiency.h
+// Created: Wed Jan 20 10:35:58 EST 2016
+// Creator: mkamel (on Linux ifarm1102 2.6.32-431.el6.x86_64 x86_64)
+//
+
+#ifndef _JEventProcessor_ST_online_efficiency_
+#define _JEventProcessor_ST_online_efficiency_
+
+#include <JANA/JEventProcessor.h>
+#include <JANA/JApplication.h>
+#include <JANA/JFactory.h>
+// ST header files
+#include "START_COUNTER/DSCHit.h"
+#include "START_COUNTER/DSCDigiHit.h"
+// PID libraries
+#include "PID/DParticleID.h"
+#include "PID/DChargedTrack.h"
+#include <PID/DDetectorMatches.h>
+#include <TRACKING/DTrackFitter.h>
+//#include <PID/DDetectorMatches.h>
+// Tracking libraries
+#include "TRACKING/DTrackTimeBased.h"
+// ROOT header files
+#include <TDirectory.h>
+#include <TH1.h>
+#include <TH2.h>
+#include "TF1.h"
+#include "TH1D.h"
+#include "TGraph.h"
+// C++ header files
+#include <stdint.h>
+#include <vector>
+#include <stdio.h>
+#include "TObjArray.h"
+#include "TMath.h"
+// Define some constants
+const double  RAD2DEG       = 57.29577951;      // Convert radians to degrees
+const uint32_t  NCHANNELS     = 30;              // number of scintillator paddles
+const uint32_t  Nof_ss_intervals = 5;
+const uint32_t  Nof_bs_intervals = 3;
+const uint32_t  Nof_ns_intervals = 4;
+// Declare 1D tracking histos
+static TH1D *h_N_trck_prd_All;
+static TH1D *h_N_recd_hit_All;
+static TH1D *h_N_trck_prd_ss;
+static TH1D *h_N_recd_hit_ss;
+static TH1D *h_N_trck_prd_bs;
+static TH1D *h_N_recd_hit_bs;
+static TH1D *h_N_trck_prd_ns;
+static TH1D *h_N_recd_hit_ns;
+static TH1D *h_ST_Eff_All;
+static TH1D *h_ST_Eff_ss;
+static TH1D *h_ST_Eff_bs;
+static TH1D *h_ST_Eff_ns;
+
+
+// Declare detection efficency counters
+uint32_t N_trck_prd_All[NCHANNELS];
+uint32_t N_recd_hit_All[NCHANNELS];
+uint32_t N_trck_prd_ss[NCHANNELS];
+uint32_t N_recd_hit_ss[NCHANNELS];
+uint32_t N_trck_prd_bs[NCHANNELS];
+uint32_t N_recd_hit_bs[NCHANNELS];
+uint32_t N_trck_prd_ns[NCHANNELS];
+uint32_t N_recd_hit_ns[NCHANNELS];
+uint32_t N_recd_hit_All_nearby_plus[NCHANNELS];
+uint32_t N_recd_hit_All_nearby_minus[NCHANNELS];
+uint32_t N_recd_hit_All_nearby[NCHANNELS];
+
+class JEventProcessor_ST_online_efficiency:public jana::JEventProcessor{
+	public:
+		JEventProcessor_ST_online_efficiency();
+		~JEventProcessor_ST_online_efficiency();
+		const char* className(void){return "JEventProcessor_ST_online_efficiency";}
+
+	private:
+		jerror_t init(void);						///< Called once at program start.
+		jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+		const DParticleID* dParticleID;
+		DSCHitMatchParams  locSCHitMatchParams;   // SC
+		vector<vector<DVector3> >sc_pos;   // SC geometry vector
+		vector<vector<DVector3> >sc_norm;  
+		double z_target_center;  // Target center along z
+		double sc_pos_soss, sc_pos_eoss, sc_pos_eobs, sc_pos_eons;
+		double ss_interval,bs_interval,ns_interval;
+		double z_ss[Nof_ss_intervals],z_bs[Nof_bs_intervals],z_ns[Nof_ss_intervals]; 
+		double theta_ss_max_left[Nof_ss_intervals];
+		double theta_ss_max_right[Nof_ss_intervals];
+		double theta_ss_min_left[Nof_ss_intervals];
+		double theta_ss_min_right[Nof_ss_intervals];
+		double smallest_ss_left[Nof_ss_intervals];
+		double theta_ss_small[Nof_ss_intervals];
+		double theta_ss_large[Nof_ss_intervals];
+	
+		double theta_bs_max_left[Nof_bs_intervals];
+		double theta_bs_max_right[Nof_bs_intervals];
+		double theta_bs_min_left[Nof_bs_intervals];
+		double theta_bs_min_right[Nof_bs_intervals];
+		double smallest_bs_left[Nof_bs_intervals];
+		double theta_bs_small[Nof_bs_intervals];
+		double theta_bs_large[Nof_bs_intervals];
+	
+		double theta_ns_max_left[Nof_ns_intervals];
+		double theta_ns_max_right[Nof_ns_intervals];
+		double theta_ns_min_left[Nof_ns_intervals];
+		double theta_ns_min_right[Nof_ns_intervals];
+		double smallest_ns_left[Nof_ns_intervals];
+		double theta_ns_small[Nof_ns_intervals];
+		double theta_ns_large[Nof_ns_intervals];
+
+                bool theta_momentum_cut_ss[Nof_ss_intervals]; 
+		bool theta_momentum_cut_bs[Nof_bs_intervals]; 	
+		double locSCzIntersection;
+		double locSCrIntersection;
+		int sc_index;
+		DVector3 locProjPos;
+		// Declare a vector which quantizes the point of the intersection of a charged particle 
+		//   with a plane in the middle of the scintillator 
+		DVector3 IntersectionPoint;
+		// Declare a vector which quantizes the unit vector of the charged particle track traversing
+		//   through the scintillator with its origin at the intersection point
+		DVector3 IntersectionDir;
+		// Grab the paramteres associated to a track matched to the ST
+		vector<DSCHitMatchParams> st_params;
+		bool foundSC;
+		bool sc_match, sc_match_pid;
+		bool Barrel;
+};
+
+#endif // _JEventProcessor_ST_online_efficiency_
+

--- a/src/plugins/monitoring/ST_online_efficiency/SConscript
+++ b/src/plugins/monitoring/ST_online_efficiency/SConscript
@@ -1,0 +1,13 @@
+
+
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddROOTSpyMacros(env)
+sbms.AddDANA(env)
+sbms.plugin(env)
+
+

--- a/src/plugins/monitoring/ST_online_efficiency/ST_Monitoring_Eff.C
+++ b/src/plugins/monitoring/ST_online_efficiency/ST_Monitoring_Eff.C
@@ -1,0 +1,204 @@
+// File: ST_Monitoring_Efficiency.C
+// Last Modified: 08/27/2015
+// Creator: Mahmoud Kamel mkame006@fiu.edu
+// Purpose: Displaying histograms for efficiency studies
+{
+  // Define the directory that contains the histograms
+   TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("st_efficiency");
+   //TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("st_tracking");
+  if(dir) dir->cd();
+  // Grab 1D histograms 
+  TH1D *h_N_trck_prd_All     = (TH1D*)dir->FindObjectAny("h_N_trck_prd_All");
+  TH1D *h_N_recd_hit_All     = (TH1D*)dir->FindObjectAny("h_N_recd_hit_All");
+  TH1D *h_ST_Eff_All = (TH1D*)dir->FindObjectAny("h_ST_Eff_All");
+  TH1D *h_N_trck_prd_ss  = (TH1D*)dir->FindObjectAny("h_N_trck_prd_ss");
+  TH1D *h_N_recd_hit_ss  = (TH1D*)dir->FindObjectAny("h_N_recd_hit_ss");
+  TH1D *h_ST_Eff_ss  = (TH1D*)dir->FindObjectAny("h_ST_Eff_ss");
+  TH1D *h_N_trck_prd_bs  = (TH1D*)dir->FindObjectAny("h_N_trck_prd_bs");
+  TH1D *h_N_recd_hit_bs  = (TH1D*)dir->FindObjectAny("h_N_recd_hit_bs");
+  TH1D *h_ST_Eff_bs  = (TH1D*)dir->FindObjectAny("h_ST_Eff_bs");
+  TH1D *h_N_trck_prd_ns  = (TH1D*)dir->FindObjectAny("h_N_trck_prd_ns");
+  TH1D *h_N_recd_hit_ns  = (TH1D*)dir->FindObjectAny("h_N_recd_hit_ns");
+  TH1D *h_ST_Eff_ns  = (TH1D*)dir->FindObjectAny("h_ST_Eff_ns");
+
+  // get Binomial errors in an efficiency plot
+  // Whole ST efficiency
+  h_N_recd_hit_All->Sumw2();
+  h_N_trck_prd_All->Sumw2();
+  h_ST_Eff_All->Sumw2();
+  h_ST_Eff_All->Divide(h_N_recd_hit_All,h_N_trck_prd_All,1,1,"B");
+
+  // SS ST efficiency
+  h_N_recd_hit_ss->Sumw2();
+  h_N_trck_prd_ss->Sumw2();
+  h_ST_Eff_ss->Sumw2();
+  h_ST_Eff_ss->Divide(h_N_recd_hit_ss,h_N_trck_prd_ss,1,1,"B");
+
+  // BS ST efficiency
+  h_N_recd_hit_bs->Sumw2();
+  h_N_trck_prd_bs->Sumw2();
+  h_ST_Eff_bs->Sumw2();
+  h_ST_Eff_bs->Divide(h_N_recd_hit_bs,h_N_trck_prd_bs,1,1,"B");
+  // NS ST efficiency
+  h_N_recd_hit_ns->Sumw2();
+  h_N_trck_prd_ns->Sumw2();
+  h_ST_Eff_ns->Sumw2();
+  h_ST_Eff_ns->Divide(h_N_recd_hit_ns,h_N_trck_prd_ns,1,1,"B");
+
+
+//Create the canvas
+  if(gPad == NULL)
+    {
+      TCanvas *c1 = new TCanvas("c1","Start Counter 1D Histograms", 200, 10, 600, 480);
+      c1->cd(0);
+      c1->Draw();
+      c1->Update();
+    }
+  if(!gPad) return;
+  TCanvas *c1 = gPad->GetCanvas();
+  c1->Divide(2,2);
+  // ST All Efficiency histogram
+  c1->cd(1);
+  gStyle->SetOptStat(0);
+  gStyle->SetErrorX(0); 
+  gPad->SetTicks();
+  gPad->SetGrid();
+  if (h_ST_Eff_All) {
+   h_ST_Eff_All->Draw("E1");
+   h_ST_Eff_All->SetMarkerStyle(21);
+   h_ST_Eff_All->SetMarkerSize(1.5);
+   h_ST_Eff_All->SetMarkerColor(4.0);
+   h_ST_Eff_All->SetAxisRange(0.5, 1.1,"Y");
+   h_ST_Eff_All->GetYaxis()->SetTitleOffset(1.26);
+   h_ST_Eff_All->GetYaxis()->SetTitle("Efficiency");
+   Double_t TWA_All=0;
+   Double_t sumE_All=0;
+   Double_t Final_All=0;
+   for (int i = 0; i < 30; i++)
+     {
+       Double_t error_All =   h_ST_Eff_All->GetBinError(i+2);
+       sumE_All = sumE_All + error_All;
+       Double_t BC_All =   h_ST_Eff_All->GetBinContent(i+2);
+       Double_t WA_All = BC_All*error_All;
+       TWA_All = TWA_All + WA_All ;
+       Double_t Final_All = TWA_All/sumE_All;
+     } 
+   TLine *lineAll = new TLine(1,Final_All,30,Final_All);
+   lineAll->SetLineWidth(3);
+   lineAll->SetLineColor(2);
+   //Write the eff value on the histogram 
+   char tFinal_All[20];
+   char terror_All[20];
+   sprintf(tFinal_All,"All Efficiency = %0.2f #pm %0.2f",Final_All*100,sumE_All*100/30);
+   //sprintf(terror_All,"All Efficiency error (%) = %g",error_All*100);
+   lineAll->Draw();
+   TPaveLabel *pAll = new TPaveLabel(0.2,0.2,0.7,0.4,tFinal_All,"brNDC");
+   pAll->Draw();
+  }
+  //SS Efficiency histogram
+  c1->cd(2);
+  gPad->SetTicks();
+  gPad->SetGrid();
+  if (h_ST_Eff_ss) {
+    h_ST_Eff_ss->Draw("E1");
+    h_ST_Eff_ss->SetMarkerStyle(21);
+    h_ST_Eff_ss->SetMarkerSize(1.5);
+    h_ST_Eff_ss->SetMarkerColor(4.0);
+    h_ST_Eff_ss->SetAxisRange(0.5, 1.1,"Y");
+    h_ST_Eff_ss->GetYaxis()->SetTitleOffset(1.26);
+    h_ST_Eff_ss->GetYaxis()->SetTitle("Efficiency");
+    Double_t TWA_ss=0;
+    Double_t sumE_ss=0;
+    Double_t Final_ss=0; 
+    for (int i = 0; i < 30; i++)
+      {
+	Double_t error_ss =    h_ST_Eff_ss->GetBinError(i+2);
+	sumE_ss = sumE_ss+error_ss;
+	Double_t BC_ss =    h_ST_Eff_ss->GetBinContent(i+2);
+	Double_t WA_ss = BC_ss*error_ss;
+	TWA_ss = TWA_ss + WA_ss ;
+	Double_t Final_ss = TWA_ss/sumE_ss;
+      } 
+    TLine *liness = new TLine(1,Final_ss,30,Final_ss);
+    liness->SetLineWidth(3);
+    liness->SetLineColor(2);
+    //Write the eff value on the histogram 
+   char tFinal_ss[20];
+   char terror_ss[20];
+   sprintf(tFinal_ss,"SS Hit Efficiency  = %0.2f #pm %0.2f",Final_ss*100,sumE_ss*100/30);
+   //   sprintf(terror_ss,"SS  Hit Efficiency error (%) = %g",error_ss*100);
+   liness->Draw();
+   TPaveLabel *pss = new TPaveLabel(0.2,0.2,0.7,0.4,tFinal_ss,"brNDC");
+   pss->Draw();
+  }
+//BS Efficiency histogram
+  c1->cd(3);
+  gPad->SetTicks();
+  gPad->SetGrid();
+  if (h_ST_Eff_bs) {
+    h_ST_Eff_bs->Draw("E1");
+    h_ST_Eff_bs->SetMarkerStyle(21);
+    h_ST_Eff_bs->SetMarkerSize(1.5);
+    h_ST_Eff_bs->SetMarkerColor(4.0);
+    h_ST_Eff_bs->SetAxisRange(0.5, 1.1,"Y");
+    h_ST_Eff_bs->GetYaxis()->SetTitleOffset(1.26);
+    h_ST_Eff_bs->GetYaxis()->SetTitle("Efficiency");
+    Double_t TWA_bs=0;
+    Double_t sumE_bs=0;
+    Double_t Final_bs=0; 
+    for (int i = 0; i < 30; i++)
+      {
+	Double_t error_bs =    h_ST_Eff_bs->GetBinError(i+2);
+	sumE_bs = sumE_bs+error_bs;
+	Double_t BC_bs =    h_ST_Eff_bs->GetBinContent(i+2);
+	Double_t WA_bs = BC_bs*error_bs;
+	TWA_bs = TWA_bs + WA_bs ;
+	Double_t Final_bs = TWA_bs/sumE_bs;
+      } 
+    TLine *linebs = new TLine(1,Final_bs,30,Final_bs);
+    linebs->SetLineWidth(3);
+    linebs->SetLineColor(2);
+    //Write the eff value on the histogram 
+   char tFinal_bs[20];
+   char terror_bs[20];
+   sprintf(tFinal_bs,"BS Hit Efficiency = %0.2f #pm %0.2f ",Final_bs*100,sumE_bs*100/30);
+   linebs->Draw();
+   TPaveLabel *pbs = new TPaveLabel(0.2,0.2,0.7,0.4,tFinal_bs,"brNDC");
+   pbs->Draw();
+  }
+//NS Efficiency histogram
+  c1->cd(4);
+  gPad->SetTicks();
+  gPad->SetGrid();
+  if (h_ST_Eff_ns) {
+    h_ST_Eff_ns->Draw("E1");
+    h_ST_Eff_ns->SetMarkerStyle(21);
+    h_ST_Eff_ns->SetMarkerSize(1.5);
+    h_ST_Eff_ns->SetMarkerColor(4.0);
+    h_ST_Eff_ns->SetAxisRange(0.5, 1.1,"Y");
+    h_ST_Eff_ns->GetYaxis()->SetTitleOffset(1.26);
+    h_ST_Eff_ns->GetYaxis()->SetTitle("Efficiency");
+    Double_t TWA_ns=0;
+    Double_t sumE_ns=0;
+    Double_t Final_ns=0; 
+    for (int i = 0; i < 30; i++)
+      {
+	Double_t error_ns =    h_ST_Eff_ns->GetBinError(i+2);
+	sumE_ns = sumE_ns+error_ns;
+	Double_t BC_ns =    h_ST_Eff_ns->GetBinContent(i+2);
+	Double_t WA_ns = BC_ns*error_ns;
+	TWA_ns = TWA_ns + WA_ns ;
+	Double_t Final_ns = TWA_ns/sumE_ns;
+      } 
+    TLine *linens = new TLine(1,Final_ns,30,Final_ns);
+    linens->SetLineWidth(3);
+    linens->SetLineColor(2);
+    //Write the eff value on the histogram 
+   char tFinal_ns[20];
+   char terror_ns[20];
+   sprintf(tFinal_ns,"NS Hit Efficiency = %0.2f #pm %0.2f",Final_ns*100,sumE_ns*100/30);
+   linens->Draw();
+   TPaveLabel *pns = new TPaveLabel(0.2,0.2,0.7,0.4,tFinal_ns,"brNDC");
+   pns->Draw();
+   }
+}

--- a/src/plugins/monitoring/ST_online_lowlevel/JEventProcessor_ST_online_lowlevel.cc
+++ b/src/plugins/monitoring/ST_online_lowlevel/JEventProcessor_ST_online_lowlevel.cc
@@ -5,117 +5,7 @@
 // Creator: mkamel (on Linux ifarm1401 2.6.32-431.el6.x86_64 x86_64)
 //
 #include "JEventProcessor_ST_online_lowlevel.h"
-using namespace jana;
-using namespace std;
-using std::vector;
-using std::string;
-// ***************** C++ header files******************
-//*****************************************************
-#include <stdint.h>
-#include <vector>
-#include <stdio.h>
-//***************** ROOT header files********************
-//*******************************************************
-#include <TMath.h>
-#include <TDirectory.h>
-#include <TH1.h>
-#include <TH2.h>
-//***************** ST header files************************
-//*********************************************************
-#include "START_COUNTER/DSCDigiHit.h"
-#include "START_COUNTER/DSCTDCDigiHit.h"
-#include "START_COUNTER/DSCHit.h"
-// ***************** DAQ header files (Triger Times)*********
-//***********************************************************
-#include "DAQ/Df250WindowRawData.h"
-#include "DAQ/Df250PulseRawData.h"
-#include "DAQ/Df250PulseTime.h"
-#include "DAQ/Df250PulseIntegral.h"
-#include "DAQ/Df250PulsePedestal.h"
-#include "DAQ/Df250Config.h"
-#include <TTAB/DTTabUtilities.h>
-//****************************** Define some constants *********
-//**************************************************************
-const uint32_t NCHANNELS  = 30;     // number of scintillator paddles
-const float_t  ADC_PT_RES = 0.0625; // fADC250 pulse time resolution (ns)
-//const float_t  TDC_RES    = 0.0559; // f1TDC resolution (ns)
-//***************** Declare Two Dimensional Histograms*************
-//*****************************************************************
-static TH2I *h2_st_adc_tdc_multi;
-static TH2I *h2_st_adc_hit_multi;
-static TH2I *h2_raw_pi_sector;
-static TH2I *h2_raw_ped_sector;
-static TH2I *h2_raw_pt_sector;
-static TH2I *h2_adc_pp_sector;
-static TH2I *h2_adc_pcpi_sector;
-static TH2I *h2_adc_pt_sector;
-static TH2I *h2_adc_ped_sector;
-static TH2I *h2_st_time_vs_pcpi;
-static TH2I *h2_st_time_vs_pp;
-static TH2I *h2_raw_tdcTime_sec;
-static TH2I *h2_tdcTime_sec;
-static TH2I *h2_t_sec; 
-static TH2I *h2_tTDC_sec; 
-static TH2I *h2_tfADC_sec;
-static TH2I *h2_dE_sec;
-//***************** Declare One Dimensional Histograms****************
-//********************************************************************
-static TH1I *h1_adc_sec;
-static TH1I *h1_tdc_sec;
-static TH1I *h1_hit_sec;
-static TH1I *st_num_events;
-//***************** Declare Dynamic Arrays of waveform Histograms********
-// &&&&&& define the Boolian variables needed &&&&&
-//***********************************************************************
-TH1I** h_amp_vs_sampl_chan = new TH1I*[NCHANNELS];
-TH1I** h_amp_vs_sampl_chan150 = new TH1I*[NCHANNELS];
-TH1I** h_amp_vs_sampl_chan1000 = new TH1I*[NCHANNELS];
-TH1I** h_amp_vs_sampl_chan2000 = new TH1I*[NCHANNELS];
-TH1I** h_amp_vs_sampl_chan3000 = new TH1I*[NCHANNELS];
-TH1I** h_amp_vs_sampl_chan4000 = new TH1I*[NCHANNELS];
-Bool_t bool_sec[NCHANNELS];
-Bool_t bool_sec150[NCHANNELS];
-Bool_t bool_sec1000[NCHANNELS];
-Bool_t bool_sec2000[NCHANNELS];
-Bool_t bool_sec3000[NCHANNELS];
-Bool_t bool_sec4000[NCHANNELS];
-Double_t adc_pp;
-Double_t adc_t;
-Double_t adc_ped;
-Double_t adc_pi;
-Double_t adc_pcpi;
-Double_t tdc_t;
-Double_t st_time;
-//// Offsets from CCDB
-vector<double> a_pedestals;
-vector<double> adc_time_offsets;
-vector<double> tdc_time_offsets;
-double t_tdc_base;
-double t_base;
-double t_scale;
-//**************Histograms limits Determination******************************
-//***************************************************************************
-const uint32_t ADC_MULTI_MIN  = 0.;      // Lower limit of adc multiplicity histogram
-const uint32_t ADC_MULTI_MAX  = 31.;     // Upper limit of adc multiplicity histogram
-const uint32_t ADC_MULTI_BINS = 31.;     // Number of bins in adc multiplicity histogram
-const uint32_t TDC_MULTI_MIN  = 0.;      // Lower limit of tdc multiplicity histogram
-const uint32_t TDC_MULTI_MAX  = 40.;     // Upper limit of tdc multiplicity histogram
-const uint32_t TDC_MULTI_BINS = 40.;     // Number of bins in tdc multiplicity histogram
-const uint32_t PI_MIN         = 0.;      // Lower limit of pulse integral histogram
-const uint32_t PI_MAX         = 40000.;  // Upper limit of pulse integral histogram  
-const uint32_t PI_BINS        = 800.;    // Number of bins in pulse integral histogram
-const uint32_t PED_MIN        = 90.;     // Lower limit of pedestal histogram
-const uint32_t PED_MAX        = 130.;    // Upper limit of pedestal histogram
-const uint32_t PED_BINS       = 40.;     // Number of bins in pedestal histogram
-const uint32_t PT_MIN         = 0.;      // Lower limit of pulse time histogram (ns)
-const uint32_t PT_MAX         = 200.;    // Upper limit of pulse time histogram (ns)
-const uint32_t PT_BINS        = 200.;    // Number of bins in pulse time histogram
-const uint32_t TDC_DHIT_MIN   = 0.;      // Lower limit of tdc digihit time histogram 
-const uint32_t TDC_DHIT_MAX   = 4000.;   // Upper limit of tdc digihit time histogram 
-const uint32_t TDC_DHIT_BINS  = 400.;    // Number of bins in tdc digihit time histogram 
-const float_t  T_HIT_MIN      =  -200.;  // Lower limit of hit time histogram (ns)
-const float_t  T_HIT_MAX      =  200.;   // Upper limit of hit time histogram (ns)
-const float_t  T_HIT_BINS     =  400.;   // Number of bins in hit time histogram 
+
 // Routine used to create our JEventProcessor
 #include <JANA/JApplication.h>
 #include <JANA/JFactory.h>
@@ -125,7 +15,6 @@ void InitPlugin(JApplication *app){
 	app->AddProcessor(new JEventProcessor_ST_online_lowlevel());
 }
 } // "C"
-
 
 //------------------
 // JEventProcessor_ST_online_lowlevel (Constructor)
@@ -179,42 +68,51 @@ jerror_t JEventProcessor_ST_online_lowlevel::init(void)
   gDirectory->mkdir("st_lowlevel")->cd();
 
   st_num_events = new TH1I("st_num_events","ST Number of events",1, 0.5, 1.5);
-
-  // 1D occupancy Histos
+  //************************************************************************
+  //**********************  1D occupancy Histos *****************************
+  //*************************************************************************
   h1_adc_sec = new TH1I("h1_adc_sec", "ST fADC250 DigiHit Occupancy; Channel Number; fADC250 Counts", NCHANNELS, 0.5, NCHANNELS + 0.5);
   h1_tdc_sec = new TH1I("h1_tdc_sec", "ST TDC DigiHit Occupancy; Channel Number; TDC Counts", NCHANNELS, 0.5, NCHANNELS + 0.5);
   h1_hit_sec = new TH1I("h1_hit_sec", "ST Hit Occupancy; Channel Number; Hit Counts", NCHANNELS, 0.5, NCHANNELS + 0.5);
-
-  // 2D Multiplicity Histos
+  //*************************************************************************
+  //**********************  2D Multiplicity Histos **************************
+  //*************************************************************************
   h2_st_adc_tdc_multi = new TH2I("h2_st_adc_tdc_multi", "ST Total Multiplicity: TDC vs ADC; f1TDC Multiplicity; fADC250 Multiplicity", TDC_MULTI_BINS, TDC_MULTI_MIN + 0.5, TDC_MULTI_MAX + 0.5, ADC_MULTI_BINS, ADC_MULTI_MIN + 0.5, ADC_MULTI_MAX + 0.5);
   h2_st_adc_hit_multi = new TH2I("h2_st_adc_hit_multi", "ST Total Multiplicity: HIT vs ADC; Hit Multiplicity; fADC250 Multiplicity", TDC_MULTI_BINS, TDC_MULTI_MIN + 0.5, TDC_MULTI_MAX + 0.5, ADC_MULTI_BINS, ADC_MULTI_MIN + 0.5, ADC_MULTI_MAX + 0.5);
-
-  // 2D Raw ADC data + TDC time if there is a n adc hit Histos
+  //**************************************************************************
+  //****  2D Raw ADC data + TDC time if there is an adc hit Histos ***********
+  //**************************************************************************
   h2_raw_pi_sector  = new TH2I("h2_raw_pi_sector", "ST fADC250 Pulse Integral; Channel Number; Pulse Integral(au)", NCHANNELS, 0.5, NCHANNELS + 0.5, PI_BINS, PI_MIN, PI_MAX);
   h2_raw_ped_sector = new TH2I("h2_raw_ped_sector", "ST fADC250 Pulse Pedestal; Channel Number;Pulse Pedestal(au)", NCHANNELS, 0.5, NCHANNELS + 0.5, PED_BINS, PED_MIN, PED_MAX);
   h2_raw_pt_sector  = new TH2I("h2_raw_pt_sector", "ST fADC250 Pulse Time; Channel Number; Pulse Time(ns)", NCHANNELS, 0.5, NCHANNELS + 0.5, PT_BINS, PT_MIN, PT_MAX);
   h2_tdcTime_sec    = new TH2I("h2_tdcTime_sec", "ST TDC Sector vs Time (While ADC hit); Channel Number; TDC Time(ns)", NCHANNELS, 0.5, NCHANNELS + 0.5, TDC_DHIT_BINS, TDC_DHIT_MIN, TDC_DHIT_MAX);
-
-  // 2D ADC/TDC data offsets applied 
-  h2_adc_pp_sector   = new TH2I("h2_adc_pp_sector","Pulse peak vs sector;Channel number; Pulse Peak (channels) ",NCHANNELS, 0.5, NCHANNELS + 0.5,400,0,4000);
+  //***************************************************************************
+  //*****************  2D ADC/TDC data offsets applied ************************
+  //*************************************************************************** 
+  h2_adc_pp_sector   = new TH2I("h2_adc_pp_sector","Pulse peak vs sector;Channel number; Pulse Peak (channels) ",NCHANNELS, 0.5, NCHANNELS + 0.5,300,0,3000);
   h2_adc_pcpi_sector = new TH2I("h2_adc_pcpi_sector", "ST fADC250 Pedstal corrected Pulse Integral; Channel Number; fADC250 Pulse Integral (au)", NCHANNELS, 0.5, NCHANNELS + 0.5, PI_BINS, PI_MIN, PI_MAX);
-  h2_adc_pt_sector   = new TH2I("h2_adc_pt_sector", "ST fADC250 Pulse Time; Channel Number; fADC250 Pulse Time (ns)", NCHANNELS, 0.5, NCHANNELS + 0.5, 400, -100., 100);
+  h2_adc_pt_sector   = new TH2I("h2_adc_pt_sector", "ST fADC250 Pulse Time; Channel Number; fADC250 Pulse Time (ns)", NCHANNELS, 0.5, NCHANNELS + 0.5, 320, -80., 80);
   h2_adc_ped_sector  = new TH2I("h2_adc_ped_sector", "ST fADC250 Pedestal; Channel Number; fADC250 Pedestal", NCHANNELS, 0.5, NCHANNELS + 0.5, 100, 1000., 7000.);
-  h2_st_time_vs_pcpi = new TH2I("h2_st_time_vs_pcpi","Ped Corrected Pulse Integral vs #delta (t_{TDC} - t_{ADC});Pulse Integral(cahnnels) ;#delta (t_{TDC} - t_{ADC}) (ns)",PI_BINS, PI_MIN, PI_MAX,80, -10., 10.);
-  h2_st_time_vs_pp   = new TH2I("h2_st_time_vs_pp","Pulse Peak vs #delta (t_{TDC} - t_{ADC});Pulse Peak (cahnnels);#delta (t_{TDC} - t_{ADC}) (ns)",400,0,4000,80, -10., 10.);
-
-  // Raw TDC data Histos
+  h2_st_time_vs_pcpi = new TH2I("h2_st_time_vs_pcpi","Ped Corrected Pulse Integral vs #delta (t_{TDC} - t_{ADC});Pulse Integral(cahnnels) ;#delta (t_{TDC} - t_{ADC}) (ns)",PI_BINS, PI_MIN, PI_MAX,32, -4., 4.);
+  h2_st_time_vs_pp   = new TH2I("h2_st_time_vs_pp","Pulse Peak vs #delta (t_{TDC} - t_{ADC});Pulse Peak (cahnnels);#delta (t_{TDC} - t_{ADC}) (ns)",300,0,3000,32, -4., 4.);
+  //***************************************************************************
+  //**********************  Raw TDC data Histos *******************************
+  //***************************************************************************
   h2_raw_tdcTime_sec = new TH2I("h2_raw_tdcTime_sec", "ST TDC Sector vs Time; Channel Number; TDC Time(ns)", NCHANNELS, 0.5, NCHANNELS + 0.5, TDC_DHIT_BINS, TDC_DHIT_MIN, TDC_DHIT_MAX);
-
-  // Raw Hit data Histos
+  //***************************************************************************
+  // ****************** Raw Hit data Histos ***********************************
+  //***************************************************************************
   h2_t_sec    = new TH2I("h2_t_sec", "ST Hit Sector vs Time (walk corrected); Channel Number; TDC Time(ns)", NCHANNELS, 0.5, NCHANNELS + 0.5, T_HIT_BINS, T_HIT_MIN, T_HIT_MAX); 
   h2_tTDC_sec = new TH2I("h2_tTDC_sec", "ST Hit Sector vs Time(No walk corrected); Channel Number; TDC Time(ns)", NCHANNELS, 0.5, NCHANNELS + 0.5, T_HIT_BINS, T_HIT_MIN, T_HIT_MAX);
   h2_tfADC_sec= new TH2I("h2_tfADC_sec", "ST Hit Sector vs ADC-Time; Channel Number; ADC Time(ns)", NCHANNELS, 0.5, NCHANNELS + 0.5, T_HIT_BINS, T_HIT_MIN, T_HIT_MAX); 
-  h2_dE_sec   = new TH2I("h2_dE_sec", "ST Hit Sector vs dE; Channel Number; dE(GeV)", NCHANNELS, 0.5, NCHANNELS + 0.5, 100, 0.0, 0.01);
-  //======================== Creat root folder for waveforms and cd to it================
+  h2_dE_sec   = new TH2I("h2_dE_sec", "ST Hit Sector vs dE; Channel Number; dE(GeV)", NCHANNELS, 0.5, NCHANNELS + 0.5, 80, 0.0, 0.004);
+  //***************************************************************************
+  //======================== Creat root folder for waveforms and cd to it======
+  //***************************************************************************
   gDirectory->mkdir("waveforms")->cd();
-
-  // Waveform Histos
+  //***************************************************************************
+  //*******************  Waveform Histos **************************************
+  //***************************************************************************
   for(unsigned int i = 0; i < NCHANNELS; i++)
     {
       h_amp_vs_sampl_chan[i]     = new TH1I(Form("amp_vs_sampl_chan_%i", i+1), Form("Channel %i, #phi #in [%i^{#circ}, %i^{#circ}]; fADC250 Sample Number; fADC250 Pulse Height (au)", i+1, 0+12*i, 12+12*i), 100, 0, 100);
@@ -227,14 +125,14 @@ jerror_t JEventProcessor_ST_online_lowlevel::init(void)
       h_amp_vs_sampl_chan3000[i] = new TH1I(Form("amp_vs_sampl_chan3000_%i", i+1), Form("Channel %i, #phi #in [%i^{#circ}, %i^{#circ}]; fADC250 Sample Number; fADC250 Pulse Height (au)", i+1, 0+12*i, 12+12*i), 100, 0, 100);
 
       h_amp_vs_sampl_chan4000[i] = new TH1I(Form("amp_vs_sampl_chan4000_%i", i+1), Form("Channel %i, #phi #in [%i^{#circ}, %i^{#circ}]; fADC250 Sample Number; fADC250 Pulse Height (au)", i+1, 0+12*i, 12+12*i), 100, 0, 100);
-      // ========================Define Boolians Arrays to be false======================= 
+      // ========================Define Boolians Arrays to be false================== 
       bool_sec[i] = false;
       bool_sec150[i] = false;
       bool_sec1000[i] = false;
       bool_sec2000[i] = false;
       bool_sec3000[i] = false;
       bool_sec4000[i] = false;
-      // =================================================================================
+      // ============================================================================
     }
   // cd back to main directory
   main->cd();
@@ -290,20 +188,6 @@ if (eventLoop->GetCalib("/START_COUNTER/digi_scales", scale_factors))
 //------------------
 jerror_t JEventProcessor_ST_online_lowlevel::evnt(JEventLoop *loop, uint64_t eventnumber)
 {
-	// This is called for every event. Use of common resources like writing
-	// to a file or filling a histogram should be mutex protected. Using
-	// loop->Get(...) to get reconstructed objects (and thereby activating the
-	// reconstruction algorithm) should be done outside of any mutex lock
-	// since multiple threads may call this method at the same time.
-	// Here's an example:
-	//
-	// vector<const MyDataClass*> mydataclasses;
-	// loop->Get(mydataclasses);
-	//
-	// japp->RootWriteLock();
-	//  ... fill historgrams or trees ...
-	// japp->RootUnLock();
-
   // Get the data objects first so we minimize the time we hold the ROOT mutex lock
   vector<const DSCDigiHit*> dscdigihits;                // ST fADC250 DigiHits
   vector<const DSCTDCDigiHit*> dsctdcdigihits;          // ST f1TDC DigiHits
@@ -321,240 +205,221 @@ jerror_t JEventProcessor_ST_online_lowlevel::evnt(JEventLoop *loop, uint64_t eve
   japp->RootWriteLock();
   if( (dscdigihits.size()>0) || (dsctdcdigihits.size()>0) || (dschits.size()>0) )
     st_num_events->Fill(1);
-
-  //Fill 2D multiplicity histos
-  h2_st_adc_tdc_multi->Fill(TDC_hits, ADC_hits);
+  //******** Fill 2D multiplicity histos ********************************
+  h2_st_adc_tdc_multi->Fill(TDC_hits, ADC_hits); //ADC single hit object
   h2_st_adc_hit_multi->Fill(Hits, ADC_hits);
-//========================== DSCDigiHits ** ADC Hits=================
-//*******************************************************************
+  //========================== DSCDigiHits ** ADC Hits=================
+  //*******************************************************************
   for(uint32_t i = 0; i < ADC_hits; i++)
-     {
-       // Sort the ADC hits
-       //   sort(dscdigihits.begin(), dscdigihits.end(), DSCHit_fadc_cmp);
-       // const DSCDigiHit *adc_dhit = dscdigihits[i];
-//=========== Wave Form online O'Scope =====================
-// Define some objects
-       
-       const Df250PulseIntegral *pulseintegral = NULL;
-       const Df250PulsePedestal *pulsepedestal = NULL;
-       const Df250WindowRawData *windowrawdata = NULL;
-
+    {
+      //***************************************************************
+      //=========== Wave Form online O'Scope ==========================
+      // **************************************************************
+      // Define some objects
+      const Df250PulseIntegral *pulseintegral = NULL;
+      const Df250PulsePedestal *pulsepedestal = NULL;
+      const Df250WindowRawData *windowrawdata = NULL;
       // Define a vector to store the adc samples
-       vector<uint16_t> samples;  // Declare empty vector
+      vector<uint16_t> samples;  // Declare empty vector
       // Get the sector values
       Int_t hit_sector_adc       = dscdigihits[i]->sector;
       Int_t hit_sector_adc_index = hit_sector_adc - 1;
       
-	  dscdigihits[i]->GetSingle(pulseintegral);
-	  dscdigihits[i]->GetSingle(pulsepedestal);
-	  dscdigihits[i]->GetSingle(windowrawdata);
-	  // Obtain the pedestal and raw window data
-	  if (pulseintegral) 
-	    {
-	      pulseintegral->GetSingle(pulsepedestal);
-	      pulseintegral->GetSingle(windowrawdata);
-	    }
-	  // Histogram the raw window data
-	  if (windowrawdata)
-	    {  const Df250PulsePedestal* PPobj = NULL;
-	      dscdigihits[i]->GetSingle(PPobj);
-	      if (PPobj != NULL)
-		{
-		  if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
-		}
-	      adc_pp   = PPobj->pulse_peak;
-	      if ((100 < adc_pp) && (adc_pp <= 150))
-		{
-		  if (!bool_sec150[hit_sector_adc_index])
-		    {
-		      bool_sec150[hit_sector_adc_index] = true;
-		      if (bool_sec150[hit_sector_adc_index])
-		      {
-			
-			for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
-			  {
-			    samples.push_back(windowrawdata->samples[j]);
-			    h_amp_vs_sampl_chan150[hit_sector_adc_index]->Fill(j, samples[j]);
-			  }
-		      }
-		    }
-		}
-	      
-	      if ((150 < adc_pp) && (adc_pp <= 1000))
-		{
-		  if (!bool_sec[hit_sector_adc_index])
-		    {
-		      bool_sec[hit_sector_adc_index] = true;
-		      if (bool_sec[hit_sector_adc_index])
-		      {
-			
-			for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
-			  {
-			    samples.push_back(windowrawdata->samples[j]);
-			    h_amp_vs_sampl_chan[hit_sector_adc_index]->Fill(j, samples[j]);
-			  }
-		      }
-		    }
-		}
-	      
-	      if ( (1000 < adc_pp) && (adc_pp <= 2000))
-		{
-		  if (!bool_sec1000[hit_sector_adc_index])
-		    {
-		      bool_sec1000[hit_sector_adc_index] = true;
-		      if (bool_sec1000[hit_sector_adc_index])
-		      {
-			
-			for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
-			  {
-			    samples.push_back(windowrawdata->samples[j]);
-			    
-			    h_amp_vs_sampl_chan1000[hit_sector_adc_index]->Fill(j, samples[j]);
-			  }
-		      }
-		    }
-		}
-
-	      if ( (2000 < adc_pp) && (adc_pp <= 3000))
-		{
-		  if (!bool_sec2000[hit_sector_adc_index])
-		    {
-		      bool_sec2000[hit_sector_adc_index] = true;
-		      if (bool_sec2000[hit_sector_adc_index])
-		      {
-			
-			for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
-			  {
-			    samples.push_back(windowrawdata->samples[j]);
-			    
-			    h_amp_vs_sampl_chan2000[hit_sector_adc_index]->Fill(j, samples[j]);
-			  }
-		      }
-		    }
-		}
-
-	      if ( (3000 < adc_pp) && (adc_pp <= 4000))
-		{
-		  if (!bool_sec3000[hit_sector_adc_index])
-		    {
-		      bool_sec3000[hit_sector_adc_index] = true;
-		      if (bool_sec3000[hit_sector_adc_index])
-		      {
-			
-			for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
-			  {
-			    samples.push_back(windowrawdata->samples[j]);
-			    
-			    h_amp_vs_sampl_chan3000[hit_sector_adc_index]->Fill(j, samples[j]);
-			  }
-		      }
-		    }
-		}
-
-	      if ( (4000 < adc_pp))
-		{
-		  if (!bool_sec4000[hit_sector_adc_index])
-		    {
-		      bool_sec4000[hit_sector_adc_index] = true;
-		      if (bool_sec4000[hit_sector_adc_index])
-		      {
-			for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
-			  {
-			    samples.push_back(windowrawdata->samples[j]);
-			    h_amp_vs_sampl_chan4000[hit_sector_adc_index]->Fill(j, samples[j]);
-			  }
-		      }
-		    }
-		}
-	    } // Windowrawdata cut
-	  // ================= Get the raw data variables from ADC digihit object==========
-	  int hit_channel       = dscdigihits[i]->sector - 1;             // channel hit (ranging from 0 to NCHANNELS-1)
-	  int adc_sector         = dscdigihits[i]->sector ;                // channel hit (ranging from 1 to NCHANNELS)   
-	  uint32_t avg_pedestal  = dscdigihits[i]->pedestal;               // average pedestal (should be around 100 chan1)
-	  uint32_t pulse_time    = dscdigihits[i]->pulse_time*ADC_PT_RES;  // converted pulse time to ns
-	  uint32_t pulse_integral= dscdigihits[i]->pulse_integral;         // pulse integral
-	  //Occupancy Histo
-	  h1_adc_sec->Fill(adc_sector);
-	  // Fill the 2D histo
-	  h2_raw_pi_sector->Fill(adc_sector,pulse_integral);
-	  h2_raw_ped_sector->Fill(adc_sector,avg_pedestal);
-	  h2_raw_pt_sector->Fill(adc_sector,pulse_time);
-	  //Apply the calibration constants=================================================
+      dscdigihits[i]->GetSingle(pulseintegral);
+      dscdigihits[i]->GetSingle(pulsepedestal);
+      dscdigihits[i]->GetSingle(windowrawdata);
+      // Obtain the pedestal and raw window data
+      if (pulseintegral) 
+	{
+	  pulseintegral->GetSingle(pulsepedestal);
+	  pulseintegral->GetSingle(windowrawdata);
+	}
+      // Histogram the raw window data
+      if (windowrawdata)
+	{  
 	  const Df250PulsePedestal* PPobj = NULL;
 	  dscdigihits[i]->GetSingle(PPobj);
 	  if (PPobj != NULL)
 	    {
 	      if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
 	    }
-       
-       // Initialize pedestal to one found in CCDB, but override it
-       // with one found in event if is available
-       double pedestal = a_pedestals[hit_channel];
-       const Df250PulseIntegral *PIobj = NULL;
-       dscdigihits[i]->GetSingle(PIobj);
-       if (PIobj != NULL) 
-	 {
-	   double single_sample_ped = (double)PIobj->pedestal;
-	   double nsamples_integral = (double)PIobj->nsamples_integral;
-	   double nsamples_pedestal = (double)PIobj->nsamples_pedestal;
-	   pedestal = single_sample_ped * nsamples_integral/nsamples_pedestal;
-	 }      	
-      
-       // Apply calibration constants here
-       adc_ped  = pedestal;
-       adc_pi   =  dscdigihits[i]->pulse_integral;
-       adc_pcpi = adc_pi - adc_ped;
-       if(PPobj != NULL)
-	 adc_pp   = PPobj->pulse_peak;
-       else
-	 adc_pp =0;
-       adc_t    =  dscdigihits[i]->pulse_time * t_scale  - adc_time_offsets[hit_channel] + t_base; // Convert to ns
-       //cout << "adc_t =  "<< adc_t << endl;
-       //Fill 2D Histos
-       h2_adc_pp_sector->Fill(adc_sector,adc_pp);
-       h2_adc_pcpi_sector->Fill(adc_sector,adc_pcpi);
-       h2_adc_pt_sector->Fill(adc_sector,adc_t);
-       h2_adc_ped_sector->Fill(adc_sector,adc_ped);
-	  // Aquire the TDC DigiHits******* get the tdc hits when there is an adc hit*****
-       	  for(uint32_t i = 0; i < TDC_hits; i++)
+	  adc_pp   = PPobj->pulse_peak;
+	  if ((100 < adc_pp) && (adc_pp <= 150))
 	    {
-	      //sort(dsctdcdigihits.begin(), dsctdcdigihits.end(), DSCHit_tdc_cmp);
-	      const DSCTDCDigiHit *tdc_dhit = dsctdcdigihits[i];
-	      float tdc_dhit_time = TTabUtilities->Convert_DigiTimeToNs_F1TDC(tdc_dhit);//tdc_dhit->time*TDC_RES;
-	      int tdc_sector = tdc_dhit->sector;
-	      if (adc_sector == tdc_sector)
+	      if (!bool_sec150[hit_sector_adc_index])
 		{
-		  h2_tdcTime_sec->Fill(tdc_sector,tdc_dhit_time);
-
-		  tdc_t = TTabUtilities->Convert_DigiTimeToNs_F1TDC(tdc_dhit) - tdc_time_offsets[tdc_sector] + t_tdc_base;
-		  // cout << "tdc_t =  "<< tdc_t << endl;
-
-		  st_time = tdc_t - adc_t;
-		  //cout << "st_time =  "<< st_time  << endl;
-
-		  h2_st_time_vs_pcpi->Fill(adc_pcpi,st_time);
-		  h2_st_time_vs_pp->Fill(adc_pp,st_time);
-
+		  bool_sec150[hit_sector_adc_index] = true;
+		  if (bool_sec150[hit_sector_adc_index])
+		    {
+		      for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
+			{
+			  samples.push_back(windowrawdata->samples[j]);
+			  h_amp_vs_sampl_chan150[hit_sector_adc_index]->Fill(j, samples[j]);
+			}
+		    }
 		}
-	    }// End TDC loop
-     }// End ADC loop
-//========================== DSCTDCDigiHits ** TDC Hits=================
-//*******************************************************************
+	    }
+	  if ((150 < adc_pp) && (adc_pp <= 1000))
+	    {
+	      if (!bool_sec[hit_sector_adc_index])
+		{
+		  bool_sec[hit_sector_adc_index] = true;
+		  if (bool_sec[hit_sector_adc_index])
+		    {
+		      for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
+			{
+			  samples.push_back(windowrawdata->samples[j]);
+			  h_amp_vs_sampl_chan[hit_sector_adc_index]->Fill(j, samples[j]);
+			}
+		    }
+		}
+	    }
+	  if ( (1000 < adc_pp) && (adc_pp <= 2000))
+	    {
+	      if (!bool_sec1000[hit_sector_adc_index])
+		{
+		  bool_sec1000[hit_sector_adc_index] = true;
+		  if (bool_sec1000[hit_sector_adc_index])
+		    {
+		      for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
+			{
+			  samples.push_back(windowrawdata->samples[j]);
+			  h_amp_vs_sampl_chan1000[hit_sector_adc_index]->Fill(j, samples[j]);
+			}
+		    }
+		}
+	    }
+	  if ( (2000 < adc_pp) && (adc_pp <= 3000))
+	    {
+	      if (!bool_sec2000[hit_sector_adc_index])
+		{
+		  bool_sec2000[hit_sector_adc_index] = true;
+		  if (bool_sec2000[hit_sector_adc_index])
+		    {
+		      for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
+			{
+			  samples.push_back(windowrawdata->samples[j]);
+			  h_amp_vs_sampl_chan2000[hit_sector_adc_index]->Fill(j, samples[j]);
+			}
+		    }
+		}
+	    }
+	  if ( (3000 < adc_pp) && (adc_pp <= 4000))
+	    {
+	      if (!bool_sec3000[hit_sector_adc_index])
+		{
+		  bool_sec3000[hit_sector_adc_index] = true;
+		  if (bool_sec3000[hit_sector_adc_index])
+		    {
+		      for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
+			{
+			  samples.push_back(windowrawdata->samples[j]);
+			  h_amp_vs_sampl_chan3000[hit_sector_adc_index]->Fill(j, samples[j]);
+			}
+		    }
+		}
+	    }
+	  if ( (4000 < adc_pp))
+	    {
+	      if (!bool_sec4000[hit_sector_adc_index])
+		{
+		  bool_sec4000[hit_sector_adc_index] = true;
+		  if (bool_sec4000[hit_sector_adc_index])
+		    {
+		      for (uint32_t j = 0; j < windowrawdata->samples.size(); j++)
+			{
+			  samples.push_back(windowrawdata->samples[j]);
+			  h_amp_vs_sampl_chan4000[hit_sector_adc_index]->Fill(j, samples[j]);
+			}
+		    }
+		}
+	    }
+	} // Windowrawdata cut
+      //****************************************************************************
+      // ================= Get the raw data variables from ADC digihit object======
+      //****************************************************************************
+      int hit_channel       = dscdigihits[i]->sector - 1;             // channel hit (ranging from 0 to NCHANNELS-1)
+      int adc_sector         = dscdigihits[i]->sector ;                // channel hit (ranging from 1 to NCHANNELS)   
+      uint32_t avg_pedestal  = dscdigihits[i]->pedestal;               // average pedestal (should be around 100 chan1)
+      uint32_t pulse_time    = dscdigihits[i]->pulse_time*ADC_PT_RES;  // converted pulse time to ns
+      uint32_t pulse_integral= dscdigihits[i]->pulse_integral;         // pulse integral
+      //Occupancy Histo
+      h1_adc_sec->Fill(adc_sector);
+      // Fill the 2D histo
+      h2_raw_pi_sector->Fill(adc_sector,pulse_integral);
+      h2_raw_ped_sector->Fill(adc_sector,avg_pedestal);
+      h2_raw_pt_sector->Fill(adc_sector,pulse_time);
+      //************************************************************************      
+      //=================Apply the calibration constants========================
+      //************************************************************************
+      const Df250PulsePedestal* PPobj = NULL;
+      dscdigihits[i]->GetSingle(PPobj);
+      if (PPobj != NULL)
+	{
+	  if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
+	}
+      // Initialize pedestal to one found in CCDB, but override it
+      // with one found in event if is available
+      double pedestal = a_pedestals[hit_channel];
+      const Df250PulseIntegral *PIobj = NULL;
+      dscdigihits[i]->GetSingle(PIobj);
+      if (PIobj != NULL) 
+	{
+	  double single_sample_ped = (double)PIobj->pedestal;
+	  double nsamples_integral = (double)PIobj->nsamples_integral;
+	  double nsamples_pedestal = (double)PIobj->nsamples_pedestal;
+	  pedestal = single_sample_ped * nsamples_integral/nsamples_pedestal;
+	}      	
+      // Apply calibration constants here
+      adc_ped  = pedestal;
+      adc_pi   =  dscdigihits[i]->pulse_integral;
+      adc_pcpi = adc_pi - adc_ped;
+      if(PPobj != NULL)
+	adc_pp   = PPobj->pulse_peak;
+      else
+	adc_pp =0;
+      adc_t    =  dscdigihits[i]->pulse_time * t_scale  - adc_time_offsets[hit_channel] + t_base; // Convert to ns
+      //Fill 2D Histos
+      h2_adc_pp_sector->Fill(adc_sector,adc_pp);
+      h2_adc_pcpi_sector->Fill(adc_sector,adc_pcpi);
+      h2_adc_pt_sector->Fill(adc_sector,adc_t);
+      h2_adc_ped_sector->Fill(adc_sector,adc_ped);
+      //******************************************************************************
+      // Aquire the TDC DigiHits******* get the tdc hits when there is an adc hit*****
+      //******************************************************************************
+      for(uint32_t i = 0; i < TDC_hits; i++)
+	{
+	  //sort(dsctdcdigihits.begin(), dsctdcdigihits.end(), DSCHit_tdc_cmp);
+	  const DSCTDCDigiHit *tdc_dhit = dsctdcdigihits[i];
+	  float tdc_dhit_time = TTabUtilities->Convert_DigiTimeToNs_F1TDC(tdc_dhit);//tdc_dhit->time*TDC_RES;
+	  int tdc_sector = tdc_dhit->sector;
+	  if (adc_sector == tdc_sector)
+	    {
+	      h2_tdcTime_sec->Fill(tdc_sector,tdc_dhit_time);
+	      tdc_t = TTabUtilities->Convert_DigiTimeToNs_F1TDC(tdc_dhit) - tdc_time_offsets[tdc_sector] + t_tdc_base;
+	      st_time = tdc_t - adc_t;
+	      h2_st_time_vs_pcpi->Fill(adc_pcpi,st_time);
+	      h2_st_time_vs_pp->Fill(adc_pp,st_time);
+	    }
+	}// End TDC loop
+    }// End ADC loop
+  //************************************************************************
+  //========================== DSCTDCDigiHits ** TDC Hits=================
+  //************************************************************************
   for(uint32_t i = 0; i < TDC_hits; i++)
     {
       const DSCTDCDigiHit *tdc_dhit = dsctdcdigihits[i];
-      //float tdc_dhit_time = tdc_dhit->time*TDC_RES;
       float tdc_dhit_time = TTabUtilities->Convert_DigiTimeToNs_F1TDC(tdc_dhit);
       int tdc_sec = tdc_dhit->sector;
       //Fill tdc occupancy histo
       h1_tdc_sec->Fill(tdc_sec);
       //Fill 2D histo
       h2_raw_tdcTime_sec->Fill(tdc_sec,tdc_dhit_time);
-
+      
     }// End TDC loop
-
-//==========================  DSCHits  ** Hits after hit factory=================
-//*******************************************************************
+  //*******************************************************************************
+  //==========================  DSCHits  ** Hits after hit factory=================
+  //*******************************************************************************
   for(uint32_t i = 0; i < dschits.size(); i++) 
     {
       const DSCHit *hit = dschits[i];
@@ -572,7 +437,6 @@ jerror_t JEventProcessor_ST_online_lowlevel::evnt(JEventLoop *loop, uint64_t eve
       h2_dE_sec->Fill(hit_sector,dE);       // dE vs sector 
       
     }// End Hit loop
-
   // Lock ROOT mutex so other threads won't interfere 
   japp->RootUnLock();
   return NOERROR;

--- a/src/plugins/monitoring/ST_online_lowlevel/JEventProcessor_ST_online_lowlevel.h
+++ b/src/plugins/monitoring/ST_online_lowlevel/JEventProcessor_ST_online_lowlevel.h
@@ -9,6 +9,117 @@
 #define _JEventProcessor_ST_online_lowlevel_
 
 #include <JANA/JEventProcessor.h>
+using namespace jana;
+using namespace std;
+using std::vector;
+using std::string;
+// ***************** C++ header files******************
+//*****************************************************
+#include <stdint.h>
+#include <vector>
+#include <stdio.h>
+//***************** ROOT header files********************
+//*******************************************************
+#include <TMath.h>
+#include <TDirectory.h>
+#include <TH1.h>
+#include <TH2.h>
+//***************** ST header files************************
+//*********************************************************
+#include "START_COUNTER/DSCDigiHit.h"
+#include "START_COUNTER/DSCTDCDigiHit.h"
+#include "START_COUNTER/DSCHit.h"
+// ***************** DAQ header files (Triger Times)*********
+//***********************************************************
+#include "DAQ/Df250WindowRawData.h"
+#include "DAQ/Df250PulseRawData.h"
+#include "DAQ/Df250PulseTime.h"
+#include "DAQ/Df250PulseIntegral.h"
+#include "DAQ/Df250PulsePedestal.h"
+#include "DAQ/Df250Config.h"
+#include <TTAB/DTTabUtilities.h>
+//****************************** Define some constants *********
+//**************************************************************
+const uint32_t NCHANNELS  = 30;     // number of scintillator paddles
+const float_t  ADC_PT_RES = 0.0625; // fADC250 pulse time resolution (ns)
+//const float_t  TDC_RES    = 0.0559; // f1TDC resolution (ns)
+//***************** Declare Two Dimensional Histograms*************
+//*****************************************************************
+static TH2I *h2_st_adc_tdc_multi;
+static TH2I *h2_st_adc_hit_multi;
+static TH2I *h2_raw_pi_sector;
+static TH2I *h2_raw_ped_sector;
+static TH2I *h2_raw_pt_sector;
+static TH2I *h2_adc_pp_sector;
+static TH2I *h2_adc_pcpi_sector;
+static TH2I *h2_adc_pt_sector;
+static TH2I *h2_adc_ped_sector;
+static TH2I *h2_st_time_vs_pcpi;
+static TH2I *h2_st_time_vs_pp;
+static TH2I *h2_raw_tdcTime_sec;
+static TH2I *h2_tdcTime_sec;
+static TH2I *h2_t_sec; 
+static TH2I *h2_tTDC_sec; 
+static TH2I *h2_tfADC_sec;
+static TH2I *h2_dE_sec;
+//***************** Declare One Dimensional Histograms****************
+//********************************************************************
+static TH1I *h1_adc_sec;
+static TH1I *h1_tdc_sec;
+static TH1I *h1_hit_sec;
+static TH1I *st_num_events;
+//***************** Declare Dynamic Arrays of waveform Histograms********
+// &&&&&& define the Boolian variables needed &&&&&
+//***********************************************************************
+TH1I** h_amp_vs_sampl_chan = new TH1I*[NCHANNELS];
+TH1I** h_amp_vs_sampl_chan150 = new TH1I*[NCHANNELS];
+TH1I** h_amp_vs_sampl_chan1000 = new TH1I*[NCHANNELS];
+TH1I** h_amp_vs_sampl_chan2000 = new TH1I*[NCHANNELS];
+TH1I** h_amp_vs_sampl_chan3000 = new TH1I*[NCHANNELS];
+TH1I** h_amp_vs_sampl_chan4000 = new TH1I*[NCHANNELS];
+Bool_t bool_sec[NCHANNELS];
+Bool_t bool_sec150[NCHANNELS];
+Bool_t bool_sec1000[NCHANNELS];
+Bool_t bool_sec2000[NCHANNELS];
+Bool_t bool_sec3000[NCHANNELS];
+Bool_t bool_sec4000[NCHANNELS];
+Double_t adc_pp;
+Double_t adc_t;
+Double_t adc_ped;
+Double_t adc_pi;
+Double_t adc_pcpi;
+Double_t tdc_t;
+Double_t st_time;
+//// Offsets from CCDB
+vector<double> a_pedestals;
+vector<double> adc_time_offsets;
+vector<double> tdc_time_offsets;
+double t_tdc_base;
+double t_base;
+double t_scale;
+//**************Histograms limits Determination******************************
+//***************************************************************************
+const uint32_t ADC_MULTI_MIN  = 0.;      // Lower limit of adc multiplicity histogram
+const uint32_t ADC_MULTI_MAX  = 31.;     // Upper limit of adc multiplicity histogram
+const uint32_t ADC_MULTI_BINS = 31.;     // Number of bins in adc multiplicity histogram
+const uint32_t TDC_MULTI_MIN  = 0.;      // Lower limit of tdc multiplicity histogram
+const uint32_t TDC_MULTI_MAX  = 40.;     // Upper limit of tdc multiplicity histogram
+const uint32_t TDC_MULTI_BINS = 40.;     // Number of bins in tdc multiplicity histogram
+const uint32_t PI_MIN         = 0.;      // Lower limit of pulse integral histogram
+const uint32_t PI_MAX         = 12000.;  // Upper limit of pulse integral histogram  
+const uint32_t PI_BINS        = 240.;    // Number of bins in pulse integral histogram
+const uint32_t PED_MIN        = 90.;     // Lower limit of pedestal histogram
+const uint32_t PED_MAX        = 120.;    // Upper limit of pedestal histogram
+const uint32_t PED_BINS       = 30.;     // Number of bins in pedestal histogram
+const uint32_t PT_MIN         = 0.;      // Lower limit of pulse time histogram (ns)
+const uint32_t PT_MAX         = 200.;    // Upper limit of pulse time histogram (ns)
+const uint32_t PT_BINS        = 200.;    // Number of bins in pulse time histogram
+const uint32_t TDC_DHIT_MIN   = 0.;      // Lower limit of tdc digihit time histogram 
+const uint32_t TDC_DHIT_MAX   = 2200.;   // Upper limit of tdc digihit time histogram 
+const uint32_t TDC_DHIT_BINS  = 220.;    // Number of bins in tdc digihit time histogram 
+const float_t  T_HIT_MIN      =  -80.;  // Lower limit of hit time histogram (ns)
+const float_t  T_HIT_MAX      =  80.;   // Upper limit of hit time histogram (ns)
+const float_t  T_HIT_BINS     =  160.;   // Number of bins in hit time histogram 
 
 class JEventProcessor_ST_online_lowlevel:public jana::JEventProcessor{
 	public:
@@ -22,6 +133,8 @@ class JEventProcessor_ST_online_lowlevel:public jana::JEventProcessor{
 		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+		
 };
 
 #endif // _JEventProcessor_ST_online_lowlevel_

--- a/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_ADC.C
+++ b/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_ADC.C
@@ -41,7 +41,7 @@
   h2_raw_pi_sector->GetYaxis()->CenterTitle();
   //t_tdc from hit object
   h2_raw_pi_sector->GetYaxis()->SetTitleOffset(1.5);
-  
+  gPad->SetLogz();
   c1->cd(2);
   gStyle->SetOptStat(10);
   gPad->SetTicks();
@@ -50,6 +50,7 @@
   h2_adc_ped_sector->GetXaxis()->CenterTitle();
   h2_adc_ped_sector->GetYaxis()->CenterTitle();
   h2_adc_ped_sector->GetYaxis()->SetTitleOffset(1.6);
+  gPad->SetLogz();
   // t from hit object (tdc time walk corrected)
   c1->cd(3);
   gPad->SetTicks();
@@ -58,6 +59,7 @@
   h2_raw_pt_sector->GetXaxis()->CenterTitle();
   h2_raw_pt_sector->GetYaxis()->CenterTitle();
   h2_raw_pt_sector->GetYaxis()->SetTitleOffset(1.55);
+  gPad->SetLogz();
   c1->cd(4);
   gStyle->SetOptStat(10);
   gPad->SetTicks();
@@ -102,6 +104,7 @@
   h2_adc_pcpi_sector->GetYaxis()->CenterTitle(); 
   h2_adc_pcpi_sector->GetYaxis()->SetTitleOffset(1.5);
   h2_adc_pcpi_sector->SetLabelSize(0.03,"Y");
+  gPad->SetLogz();
   // Energy loss from hit object
   c2->cd(2);
   gPad->SetTicks();
@@ -110,6 +113,7 @@
   h2_raw_ped_sector->GetYaxis()->SetTitleOffset(1.5);
   h2_raw_ped_sector->GetXaxis()->CenterTitle();
   h2_raw_ped_sector->GetYaxis()->CenterTitle();
+  gPad->SetLogz();
   c2->cd(3);
   gStyle->SetOptStat(10);
   gPad->SetTicks();
@@ -117,6 +121,7 @@
   if (h2_adc_pt_sector) h2_adc_pt_sector->Draw("colz");
   h2_adc_pt_sector->GetXaxis()->CenterTitle();
   h2_adc_pt_sector->GetYaxis()->CenterTitle();
+  gPad->SetLogz();
   c2->cd(4);
   gStyle->SetOptStat(10);
   gPad->SetTicks();
@@ -158,6 +163,7 @@
   h2_adc_pp_sector->GetXaxis()->CenterTitle();
   h2_adc_pp_sector->GetYaxis()->CenterTitle();
   h2_adc_pp_sector->GetYaxis()->SetTitleOffset(1.5);
+   gPad->SetLogz();
   c3->cd(2);
   gStyle->SetOptStat(10);
   gPad->SetTicks();
@@ -166,6 +172,7 @@
   h2_st_time_vs_pp->GetXaxis()->CenterTitle();
   h2_st_time_vs_pp->GetYaxis()->CenterTitle();
   h2_st_time_vs_pp->GetYaxis()->SetTitleOffset(1.4);
+  gPad->SetLogz();
   c3->cd(3);
   gStyle->SetOptStat(10);
   gPad->SetTicks();
@@ -173,6 +180,7 @@
   if (h2_st_time_vs_pcpi) h2_st_time_vs_pcpi->Draw("colz");
   h2_st_time_vs_pcpi->GetXaxis()->CenterTitle();
   h2_st_time_vs_pcpi->GetYaxis()->CenterTitle();
+  gPad->SetLogz();
   c3->cd(4);
   gStyle->SetOptStat(10);
   gPad->SetTicks();
@@ -193,7 +201,7 @@
   gStyle->SetOptStat(10);
   gPad->SetTicks();
   gPad->SetGrid();
-  TH1D *h_pcpi = h2_st_time_vs_pcpi->ProjectionY();
+  TH1D *h_pcpi = h2_st_time_vs_pcpi->ProjectionX();
   h_pcpi->Draw();
   h_pcpi->GetXaxis()->CenterTitle();
   h_pcpi->GetYaxis()->CenterTitle();

--- a/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_Hit.C
+++ b/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_Hit.C
@@ -37,6 +37,8 @@
   h2_tdcTime_sec->GetXaxis()->CenterTitle();
   h2_tdcTime_sec->GetYaxis()->CenterTitle();
   h2_tdcTime_sec->GetYaxis()->SetTitleOffset(1.5);
+  h2_tdcTime_sec->SetAxisRange(0., 800.,"Y");
+  gPad->SetLogz();
   //t_tdc from hit object
   c1->cd(2);
   gPad->SetTicks();
@@ -44,6 +46,8 @@
   if (h2_tTDC_sec) h2_tTDC_sec->Draw("colz");
   h2_tTDC_sec->GetXaxis()->CenterTitle();
   h2_tTDC_sec->GetYaxis()->CenterTitle();
+  h2_tTDC_sec->SetAxisRange(-50., 50.,"Y");
+  gPad->SetLogz();
   // t from hit object (tdc time walk corrected)
   c1->cd(3);
   gPad->SetTicks();
@@ -51,6 +55,8 @@
   if (h2_t_sec) h2_t_sec->Draw("colz");
   h2_t_sec->GetXaxis()->CenterTitle();
   h2_t_sec->GetYaxis()->CenterTitle();
+  h2_t_sec->SetAxisRange(-50., 50.,"Y");
+  gPad->SetLogz();
   c1->cd(4);
   gStyle->SetOptStat(10);
   gPad->SetTicks();
@@ -91,6 +97,8 @@
   if (h2_tfADC_sec) h2_tfADC_sec->Draw("colz");
   h2_tfADC_sec->GetXaxis()->CenterTitle();
   h2_tfADC_sec->GetYaxis()->CenterTitle();
+  h2_tfADC_sec->SetAxisRange(-50., 50.,"Y");
+  gPad->SetLogz();
   // Energy loss from hit object
   c2->cd(2);
   gStyle->SetOptStat(10);
@@ -99,6 +107,8 @@
   if (h2_dE_sec) h2_dE_sec->Draw("colz");
   h2_dE_sec->GetXaxis()->CenterTitle();
   h2_dE_sec->GetYaxis()->CenterTitle();
+  h2_dE_sec->SetAxisRange(0., 0.003,"Y");
+  gPad->SetLogz();
   c2->cd(3);
   gStyle->SetOptStat(10);
   gPad->SetTicks();

--- a/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_Multi.C
+++ b/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_Multi.C
@@ -23,19 +23,28 @@
   
   if(!gPad) return;
   TCanvas *c1 = gPad->GetCanvas();
-  c1->Divide(3,3);
+  c1->Divide(3,2);
   // ADC vs TDC
   c1->cd(1);
   gPad->SetTicks();
   gPad->SetGrid();
   if (h2_st_adc_tdc_multi) h2_st_adc_tdc_multi->Draw("colz");
+  h2_st_adc_tdc_multi->SetAxisRange(0., 40.,"X");
+  h2_st_adc_tdc_multi->SetTitle("ST ADC Vs TDC multiplicities");
+  h2_st_adc_tdc_multi->GetZaxis()->SetLabelFont(10);
+  h2_st_adc_tdc_multi->GetZaxis()->SetLabelOffset(0.0);
+
   //ADC vs Hit
-  c1->cd(2);
+  c1->cd(4);
   gPad->SetTicks();
   gPad->SetGrid();
   if (h2_st_adc_hit_multi) h2_st_adc_hit_multi->Draw("colz");
+  h2_st_adc_hit_multi->SetAxisRange(0., 40.,"X");
+  h2_st_adc_hit_multi->SetTitle("ST ADC Vs Hit multiplicities");
+  h2_st_adc_hit_multi->GetZaxis()->SetLabelFont(10);
+  h2_st_adc_hit_multi->GetZaxis()->SetLabelOffset(0.0);
   // TDC multiplicity
-  c1->cd(4);
+  c1->cd(2);
   gPad->SetTicks();
   gPad->SetGrid();
   gPad->SetLogy();
@@ -57,6 +66,7 @@
   h_hit_multi->GetYaxis()->SetTitle("Counts");
   h_hit_multi->GetXaxis()->CenterTitle();
   h_hit_multi->GetYaxis()->CenterTitle();
+  // 3, and 6 are the same quantity from two different 2D histograms
   c1->cd(3);
   gPad->SetTicks();
   gPad->SetGrid();
@@ -67,30 +77,33 @@
   h_adc_multi->GetYaxis()->SetTitle("Counts");
   h_adc_multi->GetXaxis()->CenterTitle();
   h_adc_multi->GetYaxis()->CenterTitle();
-  c1->cd(6);
-  gStyle->SetOptStat(10);
-  gPad->SetTicks();
-  gPad->SetGrid();
-  gPad->SetLogy();
-  TH1D *h_ADC_multi = h2_st_adc_hit_multi->ProjectionY();
-  h_ADC_multi->Draw();
-  h_ADC_multi->SetAxisRange(0., 40.,"X");
-  h_ADC_multi->GetYaxis()->SetTitle("Counts");
-  h_ADC_multi->GetXaxis()->CenterTitle();
-  h_ADC_multi->GetYaxis()->CenterTitle();
+ 
+  //***********  Create the OCCUPANCY canvas *****************************
+  //**********************************************************************
+  TCanvas *c2 = new TCanvas("c2","Start Counter Occupancy Histograms", 200, 10, 600, 480);
+  c2->cd(0);
+  c2->Draw();
+  c2->Update();
+  if(!gPad) return;
+  TCanvas *c2 = gPad->GetCanvas();
+  c2->Divide(3,1);
+  
   // Occupancy Histos 
-  c1->cd(7);
+  c2->cd(1);
   gStyle->SetOptStat(10);
   gStyle->SetErrorX(0); 
   gPad->SetTicks();
   gPad->SetGrid();
   if (h1_tdc_sec) h1_tdc_sec->Draw("err");
   h1_tdc_sec->SetMinimum(0);
+ 
   h1_tdc_sec->GetXaxis()->CenterTitle();
   h1_tdc_sec->GetYaxis()->CenterTitle();
-  h1_tdc_sec->SetMarkerStyle(4);
-  h1_tdc_sec->SetMarkerSize(0.5);
-  c1->cd(8);
+  h1_tdc_sec->GetYaxis()->SetTitleOffset(1.5);
+  h1_tdc_sec->SetMarkerStyle(21);
+  h1_tdc_sec->SetMarkerSize(1.2);
+  h1_tdc_sec->SetMarkerColor(4);
+  c2->cd(3);
   gStyle->SetOptStat(10);
   gPad->SetTicks();
   gPad->SetGrid();
@@ -98,9 +111,11 @@
   h1_hit_sec->SetMinimum(0);
   h1_hit_sec->GetXaxis()->CenterTitle();
   h1_hit_sec->GetYaxis()->CenterTitle();
-  h1_hit_sec->SetMarkerStyle(4);
-  h1_hit_sec->SetMarkerSize(0.5);
-  c1->cd(9);
+  h1_hit_sec->GetYaxis()->SetTitleOffset(1.5);
+  h1_hit_sec->SetMarkerStyle(21);
+  h1_hit_sec->SetMarkerSize(1.2);
+  h1_hit_sec->SetMarkerColor(4);
+  c2->cd(2);
   gStyle->SetOptStat(10);
   gPad->SetTicks();
   gPad->SetGrid();
@@ -108,6 +123,8 @@
   h1_adc_sec->SetMinimum(0);
   h1_adc_sec->GetXaxis()->CenterTitle();
   h1_adc_sec->GetYaxis()->CenterTitle();
-  h1_adc_sec->SetMarkerStyle(4);
-  h1_adc_sec->SetMarkerSize(0.5);
+  h1_adc_sec->GetYaxis()->SetTitleOffset(1.5);
+  h1_adc_sec->SetMarkerStyle(21);
+  h1_adc_sec->SetMarkerSize(1.2);
+  h1_adc_sec->SetMarkerColor(4);
 }

--- a/src/plugins/monitoring/ST_online_tracking/ST_Monitoring_2D.C
+++ b/src/plugins/monitoring/ST_online_tracking/ST_Monitoring_2D.C
@@ -40,11 +40,13 @@
   // pi_pt_dhit_2d->GetXaxis()->CenterTitle();
   // pi_pt_dhit_2d->GetYaxis()->CenterTitle();
   if(h_r_vs_z) h_r_vs_z->Draw("colz");
+  gPad->SetLogz();
   gStyle->SetOptStat(10);
   // Pulse integral vs. f1TDC DigiHit time
   c1->cd(2);
   gPad->SetTicks();
   gPad->SetGrid();
+  gPad->SetLogz();
   // pt_tdc_dhit_2d->SetStats(0);
   // pt_tdc_dhit_2d->GetYaxis()->CenterTitle();
   // pt_tdc_dhit_2d->GetXaxis()->CenterTitle();
@@ -68,52 +70,5 @@
   // pi_dhit_2d->GetXaxis()->CenterTitle();
   // pi_dhit_2d->GetYaxis()->CenterTitle();
   if(h2_dphi_sector) h2_dphi_sector->Draw("colz");
-  // h2_tdct_adct_vs_de->SetAxisRange(0.0, 0.006.,"X");
-  // h2_tdct_adct_vs_de->SetAxisRange(-2., 2.,"Y");
-  // fADC250 pulse pedestal vs. channel histogram
-  // c1->cd(5);
- //  gPad->SetTicks();
- //  gPad->SetGrid();
- //  // ped_dhit_2d->SetStats(0);
- //  // ped_dhit_2d->SetAxisRange(-1., 31.,"X");
- //  // ped_dhit_2d->GetXaxis()->CenterTitle();
- //  // ped_dhit_2d->GetYaxis()->CenterTitle();
- //  if(h2_tdctCorr_adct_vs_de) h2_tdctCorr_adct_vs_de->Draw("colz");
- //  h2_tdctCorr_adct_vs_de->SetAxisRange(0.0, 0.006.,"X");
- //  h2_tdctCorr_adct_vs_de->SetAxisRange(-2., 2.,"Y");
- //  // fADC250 pulse time vs. channel histogram
- //  c1->cd(6);
- //  gPad->SetTicks();
- //  gPad->SetGrid();
- //  // pt_dhit_2d->SetStats(0);
- //  // pt_dhit_2d->SetAxisRange(-1., 31.,"X");
- //  // pt_dhit_2d->GetXaxis()->CenterTitle();
- //  // pt_dhit_2d->GetYaxis()->CenterTitle();
- //  if(h2_hit_det_eff) h2_hit_det_eff->Draw("colz");
- //  // ST fADC250 multiplicity vs. channel histogram
- //  c1->cd(7);
- //  gPad->SetTicks();
- //  gPad->SetGrid();
- //  // adc_multi_2d->SetStats(0);
- //  // adc_multi_2d->SetAxisRange(-1., 31.,"X");
- //  // adc_multi_2d->GetXaxis()->CenterTitle();
- //  // adc_multi_2d->GetYaxis()->CenterTitle();
- //  if(h_hit_det_eff) h_hit_det_eff->Draw("");
- //  // ST f1TDC multiplicty vs. channel histogram
- //  c1->cd(8);
- //  gPad->SetTicks();
- //  gPad->SetGrid();
- //  // tdc_multi_2d->SetStats(0);
- //  // tdc_multi_2d->SetAxisRange(-1., 31.,"X");
- //  // tdc_multi_2d->GetXaxis()->CenterTitle();
- //  // tdc_multi_2d->GetYaxis()->CenterTitle();
- //  if(h2_dt_z) h2_dt_z->Draw("colz");
- // // ST ADC vs TDC Multiplicity histogram
- //  c1->cd(9);
- //  gPad->SetTicks();
- //  gPad->SetGrid();
- //  // adc_tdc_multi_2d->SetStats(0);
- //  // adc_tdc_multi_2d->GetXaxis()->CenterTitle();
- //  // adc_tdc_multi_2d->GetYaxis()->CenterTitle();
- //  if(h2_adc_det_eff) h2_adc_det_eff->Draw("colz");
+ 
 }

--- a/src/plugins/monitoring/ST_online_tracking/ST_Monitoring_Pid.C
+++ b/src/plugins/monitoring/ST_online_tracking/ST_Monitoring_Pid.C
@@ -26,51 +26,35 @@
   TCanvas *c1 = gPad->GetCanvas();
   c1->Divide(2,1);
   gStyle->SetOptStat(10);
-  
-  // Pulse integral vs. pulse time histogram
-  // c1->cd(1);
-  // gPad->SetTicks();
-  // gPad->SetGrid();
-  // // pi_pt_dhit_2d->SetStats(0);
-  // // pi_pt_dhit_2d->GetXaxis()->CenterTitle();
-  // // pi_pt_dhit_2d->GetYaxis()->CenterTitle();
-  // if(h2_dedx_P_mag) h2_dedx_P_mag->Draw("colz");
-  // h2_dedx_P_mag->GetYaxis()->SetTitle("#frac{dE}{dx} (au)");
-  // h2_dedx_P_mag->GetYaxis()->CenterTitle();
-  // h2_dedx_P_mag->GetXaxis()->CenterTitle();
-  // h2_dedx_P_mag->GetYaxis()->SetTitleOffset(1.52);
-  // //h2_dedx_P_mag->GetTitle()->SetTitle("#frac{dE}{dx} vs momentum");
-  // gStyle->SetOptStat(10);
-  // // Pulse integral vs. f1TDC DigiHit time
+  gStyle->SetTitleFontSize(0.04);
   c1->cd(1);
   gPad->SetTicks();
   gPad->SetGrid();
-  // gStyle->SetPadTopMargin(0);
-  //  gStyle->SetPadLeftMargin(.1);
+  gPad->SetLogz();
+  
   if(h2_dedx_P_mag_postv) h2_dedx_P_mag_postv->Draw("colz");
   
   h2_dedx_P_mag_postv->GetYaxis()->SetLabelSize(.02);
   h2_dedx_P_mag_postv->GetYaxis()->SetTitle("#frac{dE}{dx} (au)");
-  // h2_dedx_P_mag_postv->GetYaxis()->SetTitleSize(1);
   h2_dedx_P_mag_postv->GetYaxis()->CenterTitle();
   h2_dedx_P_mag_postv->GetYaxis()->SetTitleOffset(1.25);
 
   h2_dedx_P_mag_postv->GetXaxis()->CenterTitle();
   h2_dedx_P_mag_postv->GetZaxis()->SetLabelFont(20);
   h2_dedx_P_mag_postv->GetZaxis()->SetLabelSize(0.02);
-  // h2_dedx_P_mag_postv->GetZaxis()->SetRangeUser(0.0, 400.);
-// f1TDC DigiHit time vs. channel number
+ 
+
   c1->cd(2);
   gPad->SetTicks();
   gPad->SetGrid();
+  gPad->SetLogz(); 
   if(h2_dedx_P_mag_negtv) h2_dedx_P_mag_negtv->Draw("colz");
   h2_dedx_P_mag_negtv->GetYaxis()->SetLabelSize(.02);
   h2_dedx_P_mag_negtv->GetYaxis()->SetTitle("#frac{dE}{dx} (au)");
-  //h2_dedx_P_mag_negtv->GetYaxis()->SetLabelSize(.02);
   h2_dedx_P_mag_negtv->GetYaxis()->CenterTitle();
   h2_dedx_P_mag_negtv->GetXaxis()->CenterTitle();
   h2_dedx_P_mag_negtv->GetYaxis()->SetTitleOffset(1.25);
   h2_dedx_P_mag_negtv->GetZaxis()->SetLabelFont(20);
-  // h2_dedx_P_mag_negtv->GetZaxis()->SetRangeUser(0.0, 200.);
- h2_dedx_P_mag_negtv->GetZaxis()->SetLabelSize(0.02);
+  h2_dedx_P_mag_negtv->GetZaxis()->SetLabelSize(0.02);
+   
 }


### PR DESCRIPTION
Adding ST time resolution to the online monitoring. Separate the efficiency calculations from the online tracking plugin. Calculate the efficiency for the whole ST and its geometrical section: straight, bend, and nose sections. Modify the St_online_lowlevel to have less bins.
Minor changes in the calibration macros and saving some histograms.
