### PR TITLE
Tracking ids

### DIFF
--- a/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.cc
+++ b/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.cc
@@ -45,8 +45,8 @@ jerror_t DParticleComboBlueprint_factory::init(void)
 
 	string MASS_HYPOTHESES_POSITIVE = locMassStream_Positive.str();
 	string MASS_HYPOTHESES_NEGATIVE = locMassStream_Negative.str();
-	gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_POSITIVE", MASS_HYPOTHESES_POSITIVE);
-	gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_NEGATIVE", MASS_HYPOTHESES_NEGATIVE);
+	gPARMS->SetDefaultParameter("TRKFIT:HYPOTHESES_POSITIVE", MASS_HYPOTHESES_POSITIVE);
+	gPARMS->SetDefaultParameter("TRKFIT:HYPOTHESES_NEGATIVE", MASS_HYPOTHESES_NEGATIVE);
 
 	// Parse MASS_HYPOTHESES strings to make list of masses to try
 	SplitString(MASS_HYPOTHESES_POSITIVE, mass_hypotheses_positive, ",");

--- a/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.cc
+++ b/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.cc
@@ -21,11 +21,45 @@ jerror_t DParticleComboBlueprint_factory::init(void)
 
 	dMaxExtraGoodTracks = pair<bool, size_t>(false, 4);
 
-	dAvailablePIDs.insert(Proton);
-	dAvailablePIDs.insert(KPlus);
-	dAvailablePIDs.insert(PiPlus);
-	dAvailablePIDs.insert(KMinus);
-	dAvailablePIDs.insert(PiMinus);
+	vector<int> mass_hypotheses_positive, mass_hypotheses_negative;
+	mass_hypotheses_positive.push_back(PiPlus);
+	mass_hypotheses_positive.push_back(KPlus);
+	mass_hypotheses_positive.push_back(Proton);
+
+	mass_hypotheses_negative.push_back(PiMinus);
+	mass_hypotheses_negative.push_back(KMinus);
+
+	ostringstream locMassStream_Positive, locMassStream_Negative;
+	for(size_t loc_i = 0; loc_i < mass_hypotheses_positive.size(); ++loc_i)
+	{
+		locMassStream_Positive << mass_hypotheses_positive[loc_i];
+		if(loc_i != (mass_hypotheses_positive.size() - 1))
+			locMassStream_Positive << ", ";
+	}
+	for(size_t loc_i = 0; loc_i < mass_hypotheses_negative.size(); ++loc_i)
+	{
+		locMassStream_Negative << mass_hypotheses_negative[loc_i];
+		if(loc_i != (mass_hypotheses_negative.size() - 1))
+			locMassStream_Negative << ", ";
+	}
+
+	string MASS_HYPOTHESES_POSITIVE = locMassStream_Positive.str();
+	string MASS_HYPOTHESES_NEGATIVE = locMassStream_Negative.str();
+	gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_POSITIVE", MASS_HYPOTHESES_POSITIVE);
+	gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_NEGATIVE", MASS_HYPOTHESES_NEGATIVE);
+
+	// Parse MASS_HYPOTHESES strings to make list of masses to try
+	SplitString(MASS_HYPOTHESES_POSITIVE, mass_hypotheses_positive, ",");
+	SplitString(MASS_HYPOTHESES_NEGATIVE, mass_hypotheses_negative, ",");
+	if(mass_hypotheses_positive.empty())
+		mass_hypotheses_positive.push_back(Unknown); // If empty string is specified, assume they want massless particle
+	if(mass_hypotheses_negative.empty())
+		mass_hypotheses_negative.push_back(Unknown); // If empty string is specified, assume they want massless particle
+
+	for(size_t loc_i = 0; loc_i < mass_hypotheses_positive.size(); ++loc_i)
+		dAvailablePIDs.insert(Particle_t(mass_hypotheses_positive[loc_i]));
+	for(size_t loc_i = 0; loc_i < mass_hypotheses_negative.size(); ++loc_i)
+		dAvailablePIDs.insert(Particle_t(mass_hypotheses_negative[loc_i]));
 
 	return NOERROR;
 }

--- a/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.h
+++ b/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.h
@@ -9,6 +9,7 @@
 
 #include <JANA/JObject.h>
 #include <particleType.h>
+#include <SplitString.h>
 #include <PID/DChargedTrack.h>
 #include <PID/DNeutralShower.h>
 #include <PID/DVertex.h>
@@ -16,6 +17,7 @@
 
 #include <deque>
 #include <map>
+#include <set>
 #include <vector>
 
 using namespace std;

--- a/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.cc
+++ b/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.cc
@@ -103,8 +103,8 @@ jerror_t DTrackTimeBased_factory_Combo::init(void)
 
 	string MASS_HYPOTHESES_POSITIVE = locMassStream_Positive.str();
 	string MASS_HYPOTHESES_NEGATIVE = locMassStream_Negative.str();
-	gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_POSITIVE", MASS_HYPOTHESES_POSITIVE);
-	gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_NEGATIVE", MASS_HYPOTHESES_NEGATIVE);
+	gPARMS->SetDefaultParameter("TRKFIT:HYPOTHESES_POSITIVE", MASS_HYPOTHESES_POSITIVE);
+	gPARMS->SetDefaultParameter("TRKFIT:HYPOTHESES_NEGATIVE", MASS_HYPOTHESES_NEGATIVE);
 
 	// Parse MASS_HYPOTHESES strings to make list of masses to try
 	SplitString(MASS_HYPOTHESES_POSITIVE, mass_hypotheses_positive, ",");

--- a/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.cc
+++ b/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.cc
@@ -79,11 +79,45 @@ jerror_t DTrackTimeBased_factory_Combo::init(void)
 	locPIDDeque[0] = Proton;  locPIDDeque[1] = KPlus;  locPIDDeque[2] = PiPlus;
 	dParticleIDsToTry[Deuteron] = locPIDDeque;
 
-	dAvailablePIDs.insert(Proton);
-	dAvailablePIDs.insert(KPlus);
-	dAvailablePIDs.insert(PiPlus);
-	dAvailablePIDs.insert(KMinus);
-	dAvailablePIDs.insert(PiMinus);
+	vector<int> mass_hypotheses_positive, mass_hypotheses_negative;
+	mass_hypotheses_positive.push_back(PiPlus);
+	mass_hypotheses_positive.push_back(KPlus);
+	mass_hypotheses_positive.push_back(Proton);
+
+	mass_hypotheses_negative.push_back(PiMinus);
+	mass_hypotheses_negative.push_back(KMinus);
+
+	ostringstream locMassStream_Positive, locMassStream_Negative;
+	for(size_t loc_i = 0; loc_i < mass_hypotheses_positive.size(); ++loc_i)
+	{
+		locMassStream_Positive << mass_hypotheses_positive[loc_i];
+		if(loc_i != (mass_hypotheses_positive.size() - 1))
+			locMassStream_Positive << ", ";
+	}
+	for(size_t loc_i = 0; loc_i < mass_hypotheses_negative.size(); ++loc_i)
+	{
+		locMassStream_Negative << mass_hypotheses_negative[loc_i];
+		if(loc_i != (mass_hypotheses_negative.size() - 1))
+			locMassStream_Negative << ", ";
+	}
+
+	string MASS_HYPOTHESES_POSITIVE = locMassStream_Positive.str();
+	string MASS_HYPOTHESES_NEGATIVE = locMassStream_Negative.str();
+	gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_POSITIVE", MASS_HYPOTHESES_POSITIVE);
+	gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_NEGATIVE", MASS_HYPOTHESES_NEGATIVE);
+
+	// Parse MASS_HYPOTHESES strings to make list of masses to try
+	SplitString(MASS_HYPOTHESES_POSITIVE, mass_hypotheses_positive, ",");
+	SplitString(MASS_HYPOTHESES_NEGATIVE, mass_hypotheses_negative, ",");
+	if(mass_hypotheses_positive.empty())
+		mass_hypotheses_positive.push_back(Unknown); // If empty string is specified, assume they want massless particle
+	if(mass_hypotheses_negative.empty())
+		mass_hypotheses_negative.push_back(Unknown); // If empty string is specified, assume they want massless particle
+
+	for(size_t loc_i = 0; loc_i < mass_hypotheses_positive.size(); ++loc_i)
+		dAvailablePIDs.insert(Particle_t(mass_hypotheses_positive[loc_i]));
+	for(size_t loc_i = 0; loc_i < mass_hypotheses_negative.size(); ++loc_i)
+		dAvailablePIDs.insert(Particle_t(mass_hypotheses_negative[loc_i]));
 
 	return NOERROR;
 }

--- a/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.h
+++ b/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.h
@@ -10,9 +10,12 @@
 
 #include <iostream>
 #include <deque>
+#include <vector>
+#include <set>
 
 #include "JANA/JFactory.h"
 #include "particleType.h"
+#include "SplitString.h"
 
 #include "TRACKING/DTrackTimeBased.h"
 

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -116,8 +116,8 @@ jerror_t DTrackTimeBased_factory::init(void)
 
 	string MASS_HYPOTHESES_POSITIVE = locMassStream_Positive.str();
 	string MASS_HYPOTHESES_NEGATIVE = locMassStream_Negative.str();
-	gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_POSITIVE", MASS_HYPOTHESES_POSITIVE);
-	gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_NEGATIVE", MASS_HYPOTHESES_NEGATIVE);
+	gPARMS->SetDefaultParameter("TRKFIT:HYPOTHESES_POSITIVE", MASS_HYPOTHESES_POSITIVE);
+	gPARMS->SetDefaultParameter("TRKFIT:HYPOTHESES_NEGATIVE", MASS_HYPOTHESES_NEGATIVE);
 	
 	// Parse MASS_HYPOTHESES strings to make list of masses to try
 	SplitString(MASS_HYPOTHESES_POSITIVE, mass_hypotheses_positive, ",");

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.h
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.h
@@ -57,8 +57,8 @@ class DTrackTimeBased_factory:public jana::JFactory<DTrackTimeBased>{
   DTrackFitter *fitter;
   const DParticleID* pid_algorithm;
   vector<DReferenceTrajectory*> rtv;	
-  vector<double> mass_hypotheses_positive;
-  vector<double> mass_hypotheses_negative;
+  vector<int> mass_hypotheses_positive;
+  vector<int> mass_hypotheses_negative;
   size_t MAX_DReferenceTrajectoryPoolSize;
 
  

--- a/src/libraries/TRACKING/DTrackWireBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackWireBased_factory.cc
@@ -105,8 +105,8 @@ jerror_t DTrackWireBased_factory::init(void)
 
 		string MASS_HYPOTHESES_POSITIVE = locMassStream_Positive.str();
 		string MASS_HYPOTHESES_NEGATIVE = locMassStream_Negative.str();
-		gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_POSITIVE", MASS_HYPOTHESES_POSITIVE);
-		gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_NEGATIVE", MASS_HYPOTHESES_NEGATIVE);
+		gPARMS->SetDefaultParameter("TRKFIT:HYPOTHESES_POSITIVE", MASS_HYPOTHESES_POSITIVE);
+		gPARMS->SetDefaultParameter("TRKFIT:HYPOTHESES_NEGATIVE", MASS_HYPOTHESES_NEGATIVE);
 
 		// Parse MASS_HYPOTHESES strings to make list of masses to try
 		SplitString(MASS_HYPOTHESES_POSITIVE, mass_hypotheses_positive, ",");

--- a/src/libraries/TRACKING/DTrackWireBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackWireBased_factory.cc
@@ -80,7 +80,44 @@ jerror_t DTrackWireBased_factory::init(void)
     COSMICS=false;
     gPARMS->SetDefaultParameter("TRKFIND:COSMICS",COSMICS);
 
-	return NOERROR;
+	if(!SKIP_MASS_HYPOTHESES_WIRE_BASED)
+	{
+		mass_hypotheses_positive.push_back(PiPlus);
+		mass_hypotheses_positive.push_back(KPlus);
+		mass_hypotheses_positive.push_back(Proton);
+
+		mass_hypotheses_negative.push_back(PiMinus);
+		mass_hypotheses_negative.push_back(KMinus);
+
+		ostringstream locMassStream_Positive, locMassStream_Negative;
+		for(size_t loc_i = 0; loc_i < mass_hypotheses_positive.size(); ++loc_i)
+		{
+			locMassStream_Positive << mass_hypotheses_positive[loc_i];
+			if(loc_i != (mass_hypotheses_positive.size() - 1))
+				locMassStream_Positive << ", ";
+		}
+		for(size_t loc_i = 0; loc_i < mass_hypotheses_negative.size(); ++loc_i)
+		{
+			locMassStream_Negative << mass_hypotheses_negative[loc_i];
+			if(loc_i != (mass_hypotheses_negative.size() - 1))
+				locMassStream_Negative << ", ";
+		}
+
+		string MASS_HYPOTHESES_POSITIVE = locMassStream_Positive.str();
+		string MASS_HYPOTHESES_NEGATIVE = locMassStream_Negative.str();
+		gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_POSITIVE", MASS_HYPOTHESES_POSITIVE);
+		gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_NEGATIVE", MASS_HYPOTHESES_NEGATIVE);
+
+		// Parse MASS_HYPOTHESES strings to make list of masses to try
+		SplitString(MASS_HYPOTHESES_POSITIVE, mass_hypotheses_positive, ",");
+		SplitString(MASS_HYPOTHESES_NEGATIVE, mass_hypotheses_negative, ",");
+		if(mass_hypotheses_positive.empty())
+			mass_hypotheses_positive.push_back(Unknown); // If empty string is specified, assume they want massless particle
+		if(mass_hypotheses_negative.empty())
+			mass_hypotheses_negative.push_back(Unknown); // If empty string is specified, assume they want massless particle
+	}
+
+    return NOERROR;
 }
 
 //------------------
@@ -121,24 +158,6 @@ jerror_t DTrackWireBased_factory::brun(jana::JEventLoop *loop, int32_t runnumber
   MIN_FIT_P = 0.050; // GeV
   gPARMS->SetDefaultParameter("TRKFIT:MIN_FIT_P", MIN_FIT_P, "Minimum fit momentum in GeV/c for fit to be considered successful");
   
-  if (SKIP_MASS_HYPOTHESES_WIRE_BASED==false){
-
-	ostringstream locMassStream_Positive, locMassStream_Negative;
-	locMassStream_Positive << ParticleMass(PiPlus) << "," << ParticleMass(KPlus) << "," << ParticleMass(Proton);
-	locMassStream_Negative << ParticleMass(PiMinus) << "," << ParticleMass(KMinus);
-	string MASS_HYPOTHESES_POSITIVE = locMassStream_Positive.str();
-	string MASS_HYPOTHESES_NEGATIVE = locMassStream_Negative.str();
-	gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_POSITIVE", MASS_HYPOTHESES_POSITIVE);
-	gPARMS->SetDefaultParameter("TRKFIT:MASS_HYPOTHESES_NEGATIVE", MASS_HYPOTHESES_NEGATIVE);
-
-	// Parse MASS_HYPOTHESES strings to make list of masses to try
-	SplitString(MASS_HYPOTHESES_POSITIVE, mass_hypotheses_positive, ",");
-	SplitString(MASS_HYPOTHESES_NEGATIVE, mass_hypotheses_negative, ",");
-	if(mass_hypotheses_positive.size()==0)mass_hypotheses_positive.push_back(0.0); // If empty string is specified, assume they want massless particle
-	if(mass_hypotheses_negative.size()==0)mass_hypotheses_negative.push_back(0.0); // If empty string is specified, assume they want massless particle
-
-	
-  }
 	if(DEBUG_HISTS){
 	  dapp->Lock();
 	  
@@ -274,7 +293,7 @@ jerror_t DTrackWireBased_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
     }
     else{
       // Choose list of mass hypotheses based on charge of candidate
-      vector<double> mass_hypotheses;
+      vector<int> mass_hypotheses;
       if(candidate->charge()<0.0){
 	mass_hypotheses = mass_hypotheses_negative;
       }else{
@@ -286,7 +305,7 @@ jerror_t DTrackWireBased_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 
       // Loop over potential particle masses
       for(unsigned int j=0; j<mass_hypotheses.size(); j++){
-        if(DEBUG_LEVEL>1){_DBG__;_DBG_<<"---- Starting wire based fit with mass: "<<mass_hypotheses[j]<<endl;}
+        if(DEBUG_LEVEL>1){_DBG__;_DBG_<<"---- Starting wire based fit with id: "<<mass_hypotheses[j]<<endl;}
 	// Make sure there are enough DReferenceTrajectory objects
 	unsigned int locNumInitialReferenceTrajectories = rtv.size();
 	while(rtv.size()<=num_used_rts){
@@ -302,7 +321,7 @@ jerror_t DTrackWireBased_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 	// Increment the number of used reference trajectories
 	num_used_rts++;
 
-        DoFit(i,candidate,rt,loop,mass_hypotheses[j]);
+        DoFit(i,candidate,rt,loop,ParticleMass(Particle_t(mass_hypotheses[j])));
       }
    
     }

--- a/src/libraries/TRACKING/DTrackWireBased_factory.h
+++ b/src/libraries/TRACKING/DTrackWireBased_factory.h
@@ -65,8 +65,8 @@ class DTrackWireBased_factory:public jana::JFactory<DTrackWireBased>{
 		vector<DReferenceTrajectory*> rtv;
 
 		unsigned int num_used_rts;
-		vector<double> mass_hypotheses_positive;
-		vector<double> mass_hypotheses_negative;
+		vector<int> mass_hypotheses_positive;
+		vector<int> mass_hypotheses_negative;
 		size_t MAX_DReferenceTrajectoryPoolSize;
 
 		void FilterDuplicates(void);

--- a/src/libraries/include/SplitString.h
+++ b/src/libraries/include/SplitString.h
@@ -1,3 +1,5 @@
+#ifndef _SplitString_
+#define _SplitString_
 
 #include <sstream>
 
@@ -23,3 +25,4 @@ void SplitString(string str, vector<T> &vec, const string &delim=" ")
 	}
 }
 
+#endif


### PR DESCRIPTION
When specifying mass hypotheses to use during tracking on the command line: 

Command line argument changed from TRKFIT:MASS_HYPOTHESES_\* to TRKFIT:HYPOTHESES_\* 

It now uses GEANT PIDs (the Particle_t enum ints) instead of masses. 
This makes them easier to work with in the analysis library.

In analysis library: Now look at command line input to see which PIDs were used for reconstruction. This is necessary to make sure that hypotheses are not recreated for ones that failed pre-select cuts.

So, if the above command-line options were used during reconstruction, they should be used during analysis as well.  
