### PR TITLE
Fix for run-dependent DGeometry

### DIFF
--- a/src/libraries/BCAL/DBCALGeometry.cc
+++ b/src/libraries/BCAL/DBCALGeometry.cc
@@ -76,7 +76,7 @@ float DBCALGeometry::fADC_radius[] = { 0,
 
 float DBCALGeometry::BCALMIDRAD = DBCALGeometry::m_radius[DBCALGeometry::BCALMID-1];
 
-DBCALGeometry::DBCALGeometry()  
+DBCALGeometry::DBCALGeometry(int runnumber)  
 {
   /// End if groupings do not evenly divide SiPM cells
   bool goodGeometry=true;
@@ -107,15 +107,15 @@ DBCALGeometry::DBCALGeometry()
   }
 
   // Initialize DBCALGeometry variables
-  if(!initialized) Initialize();
+  if(!initialized) Initialize(runnumber);
 
 }
 
 void
-DBCALGeometry::Initialize() {
+DBCALGeometry::Initialize(int runnumber) {
   //Get pointer to DGeometry object
   DApplication* dapp=dynamic_cast<DApplication*>(japp);
-  const DGeometry *dgeom  = dapp->GetDGeometry(9999);
+  const DGeometry *dgeom  = dapp->GetDGeometry(runnumber);
 
   // Get inner rad of BCAL (including the support plate)
   float my_BCALINNERRAD;

--- a/src/libraries/BCAL/DBCALGeometry.h
+++ b/src/libraries/BCAL/DBCALGeometry.h
@@ -41,7 +41,7 @@ public:
   
   JOBJECT_PUBLIC( DBCALGeometry );
   
-  DBCALGeometry();
+  DBCALGeometry(int runnumber);
   
   enum End { kUpstream, kDownstream };
   
@@ -76,7 +76,7 @@ public:
   // Methods to access and initialize the private variables
   static bool initialized;
 
-  static void Initialize();
+  static void Initialize(int runnumber=9999);
 
   static float GetBCAL_inner_rad();
 

--- a/src/libraries/BCAL/DBCALGeometry_factory.cc
+++ b/src/libraries/BCAL/DBCALGeometry_factory.cc
@@ -9,15 +9,27 @@
 
 #include "DBCALGeometry_factory.h"
 
+
 //------------------
-// evnt
+// brun
 //------------------
-jerror_t DBCALGeometry_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
+jerror_t DBCALGeometry_factory::brun(JEventLoop *loop, int32_t runnumber)
 {
+    assert( _data.size() == 0 );
 
-  DBCALGeometry *bcalGeom = new DBCALGeometry;
-     
-  _data.push_back(bcalGeom);
+    flags = PERSISTANT;
+    _data.push_back( new DBCALGeometry(runnumber) );
+        
+    return NOERROR;
+}
 
-	return NOERROR;
+//------------------
+// erun
+//------------------
+jerror_t DBCALGeometry_factory::erun(void)
+{
+    for(unsigned int i=0; i<_data.size(); i++)delete _data[i];
+    _data.clear();
+        
+    return NOERROR;
 }

--- a/src/libraries/BCAL/DBCALGeometry_factory.h
+++ b/src/libraries/BCAL/DBCALGeometry_factory.h
@@ -18,9 +18,11 @@ class DBCALGeometry_factory:public JFactory<DBCALGeometry>{
 		DBCALGeometry_factory(){};
 		~DBCALGeometry_factory(){};
 
-
 	private:
-		jerror_t evnt(JEventLoop *loop, uint64_t eventnumber);	///< Invoked via JEventProcessor virtual method
+        jerror_t brun(jana::JEventLoop*, int32_t);
+		//jerror_t evnt(JEventLoop *loop, uint64_t eventnumber);	///< Invoked via JEventProcessor virtual method
+        jerror_t erun();
+
 };
 
 #endif // _DBCALGeometry_factory_


### PR DESCRIPTION
The primary DGeometry object was being generated due to a call in DBCALGeometry with a constant run number of 9999.  This commit results in the DGeometry object being created with the correct run number.

This should not actually change any current results since we don't have any run-dependent geometry/material maps yet.
