### PR TITLE
DCutAction_NoPIDHit

### DIFF
--- a/src/libraries/ANALYSIS/ANALYSIS_init.cc
+++ b/src/libraries/ANALYSIS/ANALYSIS_init.cc
@@ -111,6 +111,7 @@ jerror_t ANALYSIS_init(JEventLoop *loop)
 	DCutAction_ProtonPiPlusdEdx(NULL, 0.0);
 	DCutAction_BeamEnergy(NULL, false, 0.0, 0.0);
 	DCutAction_TrackFCALShowerEOverP(NULL, false, 0.0);
+	DCutAction_NoPIDHit(NULL);
 	DCutAction_PIDDeltaT(NULL, false, 0.0);
 	DCutAction_PIDTimingBeta(NULL, 0.0, 0.0);
 	DCutAction_OneVertexKinFit(NULL);

--- a/src/libraries/ANALYSIS/DCutActions.cc
+++ b/src/libraries/ANALYSIS/DCutActions.cc
@@ -1012,6 +1012,31 @@ bool DCutAction_PIDTimingBeta::Perform_Action(JEventLoop* locEventLoop, const DP
 	return true;
 }
 
+string DCutAction_NoPIDHit::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dPID;
+	return locStream.str();
+}
+
+bool DCutAction_NoPIDHit::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+{
+	//if dPID = Unknown, apply cut to all PIDs
+
+	deque<const DKinematicData*> locParticles;
+	locParticleCombo->Get_DetectedFinalParticles_Measured(locParticles);
+
+	for(size_t loc_i = 0; loc_i < locParticles.size(); ++loc_i)
+	{
+		if((dPID != Unknown) && (locParticles[loc_i]->PID() != dPID))
+			continue;
+		if(locParticles[loc_i]->t1_detector() == SYS_NULL)
+			return false;
+	}
+
+	return true;
+}
+
 void DCutAction_OneVertexKinFit::Initialize(JEventLoop* locEventLoop)
 {
 	dKinFitUtils = new DKinFitUtils_GlueX(locEventLoop);

--- a/src/libraries/ANALYSIS/DCutActions.h
+++ b/src/libraries/ANALYSIS/DCutActions.h
@@ -664,8 +664,6 @@ class DCutAction_NoPIDHit : public DAnalysisAction
 		Particle_t dPID;
 };
 
-DCutAction_NoPIDHit
-
 class DCutAction_OneVertexKinFit : public DAnalysisAction
 {
 	//does not cut vertex-z position if min > max

--- a/src/libraries/ANALYSIS/DCutActions.h
+++ b/src/libraries/ANALYSIS/DCutActions.h
@@ -61,6 +61,7 @@ DCutAction_BeamEnergy
 DCutAction_TrackFCALShowerEOverP
 DCutAction_PIDDeltaT
 DCutAction_PIDTimingBeta
+DCutAction_NoPIDHit
 
 DCutAction_OneVertexKinFit
 */
@@ -642,6 +643,28 @@ class DCutAction_PIDTimingBeta : public DAnalysisAction
 		Particle_t dPID;
 		DetectorSystem_t dSystem;
 };
+
+class DCutAction_NoPIDHit : public DAnalysisAction
+{
+	//if dPID = Unknown, apply cut to all PIDs
+
+	public:
+
+		DCutAction_NoPIDHit(const DReaction* locReaction, Particle_t locPID = Unknown, string locActionUniqueString = "") :
+		DAnalysisAction(locReaction, "Cut_NoPIDHit", false, locActionUniqueString),
+		dPID(locPID){}
+
+		void Initialize(JEventLoop* locEventLoop){};
+		string Get_ActionName(void) const;
+
+	private:
+
+		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
+
+		Particle_t dPID;
+};
+
+DCutAction_NoPIDHit
 
 class DCutAction_OneVertexKinFit : public DAnalysisAction
 {


### PR DESCRIPTION
Action to cut tracks with no PID hit (BCAL/FCAL/TOF) at all. (Can pass PreSelect cut with only SC hit). Recommended only to use on kaons. 
