### PR TITLE
CDC quality factor cut

### DIFF
--- a/src/libraries/CDC/DCDCHit_factory.cc
+++ b/src/libraries/CDC/DCDCHit_factory.cc
@@ -184,7 +184,7 @@ jerror_t DCDCHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
     for (unsigned int i=0; i < digihits.size(); i++) {
         const DCDCDigiHit *digihit = digihits[i];
 
-        if ( digihit->QF != 0 ) continue; // Cut bad quality factor hits... (should check effect on efficiency)
+        if ( (digihit->QF & 0x1) != 0 ) continue; // Cut bad timing quality factor hits... (should check effect on efficiency)
 
         const int &ring  = digihit->ring;
         const int &straw = digihit->straw;


### PR DESCRIPTION
Use only first bit (timing qf) for quality factor cut. The rest of the bits reflect the number of overflow samples. Do not cut on these.
