### PR TITLE
Improvements to BcalDisp

### DIFF
--- a/src/programs/Analysis/hdview2/MyProcessor.h
+++ b/src/programs/Analysis/hdview2/MyProcessor.h
@@ -119,6 +119,8 @@ class MyProcessor:public JEventProcessor
   TH2F *BCALHitMatrixU;
   TH2F *BCALHitMatrixD;
   TH2F *BCALParticles;
+  TH2F *BCALPointZphiLayer[4];
+  TLegend *LayerLegend;
   vector <TText*> BCALPLables;
   
   

--- a/src/programs/Analysis/hdview2/MyProcessor.h
+++ b/src/programs/Analysis/hdview2/MyProcessor.h
@@ -101,7 +101,8 @@ class MyProcessor:public JEventProcessor
   void GetDReferenceTrajectory(string dataname, string tag, 
 			       unsigned int index, DReferenceTrajectory* &rt, vector<const DCDCTrackHit*> &cdchits);
   void GetAllWireHits(vector<pair<const DCoordinateSystem*,double> > &allhits);
-  
+  void FormatHistogram(TH2*, int);
+
  private:	
   
   hdv_mainframe *hdvmf;
@@ -115,13 +116,17 @@ class MyProcessor:public JEventProcessor
   double RMAX_INTERIOR; // Used to allow user to extend drawing range of charged tracks
   double RMAX_EXTERIOR; // Used to allow user to extend drawing range of charged tracks
 
+  uint32_t BCALVERBOSE;
   TCanvas *BCALHitCanvas;  
   TH2F *BCALHitMatrixU;
   TH2F *BCALHitMatrixD;
   TH2F *BCALParticles;
-  TH2F *BCALPointZphiLayer[4];
-  TLegend *LayerLegend;
   vector <TText*> BCALPLables;
+  TH2F *BCALPointZphiLayer[4];
+  TH2F *BCALPointPhiTLayer[4];
+  std::vector<TH2F*> BCALClusterZphiHistos;
+  TLegend *LayerLegend;
+  TLegend *ClusterLegend;
   
   
   map<string, double> photon_track_matching;

--- a/src/programs/Analysis/hdview2/hdv_mainframe.cc
+++ b/src/programs/Analysis/hdview2/hdv_mainframe.cc
@@ -924,8 +924,7 @@ void hdv_mainframe::DoOpenDebugerWindow(void)
 void hdv_mainframe::DoBcalDispFrame(void)
 {
 	if(bcaldispmf==NULL){
-		bcaldispmf = new TCanvas("BCALHitCanvas", "BCAL Hit Distribution", 1000, 600);
-		bcaldispmf->Divide(1,2);
+		bcaldispmf = new TCanvas("BCALHitCanvas", "BCAL Hit Distribution", 900, 900);
 	}
 
 	DoUpdateBcalDisp();
@@ -2118,9 +2117,6 @@ void hdv_mainframe::SetTrig(char *trigstring)
 {
 	if(!event)return;
 
-	//stringstream ss;
-	//ss << trig;
-	//trig->SetTitle(ss.str().c_str());
 	trig->SetTitle(trigstring);
 	trig->Draw();
 }


### PR DESCRIPTION
Added new histogram to BCAL window to see Points in (Z,phi) coordinates

Created new histograms for showing the position of the Points from individual clusters.
Created new histograms for showing the time of the points.
Original histograms are still created but not plotted.
Added parameter to print output of BCAL objects. -PBCALVERBOSE=2 for the most info
Small improvements to existing histograms.
