### PR TITLE
Invmass fix

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisUtilities.cc
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.cc
@@ -939,11 +939,10 @@ DLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DParticleCombo* locPa
 	bool locDoSubsetFlag = !locToIncludePIDs.empty();
 	for(size_t loc_i = 0; loc_i < locParticles.size(); ++loc_i)
 	{
-		if(locParticleComboStep->Is_FinalParticleMissing(loc_i))
-			return (DLorentzVector()); //bad!
-
 		if(locDoSubsetFlag)
 		{
+			if(locParticleComboStep->Is_FinalParticleMissing(loc_i))
+				continue;
 			Particle_t locPID = locParticleComboStep->Get_FinalParticleID(loc_i);
 			bool locPIDFoundFlag = false;
 			for(deque<Particle_t>::iterator locIterator = locToIncludePIDs.begin(); locIterator != locToIncludePIDs.end(); ++locIterator)
@@ -957,6 +956,9 @@ DLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DParticleCombo* locPa
 			if(!locPIDFoundFlag)
 				continue; //skip it: don't want to include it
 		}
+
+		if(locParticleComboStep->Is_FinalParticleMissing(loc_i))
+			return (DLorentzVector()); //bad!
 
 		if(locParticleComboStep->Is_FinalParticleDecaying(loc_i))
 		{

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -411,7 +411,7 @@ class DHistogramAction_KinFitResults : public DAnalysisAction
 	public:
 		DHistogramAction_KinFitResults(const DReaction* locReaction, double locPullHistConfidenceLevelCut, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_KinFitResults", true, locActionUniqueString), 
-		dNumConfidenceLevelBins(400), dNumPullBins(200), dNum2DPBins(100), dNum2DThetaBins(140), dNum2DPhiBins(180), dNum2DPullBins(100),
+		dNumConfidenceLevelBins(400), dNumPullBins(200), dNum2DPBins(200), dNum2DThetaBins(140), dNum2DPhiBins(180), dNum2DPullBins(100),
 		dNum2DConfidenceLevelBins(100), dNum2DBeamEBins(240), dMinPull(-4.0), dMaxPull(4.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
 		dMinPhi(-180.0), dMaxPhi(180.0), dMinBeamE(0.0), dMaxBeamE(12.0), dPullHistConfidenceLevelCut(locPullHistConfidenceLevelCut), dAnalysisUtilities(NULL) {}
 

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -411,8 +411,8 @@ class DHistogramAction_KinFitResults : public DAnalysisAction
 	public:
 		DHistogramAction_KinFitResults(const DReaction* locReaction, double locPullHistConfidenceLevelCut, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_KinFitResults", true, locActionUniqueString), 
-		dNumConfidenceLevelBins(400), dNumPullBins(200), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180), dNum2DPullBins(200),
-		dNum2DConfidenceLevelBins(200), dNum2DBeamEBins(240), dMinPull(-4.0), dMaxPull(4.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
+		dNumConfidenceLevelBins(400), dNumPullBins(200), dNum2DPBins(100), dNum2DThetaBins(140), dNum2DPhiBins(180), dNum2DPullBins(100),
+		dNum2DConfidenceLevelBins(100), dNum2DBeamEBins(240), dMinPull(-4.0), dMaxPull(4.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
 		dMinPhi(-180.0), dMaxPhi(180.0), dMinBeamE(0.0), dMaxBeamE(12.0), dPullHistConfidenceLevelCut(locPullHistConfidenceLevelCut), dAnalysisUtilities(NULL) {}
 
 		unsigned int dNumConfidenceLevelBins, dNumPullBins, dNum2DPBins, dNum2DThetaBins, dNum2DPhiBins, dNum2DPullBins, dNum2DConfidenceLevelBins, dNum2DBeamEBins;


### PR DESCRIPTION
Fix bug in invariant-mass histogram action (only occurred when specifying specific PIDs AND there was a missing particle). 

Reduce binning in 2d pull histograms to take less memory. 
