### PR TITLE
F250 extra pulse integral fix

### DIFF
--- a/src/libraries/BCAL/DBCALUnifiedHit_factory.cc
+++ b/src/libraries/BCAL/DBCALUnifiedHit_factory.cc
@@ -170,8 +170,7 @@ jerror_t DBCALUnifiedHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber) {
         if (tdc_hits.size() > 0) haveTDChit = true;
 
         // For each ADC hit 
-        //for (unsigned int i=0; i<hits.size(); i++) {
-        for (unsigned int i=0; i<1; i++) {   // only process the first ADC hit for now
+        for (unsigned int i=0; i<hits.size(); i++) {
             const DBCALHit* hit=hits[i];
 
             float pulse_peak, E, t, t_ADC, t_TDC=0; //these are values that will be assigned to the DBCALUnifiedHit

--- a/src/libraries/TTAB/DTranslationTable.cc
+++ b/src/libraries/TTAB/DTranslationTable.cc
@@ -390,7 +390,10 @@ void DTranslationTable::ApplyTranslationTable(JEventLoop *loop) const
       const Df250PulsePedestal *pp = NULL;
 	  pi->GetSingle(pt);
 	  pi->GetSingle(pp);
-      
+
+      // Avoid f250 Error with extra PulseIntegral word
+      if( pt == NULL || pp == NULL) continue;
+
       // Create the appropriate hit type based on detector type
       switch (chaninfo.det_sys) {
          case BCAL:

--- a/src/plugins/Calibration/HLDetectorTiming/FitScripts/ExtractTDCADCTiming.C
+++ b/src/plugins/Calibration/HLDetectorTiming/FitScripts/ExtractTDCADCTiming.C
@@ -558,7 +558,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 2931
     outFile.close(); // clear file
 
     TH1D * selectedBCALOffset = new TH1D("selectedBCALOffset", "Selected BCAL TDC Offset; Column; Offset [ns]", 1152, 0.5, 1152 + 0.5);
-    TH1I * BCALOffsetDistribution = new TH1I("BCALOffsetDistribution", "BCAL TDC Offset; TDC Offset [ns]; Entries", 500, -250, 250); 
+    TH1I * BCALOffsetDistribution = new TH1I("BCALOffsetDistribution", "BCAL TDC Offset; TDC Offset [ns]; Entries", 500, -500, 500); 
 
     thisHist = Get2DHistogram("HLDetectorTiming", "BCAL", "BCALHit Upstream Per Channel TDC-ADC Hit Time");
     if(thisHist != NULL){
@@ -588,7 +588,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 2931
                 }
             }
             selectedBCALOffset->SetBinContent(2*i - 1, maxMean);
-            BCALOffsetDistribution->Fill(maxMean);
+            BCALOffsetDistribution->Fill(maxMean+bcal_tdc_offsets[2*i -2]);
         }
     }
 
@@ -621,7 +621,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 2931
             }
 
             selectedBCALOffset->SetBinContent(2*i, maxMean);
-            BCALOffsetDistribution->Fill(maxMean);
+            BCALOffsetDistribution->Fill(maxMean+bcal_tdc_offsets[2*i -1]);
         }
     }
 

--- a/src/plugins/Calibration/HLDetectorTiming/FitScripts/ExtractTrackBasedTiming.C
+++ b/src/plugins/Calibration/HLDetectorTiming/FitScripts/ExtractTrackBasedTiming.C
@@ -309,7 +309,9 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
             }
 
             if(useRF) {
-                int beamBucket = int((maxMean / RF_Period) + 0.5); // +0.5 to handle rounding correctly
+                int beamBucket;
+                if (maxMean >= 0) beamBucket = int((maxMean / RF_Period) + 0.5); // +0.5 to handle rounding correctly
+                else beamBucket = int((maxMean / RF_Period) - 0.5);
                 selectedTAGHOffset->SetBinContent(i, beamBucket);
                 TAGHOffsetDistribution->Fill(beamBucket);
             }
@@ -379,6 +381,7 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
         outFile << sc_t_base_fadc - meanSCOffset << " " << sc_t_base_tdc - meanSCOffset << endl;
         outFile.close();
     }
+    cout << "Mean SC offset " << meanSCOffset << endl;
 
     TH1I *this1DHist = Get1DHistogram("HLDetectorTiming", "TRACKING", "TOF - SC Target Time");
     if(this1DHist != NULL){

--- a/src/plugins/Calibration/HLDetectorTiming/FitScripts/ExtractTrackBasedTiming.C
+++ b/src/plugins/Calibration/HLDetectorTiming/FitScripts/ExtractTrackBasedTiming.C
@@ -229,14 +229,14 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
             int index = GetCCDBIndexTAGM(column, 0);
             double valueToUse = selectedTAGMOffset->GetBinContent(index);
             if (useRF) valueToUse *= RF_Period;
-            if (valueToUse == 0) valueToUse = meanOffset;
+            //if (valueToUse == 0) valueToUse = meanOffset;
             outFile << "0 " << column << " " << valueToUse + tagm_fadc_time_offsets[index-1] - meanOffset<< endl;
             if (column == 9 || column == 27 || column == 81 || column == 99){
                 for (unsigned int row = 1; row <= 5; row++){
                     index = GetCCDBIndexTAGM(column, row);
                     valueToUse = selectedTAGMOffset->GetBinContent(index);
                     if (useRF) valueToUse *= RF_Period;
-                    if (valueToUse == 0) valueToUse = meanOffset;
+                    //if (valueToUse == 0) valueToUse = meanOffset;
                     outFile << row << " " << column << " " << valueToUse + tagm_fadc_time_offsets[index-1] - meanOffset<< endl;
                 }
             }
@@ -250,14 +250,14 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
             int index = GetCCDBIndexTAGM(column, 0);
             double valueToUse = selectedTAGMOffset->GetBinContent(index);
             if (useRF) valueToUse *= RF_Period;
-            if (valueToUse == 0) valueToUse = meanOffset;
+            //if (valueToUse == 0) valueToUse = meanOffset;
             outFile << "0 " << column << " " << valueToUse + tagm_tdc_time_offsets[index-1] - meanOffset << endl;
             if (column == 9 || column == 27 || column == 81 || column == 99){
                 for (unsigned int row = 1; row <= 5; row++){
                     index = GetCCDBIndexTAGM(column, row);
                     valueToUse = selectedTAGMOffset->GetBinContent(index);
                     if (useRF) valueToUse *= RF_Period;
-                    if (valueToUse == 0) valueToUse = meanOffset;
+                    //if (valueToUse == 0) valueToUse = meanOffset;
                     outFile << row << " " << column << " " << valueToUse + tagm_tdc_time_offsets[index-1] - meanOffset << endl;
                 }
             }
@@ -323,7 +323,7 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
         for (int i = 1 ; i <= nBinsX; i++){
             valueToUse = selectedTAGHOffset->GetBinContent(i);
             if (useRF) valueToUse *= RF_Period;
-            if (valueToUse == 0) valueToUse = meanOffset;
+            //if (valueToUse == 0) valueToUse = meanOffset;
             outFile.open(prefix + "tagh_tdc_timing_offsets.txt", ios::out | ios::app);
             outFile << i << " " << valueToUse + tagh_tdc_time_offsets[i-1] - meanOffset << endl;
             outFile.close();

--- a/src/plugins/Calibration/HLDetectorTiming/JEventProcessor_HLDetectorTiming.cc
+++ b/src/plugins/Calibration/HLDetectorTiming/JEventProcessor_HLDetectorTiming.cc
@@ -82,14 +82,14 @@ jerror_t JEventProcessor_HLDetectorTiming::init(void)
 
     // Increase range for initial search
     if(DO_TDC_ADC_ALIGN){
-        NBINS_TDIFF = 1400; MIN_TDIFF = -150.0; MAX_TDIFF = 550.0;
+        NBINS_TDIFF = 2800; MIN_TDIFF = -150.0; MAX_TDIFF = 550.0;
     }
     else{
         NBINS_TDIFF = 50; MIN_TDIFF = -10.0; MAX_TDIFF = 10.0;
     }
 
     if (DO_TRACK_BASED){
-        NBINS_TAGGER_TIME = 1600; MIN_TAGGER_TIME = 0; MAX_TAGGER_TIME = 400;
+        NBINS_TAGGER_TIME = 1600; MIN_TAGGER_TIME = -200; MAX_TAGGER_TIME = 400;
         NBINS_MATCHING = 500; MIN_MATCHING_T = -100; MAX_MATCHING_T = 400;
     }
     else{


### PR DESCRIPTION
Guards against creating digihits when either the pulse pedestal or timing information are missing for pulse integral words in the f250. The exact cause of this bug in the firmware will have to be investigated. 

Looks like a few other commits are going along for the ride related to Spring 2016 timing calibrations, mainly updates in scripts and changes in BCAL_TDC_Timing plugin to support the default CURVATURE BCAL code.
