### PR TITLE
Don't create kinfit particles from massive neutral showers unless in spacetime fit

### DIFF
--- a/src/libraries/ANALYSIS/DKinFitUtils_GlueX.cc
+++ b/src/libraries/ANALYSIS/DKinFitUtils_GlueX.cc
@@ -354,6 +354,7 @@ void DKinFitUtils_GlueX::Make_KinFitChainStep(const DParticleCombo* locParticleC
 
 	//if doing a vertex fit, see which neutral particles can be treated as showers
 	set<pair<int, int> > locKinFitVertexParticles;
+	bool locSpactimeIsFitFlag = (locKinFitType == d_SpacetimeFit) || (locKinFitType == d_P4AndSpacetimeFit);
 	if((locKinFitType == d_VertexFit) || (locKinFitType == d_P4AndVertexFit) || (locKinFitType == d_P4AndSpacetimeFit))
 		locKinFitVertexParticles = Get_KinFitVertexParticles(locReaction);
 
@@ -410,11 +411,17 @@ void DKinFitUtils_GlueX::Make_KinFitChainStep(const DParticleCombo* locParticleC
 			//e.g. omega: cannot constrain: add its decay step to this one
 			Make_KinFitChainStep(locParticleCombo, locKinFitType, locDecayStepIndex, locKinFitChain, locKinFitChainStep, locStepCreationMap);
 		}
-		else if(ParticleCharge(locKinematicData->PID()) == 0) //detected neutral
+		else if(ParticleCharge(locPID) == 0) //detected neutral
 		{
 			const DNeutralParticleHypothesis* locNeutralParticleHypothesis = static_cast<const DNeutralParticleHypothesis*>(locKinematicData);
+
+			//Determine whether we should use the particle or the shower object
 			pair<int, int> locParticlePair(locStepIndex, loc_j);
-			if(locKinFitVertexParticles.find(locParticlePair) == locKinFitVertexParticles.end())
+			bool locNeutralShowerFlag = (locKinFitVertexParticles.find(locParticlePair) != locKinFitVertexParticles.end());
+			if((ParticleMass(locPID) > 0.0) && !locSpactimeIsFitFlag)
+				locNeutralShowerFlag = false; //massive shower momentum is defined by t, which isn't fit: use particle
+
+			if(!locNeutralShowerFlag)
 				locKinFitChainStep->Add_FinalParticle(Make_DetectedParticle(locNeutralParticleHypothesis));
 			else //in a vertex constraint: make shower
 			{

--- a/src/libraries/KINFITTER/DKinFitter.cc
+++ b/src/libraries/KINFITTER/DKinFitter.cc
@@ -12,6 +12,8 @@
 		//if a common vertex is not simultaneously kinematically fit for a neutral shower, the fit will fail
 		//To include a neutral shower in a p4 fit without a vertex fit, create a neutral particle from it 
 			//with a full 7x7 covaraince matrix and input it instead of the neutral shower
+	//Massive neutral showers (e.g. neutron) cannot be used in vertex constraints: only spacetime constraints. However, photons can. 
+		//This is because their momentum is defined by the vertex time
 
 //P4 CONSTRAINTS:
 	//Don't do if studying an inclusive channel.
@@ -34,6 +36,8 @@
 	//Neutral and missing particles included in the constraint will not be used to constrain the vertex, but will be set with the fit common vertex
 		//This is necessary if you want the neutral particle momentum (from an input shower) to change with the reconstructed vertex
 	//decaying particles should only be used to constrain a fit if the position is defined in another vertex constraint
+	//Massive neutral showers (e.g. neutron) cannot be used in vertex constraints: only spacetime constraints. However, photons can. 
+		//This is because their momentum is defined by the vertex time
 
 //SPACETIME CONSTRAINTS:
 	//THESE ARE CURRENTLY DISABLED

--- a/src/libraries/KINFITTER/DKinFitter.cc
+++ b/src/libraries/KINFITTER/DKinFitter.cc
@@ -1827,7 +1827,7 @@ void DKinFitter::Calc_dF_Vertex_Decaying_Accel(size_t locFIndex, const DKinFitPa
 		dF_dXi(locFIndex + 1, locCommonVxParamIndex + 1) -= dF_dEta(locFIndex + 1, locVxParamIndex + 1);
 		dF_dXi(locFIndex + 1, locCommonVxParamIndex + 2) -= dF_dEta(locFIndex + 1, locVxParamIndex + 2);
 	}
-	else if(locKinFitParticle->Get_IsNeutralShowerFlag())
+	else if(locKinFitParticle->Get_IsNeutralShowerFlag() && (locKinFitParticle->Get_Mass() < 0.00001))
 	{
 		if(dDebugLevel > 30)
 			cout << "DKinFitter: Calc_dF_Vertex() Section 7; PID = " << locKinFitParticle->Get_PID() << endl;
@@ -1864,6 +1864,10 @@ void DKinFitter::Calc_dF_Vertex_Decaying_Accel(size_t locFIndex, const DKinFitPa
 		dF_dXi(locFIndex + 1, locCommonVxParamIndex) -= dF_dEta(locFIndex + 1, locVxParamIndex);
 		dF_dXi(locFIndex + 1, locCommonVxParamIndex + 1) -= dF_dEta(locFIndex + 1, locVxParamIndex + 1);
 		dF_dXi(locFIndex + 1, locCommonVxParamIndex + 2) -= dF_dEta(locFIndex + 1, locVxParamIndex + 2);
+	}
+	else if(locKinFitParticle->Get_IsNeutralShowerFlag() && (locKinFitParticle->Get_Mass() >= 0.00001))
+	{
+		return;
 	}
 	else if((locKinFitParticleType == d_DetectedParticle) || (locKinFitParticleType == d_BeamParticle))
 	{
@@ -2051,7 +2055,7 @@ void DKinFitter::Calc_dF_Vertex_Decaying_NonAccel(size_t locFIndex, const DKinFi
 		dF_dXi(locFIndex + 1, locCommonVxParamIndex + 1) -= dF_dEta(locFIndex + 1, locVxParamIndex + 1);
 		dF_dXi(locFIndex + 1, locCommonVxParamIndex + 2) -= dF_dEta(locFIndex + 1, locVxParamIndex + 2);
 	}
-	else if(locKinFitParticle->Get_IsNeutralShowerFlag())
+	else if(locKinFitParticle->Get_IsNeutralShowerFlag() && (locKinFitParticle->Get_Mass() < 0.00001))
 	{
 		TVector3 locPosition_DecayingSource = locKinFitParticle_DecayingSource->Get_Position();
 		TVector3 locCommonVertex_DecayingSource = locKinFitParticle_DecayingSource->Get_CommonVertex();
@@ -2115,6 +2119,10 @@ void DKinFitter::Calc_dF_Vertex_Decaying_NonAccel(size_t locFIndex, const DKinFi
 		dF_dXi(locFIndex + 1, locCommonVxParamIndex) -= dF_dEta(locFIndex + 1, locVxParamIndex);
 		dF_dXi(locFIndex + 1, locCommonVxParamIndex + 1) -= dF_dEta(locFIndex + 1, locVxParamIndex + 1);
 		dF_dXi(locFIndex + 1, locCommonVxParamIndex + 2) -= dF_dEta(locFIndex + 1, locVxParamIndex + 2);
+	}
+	else if(locKinFitParticle->Get_IsNeutralShowerFlag() && (locKinFitParticle->Get_Mass() >= 0.00001))
+	{
+		return;
 	}
 	else if((locKinFitParticleType == d_DetectedParticle) || (locKinFitParticleType == d_BeamParticle))
 	{


### PR DESCRIPTION
Because the momentum is defined by the common time, which is not fit. 
