### PR TITLE
Save the gDirectory before making and using dedicated one for plugin

### DIFF
--- a/src/plugins/monitoring/CDC_drift/JEventProcessor_CDC_drift.cc
+++ b/src/plugins/monitoring/CDC_drift/JEventProcessor_CDC_drift.cc
@@ -38,8 +38,10 @@ static TH1I *cdc_num_events = NULL;
 static TH1I *cdc_tfit = NULL;
 static TH1I *cdc_afit = NULL;
 
+#if CREATE_TREES
 static TTree *tfit = NULL;
 static TTree *afit = NULL;
+#endif  // CREATE_TREES
 
 static bool DISABLE_FITTING = true;
 
@@ -114,7 +116,7 @@ jerror_t JEventProcessor_CDC_drift::init(void) {
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 
 	// create root folder for cdc and cd to it, store main dir
-	//TDirectory *main = gDirectory;
+	TDirectory *savedir = gDirectory;
 	gDirectory->mkdir("CDC_fits")->cd();
 
 
@@ -160,7 +162,7 @@ jerror_t JEventProcessor_CDC_drift::init(void) {
 	Double_t sigma; 
 	afit->Branch("sigma",&sigma,"sigma/D");
 
-
+	savedir->cd();
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 
 	return NOERROR;
@@ -422,7 +424,6 @@ jerror_t JEventProcessor_CDC_drift::evnt(JEventLoop *eventLoop, uint64_t eventnu
 		afit->SetBranchAddress("sigma",&ampfitparams[2]);
 
 		afit->Fill();
-
 
 
 		// **** reset histograms ****


### PR DESCRIPTION
Save the gDirectory before making and using dedicated one for plugin so it can be returned to before other plugins create histograms. Without this, the online monitoring would have histograms for the CDC_online plugin be placed inside of CDC_fits/CDC/ instead of just CDC/. This caused the macros to fail since they referenced the histograms with the expected rather than actual hnamepaths.
