### PR TITLE
Fdc pseudo and cathode timing fix

### DIFF
--- a/src/libraries/FDC/DFDCCathodeCluster_factory.cc
+++ b/src/libraries/FDC/DFDCCathodeCluster_factory.cc
@@ -78,7 +78,7 @@ DFDCCathodeCluster_factory::~DFDCCathodeCluster_factory() {
 /// Initialization
 ///
 jerror_t DFDCCathodeCluster_factory::init(void){
-  TIME_SLICE=10.0; //ns
+  TIME_SLICE=100.0; //ns,  Changed from 10->100 4/7/16 SJT
   gPARMS->SetDefaultParameter("FDC:CLUSTER_TIME_SLICE",TIME_SLICE);
   return NOERROR;	
 }


### PR DESCRIPTION
Fixes inefficiency (in terms of cpu cycles)  in computing centroids when making pseudopoints.
Increases "time slice" cut when grouping adjacent strip hits.
