### PR TITLE
Command line options to use only fADC info in DBeamPhoton creation

### DIFF
--- a/src/libraries/PID/DBeamPhoton_factory.cc
+++ b/src/libraries/PID/DBeamPhoton_factory.cc
@@ -17,7 +17,18 @@ using namespace jana;
 //------------------
 jerror_t DBeamPhoton_factory::init(void)
 {
-	return NOERROR;
+    TAGM_PEAK_CUT=0;
+    TAGH_PEAK_CUT=0;
+    TAGM_USE_ADC=0;
+    TAGH_USE_ADC=0;
+
+    if (gPARMS){
+        gPARMS->SetDefaultParameter("BEAMPHOTON:TAGM_PEAK_CUT", TAGM_PEAK_CUT, "TAGM pulse height cut [ADC Counts]");
+        gPARMS->SetDefaultParameter("BEAMPHOTON:TAGH_PEAK_CUT", TAGH_PEAK_CUT, "TAGH pulse height cut [ADC Counts]");
+        gPARMS->SetDefaultParameter("BEAMPHOTON:TAGM_USE_ADC", TAGM_USE_ADC, "Use ADC times in TAGM");
+        gPARMS->SetDefaultParameter("BEAMPHOTON:TAGH_USE_ADC", TAGH_USE_ADC, "Use ADC times in TAGH");
+    }
+    return NOERROR;
 }
 
 //------------------
@@ -25,12 +36,12 @@ jerror_t DBeamPhoton_factory::init(void)
 //------------------
 jerror_t DBeamPhoton_factory::brun(jana::JEventLoop *locEventLoop, int32_t runnumber)
 {
-	DApplication* dapp = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
-	DGeometry* locGeometry = dapp->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
-	dTargetCenterZ = 0.0;
-	locGeometry->GetTargetZ(dTargetCenterZ);
+    DApplication* dapp = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+    DGeometry* locGeometry = dapp->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+    dTargetCenterZ = 0.0;
+    locGeometry->GetTargetZ(dTargetCenterZ);
 
-	return NOERROR;
+    return NOERROR;
 }
 
 //------------------
@@ -38,47 +49,61 @@ jerror_t DBeamPhoton_factory::brun(jana::JEventLoop *locEventLoop, int32_t runnu
 //------------------
 jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t eventnumber)
 {
-	DVector3 pos(0.0, 0.0, dTargetCenterZ);
+    DVector3 pos(0.0, 0.0, dTargetCenterZ);
 
-	vector<const DTAGMHit*> tagm_hits;
-	locEventLoop->Get(tagm_hits);
+    vector<const DTAGMHit*> tagm_hits;
+    locEventLoop->Get(tagm_hits);
 
-	for (unsigned int ih=0; ih < tagm_hits.size(); ++ih)
-	{
-	        if (!tagm_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)		
-		DVector3 mom(0.0, 0.0, tagm_hits[ih]->E);
-		DBeamPhoton *gamma = new DBeamPhoton;
-		gamma->setPID(Gamma);
-		gamma->setMomentum(mom);
-		gamma->setPosition(pos);
-		gamma->setCharge(0);
-		gamma->setMass(0);
-		gamma->setTime(tagm_hits[ih]->t);
-		gamma->setT0(tagm_hits[ih]->t, 0.200, SYS_TAGM);
-		gamma->AddAssociatedObject(tagm_hits[ih]);
-		_data.push_back(gamma);
-	}
+    for (unsigned int ih=0; ih < tagm_hits.size(); ++ih)
+    {
+        if (!tagm_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)		
+        if (tagm_hits[ih]->pulse_peak < TAGM_PEAK_CUT) continue; // Cut on TAGM pulse height
+        DVector3 mom(0.0, 0.0, tagm_hits[ih]->E);
+        DBeamPhoton *gamma = new DBeamPhoton;
+        gamma->setPID(Gamma);
+        gamma->setMomentum(mom);
+        gamma->setPosition(pos);
+        gamma->setCharge(0);
+        gamma->setMass(0);
+        if (TAGM_USE_ADC) {
+            gamma->setTime(tagm_hits[ih]->time_fadc);
+            gamma->setT0(tagm_hits[ih]->time_fadc, 0.200, SYS_TAGM);
+        }
+        else {
+            gamma->setTime(tagm_hits[ih]->t);
+            gamma->setT0(tagm_hits[ih]->t, 0.200, SYS_TAGM);
+        }
+        gamma->AddAssociatedObject(tagm_hits[ih]);
+        _data.push_back(gamma);
+    }
 
-	vector<const DTAGHHit*> tagh_hits;
-	locEventLoop->Get(tagh_hits);
+    vector<const DTAGHHit*> tagh_hits;
+    locEventLoop->Get(tagh_hits);
 
-	for (unsigned int ih=0; ih < tagh_hits.size(); ++ih)
-	{
-	        if (!tagh_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)
-		DVector3 mom(0.0, 0.0, tagh_hits[ih]->E);
-		DBeamPhoton *gamma = new DBeamPhoton;
-		gamma->setPID(Gamma);
-		gamma->setMomentum(mom);
-		gamma->setPosition(pos);
-		gamma->setCharge(0);
-		gamma->setMass(0);
-		gamma->setTime(tagh_hits[ih]->t);
-		gamma->setT0(tagh_hits[ih]->t, 0.350, SYS_TAGH);
-		gamma->AddAssociatedObject(tagh_hits[ih]);
-		_data.push_back(gamma);
-	}
+    for (unsigned int ih=0; ih < tagh_hits.size(); ++ih)
+    {
+        if (!tagh_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)
+        if (tagh_hits[ih]->pulse_peak < TAGH_PEAK_CUT) continue; // Cut on TAGH pulse height
+        DVector3 mom(0.0, 0.0, tagh_hits[ih]->E);
+        DBeamPhoton *gamma = new DBeamPhoton;
+        gamma->setPID(Gamma);
+        gamma->setMomentum(mom);
+        gamma->setPosition(pos);
+        gamma->setCharge(0);
+        gamma->setMass(0);
+        if (TAGH_USE_ADC) {
+            gamma->setTime(tagh_hits[ih]->time_fadc);
+            gamma->setT0(tagh_hits[ih]->time_fadc, 0.350, SYS_TAGH);
+        }
+        else  {
+            gamma->setTime(tagh_hits[ih]->t);
+            gamma->setT0(tagh_hits[ih]->t, 0.350, SYS_TAGH);
+        }
+        gamma->AddAssociatedObject(tagh_hits[ih]);
+        _data.push_back(gamma);
+    }
 
-	return NOERROR;
+    return NOERROR;
 }
 
 //------------------
@@ -86,7 +111,7 @@ jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t even
 //------------------
 jerror_t DBeamPhoton_factory::erun(void)
 {
-	return NOERROR;
+    return NOERROR;
 }
 
 //------------------
@@ -94,6 +119,6 @@ jerror_t DBeamPhoton_factory::erun(void)
 //------------------
 jerror_t DBeamPhoton_factory::fini(void)
 {
-	return NOERROR;
+    return NOERROR;
 }
 

--- a/src/libraries/PID/DBeamPhoton_factory.cc
+++ b/src/libraries/PID/DBeamPhoton_factory.cc
@@ -17,17 +17,6 @@ using namespace jana;
 //------------------
 jerror_t DBeamPhoton_factory::init(void)
 {
-    TAGM_PEAK_CUT=0;
-    TAGH_PEAK_CUT=0;
-    TAGM_USE_ADC=0;
-    TAGH_USE_ADC=0;
-
-    if (gPARMS){
-        gPARMS->SetDefaultParameter("BEAMPHOTON:TAGM_PEAK_CUT", TAGM_PEAK_CUT, "TAGM pulse height cut [ADC Counts]");
-        gPARMS->SetDefaultParameter("BEAMPHOTON:TAGH_PEAK_CUT", TAGH_PEAK_CUT, "TAGH pulse height cut [ADC Counts]");
-        gPARMS->SetDefaultParameter("BEAMPHOTON:TAGM_USE_ADC", TAGM_USE_ADC, "Use ADC times in TAGM");
-        gPARMS->SetDefaultParameter("BEAMPHOTON:TAGH_USE_ADC", TAGH_USE_ADC, "Use ADC times in TAGH");
-    }
     return NOERROR;
 }
 
@@ -57,7 +46,6 @@ jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t even
     for (unsigned int ih=0; ih < tagm_hits.size(); ++ih)
     {
         if (!tagm_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)		
-        if (tagm_hits[ih]->pulse_peak < TAGM_PEAK_CUT) continue; // Cut on TAGM pulse height
         DVector3 mom(0.0, 0.0, tagm_hits[ih]->E);
         DBeamPhoton *gamma = new DBeamPhoton;
         gamma->setPID(Gamma);
@@ -65,14 +53,8 @@ jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t even
         gamma->setPosition(pos);
         gamma->setCharge(0);
         gamma->setMass(0);
-        if (TAGM_USE_ADC) {
-            gamma->setTime(tagm_hits[ih]->time_fadc);
-            gamma->setT0(tagm_hits[ih]->time_fadc, 0.200, SYS_TAGM);
-        }
-        else {
-            gamma->setTime(tagm_hits[ih]->t);
-            gamma->setT0(tagm_hits[ih]->t, 0.200, SYS_TAGM);
-        }
+        gamma->setTime(tagm_hits[ih]->t);
+        gamma->setT0(tagm_hits[ih]->t, 0.200, SYS_TAGM);
         gamma->AddAssociatedObject(tagm_hits[ih]);
         _data.push_back(gamma);
     }
@@ -83,7 +65,6 @@ jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t even
     for (unsigned int ih=0; ih < tagh_hits.size(); ++ih)
     {
         if (!tagh_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)
-        if (tagh_hits[ih]->pulse_peak < TAGH_PEAK_CUT) continue; // Cut on TAGH pulse height
         DVector3 mom(0.0, 0.0, tagh_hits[ih]->E);
         DBeamPhoton *gamma = new DBeamPhoton;
         gamma->setPID(Gamma);
@@ -91,14 +72,8 @@ jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t even
         gamma->setPosition(pos);
         gamma->setCharge(0);
         gamma->setMass(0);
-        if (TAGH_USE_ADC) {
-            gamma->setTime(tagh_hits[ih]->time_fadc);
-            gamma->setT0(tagh_hits[ih]->time_fadc, 0.350, SYS_TAGH);
-        }
-        else  {
-            gamma->setTime(tagh_hits[ih]->t);
-            gamma->setT0(tagh_hits[ih]->t, 0.350, SYS_TAGH);
-        }
+        gamma->setTime(tagh_hits[ih]->t);
+        gamma->setT0(tagh_hits[ih]->t, 0.350, SYS_TAGH);
         gamma->AddAssociatedObject(tagh_hits[ih]);
         _data.push_back(gamma);
     }

--- a/src/libraries/PID/DBeamPhoton_factory.h
+++ b/src/libraries/PID/DBeamPhoton_factory.h
@@ -27,6 +27,7 @@ class DBeamPhoton_factory:public jana::JFactory<DBeamPhoton>{
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
 		double dTargetCenterZ;
+        int TAGM_PEAK_CUT, TAGH_PEAK_CUT, TAGM_USE_ADC, TAGH_USE_ADC;
 };
 
 #endif // _DBeamPhoton_factory_

--- a/src/libraries/PID/DBeamPhoton_factory.h
+++ b/src/libraries/PID/DBeamPhoton_factory.h
@@ -27,7 +27,6 @@ class DBeamPhoton_factory:public jana::JFactory<DBeamPhoton>{
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
 		double dTargetCenterZ;
-        int TAGM_PEAK_CUT, TAGH_PEAK_CUT, TAGM_USE_ADC, TAGH_USE_ADC;
 };
 
 #endif // _DBeamPhoton_factory_

--- a/src/libraries/TAGGER/DTAGMHit_factory.h
+++ b/src/libraries/TAGGER/DTAGMHit_factory.h
@@ -29,6 +29,7 @@ class DTAGMHit_factory: public jana::JFactory<DTAGMHit> {
 
       // config. parameter
       double DELTA_T_ADC_TDC_MAX; 
+      int USE_ADC, PEAK_CUT;
 
       // overall scale factors
       double fadc_a_scale;  // pixels per fADC pulse integral count


### PR DESCRIPTION
- Optional creation of DBeamPhotons with TAGH or TAGM fADC times only by command line option. 
- Command line cut on TAGM or TAGH pulse height in DBeamPhoton creation.
