### PR TITLE
CDC QF and PID out of time cut

### DIFF
--- a/src/libraries/CDC/DCDCHit_factory.cc
+++ b/src/libraries/CDC/DCDCHit_factory.cc
@@ -184,6 +184,8 @@ jerror_t DCDCHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
     for (unsigned int i=0; i < digihits.size(); i++) {
         const DCDCDigiHit *digihit = digihits[i];
 
+        if ( digihit->QF != 0 ) continue; // Cut bad quality factor hits... (should check effect on efficiency)
+
         const int &ring  = digihit->ring;
         const int &straw = digihit->straw;
 
@@ -210,9 +212,9 @@ jerror_t DCDCHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 
         // There are a few values from the new data type that are critical for the interpretation of the data
         uint16_t IBIT = 0; // 2^{IBIT} Scale factor for integral
-//        uint16_t ABIT = 0; // 2^{ABIT} Scale factor for amplitude
+        //        uint16_t ABIT = 0; // 2^{ABIT} Scale factor for amplitude
         uint16_t PBIT = 0; // 2^{PBIT} Scale factor for pedestal
-		  uint16_t NW   = 0;
+        uint16_t NW   = 0;
 
         // This is the place to make quality cuts on the data. 
         // Try to get the new data type, if that fails, try to get the old...
@@ -223,25 +225,25 @@ jerror_t DCDCHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
             CDCPulseObj->GetSingle(config);
 
             // Set some constants to defaults until they appear correctly in the config words in the future
-				if(config){
-            	IBIT = config->IBIT == 0xffff ? 4 : config->IBIT;
-//            ABIT = config->ABIT == 0xffff ? 3 : config->ABIT;
-           		PBIT = config->PBIT == 0xffff ? 0 : config->PBIT;
-            	NW   = config->NW   == 0xffff ? 180 : config->NW;
-				}else{
-					static int Nwarnings = 0;
-					if(Nwarnings<10){
-						_DBG_ << "NO Df125Config object associated with Df125FDCPulse object!" << endl;
-						Nwarnings++;
-						if(Nwarnings==10) _DBG_ << " --- LAST WARNING!! ---" << endl;
-					}
-				}
-				if(NW==0) NW=180; // some data was taken (<=run 4700) where NW was written as 0 to file
-            
+            if(config){
+                IBIT = config->IBIT == 0xffff ? 4 : config->IBIT;
+                //            ABIT = config->ABIT == 0xffff ? 3 : config->ABIT;
+                PBIT = config->PBIT == 0xffff ? 0 : config->PBIT;
+                NW   = config->NW   == 0xffff ? 180 : config->NW;
+            }else{
+                static int Nwarnings = 0;
+                if(Nwarnings<10){
+                    _DBG_ << "NO Df125Config object associated with Df125FDCPulse object!" << endl;
+                    Nwarnings++;
+                    if(Nwarnings==10) _DBG_ << " --- LAST WARNING!! ---" << endl;
+                }
+            }
+            if(NW==0) NW=180; // some data was taken (<=run 4700) where NW was written as 0 to file
+
             // The integration window in the CDC should always extend past the end of the window
             // Only true after about run 4100
             nsamples_integral = (NW - (digihit->pulse_time / 10));  
-            
+
         }
         else{ // Use the old format
             // This code will at some point become deprecated in the future...

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -33,7 +33,7 @@ DParticleID::DParticleID(JEventLoop *loop)
 
 	C_EFFECTIVE = 15.0;
 	ATTEN_LENGTH = 150.0;
-	OUT_OF_TIME_CUT = 200.0;
+	OUT_OF_TIME_CUT = 35.0; // Changed 200 -> 35 ns, March 2016
     gPARMS->SetDefaultParameter("PID:OUT_OF_TIME_CUT",OUT_OF_TIME_CUT);
 
   DApplication* dapp = dynamic_cast<DApplication*>(loop->GetJApplication());


### PR DESCRIPTION
- Reject hits with quality factor != 0 in the CDC
- Change default PID out of time cut from 200 ns to 35 ns since this was too loose for accurate t0 determination. This could probably still be tighter. 35 was chosen to allow cases where the TDC times are shifted by 32ns that show up in some runs.
