### PR TITLE
Fix beam energy range, mass histograms

### DIFF
--- a/src/libraries/ANALYSIS/ANALYSIS_init.cc
+++ b/src/libraries/ANALYSIS/ANALYSIS_init.cc
@@ -84,7 +84,9 @@ jerror_t ANALYSIS_init(JEventLoop *loop)
 	DHistogramAction_KinFitResults(NULL, 0.0);
 	DHistogramAction_ParticleComboGenReconComparison(NULL, false);
 	DHistogramAction_MissingTransverseMomentum(NULL, false, 0, 0.0, 0.0);
-	
+	DHistogramAction_2DInvariantMass(NULL, 0, deque<Particle_t>(), deque<Particle_t>(), false, 0, 0.0, 0.0, 0, 0.0, 0.0);
+	DHistogramAction_Dalitz(NULL, 0, deque<Particle_t>(), deque<Particle_t>(), false, 0, 0.0, 0.0, 0, 0.0, 0.0);
+
 	DCutAction_MinTrackHits(NULL, 0);
 	DCutAction_ThrownTopology(NULL, true);
 	DCutAction_PIDFOM(NULL, Unknown, Unknown, 0.0);

--- a/src/libraries/ANALYSIS/DAnalysisUtilities.cc
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.cc
@@ -1326,7 +1326,7 @@ bool DAnalysisUtilities::Handle_Decursion(int& locParticleIndex, deque<size_t>& 
 {
 	do
 	{
-		if(locParticleIndex < locResumeAtIndices.size()) //else just saved a combo
+		if(locParticleIndex < int(locResumeAtIndices.size())) //else just saved a combo
 			locResumeAtIndices[locParticleIndex] = 0; //finding this particle failed: reset
 
 		--locParticleIndex; //go to previous particle

--- a/src/libraries/ANALYSIS/DAnalysisUtilities.cc
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.cc
@@ -1335,7 +1335,7 @@ bool DAnalysisUtilities::Handle_Decursion(int& locParticleIndex, deque<size_t>& 
 
 		locComboDeque.pop_back(); //reset this index
 	}
-	while(locResumeAtIndices[locParticleIndex] == locPossibilities[locParticleIndex].size());
+	while(locResumeAtIndices[locParticleIndex] == int(locPossibilities[locParticleIndex].size()));
 
 	return true;
 }

--- a/src/libraries/ANALYSIS/DAnalysisUtilities.h
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.h
@@ -91,16 +91,16 @@ class DAnalysisUtilities : public JObject
 
 		DLorentzVector Calc_MissingP4(const DParticleCombo* locParticleCombo, bool locUseKinFitDataFlag) const;
 		DLorentzVector Calc_MissingP4(const DParticleCombo* locParticleCombo, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const;
-		DLorentzVector Calc_MissingP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, int locUpToStepIndex, deque<Particle_t> locUpThroughPIDs, bool locUseKinFitDataFlag) const;
-		DLorentzVector Calc_MissingP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, int locUpToStepIndex, deque<Particle_t> locUpThroughPIDs, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const;
+		DLorentzVector Calc_MissingP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, int locUpToStepIndex, set<size_t> locUpThroughIndices, bool locUseKinFitDataFlag) const;
+		DLorentzVector Calc_MissingP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, int locUpToStepIndex, set<size_t> locUpThroughIndices, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const;
 		DLorentzVector Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, bool locUseKinFitDataFlag) const;
 		DLorentzVector Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const;
-		DLorentzVector Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, deque<Particle_t> locToIncludePIDs, bool locUseKinFitDataFlag) const;
-		DLorentzVector Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, deque<Particle_t> locToIncludePIDs, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const;
+		DLorentzVector Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<size_t> locToIncludeIndices, bool locUseKinFitDataFlag) const;
+		DLorentzVector Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<size_t> locToIncludeIndices, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const;
 
 		// These routines use the MEAURED particle data.  For the kinfit-data result, just use the error matrix from the missing particle
 		DMatrixDSym Calc_MissingP3Covariance(const DParticleCombo* locParticleCombo) const;
-		DMatrixDSym Calc_MissingP3Covariance(const DParticleCombo* locParticleCombo, size_t locStepIndex, int locUpToStepIndex, deque<Particle_t> locUpThroughPIDs) const;
+		DMatrixDSym Calc_MissingP3Covariance(const DParticleCombo* locParticleCombo, size_t locStepIndex, int locUpToStepIndex, set<size_t> locUpThroughIndices) const;
 
 		double Calc_CrudeTime(const deque<const DKinematicData*>& locParticles, const DVector3& locCommonVertex) const;
 		double Calc_CrudeTime(const deque<DKinFitParticle*>& locParticles, const DVector3& locCommonVertex) const;

--- a/src/libraries/ANALYSIS/DAnalysisUtilities.h
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.h
@@ -109,9 +109,11 @@ class DAnalysisUtilities : public JObject
 		DVector3 Calc_CrudeVertex(const deque<const DChargedTrackHypothesis*>& locParticles) const;
 		DVector3 Calc_CrudeVertex(const deque<const DTrackTimeBased*>& locParticles) const;
 
+		set<set<size_t> > Build_IndexCombos(const DReactionStep* locReactionStep, deque<Particle_t> locToIncludePIDs) const;
+
 	private:
 
-//		unsigned int DEBUG_LEVEL;
+		bool Handle_Decursion(int& locParticleIndex, deque<size_t>& locComboDeque, deque<int>& locResumeAtIndices, deque<set<size_t> >& locPossibilities) const;
 
 		double dTargetZCenter;
 		const DParticleID* dPIDAlgorithm;

--- a/src/libraries/ANALYSIS/DAnalysisUtilities.h
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.h
@@ -113,7 +113,7 @@ class DAnalysisUtilities : public JObject
 
 	private:
 
-		bool Handle_Decursion(int& locParticleIndex, deque<size_t>& locComboDeque, deque<int>& locResumeAtIndices, deque<set<size_t> >& locPossibilities) const;
+		bool Handle_Decursion(int& locParticleIndex, deque<size_t>& locComboDeque, deque<int>& locResumeAtIndices, deque<deque<size_t> >& locPossibilities) const;
 
 		double dTargetZCenter;
 		const DParticleID* dPIDAlgorithm;

--- a/src/libraries/ANALYSIS/DCutActions.cc
+++ b/src/libraries/ANALYSIS/DCutActions.cc
@@ -280,7 +280,7 @@ bool DCutAction_InvariantMass::Perform_Action(JEventLoop* locEventLoop, const DP
 	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
 	{
 		const DParticleComboStep* locParticleComboStep = locParticleCombo->Get_ParticleComboStep(loc_i);
-		const DReactionStep* locReactionStep = Get_Reaction->Get_ReactionStep(loc_i);
+		const DReactionStep* locReactionStep = Get_Reaction()->Get_ReactionStep(loc_i);
 		if((dInitialPID != Unknown) && (locParticleComboStep->Get_InitialParticleID() != dInitialPID))
 			continue;
 		if((dStepIndex != -1) && (int(loc_i) != dStepIndex))

--- a/src/libraries/ANALYSIS/DCutActions.cc
+++ b/src/libraries/ANALYSIS/DCutActions.cc
@@ -224,7 +224,7 @@ bool DCutAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, const DPar
 	set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
 	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
 	{
-		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, Get_UseKinFitResultsFlag());
+		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, *locComboIterator, Get_UseKinFitResultsFlag());
 		double locMissingMass = locMissingP4.M();
 		if((locMissingMass >= dMinimumMissingMass) && (locMissingMass <= dMaximumMissingMass))
 			return true;
@@ -254,7 +254,7 @@ bool DCutAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoop, con
 	set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
 	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
 	{
-		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, Get_UseKinFitResultsFlag());
+		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, *locComboIterator, Get_UseKinFitResultsFlag());
 		double locMissingMassSq = locMissingP4.M2();
 		if((locMissingMassSq >= dMinimumMissingMassSq) && (locMissingMassSq <= dMaximumMissingMassSq))
 			return true;

--- a/src/libraries/ANALYSIS/DCutActions.cc
+++ b/src/libraries/ANALYSIS/DCutActions.cc
@@ -224,7 +224,7 @@ bool DCutAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, const DPar
 	set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
 	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
 	{
-		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, locSourceObjects, Get_UseKinFitResultsFlag());
+		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, Get_UseKinFitResultsFlag());
 		double locMissingMass = locMissingP4.M();
 		if((locMissingMass >= dMinimumMissingMass) && (locMissingMass <= dMaximumMissingMass))
 			return true;
@@ -254,7 +254,7 @@ bool DCutAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoop, con
 	set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
 	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
 	{
-		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, locSourceObjects, Get_UseKinFitResultsFlag());
+		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, Get_UseKinFitResultsFlag());
 		double locMissingMassSq = locMissingP4.M2();
 		if((locMissingMassSq >= dMinimumMissingMassSq) && (locMissingMassSq <= dMaximumMissingMassSq))
 			return true;

--- a/src/libraries/ANALYSIS/DCutActions.cc
+++ b/src/libraries/ANALYSIS/DCutActions.cc
@@ -217,14 +217,20 @@ void DCutAction_MissingMass::Initialize(JEventLoop* locEventLoop)
 
 bool DCutAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
 {
-	DLorentzVector locMissingP4;
-	if(dMissingMassOffOfStepIndex == -1)
-		locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, Get_UseKinFitResultsFlag());
-	else
-		locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, Get_UseKinFitResultsFlag());
+	//build all possible combinations of the included pids
+	set<set<size_t> > locIndexCombos = dAnalysisUtilities->Build_IndexCombos(Get_Reaction()->Get_ReactionStep(dMissingMassOffOfStepIndex), dMissingMassOffOfPIDs);
 
-	double locMissingMass = locMissingP4.M();
-	return ((locMissingMass >= dMinimumMissingMass) && (locMissingMass <= dMaximumMissingMass));
+	//loop over them: Must fail ALL to fail. if any succeed, return true
+	set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
+	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
+	{
+		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, locSourceObjects, Get_UseKinFitResultsFlag());
+		double locMissingMass = locMissingP4.M();
+		if((locMissingMass >= dMinimumMissingMass) && (locMissingMass <= dMaximumMissingMass))
+			return true;
+	}
+
+	return false; //all failed
 }
 
 string DCutAction_MissingMassSquared::Get_ActionName(void) const
@@ -241,20 +247,26 @@ void DCutAction_MissingMassSquared::Initialize(JEventLoop* locEventLoop)
 
 bool DCutAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
 {
-	DLorentzVector locMissingP4;
-	if(dMissingMassOffOfStepIndex == -1)
-		locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, Get_UseKinFitResultsFlag());
-	else
-		locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, Get_UseKinFitResultsFlag());
+	//build all possible combinations of the included pids
+	set<set<size_t> > locIndexCombos = dAnalysisUtilities->Build_IndexCombos(Get_Reaction()->Get_ReactionStep(dMissingMassOffOfStepIndex), dMissingMassOffOfPIDs);
 
-	double locMissingMassSq = locMissingP4.M2();
-	return ((locMissingMassSq >= dMinimumMissingMassSq) && (locMissingMassSq <= dMaximumMissingMassSq));
+	//loop over them: Must fail ALL to fail. if any succeed, return true
+	set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
+	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
+	{
+		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, locSourceObjects, Get_UseKinFitResultsFlag());
+		double locMissingMassSq = locMissingP4.M2();
+		if((locMissingMassSq >= dMinimumMissingMassSq) && (locMissingMassSq <= dMaximumMissingMassSq))
+			return true;
+	}
+
+	return false; //all failed
 }
 
 string DCutAction_InvariantMass::Get_ActionName(void) const
 {
 	ostringstream locStream;
-	locStream << DAnalysisAction::Get_ActionName() << "_" << dMinimumInvariantMass << "_" << dMaximumInvariantMass;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dMinMass << "_" << dMaxMass;
 	return locStream.str();
 }
 
@@ -265,17 +277,34 @@ void DCutAction_InvariantMass::Initialize(JEventLoop* locEventLoop)
 
 bool DCutAction_InvariantMass::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
 {
-	double locInvariantMass;
 	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
 	{
 		const DParticleComboStep* locParticleComboStep = locParticleCombo->Get_ParticleComboStep(loc_i);
-		if(locParticleComboStep->Get_InitialParticleID() != dInitialPID)
+		const DReactionStep* locReactionStep = Get_Reaction->Get_ReactionStep(loc_i);
+		if((dInitialPID != Unknown) && (locParticleComboStep->Get_InitialParticleID() != dInitialPID))
 			continue;
-		locInvariantMass = dAnalysisUtilities->Calc_FinalStateP4(locParticleCombo, loc_i, Get_UseKinFitResultsFlag()).M();
-//cout << "flag, init pid, inv mass = " << Get_UseKinFitResultsFlag() << ", " << ParticleType(dInitialPID) << ", " << locInvariantMass << endl;
-		if((locInvariantMass > dMaximumInvariantMass) || (locInvariantMass < dMinimumInvariantMass))
+		if((dStepIndex != -1) && (int(loc_i) != dStepIndex))
+			continue;
+
+		//build all possible combinations of the included pids
+		set<set<size_t> > locIndexCombos = dAnalysisUtilities->Build_IndexCombos(locReactionStep, dToIncludePIDs);
+
+		//loop over them: Must fail ALL to fail. if any succeed, go to the next step
+		set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
+		bool locAnyOKFlag = false;
+		for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
+		{
+			DLorentzVector locFinalStateP4 = dAnalysisUtilities->Calc_FinalStateP4(locParticleCombo, loc_i, *locComboIterator, Get_UseKinFitResultsFlag());
+			double locInvariantMass = locFinalStateP4.M();
+			if((locInvariantMass > dMaxMass) || (locInvariantMass < dMinMass))
+				continue;
+			locAnyOKFlag = true;
+			break;
+		}
+		if(!locAnyOKFlag)
 			return false;
 	}
+
 	return true;
 }
 

--- a/src/libraries/ANALYSIS/DCutActions.h
+++ b/src/libraries/ANALYSIS/DCutActions.h
@@ -458,7 +458,7 @@ class DCutAction_InvariantMass : public DAnalysisAction
 
 		//e.g. if g, p -> pi+, pi-, p
 			//call with step = 0, PIDs = pi+, pi-, and will histogram rho mass
-		DHistogramAction_InvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locToIncludePIDs, bool locUseKinFitResultsFlag, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+		DCutAction_InvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locToIncludePIDs, bool locUseKinFitResultsFlag, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Cut_InvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dInitialPID(Unknown), dStepIndex(locStepIndex), dToIncludePIDs(locToIncludePIDs), dMinMass(locMinMass), dMaxMass(locMaxMass){}
 

--- a/src/libraries/ANALYSIS/DCutActions.h
+++ b/src/libraries/ANALYSIS/DCutActions.h
@@ -366,7 +366,7 @@ class DCutAction_MissingMass : public DAnalysisAction
 	public:
 		DCutAction_MissingMass(const DReaction* locReaction, bool locUseKinFitResultsFlag, double locMinimumMissingMass, double locMaximumMissingMass, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Cut_MissingMass", locUseKinFitResultsFlag, locActionUniqueString), 
-		dMinimumMissingMass(locMinimumMissingMass), dMaximumMissingMass(locMaximumMissingMass), dMissingMassOffOfStepIndex(-1){}
+		dMinimumMissingMass(locMinimumMissingMass), dMaximumMissingMass(locMaximumMissingMass), dMissingMassOffOfStepIndex(0){}
 
 		//E.g. If:
 		//g, p -> K+, K+, Xi-
@@ -410,7 +410,7 @@ class DCutAction_MissingMassSquared : public DAnalysisAction
 	public:
 		DCutAction_MissingMassSquared(const DReaction* locReaction, bool locUseKinFitResultsFlag, double locMinimumMissingMassSq, double locMaximumMissingMassSq, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Cut_MissingMassSquared", locUseKinFitResultsFlag, locActionUniqueString), 
-		dMinimumMissingMassSq(locMinimumMissingMassSq), dMaximumMissingMassSq(locMaximumMissingMassSq), dMissingMassOffOfStepIndex(-1){}
+		dMinimumMissingMassSq(locMinimumMissingMassSq), dMaximumMissingMassSq(locMaximumMissingMassSq), dMissingMassOffOfStepIndex(0){}
 
 		//E.g. If:
 		//g, p -> K+, K+, Xi-
@@ -424,7 +424,7 @@ class DCutAction_MissingMassSquared : public DAnalysisAction
 		//Then: Will cut missing-mass: g, p -> K+, K+, pi-
 		//But:
 		//locMissingMassOffOfStepIndex = 0, locMissingMassOffOfPIDs = K+
-		//Then: Will cut only missing-mass: g, p -> K+_1, (X)    and NOT K+_2!!!
+		//Then: Will cut only if BOTH missing-mass: g, p -> K+_1, (X)   AND   g, p -> K+_2, (X) fail.
 		DCutAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, double locMinimumMissingMassSq, double locMaximumMissingMassSq, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Cut_MissingMassSquared", locUseKinFitResultsFlag, locActionUniqueString), 
 		dMinimumMissingMassSq(locMinimumMissingMassSq), dMaximumMissingMassSq(locMaximumMissingMassSq), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
@@ -452,9 +452,15 @@ class DCutAction_MissingMassSquared : public DAnalysisAction
 class DCutAction_InvariantMass : public DAnalysisAction
 {
 	public:
-		DCutAction_InvariantMass(const DReaction* locReaction, Particle_t locInitialPID, bool locUseKinFitResultsFlag, double locMinimumInvariantMass, double locMaximumInvariantMass, string locActionUniqueString = "") : 
+		DCutAction_InvariantMass(const DReaction* locReaction, Particle_t locInitialPID, bool locUseKinFitResultsFlag, double locMinMass, double locMaxMass, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Cut_InvariantMass", locUseKinFitResultsFlag, locActionUniqueString), 
-		dInitialPID(locInitialPID), dMinimumInvariantMass(locMinimumInvariantMass), dMaximumInvariantMass(locMaximumInvariantMass){}
+		dInitialPID(locInitialPID), dStepIndex(-1), dToIncludePIDs(deque<Particle_t>()), dMinMass(locMinMass), dMaxMass(locMaxMass){}
+
+		//e.g. if g, p -> pi+, pi-, p
+			//call with step = 0, PIDs = pi+, pi-, and will histogram rho mass
+		DHistogramAction_InvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locToIncludePIDs, bool locUseKinFitResultsFlag, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+		DAnalysisAction(locReaction, "Cut_InvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
+		dInitialPID(Unknown), dStepIndex(locStepIndex), dToIncludePIDs(locToIncludePIDs), dMinMass(locMinMass), dMaxMass(locMaxMass){}
 
 		string Get_ActionName(void) const;
 		void Initialize(JEventLoop* locEventLoop);
@@ -463,8 +469,11 @@ class DCutAction_InvariantMass : public DAnalysisAction
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 
 		Particle_t dInitialPID;
-		double dMinimumInvariantMass;
-		double dMaximumInvariantMass;
+		int dStepIndex;
+		deque<Particle_t> dToIncludePIDs;
+
+		double dMinMass;
+		double dMaxMass;
 		const DAnalysisUtilities* dAnalysisUtilities;
 };
 

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -2487,7 +2487,7 @@ void DHistogramAction_DetectedParticleKinematics::Initialize(JEventLoop* locEven
 		CreateAndChangeTo_Directory(locParticleName, locParticleName);
 		locHistName = "Momentum";
 		locHistTitle = string("Beam ") + locParticleROOTName + string(";p (GeV/c)");
-		dBeamParticle_P = GetOrCreate_Histogram<TH1I>(locHistName, locHistTitle, dNumPBins, dMinP, dMaxP);
+		dBeamParticle_P = GetOrCreate_Histogram<TH1I>(locHistName, locHistTitle, dNumBeamEBins, dMinP, dMaxBeamE);
 		gDirectory->cd("..");
 
 		//PID

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.h
@@ -568,8 +568,8 @@ class DHistogramAction_DetectedParticleKinematics : public DAnalysisAction
 		DHistogramAction_DetectedParticleKinematics(const DReaction* locReaction, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Hist_DetectedParticleKinematics", false, locActionUniqueString), 
 		dMinPIDFOM(5.73303E-7), dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400),
-		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180),
-		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
+		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumBeamEBins(650),
+		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMaxBeamE(13.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
 		dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0),
 		dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
@@ -581,8 +581,8 @@ class DHistogramAction_DetectedParticleKinematics : public DAnalysisAction
 		DHistogramAction_DetectedParticleKinematics(string locActionUniqueString) : 
 		DAnalysisAction(NULL, "Hist_DetectedParticleKinematics", false, locActionUniqueString), 
 		dMinPIDFOM(5.73303E-7), dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400),
-		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180),
-		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
+		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumBeamEBins(650),
+		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMaxBeamE(13.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
 		dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0),
 		dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
@@ -594,8 +594,8 @@ class DHistogramAction_DetectedParticleKinematics : public DAnalysisAction
 		DHistogramAction_DetectedParticleKinematics(void) : 
 		DAnalysisAction(NULL, "Hist_DetectedParticleKinematics", false, ""), 
 		dMinPIDFOM(5.73303E-7), dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400),
-		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180),
-		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
+		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumBeamEBins(650),
+		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMaxBeamE(13.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
 		dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0),
 		dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
@@ -606,8 +606,8 @@ class DHistogramAction_DetectedParticleKinematics : public DAnalysisAction
 
 		double dMinPIDFOM;
 		unsigned int dNumPBins, dNumThetaBins, dNumPhiBins, dNumVertexZBins, dNumTBins, dNumVertexXYBins, dNumBetaBins, dNum2DDeltaBetaBins, dNum2DPBins;
-		unsigned int dNum2DThetaBins, dNum2DPhiBins;
-		double dMinT, dMaxT, dMinP, dMaxP, dMinTheta, dMaxTheta, dMinPhi, dMaxPhi, dMinVertexZ, dMaxVertexZ, dMinVertexXY, dMaxVertexXY, dMinBeta;
+		unsigned int dNum2DThetaBins, dNum2DPhiBins, dNumBeamEBins;
+		double dMinT, dMaxT, dMinP, dMaxP, dMaxBeamE, dMinTheta, dMaxTheta, dMinPhi, dMaxPhi, dMinVertexZ, dMaxVertexZ, dMinVertexXY, dMaxVertexXY, dMinBeta;
 		double dMaxBeta, dMinDeltaBeta, dMaxDeltaBeta;
 		string dTrackSelectionTag, dShowerSelectionTag; //In Initialize, will default to "PreSelect" unless otherwise specified
 

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -1472,7 +1472,7 @@ void DHistogramAction_Dalitz::Initialize(JEventLoop* locEventLoop)
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }
 
-bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+bool DHistogramAction_Dalitz::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
 {
 	if(Get_NumPreviousParticleCombos() == 0)
 		dPreviousSourceObjects.clear();

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -1266,7 +1266,7 @@ bool DHistogramAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, cons
 	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
 	{
 		set<pair<const JObject*, Particle_t> > locSourceObjects;
-		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, locSourceObjects, Get_UseKinFitResultsFlag());
+		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, *locComboIterator, locSourceObjects, Get_UseKinFitResultsFlag());
 
 		if(dPreviousSourceObjects.find(locSourceObjects) != dPreviousSourceObjects.end())
 			continue; //dupe: already histed!
@@ -1336,7 +1336,7 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoo
 	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
 	{
 		set<pair<const JObject*, Particle_t> > locSourceObjects;
-		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, locSourceObjects, Get_UseKinFitResultsFlag());
+		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, *locComboIterator, locSourceObjects, Get_UseKinFitResultsFlag());
 
 		if(dPreviousSourceObjects.find(locSourceObjects) != dPreviousSourceObjects.end())
 			continue; //dupe: already histed!
@@ -1435,7 +1435,7 @@ bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, 
 	japp->RootWriteLock();
 	{
 		for(size_t loc_i = 0; loc_i < locMassesToFill.size(); ++loc_i)
-			dHist_2DInvaraintMass->Fill(locMassesToFill.first, locMassesToFill.second);
+			dHist_2DInvaraintMass->Fill(locMassesToFill[loc_i].first, locMassesToFill[loc_i].second);
 	}
 	japp->RootUnLock();
 

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -1519,7 +1519,7 @@ bool DHistogramAction_Dalitz::Perform_Action(JEventLoop* locEventLoop, const DPa
 	japp->RootWriteLock();
 	{
 		for(size_t loc_i = 0; loc_i < locMassesToFill.size(); ++loc_i)
-			dHist_DalitzPlot->Fill(locMassesToFill.first, locMassesToFill.second);
+			dHist_DalitzPlot->Fill(locMassesToFill[loc_i].first, locMassesToFill[loc_i].second);
 	}
 	japp->RootUnLock();
 

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -1183,7 +1183,7 @@ bool DHistogramAction_InvariantMass::Perform_Action(JEventLoop* locEventLoop, co
 	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
 	{
 		const DParticleComboStep* locParticleComboStep = locParticleCombo->Get_ParticleComboStep(loc_i);
-		const DReactionStep* locReactionStep = Get_Reaction->Get_ReactionStep(loc_i);
+		const DReactionStep* locReactionStep = Get_Reaction()->Get_ReactionStep(loc_i);
 		if((dInitialPID != Unknown) && (locParticleComboStep->Get_InitialParticleID() != dInitialPID))
 			continue;
 		if((dStepIndex != -1) && (int(loc_i) != dStepIndex))
@@ -1396,7 +1396,7 @@ bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, 
 	vector<pair<double, double> > locMassesToFill;
 	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
 	{
-		const DReactionStep* locReactionStep = Get_Reaction->Get_ReactionStep(loc_i);
+		const DReactionStep* locReactionStep = Get_Reaction()->Get_ReactionStep(loc_i);
 		if((dStepIndex != -1) && (int(loc_i) != dStepIndex))
 			continue;
 
@@ -1480,7 +1480,7 @@ bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, 
 	vector<pair<double, double> > locMassesToFill;
 	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
 	{
-		const DReactionStep* locReactionStep = Get_Reaction->Get_ReactionStep(loc_i);
+		const DReactionStep* locReactionStep = Get_Reaction()->Get_ReactionStep(loc_i);
 		if((dStepIndex != -1) && (int(loc_i) != dStepIndex))
 			continue;
 

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -1272,7 +1272,7 @@ bool DHistogramAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, cons
 			continue; //dupe: already histed!
 		dPreviousSourceObjects.insert(locSourceObjects);
 
-		locMassesToFill.insert(locMissingP4.M());
+		locMassesToFill.push_back(locMissingP4.M());
 	}
 
 	japp->RootWriteLock();
@@ -1342,7 +1342,7 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoo
 			continue; //dupe: already histed!
 		dPreviousSourceObjects.insert(locSourceObjects);
 
-		locMassesToFill.insert(locMissingP4.M2());
+		locMassesToFill.push_back(locMissingP4.M2());
 	}
 
 	japp->RootWriteLock();
@@ -1396,7 +1396,6 @@ bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, 
 	vector<pair<double, double> > locMassesToFill;
 	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
 	{
-		const DParticleComboStep* locParticleComboStep = locParticleCombo->Get_ParticleComboStep(loc_i);
 		const DReactionStep* locReactionStep = Get_Reaction->Get_ReactionStep(loc_i);
 		if((dStepIndex != -1) && (int(loc_i) != dStepIndex))
 			continue;
@@ -1421,7 +1420,7 @@ bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, 
 				if(locXSourceObjects == locYSourceObjects)
 					continue; //the same!
 
-				set<set<set<pair<const JObject*, Particle_t> > > > locAllSourceObjects;
+				set<set<pair<const JObject*, Particle_t> > > locAllSourceObjects;
 				locAllSourceObjects.insert(locXSourceObjects);
 				locAllSourceObjects.insert(locYSourceObjects);
 				if(dPreviousSourceObjects.find(locAllSourceObjects) != dPreviousSourceObjects.end())
@@ -1481,7 +1480,6 @@ bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, 
 	vector<pair<double, double> > locMassesToFill;
 	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
 	{
-		const DParticleComboStep* locParticleComboStep = locParticleCombo->Get_ParticleComboStep(loc_i);
 		const DReactionStep* locReactionStep = Get_Reaction->Get_ReactionStep(loc_i);
 		if((dStepIndex != -1) && (int(loc_i) != dStepIndex))
 			continue;
@@ -1506,7 +1504,7 @@ bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, 
 				if(locXSourceObjects == locYSourceObjects)
 					continue; //the same!
 
-				set<set<set<pair<const JObject*, Particle_t> > > > locAllSourceObjects;
+				set<set<pair<const JObject*, Particle_t> > > locAllSourceObjects;
 				locAllSourceObjects.insert(locXSourceObjects);
 				locAllSourceObjects.insert(locYSourceObjects);
 				if(dPreviousSourceObjects.find(locAllSourceObjects) != dPreviousSourceObjects.end())

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -423,7 +423,7 @@ class DHistogramAction_2DInvariantMass : public DAnalysisAction
 		const DAnalysisUtilities* dAnalysisUtilities;
 		TH2I* dHist_2DInvaraintMass;
 
-		set<set<set<set<pair<const JObject*, Particle_t> > > > > dPreviousSourceObjects;
+		set<set<set<pair<const JObject*, Particle_t> > > > dPreviousSourceObjects;
 };
 
 
@@ -448,7 +448,7 @@ class DHistogramAction_Dalitz : public DAnalysisAction
 		const DAnalysisUtilities* dAnalysisUtilities;
 		TH2I* dHist_DalitzPlot;
 
-		set<pair<set<set<pair<const JObject*, Particle_t> > >, set<set<pair<const JObject*, Particle_t> > > > > dPreviousSourceObjects;
+		set<set<set<pair<const JObject*, Particle_t> > > > dPreviousSourceObjects;
 };
 
 class DHistogramAction_KinFitResults : public DAnalysisAction

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -430,7 +430,7 @@ class DHistogramAction_2DInvariantMass : public DAnalysisAction
 class DHistogramAction_Dalitz : public DAnalysisAction
 {
 	public:
-	DHistogramAction_Dalitz(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locXPIDs, deque<Particle_t> locYPIDs, bool locUseKinFitResultsFlag, unsigned int locNumXBins, double locMinX, double locMaxX, unsigned int locNumYBins, double locMinY, double locMaxY, string locActionUniqueString = "") :
+		DHistogramAction_Dalitz(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locXPIDs, deque<Particle_t> locYPIDs, bool locUseKinFitResultsFlag, unsigned int locNumXBins, double locMinX, double locMaxX, unsigned int locNumYBins, double locMinY, double locMaxY, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_Dalitz", locUseKinFitResultsFlag, locActionUniqueString),
 		dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dAnalysisUtilities(NULL) {}

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -68,6 +68,8 @@ REACTION-BASED ACTIONS:
 	DHistogramAction_InvariantMass
 	DHistogramAction_MissingMass
 	DHistogramAction_MissingMassSquared
+	DHistogramAction_2DInvariantMass
+	DHistogramAction_Dalitz
 	DHistogramAction_MissingTransverseMomentum
 */
 
@@ -248,17 +250,15 @@ class DHistogramAction_InvariantMass : public DAnalysisAction
 	public:
 		DHistogramAction_InvariantMass(const DReaction* locReaction, Particle_t locInitialPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_InvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
-		dEnableDoubleCounting(false), dInitialPID(locInitialPID), dStepIndex(-1), dToIncludePIDs(deque<Particle_t>()),
+		dInitialPID(locInitialPID), dStepIndex(-1), dToIncludePIDs(deque<Particle_t>()),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dAnalysisUtilities(NULL) {}
 
 		//e.g. if g, p -> pi+, pi-, p
 			//call with step = 0, PIDs = pi+, pi-, and will histogram rho mass
 		DHistogramAction_InvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locToIncludePIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_InvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
-		dEnableDoubleCounting(false), dInitialPID(Unknown), dStepIndex(locStepIndex), dToIncludePIDs(locToIncludePIDs),
+		dInitialPID(Unknown), dStepIndex(locStepIndex), dToIncludePIDs(locToIncludePIDs),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dAnalysisUtilities(NULL) {}
-
-		bool dEnableDoubleCounting;
 
 		void Initialize(JEventLoop* locEventLoop);
 
@@ -283,7 +283,7 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 	public:
 		DHistogramAction_MissingMass(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
-		dEnableDoubleCounting(false), dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(-1),
+		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(0),
 		dMissingMassOffOfPIDs(deque<Particle_t>()), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(1200), dMinBeamE(0.0), dMaxBeamE(12.0)
 		{
 			dAnalysisUtilities = NULL;
@@ -304,7 +304,7 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		//Then: Will histogram only missing-mass: g, p -> K+_1, (X)    and NOT K+_2!!!
 		DHistogramAction_MissingMass(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
-		dEnableDoubleCounting(false), dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex),
+		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex),
 		dMissingMassOffOfPIDs(locMissingMassOffOfPIDs), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(1200), dMinBeamE(0.0), dMaxBeamE(12.0)
 		{
 			dAnalysisUtilities = NULL;
@@ -312,13 +312,11 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 
 		DHistogramAction_MissingMass(const DReaction* locReaction, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
-		dEnableDoubleCounting(false), dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
+		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
 		dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(1200), dMinBeamE(0.0), dMaxBeamE(12.0)
 		{
 			dAnalysisUtilities = NULL;
 		}
-
-		bool dEnableDoubleCounting;
 
 		void Initialize(JEventLoop* locEventLoop);
 
@@ -347,7 +345,7 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 	public:
 		DHistogramAction_MissingMassSquared(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_MissingMassSquared", locUseKinFitResultsFlag, locActionUniqueString),
-		dEnableDoubleCounting(false), dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(-1),
+		dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(0),
 		dMissingMassOffOfPIDs(deque<Particle_t>()), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0)
 		{
 			dAnalysisUtilities = NULL;
@@ -368,7 +366,7 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		//Then: Will histogram only missing-mass: g, p -> K+_1, (X)    and NOT K+_2!!!
 		DHistogramAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
-		dEnableDoubleCounting(false), dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
+		dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
 		dMissingMassOffOfPIDs(locMissingMassOffOfPIDs), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0)
 		{
 			dAnalysisUtilities = NULL;
@@ -376,13 +374,11 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 
 		DHistogramAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
-		dEnableDoubleCounting(false), dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
+		dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
 		dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0)
 		{
 			dAnalysisUtilities = NULL;
 		}
-
-		bool dEnableDoubleCounting;
 
 		void Initialize(JEventLoop* locEventLoop);
 
@@ -411,10 +407,8 @@ class DHistogramAction_2DInvariantMass : public DAnalysisAction
 	public:
 		DHistogramAction_2DInvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locXPIDs, deque<Particle_t> locYPIDs, bool locUseKinFitResultsFlag, unsigned int locNumXBins, double locMinX, double locMaxX, unsigned int locNumYBins, double locMinY, double locMaxY, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_2DInvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
-		dEnableDoubleCounting(false), dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs),
+		dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dAnalysisUtilities(NULL) {}
-
-		bool dEnableDoubleCounting;
 
 		void Initialize(JEventLoop* locEventLoop);
 
@@ -429,7 +423,7 @@ class DHistogramAction_2DInvariantMass : public DAnalysisAction
 		const DAnalysisUtilities* dAnalysisUtilities;
 		TH2I* dHist_2DInvaraintMass;
 
-		set<pair<set<set<pair<const JObject*, Particle_t> > >, set<set<pair<const JObject*, Particle_t> > > > > dPreviousSourceObjects;
+		set<set<set<set<pair<const JObject*, Particle_t> > > > > dPreviousSourceObjects;
 };
 
 
@@ -438,10 +432,8 @@ class DHistogramAction_Dalitz : public DAnalysisAction
 	public:
 	DHistogramAction_Dalitz(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locXPIDs, deque<Particle_t> locYPIDs, bool locUseKinFitResultsFlag, unsigned int locNumXBins, double locMinX, double locMaxX, unsigned int locNumYBins, double locMinY, double locMaxY, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_Dalitz", locUseKinFitResultsFlag, locActionUniqueString),
-		dEnableDoubleCounting(false), dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs),
+		dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dAnalysisUtilities(NULL) {}
-
-		bool dEnableDoubleCounting;
 
 		void Initialize(JEventLoop* locEventLoop);
 
@@ -499,12 +491,10 @@ class DHistogramAction_MissingTransverseMomentum : public DAnalysisAction
 	public:
 		DHistogramAction_MissingTransverseMomentum(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumPtBins = 0, double locMinPt = 0, double locMaxPt = 1.0, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_MissingTransverseMomentum", locUseKinFitResultsFlag, locActionUniqueString),
-		dEnableDoubleCounting(false), dNumPtBins(locNumPtBins), dMinPt(locMinPt), dMaxPt(locMaxPt)
+		dNumPtBins(locNumPtBins), dMinPt(locMinPt), dMaxPt(locMaxPt)
 		{
 			dAnalysisUtilities = NULL;
 		}
-
-		bool dEnableDoubleCounting;
 
 		void Initialize(JEventLoop* locEventLoop);
 

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -406,6 +406,59 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		set<set<pair<const JObject*, Particle_t> > > dPreviousSourceObjects;
 };
 
+class DHistogramAction_2DInvariantMass : public DAnalysisAction
+{
+	public:
+		DHistogramAction_2DInvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locXPIDs, deque<Particle_t> locYPIDs, bool locUseKinFitResultsFlag, unsigned int locNumXBins, double locMinX, double locMaxX, unsigned int locNumYBins, double locMinY, double locMaxY, string locActionUniqueString = "") :
+		DAnalysisAction(locReaction, "Hist_2DInvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
+		dEnableDoubleCounting(false), dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs),
+		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dAnalysisUtilities(NULL) {}
+
+		bool dEnableDoubleCounting;
+
+		void Initialize(JEventLoop* locEventLoop);
+
+	private:
+		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
+
+		int dStepIndex;
+		deque<Particle_t> dXPIDs, dYPIDs;
+		unsigned int dNumXBins, dNumYBins;
+		double dMinX, dMaxX, dMinY, dMaxY;
+
+		const DAnalysisUtilities* dAnalysisUtilities;
+		TH2I* dHist_2DInvaraintMass;
+
+		set<pair<set<set<pair<const JObject*, Particle_t> > >, set<set<pair<const JObject*, Particle_t> > > > > dPreviousSourceObjects;
+};
+
+
+class DHistogramAction_Dalitz : public DAnalysisAction
+{
+	public:
+	DHistogramAction_Dalitz(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locXPIDs, deque<Particle_t> locYPIDs, bool locUseKinFitResultsFlag, unsigned int locNumXBins, double locMinX, double locMaxX, unsigned int locNumYBins, double locMinY, double locMaxY, string locActionUniqueString = "") :
+		DAnalysisAction(locReaction, "Hist_Dalitz", locUseKinFitResultsFlag, locActionUniqueString),
+		dEnableDoubleCounting(false), dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs),
+		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dAnalysisUtilities(NULL) {}
+
+		bool dEnableDoubleCounting;
+
+		void Initialize(JEventLoop* locEventLoop);
+
+	private:
+		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
+
+		int dStepIndex;
+		deque<Particle_t> dXPIDs, dYPIDs;
+		unsigned int dNumXBins, dNumYBins;
+		double dMinX, dMaxX, dMinY, dMaxY;
+
+		const DAnalysisUtilities* dAnalysisUtilities;
+		TH2I* dHist_DalitzPlot;
+
+		set<pair<set<set<pair<const JObject*, Particle_t> > >, set<set<pair<const JObject*, Particle_t> > > > > dPreviousSourceObjects;
+};
+
 class DHistogramAction_KinFitResults : public DAnalysisAction
 {
 	public:

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -407,8 +407,8 @@ class DHistogramAction_2DInvariantMass : public DAnalysisAction
 	public:
 		DHistogramAction_2DInvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locXPIDs, deque<Particle_t> locYPIDs, bool locUseKinFitResultsFlag, unsigned int locNumXBins, double locMinX, double locMaxX, unsigned int locNumYBins, double locMinY, double locMaxY, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_2DInvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
-		dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs),
-		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dAnalysisUtilities(NULL) {}
+		dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs), dNumXBins(locNumXBins), dNumYBins(locNumYBins), 
+		dMinX(locMinX), dMaxX(locMaxX), dMinY(locMinY), dMaxY(locMaxY), dAnalysisUtilities(NULL) {}
 
 		void Initialize(JEventLoop* locEventLoop);
 
@@ -432,8 +432,8 @@ class DHistogramAction_Dalitz : public DAnalysisAction
 	public:
 		DHistogramAction_Dalitz(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locXPIDs, deque<Particle_t> locYPIDs, bool locUseKinFitResultsFlag, unsigned int locNumXBins, double locMinX, double locMaxX, unsigned int locNumYBins, double locMinY, double locMaxY, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_Dalitz", locUseKinFitResultsFlag, locActionUniqueString),
-		dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs),
-		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dAnalysisUtilities(NULL) {}
+		dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs), dNumXBins(locNumXBins), dNumYBins(locNumYBins), 
+		dMinX(locMinX), dMaxX(locMaxX), dMinY(locMinY), dMaxY(locMaxY), dAnalysisUtilities(NULL) {}
 
 		void Initialize(JEventLoop* locEventLoop);
 

--- a/src/libraries/ANALYSIS/DReaction.cc
+++ b/src/libraries/ANALYSIS/DReaction.cc
@@ -57,12 +57,13 @@ string DReaction::Get_DecayChainFinalParticlesROOTNames(size_t locStepIndex, int
 	deque<Particle_t> locPIDs;
 	dReactionSteps[locStepIndex]->Get_FinalParticleIDs(locPIDs);
 	int locMissingParticleIndex = dReactionSteps[locStepIndex]->Get_MissingParticleIndex();
+	bool locSearchPIDsFlag = !locUpThroughPIDs.empty();
 	for(size_t loc_j = 0; loc_j < locPIDs.size(); ++loc_j)
 	{
 		if(int(loc_j) == locMissingParticleIndex)
 			continue; //exclude missing!
 
-		if(int(locStepIndex) == locUpToStepIndex)
+		if(locSearchPIDsFlag && (int(locStepIndex) == locUpToStepIndex))
 		{
 			bool locPIDFoundFlag = false;
 			for(deque<Particle_t>::iterator locIterator = locUpThroughPIDs.begin(); locIterator != locUpThroughPIDs.end(); ++locIterator)


### PR DESCRIPTION
Update beam energy range for 12 GeV. 
Fix bug in mass histograms when picking specific PIDs: Make sure it histograms all combos with each combo. 
