### PR TITLE
Update DTPOLHit/monitoring for current run period

### DIFF
--- a/src/libraries/TPOL/DTPOLHit.h
+++ b/src/libraries/TPOL/DTPOLHit.h
@@ -9,7 +9,9 @@ public:
     JOBJECT_PUBLIC(DTPOLHit);
 
     int sector;    // sector number 1-32
+    double phi;
     int ring;      // ring number 1-24
+    double theta;
     double pulse_peak;
     double integral;
     double dE;     // Energy loss in keV
@@ -17,7 +19,9 @@ public:
 
     void toStrings(vector<pair<string,string> > &items)const{
         AddString(items, "sector", "%d", sector);
+        AddString(items, "phi", "%3.3f", phi);
         AddString(items, "ring", "%d", ring);
+        AddString(items, "theta", "%3.3f", theta);
         AddString(items, "pulse_peak", "%3.3f", pulse_peak);
         AddString(items, "integral", "%3.3f", integral);
         AddString(items, "dE", "%3.3f", dE);

--- a/src/libraries/TPOL/DTPOLHit_factory.h
+++ b/src/libraries/TPOL/DTPOLHit_factory.h
@@ -36,6 +36,9 @@ public:
     double HIT_TIME_WINDOW;
     double ADC_THRESHOLD;
 
+    int GetSector(int slot,int channel);
+    double GetPhi(int sector);
+    double GetPulseTime(const vector<uint16_t> waveform,double w_min,double w_max,double minpeakheight);
     DTPOLHit* FindMatch(int sector, double T);
     const double GetConstant(const vector<double>  &the_table,const int in_sector) const;
     const double GetConstant(const vector<double>  &the_table,const DTPOLHit *the_hit) const;

--- a/src/plugins/Calibration/TAGH_timewalk/scripts/gaussian_fits.C
+++ b/src/plugins/Calibration/TAGH_timewalk/scripts/gaussian_fits.C
@@ -42,7 +42,7 @@ void WriteGaussianFitResults(ofstream &fout,TH1 *h,int counter,int ph_bin) {
     // f1: fraction of entries in first gaussian
     RooRealVar f1("f1","f1",0.75,0.01,1.);
     RooAddPdf doubleGauss("doubleGauss","doubleGauss",RooArgList(gauss1,gauss2),RooArgList(f1));
-    doubleGauss.fitTo(data);
+    doubleGauss.fitTo(data,PrintLevel(-1));
     // make plot
     TCanvas *canvas = new TCanvas("c","c",800,500);
     RooPlot *plot = x.frame();

--- a/src/plugins/monitoring/PSPair_online/JEventProcessor_PSPair_online.cc
+++ b/src/plugins/monitoring/PSPair_online/JEventProcessor_PSPair_online.cc
@@ -18,6 +18,8 @@ using namespace jana;
 #include <TAGGER/DTAGHGeometry.h>
 #include <TAGGER/DTAGMHit.h>
 #include <TAGGER/DTAGMGeometry.h>
+#include <TPOL/DTPOLHit.h>
+#include <TPOL/DTPOLHit_factory.h>
 
 #include <JANA/JApplication.h>
 #include <JANA/JFactory.h>
@@ -31,6 +33,7 @@ const int NC_PSC = DPSGeometry::NUM_COARSE_COLUMNS; // 8: number of PSC modules 
 const int NC_PS = DPSGeometry::NUM_FINE_COLUMNS; // 145: number of PS columns (tiles) per arm
 const int NC_TAGH = DTAGHGeometry::kCounterCount; // 274: number of TAGH counters
 const int NC_TAGM = DTAGMGeometry::kColumnCount; // 102: number of TAGM columns
+const int NS_TPOL = DTPOLHit_factory::NSECTORS; // 32: number of TPOL sectors
 // root hist pointers
 static TH1I *hPSC_NHitPairs;
 static TH1I *hPS_NHitPairs;
@@ -44,6 +47,7 @@ static TH2F *hPS_PSCIDLeftVsIDRight;
 static TH2F *hPS_PSIDLeftVsIDRight;
 static TH2F *hPS_ElVsEr;
 static TH1F *hPS_E;
+static TH1F *hPS_Ediff;
 static TH2F *hPS_timeVsE;
 static TH2I *hPS_PSIDLeftVsPSCIDLeft;
 static TH2I *hPS_PSIDRightVsPSCIDRight;
@@ -86,14 +90,24 @@ static TH2I *hPSTAGM_EdiffVsTAGMColumn;
 static TH2I *hPSTAGM_EdiffVsEtagm;
 static TH2I *hPSTAGM_tdiffVsTAGMColumn_L[NC_PSC];
 static TH2I *hPSTAGM_tdiffVsTAGMColumn_R[NC_PSC];
+// PSC,PS,TPOL coincidences
+static TH1I *hPSTPOL_NHits;
+static TH1I *hPSTPOL_sector;
+static TH1F *hPSTPOL_phi;
+static TH1I *hPSTPOL_peak;
+static TH2I *hPSTPOL_peakVsSector;
+static TH1I *hPSTPOL_time;
+static TH2I *hPSTPOL_timeVsSector;
+static TH2F *hPSTPOL_timeVsPhi;
+static TH2I *hPSTPOL_timeVsPeak;
 //-------------------------
 // Routine used to create our JEventProcessor
 extern "C"{
-  void InitPlugin(JApplication *app){
-    InitJANAPlugin(app);
-    app->AddProcessor(new JEventProcessor_PSPair_online());
+    void InitPlugin(JApplication *app){
+        InitJANAPlugin(app);
+        app->AddProcessor(new JEventProcessor_PSPair_online());
 
-  }
+    }
 } // "C"
 
 
@@ -118,134 +132,147 @@ JEventProcessor_PSPair_online::~JEventProcessor_PSPair_online()
 //------------------
 jerror_t JEventProcessor_PSPair_online::init(void)
 {
-  // energy binning
-  const double Ebw_PS = 0.1;
-  const double Ebl_PS = 5.0; const double Ebl_PSarm = 2.0;
-  const double Ebh_PS = 13.0; const double Ebh_PSarm = 7.0;
-  const int NEb_PS = int((Ebh_PS-Ebl_PS)/Ebw_PS); const int NEb_PSarm = int((Ebh_PSarm-Ebl_PSarm)/Ebw_PS);
-  const double Ebw_TAG = 0.1;
-  const double Ebl_TAG = 2.5;
-  const double Ebh_TAG = 10.5;
-  const int NEb_TAG = int((Ebh_TAG-Ebl_TAG)/Ebw_TAG);
-  // time binning
-  const double Tbw = 0.06;
-  const double Tbl_PS = -4.5;
-  const double Tbh_PS = 4.5;
-  const int NTb_PS = int((Tbh_PS-Tbl_PS)/Tbw);
-  const double Tbl_TAG = -30.0;
-  const double Tbh_TAG = 30.0;
-  const int NTb_TAG = int((Tbh_TAG-Tbl_TAG)/Tbw);
-  //
-  japp->RootWriteLock();
-  // create root folder for pspair and cd to it, store main dir
-  TDirectory *mainDir = gDirectory;
-  TDirectory *psPairDir = gDirectory->mkdir("PSPair");
-  psPairDir->cd();
-  // book hists
-  pspair_num_events = new TH1I("pspair_num_events","PS pair number of events",1,0.5,1.5);
-  hPSC_NHitPairs = new TH1I("PSC_NHitPairs","PSC pair multiplicity",8,0.5,8.5);
-  hPS_NHitPairs = new TH1I("PS_NHitPairs","PS pair multiplicity",8,0.5,8.5);
-  //
-  gDirectory->mkdir("PSC")->cd();
-  hPSC_PSCIDLeftVsIDRight = new TH2F("PSC_PSCIDLeftVsIDRight","PSC pair: Coarse PS ID left arm vs. ID right arm;module(right arm);module(left arm)",NC_PSC,0.5,0.5+NC_PSC,NC_PSC,0.5,0.5+NC_PSC);
-  gDirectory->mkdir("PSCRightArmTimeOffsets")->cd();
-  for (int i=0;i<NC_PSC;i++) {
-    stringstream ss; ss << i+1;
-    TString id = ss.str();
-    TString strN = "_L" + id;
-    hPSC_tdiffVsPSCIDRight[i] = new TH2I("PSC_tdiffVsPSCIDRight"+strN,"PSC pair: TDC time difference vs. right arm module, fixed left arm module "+id+";module(right arm);time(module "+id+", left arm) - time(right arm) [ns]",NC_PSC,0.5,0.5+NC_PSC,NTb_PS,Tbl_PS,Tbh_PS);
-  }
-  gDirectory->cd("../");
-  gDirectory->mkdir("PSCLeftArmTimeOffsets")->cd();
-  for (int i=0;i<NC_PSC;i++) {
-    stringstream ss; ss << i+1;
-    TString id = ss.str();
-    TString strN = "_R" + id;
-    hPSC_tdiffVsPSCIDLeft[i] = new TH2I("PSC_tdiffVsPSCIDLeft"+strN,"PSC pair: TDC time difference vs. left arm module, fixed right arm module "+id+";module(left arm);time(left arm) - time(module "+id+", right arm) [ns]",NC_PSC,0.5,0.5+NC_PSC,NTb_PS,Tbl_PS,Tbh_PS);
-  }
-  psPairDir->cd();
-  //
-  gDirectory->mkdir("PSC_PS")->cd();
-  hPS_PSCIDLeftVsIDRight = new TH2F("PS_PSCIDLeftVsIDRight","PS pair: Coarse PS ID left arm vs. ID right arm;module(right arm);module(left arm)",NC_PSC,0.5,0.5+NC_PSC,NC_PSC,0.5,0.5+NC_PSC);
-  hPS_PSIDLeftVsIDRight = new TH2F("PS_PSIDLeftVsIDRight","PS pair: Fine PS ID left arm vs. ID right arm;column(right arm);column(left arm)",NC_PS,0.5,0.5+NC_PS,NC_PS,0.5,0.5+NC_PS);
-  hPS_ElVsEr = new TH2F("PS_ElVsEr","PS pair: left-arm energy vs. right-arm energy;energy(right arm) [GeV];energy(left arm) [GeV]",NEb_PSarm,Ebl_PSarm,Ebh_PSarm,NEb_PSarm,Ebl_PSarm,Ebh_PSarm);
-  hPS_E = new TH1F("PS_E","PS pair energy;PS pair energy [GeV];events",NEb_PS,Ebl_PS,Ebh_PS);
-  hPS_timeVsE = new TH2F("PS_timeVsE","PSC TDC time, Left arm vs. PS pair energy;PS pair energy [GeV];PSC TDC time, Left arm [ns]",NEb_PS,Ebl_PS,Ebh_PS,NTb_PS,Tbl_PS,Tbh_PS);
-  //
-  hPS_PSIDLeftVsPSCIDLeft = new TH2I("PS_PSIDLeftVsPSCIDLeft","PS pair: Fine PS ID left arm vs. Coarse PS ID left arm;coarse PS module(left arm);fine PS column(left arm)",NC_PSC,0.5,0.5+NC_PSC,NC_PS,0.5,0.5+NC_PS);
-  hPS_PSIDRightVsPSCIDRight = new TH2I("PS_PSIDRightVsPSCIDRight","PS pair: Fine PS ID right arm vs. Coarse PS ID right arm;coarse PS module(right arm);fine PS column(right arm)",NC_PSC,0.5,0.5+NC_PSC,NC_PS,0.5,0.5+NC_PS); 
-  hPS_ElVsPSCIDLeft = new TH2I("PS_ElVsPSCIDLeft","PS pair: PS left-arm energy vs. Coarse PS ID left arm;coarse PS module(left arm);PS energy(left arm)",NC_PSC,0.5,0.5+NC_PSC,NEb_PSarm,Ebl_PSarm,Ebh_PSarm);
-  hPS_ErVsPSCIDRight = new TH2I("PS_ErVsPSCIDRight","PS pair: PS right-arm energy vs. Coarse PS ID right arm;coarse PS module(right arm);PS energy(right arm)",NC_PSC,0.5,0.5+NC_PSC,NEb_PSarm,Ebl_PSarm,Ebh_PSarm); 
-  //
-  gDirectory->mkdir("TAGX_AllHits")->cd();
-  hPS_TAGHCounterID = new TH1F("PS_TAGHCounterID","PS pair: TAGH counter ID, all hits;TAGH counter ID;hits",NC_TAGH,0.5,0.5+NC_TAGH);
-  hPS_Etagh = new TH1F("PS_Etagh","PS pair: TAGH photon energy, all hits;TAGH photon energy [GeV];hits",NEb_TAG,Ebl_TAG,Ebh_TAG);
-  hPS_timeVsEtagh = new TH2F("PS_timeVsEtagh","PS pair: TAGH time vs. photon energy, all hits;TAGH photon energy [GeV];time [ns]",NEb_TAG,Ebl_TAG,Ebh_TAG,NTb_TAG,Tbl_TAG,Tbh_TAG);
-  hPS_TAGMColumn = new TH1F("PS_TAGMColumn","PS pair: TAGM column, all hits;TAGM column;hits",NC_TAGM,0.5,0.5+NC_TAGM);
-  hPS_Etagm = new TH1F("PS_Etagm","PS pair: TAGM photon energy, all hits;TAGM photon energy [GeV];hits",NEb_PS,Ebl_PS,Ebh_PS);
-  hPS_timeVsEtagm = new TH2F("PS_timeVsEtagm","PS pair: TAGM time vs. photon energy, all hits;TAGM photon energy [GeV];time [ns]",NEb_PS,Ebl_PS,Ebh_PS,NTb_TAG,Tbl_TAG,Tbh_TAG);
-  psPairDir->cd();
-  //
-  gDirectory->mkdir("PSC_PS_TAGH")->cd();  
-  hPSTAGH_tdiffVsEdiff = new TH2F("PSTAGH_tdiffVsEdiff","PS pair - TAGH: PS-TAGH time difference vs. PS-TAGH energy difference;[E(PS) - E(TAGH)] / E(PS);PSC/TAGH time difference [ns]",80,-0.15,0.15,NTb_TAG,Tbl_TAG,Tbh_TAG);
-  hPSTAGH_TAGHCounterID = new TH1F("PSTAGH_TAGHCounterID","PS pair - TAGH: TAGH counter ID;TAGH counter ID;events",NC_TAGH,0.5,0.5+NC_TAGH);
-  hPSTAGH_Etagh = new TH1F("PSTAGH_Etagh","PS pair - TAGH: TAGH photon energy;TAGH photon energy [GeV];events",NEb_TAG,Ebl_TAG,Ebh_TAG);
-  hPSTAGH_timeVsEtagh = new TH2F("PSTAGH_timeVsEtagh","PS pair - TAGH: TAGH time vs. photon energy;TAGH photon energy [GeV];time [ns]",NEb_TAG,Ebl_TAG,Ebh_TAG,NTb_TAG,Tbl_TAG,Tbh_TAG);
-  hPSTAGH_EVsEtagh = new TH2I("PSTAGH_EVsEtagh","PS pair - TAGH: PS energy vs. TAGH energy;TAGH energy [GeV];PS energy [GeV]",NEb_PS,Ebl_PS,Ebh_PS,NEb_PS,Ebl_PS,Ebh_PS);
-  hPSTAGH_EdiffVsEtagh = new TH2I("PSTAGH_EdiffVsEtagh","PS pair - TAGH: PS-TAGH energy difference vs. TAGH energy;TAGH energy [GeV];[E(PS) - E(TAGH)] / E(PS)",NEb_TAG,Ebl_TAG,Ebh_TAG,80,-0.15,0.15);
-  hPSTAGH_EdiffVsTAGHCounterID = new TH2I("PSTAGH_EdiffVsTAGHCounterID","PS pair - TAGH: PS-TAGH energy difference vs. TAGH counter ID;TAGH counter ID;[E(PS) - E(TAGH)] / E(PS)",NC_TAGH,0.5,0.5+NC_TAGH,80,-0.15,0.15);
-  hPSTAGH_PSCIDLeftVsIDRight = new TH2F("PSTAGH_PSCIDLeftVsIDRight","PS pair - TAGH: Coarse PS ID left arm vs. ID right arm;module(right arm);module(left arm)",NC_PSC,0.5,0.5+NC_PSC,NC_PSC,0.5,0.5+NC_PSC);
-  hPSTAGH_PSIDLeftVsIDRight = new TH2F("PSTAGH_PSIDLeftVsIDRight","PS pair - TAGH: Fine PS ID left arm vs. ID right arm;column(right arm);column(left arm)",NC_PS,0.5,0.5+NC_PS,NC_PS,0.5,0.5+NC_PS);
-  hPSTAGH_ElVsEr = new TH2F("PSTAGH_ElVsEr","PS pair - TAGH: left-arm energy vs. right-arm energy;energy(right arm) [GeV];energy(left arm) [GeV]",NEb_PSarm,Ebl_PSarm,Ebh_PSarm,NEb_PSarm,Ebl_PSarm,Ebh_PSarm);
-  hPSTAGH_E = new TH1F("PSTAGH_E","PS pair - TAGH: PS pair energy;PS pair energy [GeV];events",NEb_PS,Ebl_PS,Ebh_PS);
-  hPSTAGH_timeVsE = new TH2F("PSTAGH_timeVsE","PSC/TAGH time difference vs. PS pair energy;PS pair energy [GeV];PSC/TAGH time difference [ns]",NEb_PS,Ebl_PS,Ebh_PS,NTb_TAG,Tbl_TAG,Tbh_TAG);
-  gDirectory->mkdir("PSTAGHTimeOffsets_L")->cd();
-  for (int i=0; i<NC_PSC; i++) {
-    stringstream ss; ss << i+1;
-    TString id = ss.str();
-    hPSTAGH_tdiffVsTAGHCounterID_L[i] = new TH2I("PSTAGH_tdiffVsTAGHCounterID_L"+id,"PS-TAGH TDC time difference vs. TAGH counter ID, fixed left arm PSC module "+id+";TAGH counter ID;time(PSC module "+id+", left arm) - time(TAGH) [ns]",NC_TAGH,0.5,0.5+NC_TAGH,NTb_TAG,Tbl_TAG,Tbh_TAG);
-  }
-  gDirectory->cd("../");
-  gDirectory->mkdir("PSTAGHTimeOffsets_R")->cd();
-  for (int i=0; i<NC_PSC; i++) {
-    stringstream ss; ss << i+1;
-    TString id = ss.str();
-    hPSTAGH_tdiffVsTAGHCounterID_R[i] = new TH2I("PSTAGH_tdiffVsTAGHCounterID_R"+id,"PS-TAGH TDC time difference vs. TAGH counter ID, fixed right arm PSC module "+id+";TAGH counter ID;time(PSC module "+id+", right arm) - time(TAGH) [ns]",NC_TAGH,0.5,0.5+NC_TAGH,NTb_TAG,Tbl_TAG,Tbh_TAG);
-  }
-  psPairDir->cd();
-  //
-  gDirectory->mkdir("PSC_PS_TAGM")->cd();  
-  hPSTAGM_tdiffVsEdiff = new TH2F("PSTAGM_tdiffVsEdiff","PS pair - TAGM: PS-TAGM time difference vs. PS-TAGM energy difference;[E(PS) - E(TAGM)] / E(PS);PSC/TAGM time difference [ns]",80,-0.15,0.15,NTb_TAG,Tbl_TAG,Tbh_TAG);
-  hPSTAGM_TAGMColumn = new TH1F("PSTAGM_TAGMColumn","PS pair - TAGM: TAGM column;TAGM column;events",NC_TAGM,0.5,0.5+NC_TAGM);
-  hPSTAGM_Etagm = new TH1F("PSTAGM_Etagm","PS pair - TAGM: TAGM photon energy;TAGM photon energy [GeV];events",NEb_PS,Ebl_PS,Ebh_PS);
-  hPSTAGM_timeVsEtagm = new TH2F("PSTAGM_timeVsEtagm","PS pair - TAGM: TAGM time vs. photon energy;TAGM photon energy [GeV];time [ns]",NEb_PS,Ebl_PS,Ebh_PS,NTb_TAG,Tbl_TAG,Tbh_TAG);
-  hPSTAGM_EVsEtagm = new TH2I("PSTAGM_EVsEtagm","PS pair - TAGM: PS energy vs. TAGM energy;TAGM energy [GeV];PS energy [GeV]",NEb_PS,Ebl_PS,Ebh_PS,NEb_PS,Ebl_PS,Ebh_PS);
-  hPSTAGM_EdiffVsEtagm = new TH2I("PSTAGM_EdiffVsEtagm","PS pair - TAGM: PS-TAGM energy difference vs. TAGM energy;TAGM energy [GeV];[E(PS) - E(TAGM)] / E(PS)",NEb_PS,Ebl_PS,Ebh_PS,80,-0.15,0.15);
-  hPSTAGM_EdiffVsTAGMColumn = new TH2I("PSTAGM_EdiffVsTAGMColumn","PS pair - TAGM: PS-TAGM energy difference vs. TAGM column;TAGM column;[E(PS) - E(TAGM)] / E(PS)",NC_TAGM,0.5,0.5+NC_TAGM,80,-0.15,0.15);
-  hPSTAGM_PSCIDLeftVsIDRight = new TH2F("PSTAGM_PSCIDLeftVsIDRight","PS pair - TAGM: Coarse PS ID left arm vs. ID right arm;module(right arm);module(left arm)",NC_PSC,0.5,0.5+NC_PSC,NC_PSC,0.5,0.5+NC_PSC);
-  hPSTAGM_PSIDLeftVsIDRight = new TH2F("PSTAGM_PSIDLeftVsIDRight","PS pair - TAGM: Fine PS ID left arm vs. ID right arm;column(right arm);column(left arm)",NC_PS,0.5,0.5+NC_PS,NC_PS,0.5,0.5+NC_PS);
-  hPSTAGM_ElVsEr = new TH2F("PSTAGM_ElVsEr","PS pair - TAGM: left-arm energy vs. right-arm energy;energy(right arm) [GeV];energy(left arm) [GeV]",NEb_PSarm,Ebl_PSarm,Ebh_PSarm,NEb_PSarm,Ebl_PSarm,Ebh_PSarm);
-  hPSTAGM_E = new TH1F("PSTAGM_E","PS pair - TAGM: PS pair energy;PS pair energy [GeV];events",NEb_PS,Ebl_PS,Ebh_PS);
-  hPSTAGM_timeVsE = new TH2F("PSTAGM_timeVsE","PSC/TAGM time difference vs. PS pair energy;PS pair energy [GeV];PSC/TAGM time difference [ns]",NEb_PS,Ebl_PS,Ebh_PS,NTb_TAG,Tbl_TAG,Tbh_TAG);
-  gDirectory->mkdir("PSTAGMTimeOffsets_L")->cd();
-  for (int i=0; i<NC_PSC; i++) {
-    stringstream ss; ss << i+1;
-    TString id = ss.str();
-    hPSTAGM_tdiffVsTAGMColumn_L[i] = new TH2I("PSTAGM_tdiffVsTAGMColumn_L"+id,"PS-TAGM TDC time difference vs. TAGM column, fixed left arm PSC module "+id+";TAGM column;time(PSC module "+id+", left arm) - time(TAGM) [ns]",NC_TAGM,0.5,0.5+NC_TAGM,NTb_TAG,Tbl_TAG,Tbh_TAG);
-  }
-  gDirectory->cd("../");
-  gDirectory->mkdir("PSTAGMTimeOffsets_R")->cd();
-  for (int i=0; i<NC_PSC; i++) {
-    stringstream ss; ss << i+1;
-    TString id = ss.str();
-    hPSTAGM_tdiffVsTAGMColumn_R[i] = new TH2I("PSTAGM_tdiffVsTAGMColumn_R"+id,"PS-TAGM TDC time difference vs. TAGM column, fixed right arm PSC module "+id+";TAGM column;time(PSC module "+id+", right arm) - time(TAGM) [ns]",NC_TAGM,0.5,0.5+NC_TAGM,NTb_TAG,Tbl_TAG,Tbh_TAG);
-  }
-  // back to main dir
-  mainDir->cd();
+    // energy binning
+    const double Ebw_PS = 0.1;
+    const double Ebl_PS = 5.0; const double Ebl_PSarm = 2.0;
+    const double Ebh_PS = 13.0; const double Ebh_PSarm = 7.0;
+    const int NEb_PS = int((Ebh_PS-Ebl_PS)/Ebw_PS); const int NEb_PSarm = int((Ebh_PSarm-Ebl_PSarm)/Ebw_PS);
+    const double Ebw_TAG = 0.1;
+    const double Ebl_TAG = 2.5;
+    const double Ebh_TAG = 10.5;
+    const int NEb_TAG = int((Ebh_TAG-Ebl_TAG)/Ebw_TAG);
+    // time binning
+    const double Tbw = 0.06;
+    const double Tbl_PS = -4.5;
+    const double Tbh_PS = 4.5;
+    const int NTb_PS = int((Tbh_PS-Tbl_PS)/Tbw);
+    const double Tbl_TAG = -30.0;
+    const double Tbh_TAG = 30.0;
+    const int NTb_TAG = int((Tbh_TAG-Tbl_TAG)/Tbw);
+    //
+    japp->RootWriteLock();
+    // create root folder for pspair and cd to it, store main dir
+    TDirectory *mainDir = gDirectory;
+    TDirectory *psPairDir = gDirectory->mkdir("PSPair");
+    psPairDir->cd();
+    // book hists
+    pspair_num_events = new TH1I("pspair_num_events","PS pair number of events",1,0.5,1.5);
+    hPSC_NHitPairs = new TH1I("PSC_NHitPairs","PSC pair multiplicity",8,0.5,8.5);
+    hPS_NHitPairs = new TH1I("PS_NHitPairs","PS pair multiplicity",8,0.5,8.5);
+    //
+    gDirectory->mkdir("PSC")->cd();
+    hPSC_PSCIDLeftVsIDRight = new TH2F("PSC_PSCIDLeftVsIDRight","PSC pair: Coarse PS ID left arm vs. ID right arm;module(right arm);module(left arm)",NC_PSC,0.5,0.5+NC_PSC,NC_PSC,0.5,0.5+NC_PSC);
+    gDirectory->mkdir("PSCRightArmTimeOffsets")->cd();
+    for (int i=0;i<NC_PSC;i++) {
+        stringstream ss; ss << i+1;
+        TString id = ss.str();
+        TString strN = "_L" + id;
+        hPSC_tdiffVsPSCIDRight[i] = new TH2I("PSC_tdiffVsPSCIDRight"+strN,"PSC pair: TDC time difference vs. right arm module, fixed left arm module "+id+";module(right arm);time(module "+id+", left arm) - time(right arm) [ns]",NC_PSC,0.5,0.5+NC_PSC,NTb_PS,Tbl_PS,Tbh_PS);
+    }
+    gDirectory->cd("../");
+    gDirectory->mkdir("PSCLeftArmTimeOffsets")->cd();
+    for (int i=0;i<NC_PSC;i++) {
+        stringstream ss; ss << i+1;
+        TString id = ss.str();
+        TString strN = "_R" + id;
+        hPSC_tdiffVsPSCIDLeft[i] = new TH2I("PSC_tdiffVsPSCIDLeft"+strN,"PSC pair: TDC time difference vs. left arm module, fixed right arm module "+id+";module(left arm);time(left arm) - time(module "+id+", right arm) [ns]",NC_PSC,0.5,0.5+NC_PSC,NTb_PS,Tbl_PS,Tbh_PS);
+    }
+    psPairDir->cd();
+    //
+    gDirectory->mkdir("PSC_PS")->cd();
+    hPS_PSCIDLeftVsIDRight = new TH2F("PS_PSCIDLeftVsIDRight","PS pair: Coarse PS ID left arm vs. ID right arm;module(right arm);module(left arm)",NC_PSC,0.5,0.5+NC_PSC,NC_PSC,0.5,0.5+NC_PSC);
+    hPS_PSIDLeftVsIDRight = new TH2F("PS_PSIDLeftVsIDRight","PS pair: Fine PS ID left arm vs. ID right arm;column(right arm);column(left arm)",NC_PS,0.5,0.5+NC_PS,NC_PS,0.5,0.5+NC_PS);
+    hPS_ElVsEr = new TH2F("PS_ElVsEr","PS pair: left-arm energy vs. right-arm energy;energy(right arm) [GeV];energy(left arm) [GeV]",NEb_PSarm,Ebl_PSarm,Ebh_PSarm,NEb_PSarm,Ebl_PSarm,Ebh_PSarm);
+    hPS_E = new TH1F("PS_E","PS pair energy;PS pair energy [GeV];events",NEb_PS,Ebl_PS,Ebh_PS);
+    hPS_Ediff = new TH1F("PS_Ediff","PS pair energy difference;PS pair energy difference [GeV];events",80,-4.0,4.0);
+    hPS_timeVsE = new TH2F("PS_timeVsE","PSC TDC time, Left arm vs. PS pair energy;PS pair energy [GeV];PSC TDC time, Left arm [ns]",NEb_PS,Ebl_PS,Ebh_PS,NTb_PS,Tbl_PS,Tbh_PS);
+    //
+    hPS_PSIDLeftVsPSCIDLeft = new TH2I("PS_PSIDLeftVsPSCIDLeft","PS pair: Fine PS ID left arm vs. Coarse PS ID left arm;coarse PS module(left arm);fine PS column(left arm)",NC_PSC,0.5,0.5+NC_PSC,NC_PS,0.5,0.5+NC_PS);
+    hPS_PSIDRightVsPSCIDRight = new TH2I("PS_PSIDRightVsPSCIDRight","PS pair: Fine PS ID right arm vs. Coarse PS ID right arm;coarse PS module(right arm);fine PS column(right arm)",NC_PSC,0.5,0.5+NC_PSC,NC_PS,0.5,0.5+NC_PS);
+    hPS_ElVsPSCIDLeft = new TH2I("PS_ElVsPSCIDLeft","PS pair: PS left-arm energy vs. Coarse PS ID left arm;coarse PS module(left arm);PS energy(left arm)",NC_PSC,0.5,0.5+NC_PSC,NEb_PSarm,Ebl_PSarm,Ebh_PSarm);
+    hPS_ErVsPSCIDRight = new TH2I("PS_ErVsPSCIDRight","PS pair: PS right-arm energy vs. Coarse PS ID right arm;coarse PS module(right arm);PS energy(right arm)",NC_PSC,0.5,0.5+NC_PSC,NEb_PSarm,Ebl_PSarm,Ebh_PSarm);
+    //
+    gDirectory->mkdir("TAGX_AllHits")->cd();
+    hPS_TAGHCounterID = new TH1F("PS_TAGHCounterID","PS pair: TAGH counter ID, all hits;TAGH counter ID;hits",NC_TAGH,0.5,0.5+NC_TAGH);
+    hPS_Etagh = new TH1F("PS_Etagh","PS pair: TAGH photon energy, all hits;TAGH photon energy [GeV];hits",NEb_TAG,Ebl_TAG,Ebh_TAG);
+    hPS_timeVsEtagh = new TH2F("PS_timeVsEtagh","PS pair: TAGH time vs. photon energy, all hits;TAGH photon energy [GeV];time [ns]",NEb_TAG,Ebl_TAG,Ebh_TAG,NTb_TAG,Tbl_TAG,Tbh_TAG);
+    hPS_TAGMColumn = new TH1F("PS_TAGMColumn","PS pair: TAGM column, all hits;TAGM column;hits",NC_TAGM,0.5,0.5+NC_TAGM);
+    hPS_Etagm = new TH1F("PS_Etagm","PS pair: TAGM photon energy, all hits;TAGM photon energy [GeV];hits",NEb_PS,Ebl_PS,Ebh_PS);
+    hPS_timeVsEtagm = new TH2F("PS_timeVsEtagm","PS pair: TAGM time vs. photon energy, all hits;TAGM photon energy [GeV];time [ns]",NEb_PS,Ebl_PS,Ebh_PS,NTb_TAG,Tbl_TAG,Tbh_TAG);
+    psPairDir->cd();
+    //
+    gDirectory->mkdir("PSC_PS_TAGH")->cd();
+    hPSTAGH_tdiffVsEdiff = new TH2F("PSTAGH_tdiffVsEdiff","PS pair - TAGH: PS-TAGH time difference vs. PS-TAGH energy difference;[E(PS) - E(TAGH)] / E(PS);PSC/TAGH time difference [ns]",80,-0.15,0.15,NTb_TAG,Tbl_TAG,Tbh_TAG);
+    hPSTAGH_TAGHCounterID = new TH1F("PSTAGH_TAGHCounterID","PS pair - TAGH: TAGH counter ID;TAGH counter ID;events",NC_TAGH,0.5,0.5+NC_TAGH);
+    hPSTAGH_Etagh = new TH1F("PSTAGH_Etagh","PS pair - TAGH: TAGH photon energy;TAGH photon energy [GeV];events",NEb_TAG,Ebl_TAG,Ebh_TAG);
+    hPSTAGH_timeVsEtagh = new TH2F("PSTAGH_timeVsEtagh","PS pair - TAGH: TAGH time vs. photon energy;TAGH photon energy [GeV];time [ns]",NEb_TAG,Ebl_TAG,Ebh_TAG,NTb_TAG,Tbl_TAG,Tbh_TAG);
+    hPSTAGH_EVsEtagh = new TH2I("PSTAGH_EVsEtagh","PS pair - TAGH: PS energy vs. TAGH energy;TAGH energy [GeV];PS energy [GeV]",NEb_PS,Ebl_PS,Ebh_PS,NEb_PS,Ebl_PS,Ebh_PS);
+    hPSTAGH_EdiffVsEtagh = new TH2I("PSTAGH_EdiffVsEtagh","PS pair - TAGH: PS-TAGH energy difference vs. TAGH energy;TAGH energy [GeV];[E(PS) - E(TAGH)] / E(PS)",NEb_TAG,Ebl_TAG,Ebh_TAG,80,-0.15,0.15);
+    hPSTAGH_EdiffVsTAGHCounterID = new TH2I("PSTAGH_EdiffVsTAGHCounterID","PS pair - TAGH: PS-TAGH energy difference vs. TAGH counter ID;TAGH counter ID;[E(PS) - E(TAGH)] / E(PS)",NC_TAGH,0.5,0.5+NC_TAGH,80,-0.15,0.15);
+    hPSTAGH_PSCIDLeftVsIDRight = new TH2F("PSTAGH_PSCIDLeftVsIDRight","PS pair - TAGH: Coarse PS ID left arm vs. ID right arm;module(right arm);module(left arm)",NC_PSC,0.5,0.5+NC_PSC,NC_PSC,0.5,0.5+NC_PSC);
+    hPSTAGH_PSIDLeftVsIDRight = new TH2F("PSTAGH_PSIDLeftVsIDRight","PS pair - TAGH: Fine PS ID left arm vs. ID right arm;column(right arm);column(left arm)",NC_PS,0.5,0.5+NC_PS,NC_PS,0.5,0.5+NC_PS);
+    hPSTAGH_ElVsEr = new TH2F("PSTAGH_ElVsEr","PS pair - TAGH: left-arm energy vs. right-arm energy;energy(right arm) [GeV];energy(left arm) [GeV]",NEb_PSarm,Ebl_PSarm,Ebh_PSarm,NEb_PSarm,Ebl_PSarm,Ebh_PSarm);
+    hPSTAGH_E = new TH1F("PSTAGH_E","PS pair - TAGH: PS pair energy;PS pair energy [GeV];events",NEb_PS,Ebl_PS,Ebh_PS);
+    hPSTAGH_timeVsE = new TH2F("PSTAGH_timeVsE","PSC/TAGH time difference vs. PS pair energy;PS pair energy [GeV];PSC/TAGH time difference [ns]",NEb_PS,Ebl_PS,Ebh_PS,NTb_TAG,Tbl_TAG,Tbh_TAG);
+    gDirectory->mkdir("PSTAGHTimeOffsets_L")->cd();
+    for (int i=0; i<NC_PSC; i++) {
+        stringstream ss; ss << i+1;
+        TString id = ss.str();
+        hPSTAGH_tdiffVsTAGHCounterID_L[i] = new TH2I("PSTAGH_tdiffVsTAGHCounterID_L"+id,"PS-TAGH TDC time difference vs. TAGH counter ID, fixed left arm PSC module "+id+";TAGH counter ID;time(PSC module "+id+", left arm) - time(TAGH) [ns]",NC_TAGH,0.5,0.5+NC_TAGH,NTb_TAG,Tbl_TAG,Tbh_TAG);
+    }
+    gDirectory->cd("../");
+    gDirectory->mkdir("PSTAGHTimeOffsets_R")->cd();
+    for (int i=0; i<NC_PSC; i++) {
+        stringstream ss; ss << i+1;
+        TString id = ss.str();
+        hPSTAGH_tdiffVsTAGHCounterID_R[i] = new TH2I("PSTAGH_tdiffVsTAGHCounterID_R"+id,"PS-TAGH TDC time difference vs. TAGH counter ID, fixed right arm PSC module "+id+";TAGH counter ID;time(PSC module "+id+", right arm) - time(TAGH) [ns]",NC_TAGH,0.5,0.5+NC_TAGH,NTb_TAG,Tbl_TAG,Tbh_TAG);
+    }
+    psPairDir->cd();
+    //
+    gDirectory->mkdir("PSC_PS_TAGM")->cd();
+    hPSTAGM_tdiffVsEdiff = new TH2F("PSTAGM_tdiffVsEdiff","PS pair - TAGM: PS-TAGM time difference vs. PS-TAGM energy difference;[E(PS) - E(TAGM)] / E(PS);PSC/TAGM time difference [ns]",80,-0.15,0.15,NTb_TAG,Tbl_TAG,Tbh_TAG);
+    hPSTAGM_TAGMColumn = new TH1F("PSTAGM_TAGMColumn","PS pair - TAGM: TAGM column;TAGM column;events",NC_TAGM,0.5,0.5+NC_TAGM);
+    hPSTAGM_Etagm = new TH1F("PSTAGM_Etagm","PS pair - TAGM: TAGM photon energy;TAGM photon energy [GeV];events",NEb_PS,Ebl_PS,Ebh_PS);
+    hPSTAGM_timeVsEtagm = new TH2F("PSTAGM_timeVsEtagm","PS pair - TAGM: TAGM time vs. photon energy;TAGM photon energy [GeV];time [ns]",NEb_PS,Ebl_PS,Ebh_PS,NTb_TAG,Tbl_TAG,Tbh_TAG);
+    hPSTAGM_EVsEtagm = new TH2I("PSTAGM_EVsEtagm","PS pair - TAGM: PS energy vs. TAGM energy;TAGM energy [GeV];PS energy [GeV]",NEb_PS,Ebl_PS,Ebh_PS,NEb_PS,Ebl_PS,Ebh_PS);
+    hPSTAGM_EdiffVsEtagm = new TH2I("PSTAGM_EdiffVsEtagm","PS pair - TAGM: PS-TAGM energy difference vs. TAGM energy;TAGM energy [GeV];[E(PS) - E(TAGM)] / E(PS)",NEb_PS,Ebl_PS,Ebh_PS,80,-0.15,0.15);
+    hPSTAGM_EdiffVsTAGMColumn = new TH2I("PSTAGM_EdiffVsTAGMColumn","PS pair - TAGM: PS-TAGM energy difference vs. TAGM column;TAGM column;[E(PS) - E(TAGM)] / E(PS)",NC_TAGM,0.5,0.5+NC_TAGM,80,-0.15,0.15);
+    hPSTAGM_PSCIDLeftVsIDRight = new TH2F("PSTAGM_PSCIDLeftVsIDRight","PS pair - TAGM: Coarse PS ID left arm vs. ID right arm;module(right arm);module(left arm)",NC_PSC,0.5,0.5+NC_PSC,NC_PSC,0.5,0.5+NC_PSC);
+    hPSTAGM_PSIDLeftVsIDRight = new TH2F("PSTAGM_PSIDLeftVsIDRight","PS pair - TAGM: Fine PS ID left arm vs. ID right arm;column(right arm);column(left arm)",NC_PS,0.5,0.5+NC_PS,NC_PS,0.5,0.5+NC_PS);
+    hPSTAGM_ElVsEr = new TH2F("PSTAGM_ElVsEr","PS pair - TAGM: left-arm energy vs. right-arm energy;energy(right arm) [GeV];energy(left arm) [GeV]",NEb_PSarm,Ebl_PSarm,Ebh_PSarm,NEb_PSarm,Ebl_PSarm,Ebh_PSarm);
+    hPSTAGM_E = new TH1F("PSTAGM_E","PS pair - TAGM: PS pair energy;PS pair energy [GeV];events",NEb_PS,Ebl_PS,Ebh_PS);
+    hPSTAGM_timeVsE = new TH2F("PSTAGM_timeVsE","PSC/TAGM time difference vs. PS pair energy;PS pair energy [GeV];PSC/TAGM time difference [ns]",NEb_PS,Ebl_PS,Ebh_PS,NTb_TAG,Tbl_TAG,Tbh_TAG);
+    gDirectory->mkdir("PSTAGMTimeOffsets_L")->cd();
+    for (int i=0; i<NC_PSC; i++) {
+        stringstream ss; ss << i+1;
+        TString id = ss.str();
+        hPSTAGM_tdiffVsTAGMColumn_L[i] = new TH2I("PSTAGM_tdiffVsTAGMColumn_L"+id,"PS-TAGM TDC time difference vs. TAGM column, fixed left arm PSC module "+id+";TAGM column;time(PSC module "+id+", left arm) - time(TAGM) [ns]",NC_TAGM,0.5,0.5+NC_TAGM,NTb_TAG,Tbl_TAG,Tbh_TAG);
+    }
+    gDirectory->cd("../");
+    gDirectory->mkdir("PSTAGMTimeOffsets_R")->cd();
+    for (int i=0; i<NC_PSC; i++) {
+        stringstream ss; ss << i+1;
+        TString id = ss.str();
+        hPSTAGM_tdiffVsTAGMColumn_R[i] = new TH2I("PSTAGM_tdiffVsTAGMColumn_R"+id,"PS-TAGM TDC time difference vs. TAGM column, fixed right arm PSC module "+id+";TAGM column;time(PSC module "+id+", right arm) - time(TAGM) [ns]",NC_TAGM,0.5,0.5+NC_TAGM,NTb_TAG,Tbl_TAG,Tbh_TAG);
+    }
+    psPairDir->cd();
+    //
+    gDirectory->mkdir("PSC_PS_TPOL")->cd();
+    hPSTPOL_NHits = new TH1I("PSTPOL_NHits","TPOL hit multiplicity;hits;events",5,0.5,5.5);
+    hPSTPOL_sector = new TH1I("PSTPOL_sector","TPOL sector;sector;hits / sector",NS_TPOL,0.5,0.5+NS_TPOL);
+    hPSTPOL_phi = new TH1F("PSTPOL_phi","TPOL azimuthal angle;triplet azimuthal angle [degrees];hits / sector",NS_TPOL,0.0,360.0);
+    hPSTPOL_peak = new TH1I("PSTPOL_peak","TPOL fADC pulse peak;pulse peak;hits",410,0.0,4100.0);
+    hPSTPOL_peakVsSector = new TH2I("PSTPOL_peakVsSector","TPOL fADC pulse peak vs. sector;sector;pulse peak",NS_TPOL,0.5,0.5+NS_TPOL,410,0.0,4100.0);
+    hPSTPOL_time = new TH1I("PSTPOL_time","TPOL time;time [ns];hits / 800 ps",1000,-400.0,400.0);
+    hPSTPOL_timeVsSector = new TH2I("PSTPOL_timeVsSector","TPOL time vs. sector;sector;time [ns]",NS_TPOL,0.5,0.5+NS_TPOL,1000,-400.0,400.0);
+    hPSTPOL_timeVsPhi = new TH2F("PSTPOL_timeVsPhi","TPOL time vs. phi;#phi [degrees];time [ns]",NS_TPOL,0.0,360.0,1000,-400.0,400.0);
+    hPSTPOL_timeVsPeak = new TH2I("PSTPOL_timeVsPeak","TPOL time vs. peak;pulse peak;time [ns]",410,0.0,4100.0,1000,-400.0,400.0);
+    // back to main dir
+    mainDir->cd();
 
-  japp->RootUnLock();
-  
-  return NOERROR;
+    japp->RootUnLock();
+
+    return NOERROR;
 }
 
 //------------------
@@ -253,112 +280,110 @@ jerror_t JEventProcessor_PSPair_online::init(void)
 //------------------
 jerror_t JEventProcessor_PSPair_online::brun(JEventLoop *eventLoop, int32_t runnumber)
 {
-  // This is called whenever the run number changes
-  // extract the PS geometry
-  vector<const DPSGeometry*> psGeomVect;
-  eventLoop->Get(psGeomVect);
-  if (psGeomVect.size() < 1)
+    // This is called whenever the run number changes
+    // extract the PS geometry
+    vector<const DPSGeometry*> psGeomVect;
+    eventLoop->Get(psGeomVect);
+    if (psGeomVect.size() < 1)
     return OBJECT_NOT_AVAILABLE;
-  const DPSGeometry& psGeom = *(psGeomVect[0]);
-  // get photon energy bin lows for variable-width energy binning
-  double Elows_PSarm[Narms][NC_PS+1];
-  double wl_min=0.05,wr_min = 0.05;
-  for (int i=0;i<NC_PS;i++) {
-    Elows_PSarm[0][i] = psGeom.getElow(0,i+1); 
-    Elows_PSarm[1][i] = psGeom.getElow(1,i+1); 
-    // find smallest bin widths to use for PS pair energy binning
-    double wl = psGeom.getEhigh(0,i+1) - psGeom.getElow(0,i+1);
-    double wr = psGeom.getEhigh(1,i+1) - psGeom.getElow(1,i+1);
-    if (wl<wl_min) wl_min = wl;
-    if (wr<wr_min) wr_min = wr;
-  }
-  // add the upper limits
-  Elows_PSarm[0][NC_PS] = psGeom.getEhigh(0,NC_PS); 
-  Elows_PSarm[1][NC_PS] = psGeom.getEhigh(1,NC_PS);
-  // PS pair energy binning
-  double Ebw_PS = wl_min + wr_min;
-  const double Ebl_PS = psGeom.getElow(0,1) + psGeom.getElow(1,1);
-  double Ebh_PS = psGeom.getEhigh(0,NC_PS) + psGeom.getEhigh(1,NC_PS);
-  double range = Ebh_PS-Ebl_PS;
-  int NEb_PS = range/Ebw_PS-int(range/Ebw_PS) < 0.5 ? int(range/Ebw_PS) : int(range/Ebw_PS) + 1;
-//  double desired_range = NEb_PS*Ebw_PS;
-//  Ebh_PS = Ebl_PS + desired_range; // tweak the upper limit to obtain the desired constant bin width
-  double Elows_PS[NEb_PS+1];
-  for (int i=0;i<NEb_PS+1;i++) {
-    Elows_PS[i] = Ebl_PS + i*Ebw_PS;
-  }
-  // extract the TAGH geometry
-  vector<const DTAGHGeometry*> taghGeomVect;
-  eventLoop->Get(taghGeomVect);
-  if (taghGeomVect.size() < 1)
+    const DPSGeometry& psGeom = *(psGeomVect[0]);
+    // get photon energy bin lows for variable-width energy binning
+    double Elows_PSarm[Narms][NC_PS+1];
+    double wl_min=0.05,wr_min = 0.05;
+    for (int i=0;i<NC_PS;i++) {
+        Elows_PSarm[0][i] = psGeom.getElow(0,i+1);
+        Elows_PSarm[1][i] = psGeom.getElow(1,i+1);
+        // find smallest bin widths to use for PS pair energy binning
+        double wl = psGeom.getEhigh(0,i+1) - psGeom.getElow(0,i+1);
+        double wr = psGeom.getEhigh(1,i+1) - psGeom.getElow(1,i+1);
+        if (wl<wl_min) wl_min = wl;
+        if (wr<wr_min) wr_min = wr;
+    }
+    // add the upper limits
+    Elows_PSarm[0][NC_PS] = psGeom.getEhigh(0,NC_PS);
+    Elows_PSarm[1][NC_PS] = psGeom.getEhigh(1,NC_PS);
+    // PS pair energy binning
+    double Ebw_PS = wl_min + wr_min;
+    const double Ebl_PS = psGeom.getElow(0,1) + psGeom.getElow(1,1);
+    double Ebh_PS = psGeom.getEhigh(0,NC_PS) + psGeom.getEhigh(1,NC_PS);
+    double range = Ebh_PS-Ebl_PS;
+    int NEb_PS = range/Ebw_PS-int(range/Ebw_PS) < 0.5 ? int(range/Ebw_PS) : int(range/Ebw_PS) + 1;
+    double Elows_PS[NEb_PS+1];
+    for (int i=0;i<NEb_PS+1;i++) {
+        Elows_PS[i] = Ebl_PS + i*Ebw_PS;
+    }
+    // extract the TAGH geometry
+    vector<const DTAGHGeometry*> taghGeomVect;
+    eventLoop->Get(taghGeomVect);
+    if (taghGeomVect.size() < 1)
     return OBJECT_NOT_AVAILABLE;
-  const DTAGHGeometry& taghGeom = *(taghGeomVect[0]);
-  // get photon energy bin low of each counter for energy histogram binning
-  double Elows_TAGH[NC_TAGH+1];
-  for (int i=0;i<NC_TAGH;i++) {
-    Elows_TAGH[i] = taghGeom.getElow(NC_TAGH-i); 
-  }
-  // add the upper limit
-  Elows_TAGH[NC_TAGH] = taghGeom.getEhigh(1); 
-  // extract the TAGM geometry
-  vector<const DTAGMGeometry*> tagmGeomVect;
-  eventLoop->Get(tagmGeomVect);
-  if (tagmGeomVect.size() < 1)
+    const DTAGHGeometry& taghGeom = *(taghGeomVect[0]);
+    // get photon energy bin low of each counter for energy histogram binning
+    double Elows_TAGH[NC_TAGH+1];
+    for (int i=0;i<NC_TAGH;i++) {
+        Elows_TAGH[i] = taghGeom.getElow(NC_TAGH-i);
+    }
+    // add the upper limit
+    Elows_TAGH[NC_TAGH] = taghGeom.getEhigh(1);
+    // extract the TAGM geometry
+    vector<const DTAGMGeometry*> tagmGeomVect;
+    eventLoop->Get(tagmGeomVect);
+    if (tagmGeomVect.size() < 1)
     return OBJECT_NOT_AVAILABLE;
-  const DTAGMGeometry& tagmGeom = *(tagmGeomVect[0]);
-  // get photon energy bin low of each counter for energy histogram binning
-  double Elows_TAGM[NC_TAGM+1];
-  for (int i=0;i<NC_TAGM;i++) {
-    Elows_TAGM[i] = tagmGeom.getElow(NC_TAGM-i); 
-  }
-  // add the upper limit
-  Elows_TAGM[NC_TAGM] = tagmGeom.getEhigh(1); 
-  //  
-  const int NEdiff = 80;
-  double EdiffLows[NEdiff+1];
-  for (int i=0;i<NEdiff+1;i++) {
-    EdiffLows[i] = -0.15 + i*0.00375;
-  }
-  double modules[NC_PSC+1];
-  for (int i=0;i<=NC_PSC;i++) {
-    modules[i] = 0.5+i;
-  }
-  const int NTb = 2000;
-  double Tlows[NTb+1];
-  for (int i=0;i<=NTb;i++) {
-    Tlows[i] = -400.0+i*0.4;
-  }
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-  // set variable-width energy bins if histogram is empty
-  // PS
-  if (hPS_ElVsEr->GetEntries()==0) hPS_ElVsEr->SetBins(NC_PS,Elows_PSarm[1],NC_PS,Elows_PSarm[0]);
-  if (hPS_ElVsPSCIDLeft->GetEntries()==0) hPS_ElVsPSCIDLeft->SetBins(NC_PSC,modules,NC_PS,Elows_PSarm[0]);
-  if (hPS_ErVsPSCIDRight->GetEntries()==0) hPS_ErVsPSCIDRight->SetBins(NC_PSC,modules,NC_PS,Elows_PSarm[1]);
-  if (hPSTAGH_ElVsEr->GetEntries()==0) hPSTAGH_ElVsEr->SetBins(NC_PS,Elows_PSarm[1],NC_PS,Elows_PSarm[0]);
-  if (hPSTAGM_ElVsEr->GetEntries()==0) hPSTAGM_ElVsEr->SetBins(NC_PS,Elows_PSarm[1],NC_PS,Elows_PSarm[0]);
-  if (hPS_E->GetEntries()==0) hPS_E->SetBins(NEb_PS,Elows_PS);
-  if (hPSTAGH_E->GetEntries()==0) hPSTAGH_E->SetBins(NEb_PS,Elows_PS);
-  if (hPSTAGM_E->GetEntries()==0) hPSTAGM_E->SetBins(NEb_PS,Elows_PS);
-  if (hPS_timeVsE->GetEntries()==0) hPS_timeVsE->SetBins(NEb_PS,Elows_PS,NTb,Tlows);
-  if (hPSTAGH_timeVsE->GetEntries()==0) hPSTAGH_timeVsE->SetBins(NEb_PS,Elows_PS,NTb,Tlows);
-  if (hPSTAGM_timeVsE->GetEntries()==0) hPSTAGM_timeVsE->SetBins(NEb_PS,Elows_PS,NTb,Tlows);
-  // TAGH
-  if (hPS_Etagh->GetEntries()==0) hPS_Etagh->SetBins(NC_TAGH,Elows_TAGH);
-  if (hPS_timeVsEtagh->GetEntries()==0) hPS_timeVsEtagh->SetBins(NC_TAGH,Elows_TAGH,NTb,Tlows);
-  if (hPSTAGH_Etagh->GetEntries()==0) hPSTAGH_Etagh->SetBins(NC_TAGH,Elows_TAGH);
-  if (hPSTAGH_EVsEtagh->GetEntries()==0) hPSTAGH_EVsEtagh->SetBins(NC_TAGH,Elows_TAGH,NEb_PS,Elows_PS);
-  if (hPSTAGH_timeVsEtagh->GetEntries()==0) hPSTAGH_timeVsEtagh->SetBins(NC_TAGH,Elows_TAGH,NTb,Tlows);
-  if (hPSTAGH_EdiffVsEtagh->GetEntries()==0) hPSTAGH_EdiffVsEtagh->SetBins(NC_TAGH,Elows_TAGH,NEdiff,EdiffLows);
-  // TAGM
-  if (hPS_Etagm->GetEntries()==0) hPS_Etagm->SetBins(NC_TAGM,Elows_TAGM);
-  if (hPS_timeVsEtagm->GetEntries()==0) hPS_timeVsEtagm->SetBins(NC_TAGM,Elows_TAGM,NTb,Tlows);
-  if (hPSTAGM_Etagm->GetEntries()==0) hPSTAGM_Etagm->SetBins(NC_TAGM,Elows_TAGM);
-  if (hPSTAGM_EVsEtagm->GetEntries()==0) hPSTAGM_EVsEtagm->SetBins(NC_TAGM,Elows_TAGM,NEb_PS,Elows_PS);
-  if (hPSTAGM_timeVsEtagm->GetEntries()==0) hPSTAGM_timeVsEtagm->SetBins(NC_TAGM,Elows_TAGM,NTb,Tlows);
-  if (hPSTAGM_EdiffVsEtagm->GetEntries()==0) hPSTAGM_EdiffVsEtagm->SetBins(NC_TAGM,Elows_TAGM,NEdiff,EdiffLows);
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
-  //
-  return NOERROR;
+    const DTAGMGeometry& tagmGeom = *(tagmGeomVect[0]);
+    // get photon energy bin low of each counter for energy histogram binning
+    double Elows_TAGM[NC_TAGM+1];
+    for (int i=0;i<NC_TAGM;i++) {
+        Elows_TAGM[i] = tagmGeom.getElow(NC_TAGM-i);
+    }
+    // add the upper limit
+    Elows_TAGM[NC_TAGM] = tagmGeom.getEhigh(1);
+    //
+    const int NEdiff = 80;
+    double EdiffLows[NEdiff+1];
+    for (int i=0;i<NEdiff+1;i++) {
+        EdiffLows[i] = -0.15 + i*0.00375;
+    }
+    double modules[NC_PSC+1];
+    for (int i=0;i<=NC_PSC;i++) {
+        modules[i] = 0.5+i;
+    }
+    const int NTb = 2000;
+    double Tlows[NTb+1];
+    for (int i=0;i<=NTb;i++) {
+        Tlows[i] = -400.0+i*0.4;
+    }
+    japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+    // set variable-width energy bins if histogram is empty
+    // PS
+    if (hPS_ElVsEr->GetEntries()==0) hPS_ElVsEr->SetBins(NC_PS,Elows_PSarm[1],NC_PS,Elows_PSarm[0]);
+    if (hPS_ElVsPSCIDLeft->GetEntries()==0) hPS_ElVsPSCIDLeft->SetBins(NC_PSC,modules,NC_PS,Elows_PSarm[0]);
+    if (hPS_ErVsPSCIDRight->GetEntries()==0) hPS_ErVsPSCIDRight->SetBins(NC_PSC,modules,NC_PS,Elows_PSarm[1]);
+    if (hPSTAGH_ElVsEr->GetEntries()==0) hPSTAGH_ElVsEr->SetBins(NC_PS,Elows_PSarm[1],NC_PS,Elows_PSarm[0]);
+    if (hPSTAGM_ElVsEr->GetEntries()==0) hPSTAGM_ElVsEr->SetBins(NC_PS,Elows_PSarm[1],NC_PS,Elows_PSarm[0]);
+    if (hPS_E->GetEntries()==0) hPS_E->SetBins(NEb_PS,Elows_PS);
+    if (hPSTAGH_E->GetEntries()==0) hPSTAGH_E->SetBins(NEb_PS,Elows_PS);
+    if (hPSTAGM_E->GetEntries()==0) hPSTAGM_E->SetBins(NEb_PS,Elows_PS);
+    if (hPS_timeVsE->GetEntries()==0) hPS_timeVsE->SetBins(NEb_PS,Elows_PS,NTb,Tlows);
+    if (hPSTAGH_timeVsE->GetEntries()==0) hPSTAGH_timeVsE->SetBins(NEb_PS,Elows_PS,NTb,Tlows);
+    if (hPSTAGM_timeVsE->GetEntries()==0) hPSTAGM_timeVsE->SetBins(NEb_PS,Elows_PS,NTb,Tlows);
+    // TAGH
+    if (hPS_Etagh->GetEntries()==0) hPS_Etagh->SetBins(NC_TAGH,Elows_TAGH);
+    if (hPS_timeVsEtagh->GetEntries()==0) hPS_timeVsEtagh->SetBins(NC_TAGH,Elows_TAGH,NTb,Tlows);
+    if (hPSTAGH_Etagh->GetEntries()==0) hPSTAGH_Etagh->SetBins(NC_TAGH,Elows_TAGH);
+    if (hPSTAGH_EVsEtagh->GetEntries()==0) hPSTAGH_EVsEtagh->SetBins(NC_TAGH,Elows_TAGH,NEb_PS,Elows_PS);
+    if (hPSTAGH_timeVsEtagh->GetEntries()==0) hPSTAGH_timeVsEtagh->SetBins(NC_TAGH,Elows_TAGH,NTb,Tlows);
+    if (hPSTAGH_EdiffVsEtagh->GetEntries()==0) hPSTAGH_EdiffVsEtagh->SetBins(NC_TAGH,Elows_TAGH,NEdiff,EdiffLows);
+    // TAGM
+    if (hPS_Etagm->GetEntries()==0) hPS_Etagm->SetBins(NC_TAGM,Elows_TAGM);
+    if (hPS_timeVsEtagm->GetEntries()==0) hPS_timeVsEtagm->SetBins(NC_TAGM,Elows_TAGM,NTb,Tlows);
+    if (hPSTAGM_Etagm->GetEntries()==0) hPSTAGM_Etagm->SetBins(NC_TAGM,Elows_TAGM);
+    if (hPSTAGM_EVsEtagm->GetEntries()==0) hPSTAGM_EVsEtagm->SetBins(NC_TAGM,Elows_TAGM,NEb_PS,Elows_PS);
+    if (hPSTAGM_timeVsEtagm->GetEntries()==0) hPSTAGM_timeVsEtagm->SetBins(NC_TAGM,Elows_TAGM,NTb,Tlows);
+    if (hPSTAGM_EdiffVsEtagm->GetEntries()==0) hPSTAGM_EdiffVsEtagm->SetBins(NC_TAGM,Elows_TAGM,NEdiff,EdiffLows);
+    japp->RootUnLock(); //RELEASE ROOT LOCK!!
+    //
+    return NOERROR;
 }
 
 //------------------
@@ -366,105 +391,134 @@ jerror_t JEventProcessor_PSPair_online::brun(JEventLoop *eventLoop, int32_t runn
 //------------------
 jerror_t JEventProcessor_PSPair_online::evnt(JEventLoop *loop, uint64_t eventnumber)
 {
-  // This is called for every event. Use of common resources like writing
-  // to a file or filling a histogram should be mutex protected. Using
-  // loop->Get(...) to get reconstructed objects (and thereby activating the
-  // reconstruction algorithm) should be done outside of any mutex lock
-  // since multiple threads may call this method at the same time.
-  // coarse PS pairs
-  vector<const DPSCPair*> cpairs;
-  loop->Get(cpairs);
-  // fine PS pairs
-  vector<const DPSPair*> fpairs;
-  loop->Get(fpairs);
-  // tagger hits
-  vector<const DTAGHHit*> taghhits;
-  loop->Get(taghhits);
-  vector<const DTAGMHit*> tagmhits;
-  loop->Get(tagmhits);
-  //
-  japp->RootWriteLock();
-  hPSC_NHitPairs->Fill(cpairs.size());
-  hPS_NHitPairs->Fill(fpairs.size());
-  // PSC coincidences
-  if (cpairs.size()>=1) {
-    // take pair with smallest time difference from sorted vector
-    const DPSCHit* clhit = cpairs[0]->ee.first; // left hit in coarse PS
-    const DPSCHit* crhit = cpairs[0]->ee.second;// right hit in coarse PS
-    hPSC_PSCIDLeftVsIDRight->Fill(crhit->module,clhit->module); 
-    hPSC_tdiffVsPSCIDRight[clhit->module-1]->Fill(crhit->module,clhit->t-crhit->t);
-    hPSC_tdiffVsPSCIDLeft[crhit->module-1]->Fill(clhit->module,clhit->t-crhit->t);
-    // PSC,PS coincidences
-    if (fpairs.size()>=1) {
-      pspair_num_events->Fill(1);
-      // take pair with smallest time difference from sorted vector
-      const DPSHit* flhit = fpairs[0]->ee.first;  // left hit in fine PS
-      const DPSHit* frhit = fpairs[0]->ee.second; // right hit in fine PS
-      double E_pair = flhit->E+frhit->E;
-      hPS_PSCIDLeftVsIDRight->Fill(crhit->module,clhit->module);  
-      hPS_PSIDLeftVsIDRight->Fill(frhit->column,flhit->column);  
-      hPS_ElVsEr->Fill(frhit->E,flhit->E);
-      hPS_E->Fill(E_pair);
-      hPS_timeVsE->Fill(E_pair,clhit->t);
-      // correlation between PSC and PS ids for each arm
-      hPS_PSIDLeftVsPSCIDLeft->Fill(clhit->module,flhit->column);
-      hPS_PSIDRightVsPSCIDRight->Fill(crhit->module,frhit->column);
-      hPS_ElVsPSCIDLeft->Fill(clhit->module,flhit->E);
-      hPS_ErVsPSCIDRight->Fill(crhit->module,frhit->E);
-      // PSC,PS,TAGH coincidences
-      double EdiffMax = 0.15; // max percent difference of tagger hit and pair energies 
-      for (unsigned int i=0; i < taghhits.size(); i++) {
-	const DTAGHHit* tag = taghhits[i];
-	if (!tag->has_TDC||!tag->has_fADC) continue;
-	hPS_TAGHCounterID->Fill(tag->counter_id);
-	hPS_Etagh->Fill(tag->E);
-	hPS_timeVsEtagh->Fill(tag->E,tag->t);
-	hPSTAGH_tdiffVsEdiff->Fill((E_pair-tag->E)/E_pair,clhit->t-tag->t);
-	if (fabs(E_pair-tag->E)/E_pair > EdiffMax) continue; // loose cut on energy difference
-	hPSTAGH_TAGHCounterID->Fill(tag->counter_id);
-	hPSTAGH_Etagh->Fill(tag->E);
-	hPSTAGH_timeVsEtagh->Fill(tag->E,tag->t);
-	hPSTAGH_EVsEtagh->Fill(tag->E,E_pair);
-	hPSTAGH_EdiffVsEtagh->Fill(tag->E,(E_pair-tag->E)/E_pair);
-	hPSTAGH_EdiffVsTAGHCounterID->Fill(tag->counter_id,(E_pair-tag->E)/E_pair);
-	hPSTAGH_tdiffVsTAGHCounterID_L[clhit->module-1]->Fill(tag->counter_id,clhit->t-tag->t);
-	hPSTAGH_tdiffVsTAGHCounterID_R[crhit->module-1]->Fill(tag->counter_id,crhit->t-tag->t);
-	hPSTAGH_PSCIDLeftVsIDRight->Fill(crhit->module,clhit->module);  
-	hPSTAGH_PSIDLeftVsIDRight->Fill(frhit->column,flhit->column);  
-	hPSTAGH_ElVsEr->Fill(frhit->E,flhit->E);
-	hPSTAGH_E->Fill(E_pair);
-	hPSTAGH_timeVsE->Fill(E_pair,clhit->t-tag->t);
-      }
-      // PSC,PS,TAGM coincidences
-      for (unsigned int i=0; i < tagmhits.size(); i++) {
-	const DTAGMHit* tag = tagmhits[i];
-	if (!tag->has_TDC||!tag->has_fADC) continue;
-	if (tag->row!=0) continue;
-	hPS_TAGMColumn->Fill(tag->column);
-	hPS_Etagm->Fill(tag->E);
-	hPS_timeVsEtagm->Fill(tag->E,tag->t);
-	hPSTAGM_tdiffVsEdiff->Fill((E_pair-tag->E)/E_pair,clhit->t-tag->t);
-	if (fabs(E_pair-tag->E)/E_pair > EdiffMax) continue; // loose cut on energy difference
-	hPSTAGM_TAGMColumn->Fill(tag->column);
-	hPSTAGM_Etagm->Fill(tag->E);
-	hPSTAGM_timeVsEtagm->Fill(tag->E,tag->t);
-	hPSTAGM_EVsEtagm->Fill(tag->E,E_pair);
-	hPSTAGM_EdiffVsEtagm->Fill(tag->E,(E_pair-tag->E)/E_pair);
-	hPSTAGM_EdiffVsTAGMColumn->Fill(tag->column,(E_pair-tag->E)/E_pair);
-	hPSTAGM_tdiffVsTAGMColumn_L[clhit->module-1]->Fill(tag->column,clhit->t-tag->t);
-	hPSTAGM_tdiffVsTAGMColumn_R[crhit->module-1]->Fill(tag->column,crhit->t-tag->t);
-	hPSTAGM_PSCIDLeftVsIDRight->Fill(crhit->module,clhit->module);  
-	hPSTAGM_PSIDLeftVsIDRight->Fill(frhit->column,flhit->column);  
-	hPSTAGM_ElVsEr->Fill(frhit->E,flhit->E);
-	hPSTAGM_E->Fill(E_pair);
-	hPSTAGM_timeVsE->Fill(E_pair,clhit->t-tag->t);
-      }
+    // This is called for every event. Use of common resources like writing
+    // to a file or filling a histogram should be mutex protected. Using
+    // loop->Get(...) to get reconstructed objects (and thereby activating the
+    // reconstruction algorithm) should be done outside of any mutex lock
+    // since multiple threads may call this method at the same time.
+    // coarse PS pairs
+    vector<const DPSCPair*> cpairs;
+    loop->Get(cpairs);
+    // fine PS pairs
+    vector<const DPSPair*> fpairs;
+    loop->Get(fpairs);
+    // tagger hits
+    vector<const DTAGHHit*> taghhits;
+    loop->Get(taghhits);
+    vector<const DTAGMHit*> tagmhits;
+    loop->Get(tagmhits);
+    // TPOL hits
+    vector<const DTPOLHit*> tpolhits;
+    loop->Get(tpolhits);
+    //
+    japp->RootWriteLock();
+    hPSC_NHitPairs->Fill(cpairs.size());
+    hPS_NHitPairs->Fill(fpairs.size());
+    // PSC coincidences
+    if (cpairs.size()>=1) {
+        // take pair with smallest time difference from sorted vector
+        const DPSCHit* clhit = cpairs[0]->ee.first; // left hit in coarse PS
+        const DPSCHit* crhit = cpairs[0]->ee.second;// right hit in coarse PS
+        hPSC_PSCIDLeftVsIDRight->Fill(crhit->module,clhit->module);
+        hPSC_tdiffVsPSCIDRight[clhit->module-1]->Fill(crhit->module,clhit->t-crhit->t);
+        hPSC_tdiffVsPSCIDLeft[crhit->module-1]->Fill(clhit->module,clhit->t-crhit->t);
+        // PSC,PS coincidences
+        if (fpairs.size()>=1) {
+            pspair_num_events->Fill(1);
+            // take pair with smallest time difference from sorted vector
+            const DPSHit* flhit = fpairs[0]->ee.first;  // left hit in fine PS
+            const DPSHit* frhit = fpairs[0]->ee.second; // right hit in fine PS
+            double E_pair = flhit->E+frhit->E;
+            hPS_PSCIDLeftVsIDRight->Fill(crhit->module,clhit->module);
+            hPS_PSIDLeftVsIDRight->Fill(frhit->column,flhit->column);
+            double PS_Ediff = flhit->E-frhit->E;
+            double PSC_tdiff = clhit->t-crhit->t;
+            hPS_Ediff->Fill(PS_Ediff);
+            hPS_ElVsEr->Fill(frhit->E,flhit->E);
+            hPS_E->Fill(E_pair);
+            hPS_timeVsE->Fill(E_pair,clhit->t);
+            // correlation between PSC and PS ids for each arm
+            hPS_PSIDLeftVsPSCIDLeft->Fill(clhit->module,flhit->column);
+            hPS_PSIDRightVsPSCIDRight->Fill(crhit->module,frhit->column);
+            hPS_ElVsPSCIDLeft->Fill(clhit->module,flhit->E);
+            hPS_ErVsPSCIDRight->Fill(crhit->module,frhit->E);
+            // PSC,PS,TAGH coincidences
+            double EdiffMax = 0.15; // max percent difference of tagger hit and pair energies
+            for (unsigned int i=0; i < taghhits.size(); i++) {
+                const DTAGHHit* tag = taghhits[i];
+                if (!tag->has_TDC||!tag->has_fADC) continue;
+                hPS_TAGHCounterID->Fill(tag->counter_id);
+                hPS_Etagh->Fill(tag->E);
+                hPS_timeVsEtagh->Fill(tag->E,tag->t);
+                hPSTAGH_tdiffVsEdiff->Fill((E_pair-tag->E)/E_pair,clhit->t-tag->t);
+                if (fabs(E_pair-tag->E)/E_pair > EdiffMax) continue; // loose cut on energy difference
+                hPSTAGH_TAGHCounterID->Fill(tag->counter_id);
+                hPSTAGH_Etagh->Fill(tag->E);
+                hPSTAGH_timeVsEtagh->Fill(tag->E,tag->t);
+                hPSTAGH_EVsEtagh->Fill(tag->E,E_pair);
+                hPSTAGH_EdiffVsEtagh->Fill(tag->E,(E_pair-tag->E)/E_pair);
+                hPSTAGH_EdiffVsTAGHCounterID->Fill(tag->counter_id,(E_pair-tag->E)/E_pair);
+                hPSTAGH_tdiffVsTAGHCounterID_L[clhit->module-1]->Fill(tag->counter_id,clhit->t-tag->t);
+                hPSTAGH_tdiffVsTAGHCounterID_R[crhit->module-1]->Fill(tag->counter_id,crhit->t-tag->t);
+                hPSTAGH_PSCIDLeftVsIDRight->Fill(crhit->module,clhit->module);
+                hPSTAGH_PSIDLeftVsIDRight->Fill(frhit->column,flhit->column);
+                hPSTAGH_ElVsEr->Fill(frhit->E,flhit->E);
+                hPSTAGH_E->Fill(E_pair);
+                hPSTAGH_timeVsE->Fill(E_pair,clhit->t-tag->t);
+            }
+            // PSC,PS,TAGM coincidences
+            for (unsigned int i=0; i < tagmhits.size(); i++) {
+                const DTAGMHit* tag = tagmhits[i];
+                if (!tag->has_TDC||!tag->has_fADC) continue;
+                if (tag->row!=0) continue;
+                hPS_TAGMColumn->Fill(tag->column);
+                hPS_Etagm->Fill(tag->E);
+                hPS_timeVsEtagm->Fill(tag->E,tag->t);
+                hPSTAGM_tdiffVsEdiff->Fill((E_pair-tag->E)/E_pair,clhit->t-tag->t);
+                if (fabs(E_pair-tag->E)/E_pair > EdiffMax) continue; // loose cut on energy difference
+                hPSTAGM_TAGMColumn->Fill(tag->column);
+                hPSTAGM_Etagm->Fill(tag->E);
+                hPSTAGM_timeVsEtagm->Fill(tag->E,tag->t);
+                hPSTAGM_EVsEtagm->Fill(tag->E,E_pair);
+                hPSTAGM_EdiffVsEtagm->Fill(tag->E,(E_pair-tag->E)/E_pair);
+                hPSTAGM_EdiffVsTAGMColumn->Fill(tag->column,(E_pair-tag->E)/E_pair);
+                hPSTAGM_tdiffVsTAGMColumn_L[clhit->module-1]->Fill(tag->column,clhit->t-tag->t);
+                hPSTAGM_tdiffVsTAGMColumn_R[crhit->module-1]->Fill(tag->column,crhit->t-tag->t);
+                hPSTAGM_PSCIDLeftVsIDRight->Fill(crhit->module,clhit->module);
+                hPSTAGM_PSIDLeftVsIDRight->Fill(frhit->column,flhit->column);
+                hPSTAGM_ElVsEr->Fill(frhit->E,flhit->E);
+                hPSTAGM_E->Fill(E_pair);
+                hPSTAGM_timeVsE->Fill(E_pair,clhit->t-tag->t);
+            }
+            // PSC,PS,TPOL coincidences
+            if (fabs(PS_Ediff) > 1.75) {japp->RootUnLock(); return NOERROR;}
+            if (fabs(PSC_tdiff) > 1.3) {japp->RootUnLock(); return NOERROR;}
+            if (E_pair < 8.4 || E_pair > 9.2) {japp->RootUnLock(); return NOERROR;}
+            double ph_cut = 100.0;
+            int N_TPOL = 0;
+            for(unsigned int i=0; i<tpolhits.size(); i++) {
+                if (tpolhits[i]->pulse_peak>=ph_cut) N_TPOL++;
+            }
+            hPSTPOL_NHits->Fill(N_TPOL);
+            if (N_TPOL>1) {japp->RootUnLock(); return NOERROR;}
+            for(unsigned int i=0; i<tpolhits.size(); i++) {
+                const DTPOLHit* hit = tpolhits[i];
+                hPSTPOL_peak->Fill(hit->pulse_peak);
+                hPSTPOL_peakVsSector->Fill(hit->sector,hit->pulse_peak);
+                hPSTPOL_timeVsPeak->Fill(hit->pulse_peak,hit->t);
+                if (hit->pulse_peak<ph_cut) continue;
+                hPSTPOL_sector->Fill(hit->sector);
+                hPSTPOL_phi->Fill(hit->phi);
+                hPSTPOL_time->Fill(hit->t);
+                hPSTPOL_timeVsSector->Fill(hit->sector,hit->t);
+                hPSTPOL_timeVsPhi->Fill(hit->phi,hit->t);
+            }
+        }
     }
-  }
-  //
-  japp->RootUnLock();
+    //
+    japp->RootUnLock();
 
-  return NOERROR;
+    return NOERROR;
 }
 
 //------------------
@@ -472,10 +526,10 @@ jerror_t JEventProcessor_PSPair_online::evnt(JEventLoop *loop, uint64_t eventnum
 //------------------
 jerror_t JEventProcessor_PSPair_online::erun(void)
 {
-  // This is called whenever the run number changes, before it is
-  // changed to give you a chance to clean up before processing
-  // events from the next run number.
-  return NOERROR;
+    // This is called whenever the run number changes, before it is
+    // changed to give you a chance to clean up before processing
+    // events from the next run number.
+    return NOERROR;
 }
 
 //------------------
@@ -483,7 +537,7 @@ jerror_t JEventProcessor_PSPair_online::erun(void)
 //------------------
 jerror_t JEventProcessor_PSPair_online::fini(void)
 {
-  // Called before program exit after event processing is finished.
-  return NOERROR;
+    // Called before program exit after event processing is finished.
+    return NOERROR;
 }
 

--- a/src/plugins/monitoring/PSPair_online/JEventProcessor_PSPair_online.h
+++ b/src/plugins/monitoring/PSPair_online/JEventProcessor_PSPair_online.h
@@ -11,17 +11,17 @@
 #include <JANA/JEventProcessor.h>
 
 class JEventProcessor_PSPair_online:public jana::JEventProcessor{
- public:
-  JEventProcessor_PSPair_online();
-  ~JEventProcessor_PSPair_online();
-  const char* className(void){return "JEventProcessor_PSPair_online";}
+public:
+    JEventProcessor_PSPair_online();
+    ~JEventProcessor_PSPair_online();
+    const char* className(void){return "JEventProcessor_PSPair_online";}
 
- private:
-  jerror_t init(void);						///< Called once at program start.
-  jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
-  jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
-  jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
-  jerror_t fini(void);						///< Called after last event of last event source has been processed.
+private:
+    jerror_t init(void); ///< Called once at program start.
+    jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber); ///< Called everytime a new run number is detected.
+    jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber); ///< Called every event.
+    jerror_t erun(void); ///< Called everytime run number changes, provided brun has been called.
+    jerror_t fini(void); ///< Called after last event of last event source has been processed.
 };
 
 #endif // _JEventProcessor_PSPair_online_

--- a/src/plugins/monitoring/PSPair_online/PS_PSC_coinc.C
+++ b/src/plugins/monitoring/PSPair_online/PS_PSC_coinc.C
@@ -8,46 +8,46 @@
 // hnamepath: /PSPair/PSC_PS/PS_ErVsPSCIDRight
 
 {
-  TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("PSPair");
-  if(dir) dir->cd();
+    TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("PSPair");
+    if(dir) dir->cd();
 
-  TH2I* id_LL =(TH2I*)gDirectory->Get("PSC_PS/PS_PSIDLeftVsPSCIDLeft");
-  TH2I* id_RR =(TH2I*)gDirectory->Get("PSC_PS/PS_PSIDRightVsPSCIDRight");
-  TH2I* Eid_LL =(TH2I*)gDirectory->Get("PSC_PS/PS_ElVsPSCIDLeft");
-  TH2I* Eid_RR =(TH2I*)gDirectory->Get("PSC_PS/PS_ErVsPSCIDRight");
+    TH2I* id_LL =(TH2I*)gDirectory->Get("PSC_PS/PS_PSIDLeftVsPSCIDLeft");
+    TH2I* id_RR =(TH2I*)gDirectory->Get("PSC_PS/PS_PSIDRightVsPSCIDRight");
+    TH2I* Eid_LL =(TH2I*)gDirectory->Get("PSC_PS/PS_ElVsPSCIDLeft");
+    TH2I* Eid_RR =(TH2I*)gDirectory->Get("PSC_PS/PS_ErVsPSCIDRight");
 
-  if(gPad == NULL){
-    TCanvas *c1 = new TCanvas("c1","PS/PSC Geometrical Coincidence Monitor",150,10,990,660);
-    c1->cd(0);
-    c1->Draw();
-    c1->Update();
-  }
-    
-  if(!gPad) return;
-  TCanvas* c1 = gPad->GetCanvas();
-  c1->Divide(2,2);
-  
-  double tsize = 0.0475;
-  gStyle->SetOptStat("emr");
-  if (id_LL){
-    c1->cd(3);
-    id_LL->SetTitleSize(tsize,"xy");
-    id_LL->Draw();
-  }
-  if (id_RR) {
-    c1->cd(4);
-    id_RR->SetTitleSize(tsize,"xy");
-    id_RR->Draw();
-  }
-  if (Eid_LL){
-    c1->cd(1);
-    Eid_LL->SetTitleSize(tsize,"xy");
-    Eid_LL->Draw();
-  }
-  if (Eid_RR) {
-    c1->cd(2);
-    Eid_RR->SetTitleSize(tsize,"xy");
-    Eid_RR->Draw();
-  }
+    if(gPad == NULL){
+        TCanvas *c1 = new TCanvas("c1","PS/PSC Geometrical Coincidence Monitor",150,10,990,660);
+        c1->cd(0);
+        c1->Draw();
+        c1->Update();
+    }
+
+    if(!gPad) return;
+    TCanvas* c1 = gPad->GetCanvas();
+    c1->Divide(2,2);
+
+    double tsize = 0.0475;
+    gStyle->SetOptStat("emr");
+    if (id_LL){
+        c1->cd(3);
+        id_LL->SetTitleSize(tsize,"xy");
+        id_LL->Draw();
+    }
+    if (id_RR) {
+        c1->cd(4);
+        id_RR->SetTitleSize(tsize,"xy");
+        id_RR->Draw();
+    }
+    if (Eid_LL){
+        c1->cd(1);
+        Eid_LL->SetTitleSize(tsize,"xy");
+        Eid_LL->Draw();
+    }
+    if (Eid_RR) {
+        c1->cd(2);
+        Eid_RR->SetTitleSize(tsize,"xy");
+        Eid_RR->Draw();
+    }
 
 }

--- a/src/plugins/monitoring/PSPair_online/PS_TAG_energy.C
+++ b/src/plugins/monitoring/PSPair_online/PS_TAG_energy.C
@@ -7,58 +7,58 @@
 // hnamepath: /PSPair/PSC_PS_TAGM/PSTAGM_EdiffVsEtagm
 // hnamepath: /PSPair/PSC_PS_TAGM/PSTAGM_EVsEtagm
 
-{  
-  TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("PSPair");
-  if(dir) dir->cd();
+{
+    TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("PSPair");
+    if(dir) dir->cd();
 
-  TH2I* hEdiff_tagh = (TH2I*)gDirectory->Get("PSC_PS_TAGH/PSTAGH_EdiffVsEtagh");
-  TH2I* hE_tagh = (TH2I*)gDirectory->Get("PSC_PS_TAGH/PSTAGH_EVsEtagh");
-  TH2I* hEdiff_tagm = (TH2I*)gDirectory->Get("PSC_PS_TAGM/PSTAGM_EdiffVsEtagm");
-  TH2I* hE_tagm = (TH2I*)gDirectory->Get("PSC_PS_TAGM/PSTAGM_EVsEtagm");
+    TH2I* hEdiff_tagh = (TH2I*)gDirectory->Get("PSC_PS_TAGH/PSTAGH_EdiffVsEtagh");
+    TH2I* hE_tagh = (TH2I*)gDirectory->Get("PSC_PS_TAGH/PSTAGH_EVsEtagh");
+    TH2I* hEdiff_tagm = (TH2I*)gDirectory->Get("PSC_PS_TAGM/PSTAGM_EdiffVsEtagm");
+    TH2I* hE_tagm = (TH2I*)gDirectory->Get("PSC_PS_TAGM/PSTAGM_EVsEtagm");
 
-  if(gPad == NULL){
-    TCanvas *c1 = new TCanvas("c1","PS/Tagger Energy Correlation Monitor",150,10,990,660);
-    c1->cd(0);
-    c1->Draw();
-    c1->Update();
-  }
+    if(gPad == NULL){
+        TCanvas *c1 = new TCanvas("c1","PS/Tagger Energy Correlation Monitor",150,10,990,660);
+        c1->cd(0);
+        c1->Draw();
+        c1->Update();
+    }
 
-  if(!gPad) return;
-  TCanvas* c1 = gPad->GetCanvas();
-  c1->Divide(2,2);
+    if(!gPad) return;
+    TCanvas* c1 = gPad->GetCanvas();
+    c1->Divide(2,2);
 
-  double tsize = 0.0475;  
-  gStyle->SetOptStat("emr");
-  if(hE_tagh){
-    c1->cd(2);
-    hE_tagh->SetTitleSize(tsize,"xy");
-    hE_tagh->GetXaxis()->SetRange(hE_tagh->FindFirstBinAbove(10.0),hE_tagh->FindLastBinAbove(10.0));
-    hE_tagh->GetYaxis()->SetRange(hE_tagh->FindFirstBinAbove(10.0,2),hE_tagh->FindLastBinAbove(10.0,2));
-    hE_tagh->Draw("colz");
-  }
- 
-  if(hE_tagm){
-    c1->cd(1);
-    hE_tagm->SetTitleSize(tsize,"xy");
-    hE_tagm->GetXaxis()->SetRange(hE_tagm->FindFirstBinAbove(10.0),hE_tagm->FindLastBinAbove(10.0));
-    hE_tagm->GetYaxis()->SetRange(hE_tagm->FindFirstBinAbove(10.0,2),hE_tagm->FindLastBinAbove(10.0,2));
-    hE_tagm->Draw("colz");
-  }
- 
-  if(hEdiff_tagh){
-    c1->cd(4);
-    hEdiff_tagh->SetTitleSize(tsize,"xy");
-    hEdiff_tagh->GetXaxis()->SetRange(hEdiff_tagh->FindFirstBinAbove(10.0),hEdiff_tagh->FindLastBinAbove(10.0));
-    hEdiff_tagh->GetYaxis()->SetRange(hEdiff_tagh->FindFirstBinAbove(10.0,2),hEdiff_tagh->FindLastBinAbove(10.0,2));
-    hEdiff_tagh->Draw("colz");
-  }
+    double tsize = 0.0475;
+    gStyle->SetOptStat("emr");
+    if(hE_tagh){
+        c1->cd(2);
+        hE_tagh->SetTitleSize(tsize,"xy");
+        hE_tagh->GetXaxis()->SetRange(hE_tagh->FindFirstBinAbove(10.0),hE_tagh->FindLastBinAbove(10.0));
+        hE_tagh->GetYaxis()->SetRange(hE_tagh->FindFirstBinAbove(10.0,2),hE_tagh->FindLastBinAbove(10.0,2));
+        hE_tagh->Draw("colz");
+    }
 
-  if(hEdiff_tagm){
-    c1->cd(3);
-    hEdiff_tagm->SetTitleSize(tsize,"xy");
-    hEdiff_tagm->GetXaxis()->SetRange(hEdiff_tagm->FindFirstBinAbove(10.0),hEdiff_tagm->FindLastBinAbove(10.0));
-    hEdiff_tagm->GetYaxis()->SetRange(hEdiff_tagm->FindFirstBinAbove(10.0,2),hEdiff_tagm->FindLastBinAbove(10.0,2));
-    hEdiff_tagm->Draw("colz");
-  }
+    if(hE_tagm){
+        c1->cd(1);
+        hE_tagm->SetTitleSize(tsize,"xy");
+        hE_tagm->GetXaxis()->SetRange(hE_tagm->FindFirstBinAbove(10.0),hE_tagm->FindLastBinAbove(10.0));
+        hE_tagm->GetYaxis()->SetRange(hE_tagm->FindFirstBinAbove(10.0,2),hE_tagm->FindLastBinAbove(10.0,2));
+        hE_tagm->Draw("colz");
+    }
+
+    if(hEdiff_tagh){
+        c1->cd(4);
+        hEdiff_tagh->SetTitleSize(tsize,"xy");
+        hEdiff_tagh->GetXaxis()->SetRange(hEdiff_tagh->FindFirstBinAbove(10.0),hEdiff_tagh->FindLastBinAbove(10.0));
+        hEdiff_tagh->GetYaxis()->SetRange(hEdiff_tagh->FindFirstBinAbove(10.0,2),hEdiff_tagh->FindLastBinAbove(10.0,2));
+        hEdiff_tagh->Draw("colz");
+    }
+
+    if(hEdiff_tagm){
+        c1->cd(3);
+        hEdiff_tagm->SetTitleSize(tsize,"xy");
+        hEdiff_tagm->GetXaxis()->SetRange(hEdiff_tagm->FindFirstBinAbove(10.0),hEdiff_tagm->FindLastBinAbove(10.0));
+        hEdiff_tagm->GetYaxis()->SetRange(hEdiff_tagm->FindFirstBinAbove(10.0,2),hEdiff_tagm->FindLastBinAbove(10.0,2));
+        hEdiff_tagm->Draw("colz");
+    }
 
 }

--- a/src/plugins/monitoring/PSPair_online/PS_eff.C
+++ b/src/plugins/monitoring/PSPair_online/PS_eff.C
@@ -6,31 +6,31 @@
 // hnamepath: /PSPair/PSC_PS/PS_PSCIDLeftVsIDRight
 
 {
-  TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("PSPair");
-  if(dir) dir->cd();
-  
-  TH2F *id_LR_D =(TH2F*)gDirectory->Get("PSC/PSC_PSCIDLeftVsIDRight");
-  TH2F *id_LR_N =(TH2F*)gDirectory->Get("PSC_PS/PS_PSCIDLeftVsIDRight");
-    
-  TH2F *eff = (TH2F*)id_LR_N->Clone(); 
-  eff->Sumw2();
-  eff->Divide(id_LR_N,id_LR_D);
+    TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("PSPair");
+    if(dir) dir->cd();
 
-  if(gPad == NULL){
-    TCanvas *c1 = new TCanvas("c1","Fine PS Efficiency",150,10,990,660);
-    c1->cd(0);
-    c1->Draw();
-    c1->Update();
-  }
-    
-  if(!gPad) return;
-  TCanvas* c1 = gPad->GetCanvas();
+    TH2F *id_LR_D =(TH2F*)gDirectory->Get("PSC/PSC_PSCIDLeftVsIDRight");
+    TH2F *id_LR_N =(TH2F*)gDirectory->Get("PSC_PS/PS_PSCIDLeftVsIDRight");
 
-  double tsize = 0.045;
-  gStyle->SetOptStat("");
-  eff->SetTitle("Fine PS Efficiency: N(PSC,PS) / N(PSC)");
-  eff->SetTitleSize(tsize);
-  eff->SetTitleSize(tsize,"xy");
-  eff->Draw("colz");
-    
+    TH2F *eff = (TH2F*)id_LR_N->Clone();
+    eff->Sumw2();
+    eff->Divide(id_LR_N,id_LR_D);
+
+    if(gPad == NULL){
+        TCanvas *c1 = new TCanvas("c1","Fine PS Efficiency",150,10,990,660);
+        c1->cd(0);
+        c1->Draw();
+        c1->Update();
+    }
+
+    if(!gPad) return;
+    TCanvas* c1 = gPad->GetCanvas();
+
+    double tsize = 0.045;
+    gStyle->SetOptStat("");
+    eff->SetTitle("Fine PS Efficiency: N(PSC,PS) / N(PSC)");
+    eff->SetTitleSize(tsize);
+    eff->SetTitleSize(tsize,"xy");
+    eff->Draw("colz");
+
 }

--- a/src/plugins/monitoring/PSPair_online/TAG_2D_eff.C
+++ b/src/plugins/monitoring/PSPair_online/TAG_2D_eff.C
@@ -10,59 +10,59 @@
 // hnamepath: /PSPair/PSC_PS_TAGM/PSTAGM_ElVsEr
 
 {
-  TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("PSPair");
-  if(dir) dir->cd();
+    TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("PSPair");
+    if(dir) dir->cd();
 
-  TH2F *id_LR_D =(TH2F*)gDirectory->Get("PSC_PS/PS_PSIDLeftVsIDRight");
-  TH2F *id_LR_N_tagh =(TH2F*)gDirectory->Get("PSC_PS_TAGH/PSTAGH_PSIDLeftVsIDRight");
-  TH2F *id_LR_N_tagm =(TH2F*)gDirectory->Get("PSC_PS_TAGM/PSTAGM_PSIDLeftVsIDRight");
-  //
-  TH2F *E_LR_D =(TH2F*)gDirectory->Get("PSC_PS/PS_ElVsEr");
-  TH2F *E_LR_N_tagh =(TH2F*)gDirectory->Get("PSC_PS_TAGH/PSTAGH_ElVsEr");
-  TH2F *E_LR_N_tagm =(TH2F*)gDirectory->Get("PSC_PS_TAGM/PSTAGM_ElVsEr");
+    TH2F *id_LR_D =(TH2F*)gDirectory->Get("PSC_PS/PS_PSIDLeftVsIDRight");
+    TH2F *id_LR_N_tagh =(TH2F*)gDirectory->Get("PSC_PS_TAGH/PSTAGH_PSIDLeftVsIDRight");
+    TH2F *id_LR_N_tagm =(TH2F*)gDirectory->Get("PSC_PS_TAGM/PSTAGM_PSIDLeftVsIDRight");
+    //
+    TH2F *E_LR_D =(TH2F*)gDirectory->Get("PSC_PS/PS_ElVsEr");
+    TH2F *E_LR_N_tagh =(TH2F*)gDirectory->Get("PSC_PS_TAGH/PSTAGH_ElVsEr");
+    TH2F *E_LR_N_tagm =(TH2F*)gDirectory->Get("PSC_PS_TAGM/PSTAGM_ElVsEr");
 
-  TH2F *eff_tagh2d = (TH2F*)id_LR_N_tagh->Clone(); 
-  TH2F *eff_tagm2d = (TH2F*)id_LR_N_tagm->Clone();
-  eff_tagh2d->Sumw2();
-  eff_tagm2d->Sumw2();
-  eff_tagh2d->Divide(id_LR_N_tagh,id_LR_D);
-  eff_tagm2d->Divide(id_LR_N_tagm,id_LR_D);
-  //
-  TH2F *eff_tagh_E = (TH2F*)E_LR_N_tagh->Clone(); 
-  TH2F *eff_tagm_E = (TH2F*)E_LR_N_tagm->Clone();
-  eff_tagh_E->Sumw2();
-  eff_tagm_E->Sumw2();
-  eff_tagh_E->Divide(E_LR_N_tagh,E_LR_D);
-  eff_tagm_E->Divide(E_LR_N_tagm,E_LR_D);
+    TH2F *eff_tagh2d = (TH2F*)id_LR_N_tagh->Clone();
+    TH2F *eff_tagm2d = (TH2F*)id_LR_N_tagm->Clone();
+    eff_tagh2d->Sumw2();
+    eff_tagm2d->Sumw2();
+    eff_tagh2d->Divide(id_LR_N_tagh,id_LR_D);
+    eff_tagm2d->Divide(id_LR_N_tagm,id_LR_D);
+    //
+    TH2F *eff_tagh_E = (TH2F*)E_LR_N_tagh->Clone();
+    TH2F *eff_tagm_E = (TH2F*)E_LR_N_tagm->Clone();
+    eff_tagh_E->Sumw2();
+    eff_tagm_E->Sumw2();
+    eff_tagh_E->Divide(E_LR_N_tagh,E_LR_D);
+    eff_tagm_E->Divide(E_LR_N_tagm,E_LR_D);
 
-  if(gPad == NULL){
-    TCanvas *c1 = new TCanvas("c1","Tagging Efficiency",150,10,990,660);
-    c1->cd(0);
-    c1->Draw();
-    c1->Update();
-  }
-    
-  if(!gPad) return;
-  TCanvas* c1 = gPad->GetCanvas();
-  c1->Divide(2,2);
+    if(gPad == NULL){
+        TCanvas *c1 = new TCanvas("c1","Tagging Efficiency",150,10,990,660);
+        c1->cd(0);
+        c1->Draw();
+        c1->Update();
+    }
 
-  double tsize = 0.0475;
-  gStyle->SetOptStat("");
-  c1->cd(4);
-  eff_tagh2d->SetTitle("TAGH Tagging Efficiency: N(TAGH,PSC,PS) / N(PSC,PS)");
-  eff_tagh2d->SetTitleSize(tsize,"xy");
-  eff_tagh2d->Draw("colz");
-  c1->cd(3);
-  eff_tagm2d->SetTitle("TAGM Tagging Efficiency: N(TAGM,PSC,PS) / N(PSC,PS)");
-  eff_tagm2d->SetTitleSize(tsize,"xy");
-  eff_tagm2d->Draw("colz");
-  c1->cd(2);
-  eff_tagh_E->SetTitle("TAGH Tagging Efficiency: N(TAGH,PSC,PS) / N(PSC,PS)");
-  eff_tagh_E->SetTitleSize(tsize,"xy");
-  eff_tagh_E->Draw("colz");
-  c1->cd(1);
-  eff_tagm_E->SetTitle("TAGM Tagging Efficiency: N(TAGM,PSC,PS) / N(PSC,PS)");
-  eff_tagm_E->SetTitleSize(tsize,"xy");
-  eff_tagm_E->Draw("colz");
+    if(!gPad) return;
+    TCanvas* c1 = gPad->GetCanvas();
+    c1->Divide(2,2);
+
+    double tsize = 0.0475;
+    gStyle->SetOptStat("");
+    c1->cd(4);
+    eff_tagh2d->SetTitle("TAGH Tagging Efficiency: N(TAGH,PSC,PS) / N(PSC,PS)");
+    eff_tagh2d->SetTitleSize(tsize,"xy");
+    eff_tagh2d->Draw("colz");
+    c1->cd(3);
+    eff_tagm2d->SetTitle("TAGM Tagging Efficiency: N(TAGM,PSC,PS) / N(PSC,PS)");
+    eff_tagm2d->SetTitleSize(tsize,"xy");
+    eff_tagm2d->Draw("colz");
+    c1->cd(2);
+    eff_tagh_E->SetTitle("TAGH Tagging Efficiency: N(TAGH,PSC,PS) / N(PSC,PS)");
+    eff_tagh_E->SetTitleSize(tsize,"xy");
+    eff_tagh_E->Draw("colz");
+    c1->cd(1);
+    eff_tagm_E->SetTitle("TAGM Tagging Efficiency: N(TAGM,PSC,PS) / N(PSC,PS)");
+    eff_tagm_E->SetTitleSize(tsize,"xy");
+    eff_tagm_E->Draw("colz");
 
 }

--- a/src/plugins/monitoring/PSPair_online/TAG_eff.C
+++ b/src/plugins/monitoring/PSPair_online/TAG_eff.C
@@ -7,47 +7,47 @@
 // hnamepath: /PSPair/PSC_PS/PS_E
 
 {
-  TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("PSPair");
-  if(dir) dir->cd();
-  
-  TH1F *E_tagh =(TH1F*)gDirectory->Get("PSC_PS_TAGH/PSTAGH_E");
-  TH1F *E_tagm =(TH1F*)gDirectory->Get("PSC_PS_TAGM/PSTAGM_E");
-  TH1F *E_ps =(TH1F*)gDirectory->Get("PSC_PS/PS_E");
-    
-  TH1F *eff_tagh = (TH1F*)E_tagh->Clone(); 
-  TH1F *eff_tagm = (TH1F*)E_tagm->Clone();
-  eff_tagh->Sumw2();
-  eff_tagm->Sumw2();
-  eff_tagh->Divide(E_tagh,E_ps);
-  eff_tagm->Divide(E_tagm,E_ps);
+    TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("PSPair");
+    if(dir) dir->cd();
 
-  if(gPad == NULL){
-    TCanvas *c1 = new TCanvas("c1","Tagging Efficiency",150,10,990,660);
-    c1->cd(0);
-    c1->Draw();
-    c1->Update();
-  }
-    
-  if(!gPad) return;
-  TCanvas* c1 = gPad->GetCanvas();
-    
-  gStyle->SetOptStat("");
-  TLegend *tleg = new TLegend(0.75,0.75,0.90,0.90);
-  tleg->SetTextSize(0.045);
-  tleg->AddEntry(eff_tagm,"TAGM","l");
-  tleg->AddEntry(eff_tagh,"TAGH","l");
-  eff_tagh->SetTitle("Tagging Efficiency");
-  eff_tagh->SetTitleSize(0.045);
-  eff_tagh->GetXaxis()->SetTitleSize(0.045);
-  eff_tagh->GetYaxis()->SetTitleSize(0.045);
-  eff_tagh->GetXaxis()->SetTitle("PS energy [GeV]");
-  eff_tagh->GetYaxis()->SetTitle("N(TAGX,PSC,PS) / N(PSC,PS)");
-  eff_tagh->GetXaxis()->SetRange(eff_tagh->FindFirstBinAbove(0.001),eff_tagh->FindLastBinAbove(0.001));
-  eff_tagh->SetAxisRange(0.0,1.0,"Y");
-  eff_tagh->SetLineColor(kGreen);
-  eff_tagh->Draw();
-  eff_tagm->SetLineColor(kRed);
-  eff_tagm->Draw("same");
-  tleg->Draw();
-    
+    TH1F *E_tagh =(TH1F*)gDirectory->Get("PSC_PS_TAGH/PSTAGH_E");
+    TH1F *E_tagm =(TH1F*)gDirectory->Get("PSC_PS_TAGM/PSTAGM_E");
+    TH1F *E_ps =(TH1F*)gDirectory->Get("PSC_PS/PS_E");
+
+    TH1F *eff_tagh = (TH1F*)E_tagh->Clone();
+    TH1F *eff_tagm = (TH1F*)E_tagm->Clone();
+    eff_tagh->Sumw2();
+    eff_tagm->Sumw2();
+    eff_tagh->Divide(E_tagh,E_ps);
+    eff_tagm->Divide(E_tagm,E_ps);
+
+    if(gPad == NULL){
+        TCanvas *c1 = new TCanvas("c1","Tagging Efficiency",150,10,990,660);
+        c1->cd(0);
+        c1->Draw();
+        c1->Update();
+    }
+
+    if(!gPad) return;
+    TCanvas* c1 = gPad->GetCanvas();
+
+    gStyle->SetOptStat("");
+    TLegend *tleg = new TLegend(0.75,0.75,0.90,0.90);
+    tleg->SetTextSize(0.045);
+    tleg->AddEntry(eff_tagm,"TAGM","l");
+    tleg->AddEntry(eff_tagh,"TAGH","l");
+    eff_tagh->SetTitle("Tagging Efficiency");
+    eff_tagh->SetTitleSize(0.045);
+    eff_tagh->GetXaxis()->SetTitleSize(0.045);
+    eff_tagh->GetYaxis()->SetTitleSize(0.045);
+    eff_tagh->GetXaxis()->SetTitle("PS energy [GeV]");
+    eff_tagh->GetYaxis()->SetTitle("N(TAGX,PSC,PS) / N(PSC,PS)");
+    eff_tagh->GetXaxis()->SetRange(eff_tagh->FindFirstBinAbove(0.001),eff_tagh->FindLastBinAbove(0.001));
+    eff_tagh->SetAxisRange(0.0,1.0,"Y");
+    eff_tagh->SetLineColor(kGreen);
+    eff_tagh->Draw();
+    eff_tagm->SetLineColor(kRed);
+    eff_tagm->Draw("same");
+    tleg->Draw();
+
 }

--- a/src/plugins/monitoring/TAGH_online/JEventProcessor_TAGH_online.cc
+++ b/src/plugins/monitoring/TAGH_online/JEventProcessor_TAGH_online.cc
@@ -31,10 +31,10 @@ using namespace jana;
 
 // Nslots: total number of TAGH counter slots
 // 274 total (218 have counters for default GlueX configuration)
-const int Nslots = DTAGHGeometry::kCounterCount; 
+const int Nslots = DTAGHGeometry::kCounterCount;
 // counter (slot) id =  HV id for hv id from 1-131 (upstream of microscope)
 // counter (slot) id =  41 + HV id for hv id from 132-233 (downstream of microscope)
-const int NHVchannels = 233; 
+const int NHVchannels = 233;
 const int NupstreamCounters = 131;
 //
 const int NmultBins = 300; // number of bins for multiplicity histograms
@@ -112,10 +112,10 @@ static TH2I *hDigiHit_adctdcMatchesVsSlotID_cut;
 
 // Routine used to create our JEventProcessor
 extern "C"{
-  void InitPlugin(JApplication *app){
-    InitJANAPlugin(app);
-    app->AddProcessor(new JEventProcessor_TAGH_online());
-  }
+    void InitPlugin(JApplication *app){
+        InitJANAPlugin(app);
+        app->AddProcessor(new JEventProcessor_TAGH_online());
+    }
 }
 
 
@@ -136,130 +136,130 @@ JEventProcessor_TAGH_online::~JEventProcessor_TAGH_online() {
 //----------------------------------------------------------------------------------
 
 jerror_t JEventProcessor_TAGH_online::init(void) {
-  
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-  
-  // create root folder for tagh and cd to it, store main dir
-  TDirectory *mainDir = gDirectory;
-  TDirectory *taghDir = gDirectory->mkdir("TAGH");
-  taghDir->cd();
 
-  // book hists
-  tagh_num_events = new TH1I("tagh_num_events","TAGH number of events",1,0.5,1.5);
-  hBeamCurrent = new TH1I("BeamCurrent","Average beam current;average current [nA]",600,0.0,300.0);
-  // hit-level hists (after calibration)	  
-  gDirectory->mkdir("Hit")->cd();
-  hHit_HasTDCvsHasADC = new TH2F("Hit_HasTDCvsHasADC","TAGH has TDC? vs. has ADC?;fADC status;TDC status",2,-0.5,1.5,2,-0.5,1.5);
-  hHit_RawNHits = new TH1I("Hit_RawNHits","TAGH hit multiplicity (raw);hits (raw);events",NmultBins,0.5,0.5+NmultBins);
-  //
-  hHit_NHits = new TH1I("Hit_NHits","TAGH hit multiplicity;hits;events",NmultBins,0.5,0.5+NmultBins);
-  hHit_NHits_us = new TH1I("Hit_NHits_us","TAGH upstream hit multiplicity;upstream hits;events",NmultBins,0.5,0.5+NmultBins);
-  hHit_NHits_ds = new TH1I("Hit_NHits_ds","TAGH downstream hit multiplicity;downstream hits;events",NmultBins,0.5,0.5+NmultBins);
-  hHit_Occupancy    = new TH1F("Hit_Occupancy","TAGH occupancy;counter (slot) ID;hits / counter",Nslots,0.5,0.5+Nslots);
-  hHit_HVidVsSlotID    = new TH2I("Hit_HVidVsSlotID","TAGH high voltage channel ID vs. counter ID;counter (slot) ID;high voltage channel ID",Nslots,0.5,0.5+Nslots,NHVchannels,0.5,0.5+NHVchannels);
-  hHit_Energy    = new TH1F("Hit_Energy","TAGH energy;photon energy [GeV];hits / counter",120,0.0,12.0);
-  hHit_EnergyVsSlotID    = new TH2I("Hit_EnergyVsSlotID","TAGH energy vs. counter ID;counter (slot) ID;photon energy [GeV]",Nslots,0.5,0.5+Nslots,120,0.0,12.0);
-  hHit_Integral    = new TH1I("Hit_Integral","TAGH fADC pulse integral;pulse integral;hits",1000,0.0,30000.0);
-  hHit_IntegralVsSlotID    = new TH2I("Hit_IntegralVsSlotID","TAGH fADC pulse integral vs. counter ID;counter (slot) ID;pulse integral",Nslots,0.5,0.5+Nslots,1000,0.0,30000.0);
-  //hHit_fadcNpe    = new TH1I("Hit_fadcNpe","TAGH fADC number of photoelectrons;photoelectrons;hits",1000,0.0,30000.0);
-  hHit_fadcTime    = new TH1I("Hit_fadcTime","TAGH fADC time;time [ns];hits / 400 ps",2000,-400.0,400.0);
-  hHit_fadcTimeVsSlotID    = new TH2I("Hit_fadcTimeVsSlotID","TAGH fADC time vs. counter ID;counter (slot) ID;time [ns]",Nslots,0.5,0.5+Nslots,2000,-400.0,400.0);
-  hHit_Time    = new TH1I("Hit_Time","TAGH time;time [ns];hits / 400 ps",2000,-400.0,400.0);
-  hHit_TimeVsSlotID    = new TH2F("Hit_TimeVsSlotID","TAGH time vs. counter ID;counter (slot) ID;time [ns]",Nslots,0.5,0.5+Nslots,2000,-400.0,400.0);
-  hHit_TimeVsEnergy    = new TH2F("Hit_TimeVsEnergy","TAGH time vs. energy;energy [GeV];time [ns]",120,0.0,12.0,2000,-400.0,400.0);
-  hHit_TimeVsIntegral    = new TH2I("Hit_TimeVsIntegral","TAGH time vs. integral;pulse integral;time [ns]",500,0.0,15000.0,2000,-400.0,400.0); 
-  hHit_tdcTime    = new TH1I("Hit_tdcTime","TAGH TDC time;time [ns];hits / 400 ps",2000,-400.0,400.0);
-  hHit_tdcTimeVsSlotID    = new TH2I("Hit_tdcTimeVsSlotID","TAGH TDC time vs. counter ID;counter (slot) ID;time [ns]",Nslots,0.5,0.5+Nslots,2000,-400.0,400.0);
-  hHit_tdcadcTimeDiffVsSlotID    = new TH2I("Hit_tdcadcTimeDiffVsSlotID","TAGH TDC/ADC time difference vs. counter ID;counter (slot) ID;time(TDC) - time(ADC) [ns]",Nslots,0.5,0.5+Nslots,200,-40.0,40.0);
-  hHit_tdcadcTimeDiffVsIntegral    = new TH2I("Hit_tdcadcTimeDiffVsIntegral","TAGH TDC/ADC time difference vs. integral;pulse integral;time(TDC) - time(ADC) [ns]",500,0.0,15000.0,200,-40.0,40.0);
-  // digihit-level hists
-  taghDir->cd();
-  gDirectory->mkdir("DigiHit")->cd();
-  hDigiHit_NfadcHits = new TH1I("DigiHit_NfadcHits","TAGH fADC hit multiplicity;raw hits;events",NmultBins,0.5,0.5+NmultBins);
-  hDigiHit_NSamplesPedestal    = new TH1I("DigiHit_NSamplesPedestal","TAGH fADC pedestal samples;pedestal samples;raw hits",50,-0.5,49.5);
-  hDigiHit_Pedestal = new TH1I("DigiHit_Pedestal","TAGH fADC pedestals;pedestal [fADC counts];raw hits",200,0.0,200.0);
-  hDigiHit_PedestalVsSlotID = new TProfile("DigiHit_PedestalVsSlotID","TAGH pedestal vs. counter ID;counter (slot) ID;average pedestal [fADC counts]",Nslots,0.5,0.5+Nslots,"s"); 
-  hDigiHit_QualityFactor = new TH1I("DigiHit_QualityFactor","TAGH fADC quality factor;quality factor;raw hits",4,-0.5,3.5);
-  hDigiHit_PulseNumber = new TH1I("DigiHit_PulseNumber","TAGH fADC pulse number;pulse number;raw hits",4,-0.5,3.5);
-  hDigiHit_PulseNumberVsSlotID = new TH2I("DigiHit_PulseNumberVsSlotID","TAGH fADC pulse number vs. counter ID;counter (slot) ID;pulse number;raw hits",Nslots,0.5,0.5+Nslots,4,-0.5,3.5);
-  hDigiHit_fadcOccupancy    = new TH1I("DigiHit_fadcOccupancy","TAGH fADC hit occupancy;counter (slot) ID;raw hits / counter",Nslots,0.5,0.5+Nslots);
-  hDigiHit_RawPeak    = new TH1I("DigiHit_RawPeak","TAGH fADC pulse peak (raw);pulse peak (raw);raw hits",410,0.0,4100.0);
-  hDigiHit_RawPeakVsSlotID    = new TH2I("DigiHit_RawPeakVsSlotID","TAGH fADC pulse peak (raw) vs. counter ID;counter (slot) ID;pulse peak (raw)",Nslots,0.5,0.5+Nslots,410,0.0,4100.0);
-  hDigiHit_RawIntegral    = new TH1I("DigiHit_RawIntegral","TAGH fADC pulse integral (raw);pulse integral (raw);raw hits",1000,0.0,30000.0);
-  hDigiHit_RawIntegralVsSlotID    = new TH2I("DigiHit_RawIntegralVsSlotID","TAGH fADC pulse integral (raw) vs. counter ID;counter (slot) ID;pulse integral (raw)",Nslots,0.5,0.5+Nslots,1000,0.0,30000.0);
-  hDigiHit_NSamplesIntegral    = new TH1I("DigiHit_NSamplesIntegral","TAGH fADC integral samples;integral samples;raw hits",60,-0.5,59.5);
-  hDigiHit_PeakVsSlotID    = new TH2I("DigiHit_PeakVsSlotID","TAGH fADC pulse peak vs. counter ID;counter (slot) ID;pulse peak",Nslots,0.5,0.5+Nslots,410,0.0,4100.0);
-  hDigiHit_IntegralVsPeak    = new TH2I("DigiHit_IntegralVsPeak","TAGH fADC pulse integral vs. peak;pulse peak;pulse integral",410,0.0,4100.0,1000,0.0,30000.0);
-  hDigiHit_IntegralVsSlotID    = new TH2I("DigiHit_IntegralVsSlotID","TAGH fADC pulse integral vs. counter ID;counter (slot) ID;pulse integral",Nslots,0.5,0.5+Nslots,1000,0.0,30000.0);
-  hDigiHit_PulseTime    = new TH1I("DigiHit_PulseTime","TAGH fADC pulse time;pulse time [62.5 ps];raw hits",1000,0.0,6500.0);
-  hDigiHit_fadcTime    = new TH1I("DigiHit_fadcTime","TAGH fADC pulse time;pulse time [ns];raw hits / 400 ps",1000,0.0,400.0);
-  hDigiHit_fadcTimeVsSlotID    = new TH2I("DigiHit_fadcTimeVsSlotID","TAGH fADC pulse time vs. counter ID;counter (slot) ID;pulse time [ns]",Nslots,0.5,0.5+Nslots,1000,0.0,400.0);
-  hDigiHit_fadcTimeVsIntegral    = new TH2I("DigiHit_fadcTimeVsIntegral","TAGH fADC pulse time vs. integral;pulse integral;pulse time [ns]",500,0.0,15000.0,1000,0.0,400.0);
-  hDigiHit_NtdcHits = new TH1I("DigiHit_NtdcHits","TAGH TDC hit multiplicity;raw hits;events",NmultBins,0.5,0.5+NmultBins);
-  hDigiHit_NtdcHitsVsSlotID = new TH2I("DigiHit_NtdcHitsVsSlotID","TAGH TDC hit multiplicity vs. counter ID;counter ID;raw hits",Nslots,0.5,0.5+Nslots,8,0.5,8.5);
-  hDigiHit_tdcOccupancy    = new TH1I("DigiHit_tdcOccupancy","TAGH TDC hit occupancy;counter (slot) ID;raw hits / counter",Nslots,0.5,0.5+Nslots);
-  hDigiHit_tdcRawTime    = new TH1I("DigiHit_tdcRawTime","TAGH TDC raw time;time [60 ps];raw hits",1000,0.0,65500.0);
-  hDigiHit_tdcTime    = new TH1I("DigiHit_tdcTime","TAGH TDC time;time [ns];raw hits / 400 ps",2000,0.0,800.0);
-  hDigiHit_tdcTimeVsSlotID    = new TH2I("DigiHit_tdcTimeVsSlotID","TAGH TDC time vs. counter ID;counter ID;TDC time [ns]",Nslots,0.5,0.5+Nslots,2000,0.0,800.0);
-  hDigiHit_tdcTimeVsfadcTime    = new TH2I("DigiHit_tdcTimeVsfadcTime","TAGH TDC time vs. ADC time;fADC time [ns];TDC time [ns]",400,0.0,400.0,800,0.0,800.0);
-  hDigiHit_tdcadcTimeDiff    = new TH1I("DigiHit_tdcadcTimeDiff","TAGH TDC/ADC time difference;time(TDC) - time(ADC) [ns];raw hits / 400 ps",1000,0.0,400.0);
-  hDigiHit_tdcadcTimeDiffVsSlotID    = new TH2I("DigiHit_tdcadcTimeDiffVsSlotID","TAGH TDC/ADC time difference vs. counter ID;counter ID;time(TDC) - time(ADC) [ns]",Nslots,0.5,0.5+Nslots,1000,0.0,400.0);
-  hDigiHit_tdcadcTimeDiffVsIntegral    = new TH2I("DigiHit_tdcadcTimeDiffVsIntegral","TAGH TDC/ADC time difference vs. pulse integral;pulse integral;time(TDC) - time(ADC) [ns]",500,0.0,15000.0,1000,0.0,400.0);
-  // allow multiple peaks in window and cut on ADC counts
-  hDigiHit_NfadcHits_multiPeak = new TH1I("DigiHit_NfadcHits_multiPeak","TAGH fADC hit multiplicity (> 400 counts,multiple peaks allowed);raw hits;events",NmultBins,0.5,0.5+NmultBins);
-  hDigiHit_NfadcHitsVsSlotID = new TH2I("DigiHit_NfadcHitsVsSlotID","TAGH fADC hit multiplicity vs. counter ID (> 400 counts);counter ID;raw hits",Nslots,0.5,0.5+Nslots,8,0.5,8.5);
-  // digihit-level hists after cut on ADC integral counts
-  hDigiHit_NfadcHits_cut = new TH1I("DigiHit_NfadcHits_cut","TAGH fADC hit multiplicity (> 1k ADC integral counts);raw hits;events",NmultBins,0.5,0.5+NmultBins);
-  hDigiHit_fadcOccupancy_cut    = new TH1I("DigiHit_fadcOccupancy_cut","TAGH fADC hit occupancy (> 1k ADC integral counts);counter (slot) ID;raw hits / counter",Nslots,0.5,0.5+Nslots);
-  hDigiHit_fadcTime_cut    = new TH1I("DigiHit_fadcTime_cut","TAGH fADC pulse time (> 1k ADC integral counts);pulse time [ns];raw hits / 400 ps",1000,0.0,400.0);
-  hDigiHit_fadcTimeVsSlotID_cut    = new TH2I("DigiHit_fadcTimeVsSlotID_cut","TAGH fADC pulse time vs. counter ID (> 1k ADC integral counts);counter (slot) ID;pulse time [ns]",Nslots,0.5,0.5+Nslots,1000,0.0,400.0);
-  hDigiHit_fadcTimeVsQF_cut    = new TH2I("DigiHit_fadcTimeVsQF_cut","TAGH fADC pulse time vs. quality factor (> 1k ADC integral counts);fADC quality factor;pulse time [ns]",4,-0.5,3.5,1000,0.0,400.0); 
-  hDigiHit_adctdcMatchesVsSlotID_cut = new TH2I("DigiHit_adctdcMatchesVsSlotID_cut","TAGH #TDC matches / fADC hit vs. counter ID (> 1k ADC integral counts);counter ID;#TDC matches / fADC hit",Nslots,0.5,0.5+Nslots,8,-0.5,7.5);
-  // back to main dir
-  mainDir->cd();
+    japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
+    // create root folder for tagh and cd to it, store main dir
+    TDirectory *mainDir = gDirectory;
+    TDirectory *taghDir = gDirectory->mkdir("TAGH");
+    taghDir->cd();
 
-  return NOERROR;
+    // book hists
+    tagh_num_events = new TH1I("tagh_num_events","TAGH number of events",1,0.5,1.5);
+    hBeamCurrent = new TH1I("BeamCurrent","Average beam current;average current [nA]",600,0.0,300.0);
+    // hit-level hists (after calibration)
+    gDirectory->mkdir("Hit")->cd();
+    hHit_HasTDCvsHasADC = new TH2F("Hit_HasTDCvsHasADC","TAGH has TDC? vs. has ADC?;fADC status;TDC status",2,-0.5,1.5,2,-0.5,1.5);
+    hHit_RawNHits = new TH1I("Hit_RawNHits","TAGH hit multiplicity (raw);hits (raw);events",NmultBins,0.5,0.5+NmultBins);
+    //
+    hHit_NHits = new TH1I("Hit_NHits","TAGH hit multiplicity;hits;events",NmultBins,0.5,0.5+NmultBins);
+    hHit_NHits_us = new TH1I("Hit_NHits_us","TAGH upstream hit multiplicity;upstream hits;events",NmultBins,0.5,0.5+NmultBins);
+    hHit_NHits_ds = new TH1I("Hit_NHits_ds","TAGH downstream hit multiplicity;downstream hits;events",NmultBins,0.5,0.5+NmultBins);
+    hHit_Occupancy    = new TH1F("Hit_Occupancy","TAGH occupancy;counter (slot) ID;hits / counter",Nslots,0.5,0.5+Nslots);
+    hHit_HVidVsSlotID    = new TH2I("Hit_HVidVsSlotID","TAGH high voltage channel ID vs. counter ID;counter (slot) ID;high voltage channel ID",Nslots,0.5,0.5+Nslots,NHVchannels,0.5,0.5+NHVchannels);
+    hHit_Energy    = new TH1F("Hit_Energy","TAGH energy;photon energy [GeV];hits / counter",120,0.0,12.0);
+    hHit_EnergyVsSlotID    = new TH2I("Hit_EnergyVsSlotID","TAGH energy vs. counter ID;counter (slot) ID;photon energy [GeV]",Nslots,0.5,0.5+Nslots,120,0.0,12.0);
+    hHit_Integral    = new TH1I("Hit_Integral","TAGH fADC pulse integral;pulse integral;hits",1000,0.0,30000.0);
+    hHit_IntegralVsSlotID    = new TH2I("Hit_IntegralVsSlotID","TAGH fADC pulse integral vs. counter ID;counter (slot) ID;pulse integral",Nslots,0.5,0.5+Nslots,1000,0.0,30000.0);
+    //hHit_fadcNpe    = new TH1I("Hit_fadcNpe","TAGH fADC number of photoelectrons;photoelectrons;hits",1000,0.0,30000.0);
+    hHit_fadcTime    = new TH1I("Hit_fadcTime","TAGH fADC time;time [ns];hits / 400 ps",2000,-400.0,400.0);
+    hHit_fadcTimeVsSlotID    = new TH2I("Hit_fadcTimeVsSlotID","TAGH fADC time vs. counter ID;counter (slot) ID;time [ns]",Nslots,0.5,0.5+Nslots,2000,-400.0,400.0);
+    hHit_Time    = new TH1I("Hit_Time","TAGH time;time [ns];hits / 400 ps",2000,-400.0,400.0);
+    hHit_TimeVsSlotID    = new TH2F("Hit_TimeVsSlotID","TAGH time vs. counter ID;counter (slot) ID;time [ns]",Nslots,0.5,0.5+Nslots,2000,-400.0,400.0);
+    hHit_TimeVsEnergy    = new TH2F("Hit_TimeVsEnergy","TAGH time vs. energy;energy [GeV];time [ns]",120,0.0,12.0,2000,-400.0,400.0);
+    hHit_TimeVsIntegral    = new TH2I("Hit_TimeVsIntegral","TAGH time vs. integral;pulse integral;time [ns]",500,0.0,15000.0,2000,-400.0,400.0);
+    hHit_tdcTime    = new TH1I("Hit_tdcTime","TAGH TDC time;time [ns];hits / 400 ps",2000,-400.0,400.0);
+    hHit_tdcTimeVsSlotID    = new TH2I("Hit_tdcTimeVsSlotID","TAGH TDC time vs. counter ID;counter (slot) ID;time [ns]",Nslots,0.5,0.5+Nslots,2000,-400.0,400.0);
+    hHit_tdcadcTimeDiffVsSlotID    = new TH2I("Hit_tdcadcTimeDiffVsSlotID","TAGH TDC/ADC time difference vs. counter ID;counter (slot) ID;time(TDC) - time(ADC) [ns]",Nslots,0.5,0.5+Nslots,200,-40.0,40.0);
+    hHit_tdcadcTimeDiffVsIntegral    = new TH2I("Hit_tdcadcTimeDiffVsIntegral","TAGH TDC/ADC time difference vs. integral;pulse integral;time(TDC) - time(ADC) [ns]",500,0.0,15000.0,200,-40.0,40.0);
+    // digihit-level hists
+    taghDir->cd();
+    gDirectory->mkdir("DigiHit")->cd();
+    hDigiHit_NfadcHits = new TH1I("DigiHit_NfadcHits","TAGH fADC hit multiplicity;raw hits;events",NmultBins,0.5,0.5+NmultBins);
+    hDigiHit_NSamplesPedestal    = new TH1I("DigiHit_NSamplesPedestal","TAGH fADC pedestal samples;pedestal samples;raw hits",50,-0.5,49.5);
+    hDigiHit_Pedestal = new TH1I("DigiHit_Pedestal","TAGH fADC pedestals;pedestal [fADC counts];raw hits",200,0.0,200.0);
+    hDigiHit_PedestalVsSlotID = new TProfile("DigiHit_PedestalVsSlotID","TAGH pedestal vs. counter ID;counter (slot) ID;average pedestal [fADC counts]",Nslots,0.5,0.5+Nslots,"s");
+    hDigiHit_QualityFactor = new TH1I("DigiHit_QualityFactor","TAGH fADC quality factor;quality factor;raw hits",4,-0.5,3.5);
+    hDigiHit_PulseNumber = new TH1I("DigiHit_PulseNumber","TAGH fADC pulse number;pulse number;raw hits",4,-0.5,3.5);
+    hDigiHit_PulseNumberVsSlotID = new TH2I("DigiHit_PulseNumberVsSlotID","TAGH fADC pulse number vs. counter ID;counter (slot) ID;pulse number;raw hits",Nslots,0.5,0.5+Nslots,4,-0.5,3.5);
+    hDigiHit_fadcOccupancy    = new TH1I("DigiHit_fadcOccupancy","TAGH fADC hit occupancy;counter (slot) ID;raw hits / counter",Nslots,0.5,0.5+Nslots);
+    hDigiHit_RawPeak    = new TH1I("DigiHit_RawPeak","TAGH fADC pulse peak (raw);pulse peak (raw);raw hits",410,0.0,4100.0);
+    hDigiHit_RawPeakVsSlotID    = new TH2I("DigiHit_RawPeakVsSlotID","TAGH fADC pulse peak (raw) vs. counter ID;counter (slot) ID;pulse peak (raw)",Nslots,0.5,0.5+Nslots,410,0.0,4100.0);
+    hDigiHit_RawIntegral    = new TH1I("DigiHit_RawIntegral","TAGH fADC pulse integral (raw);pulse integral (raw);raw hits",1000,0.0,30000.0);
+    hDigiHit_RawIntegralVsSlotID    = new TH2I("DigiHit_RawIntegralVsSlotID","TAGH fADC pulse integral (raw) vs. counter ID;counter (slot) ID;pulse integral (raw)",Nslots,0.5,0.5+Nslots,1000,0.0,30000.0);
+    hDigiHit_NSamplesIntegral    = new TH1I("DigiHit_NSamplesIntegral","TAGH fADC integral samples;integral samples;raw hits",60,-0.5,59.5);
+    hDigiHit_PeakVsSlotID    = new TH2I("DigiHit_PeakVsSlotID","TAGH fADC pulse peak vs. counter ID;counter (slot) ID;pulse peak",Nslots,0.5,0.5+Nslots,410,0.0,4100.0);
+    hDigiHit_IntegralVsPeak    = new TH2I("DigiHit_IntegralVsPeak","TAGH fADC pulse integral vs. peak;pulse peak;pulse integral",410,0.0,4100.0,1000,0.0,30000.0);
+    hDigiHit_IntegralVsSlotID    = new TH2I("DigiHit_IntegralVsSlotID","TAGH fADC pulse integral vs. counter ID;counter (slot) ID;pulse integral",Nslots,0.5,0.5+Nslots,1000,0.0,30000.0);
+    hDigiHit_PulseTime    = new TH1I("DigiHit_PulseTime","TAGH fADC pulse time;pulse time [62.5 ps];raw hits",1000,0.0,6500.0);
+    hDigiHit_fadcTime    = new TH1I("DigiHit_fadcTime","TAGH fADC pulse time;pulse time [ns];raw hits / 400 ps",1000,0.0,400.0);
+    hDigiHit_fadcTimeVsSlotID    = new TH2I("DigiHit_fadcTimeVsSlotID","TAGH fADC pulse time vs. counter ID;counter (slot) ID;pulse time [ns]",Nslots,0.5,0.5+Nslots,1000,0.0,400.0);
+    hDigiHit_fadcTimeVsIntegral    = new TH2I("DigiHit_fadcTimeVsIntegral","TAGH fADC pulse time vs. integral;pulse integral;pulse time [ns]",500,0.0,15000.0,1000,0.0,400.0);
+    hDigiHit_NtdcHits = new TH1I("DigiHit_NtdcHits","TAGH TDC hit multiplicity;raw hits;events",NmultBins,0.5,0.5+NmultBins);
+    hDigiHit_NtdcHitsVsSlotID = new TH2I("DigiHit_NtdcHitsVsSlotID","TAGH TDC hit multiplicity vs. counter ID;counter ID;raw hits",Nslots,0.5,0.5+Nslots,8,0.5,8.5);
+    hDigiHit_tdcOccupancy    = new TH1I("DigiHit_tdcOccupancy","TAGH TDC hit occupancy;counter (slot) ID;raw hits / counter",Nslots,0.5,0.5+Nslots);
+    hDigiHit_tdcRawTime    = new TH1I("DigiHit_tdcRawTime","TAGH TDC raw time;time [60 ps];raw hits",1000,0.0,65500.0);
+    hDigiHit_tdcTime    = new TH1I("DigiHit_tdcTime","TAGH TDC time;time [ns];raw hits / 400 ps",2000,0.0,800.0);
+    hDigiHit_tdcTimeVsSlotID    = new TH2I("DigiHit_tdcTimeVsSlotID","TAGH TDC time vs. counter ID;counter ID;TDC time [ns]",Nslots,0.5,0.5+Nslots,2000,0.0,800.0);
+    hDigiHit_tdcTimeVsfadcTime    = new TH2I("DigiHit_tdcTimeVsfadcTime","TAGH TDC time vs. ADC time;fADC time [ns];TDC time [ns]",400,0.0,400.0,800,0.0,800.0);
+    hDigiHit_tdcadcTimeDiff    = new TH1I("DigiHit_tdcadcTimeDiff","TAGH TDC/ADC time difference;time(TDC) - time(ADC) [ns];raw hits / 400 ps",1000,0.0,400.0);
+    hDigiHit_tdcadcTimeDiffVsSlotID    = new TH2I("DigiHit_tdcadcTimeDiffVsSlotID","TAGH TDC/ADC time difference vs. counter ID;counter ID;time(TDC) - time(ADC) [ns]",Nslots,0.5,0.5+Nslots,1000,0.0,400.0);
+    hDigiHit_tdcadcTimeDiffVsIntegral    = new TH2I("DigiHit_tdcadcTimeDiffVsIntegral","TAGH TDC/ADC time difference vs. pulse integral;pulse integral;time(TDC) - time(ADC) [ns]",500,0.0,15000.0,1000,0.0,400.0);
+    // allow multiple peaks in window and cut on ADC counts
+    hDigiHit_NfadcHits_multiPeak = new TH1I("DigiHit_NfadcHits_multiPeak","TAGH fADC hit multiplicity (> 400 counts,multiple peaks allowed);raw hits;events",NmultBins,0.5,0.5+NmultBins);
+    hDigiHit_NfadcHitsVsSlotID = new TH2I("DigiHit_NfadcHitsVsSlotID","TAGH fADC hit multiplicity vs. counter ID (> 400 counts);counter ID;raw hits",Nslots,0.5,0.5+Nslots,8,0.5,8.5);
+    // digihit-level hists after cut on ADC integral counts
+    hDigiHit_NfadcHits_cut = new TH1I("DigiHit_NfadcHits_cut","TAGH fADC hit multiplicity (> 1k ADC integral counts);raw hits;events",NmultBins,0.5,0.5+NmultBins);
+    hDigiHit_fadcOccupancy_cut    = new TH1I("DigiHit_fadcOccupancy_cut","TAGH fADC hit occupancy (> 1k ADC integral counts);counter (slot) ID;raw hits / counter",Nslots,0.5,0.5+Nslots);
+    hDigiHit_fadcTime_cut    = new TH1I("DigiHit_fadcTime_cut","TAGH fADC pulse time (> 1k ADC integral counts);pulse time [ns];raw hits / 400 ps",1000,0.0,400.0);
+    hDigiHit_fadcTimeVsSlotID_cut    = new TH2I("DigiHit_fadcTimeVsSlotID_cut","TAGH fADC pulse time vs. counter ID (> 1k ADC integral counts);counter (slot) ID;pulse time [ns]",Nslots,0.5,0.5+Nslots,1000,0.0,400.0);
+    hDigiHit_fadcTimeVsQF_cut    = new TH2I("DigiHit_fadcTimeVsQF_cut","TAGH fADC pulse time vs. quality factor (> 1k ADC integral counts);fADC quality factor;pulse time [ns]",4,-0.5,3.5,1000,0.0,400.0);
+    hDigiHit_adctdcMatchesVsSlotID_cut = new TH2I("DigiHit_adctdcMatchesVsSlotID_cut","TAGH #TDC matches / fADC hit vs. counter ID (> 1k ADC integral counts);counter ID;#TDC matches / fADC hit",Nslots,0.5,0.5+Nslots,8,-0.5,7.5);
+    // back to main dir
+    mainDir->cd();
+
+    japp->RootUnLock(); //RELEASE ROOT LOCK!!
+
+    return NOERROR;
 }
 
 //----------------------------------------------------------------------------------
 
 
 jerror_t JEventProcessor_TAGH_online::brun(JEventLoop *eventLoop, int32_t runnumber) {
-  // This is called whenever the run number changes
-  // extract the TAGH geometry
-  vector<const DTAGHGeometry*> taghGeomVect;
-  eventLoop->Get(taghGeomVect);
-  if (taghGeomVect.size() < 1)
+    // This is called whenever the run number changes
+    // extract the TAGH geometry
+    vector<const DTAGHGeometry*> taghGeomVect;
+    eventLoop->Get(taghGeomVect);
+    if (taghGeomVect.size() < 1)
     return OBJECT_NOT_AVAILABLE;
-  const DTAGHGeometry& taghGeom = *(taghGeomVect[0]);
-  // get photon energy bin low of each counter for energy histogram binning
-  double Elows[Nslots+1];
-  double slots[Nslots+1];
-  for (int i=0;i<Nslots;i++) {
-    Elows[i] = taghGeom.getElow(Nslots-i); 
-    slots[i] = 0.5+i;
-  }
-  // add the upper limit
-  Elows[Nslots] = taghGeom.getEhigh(1); 
-  slots[Nslots] = 0.5+Nslots;
-  //
-  const int Ntime = 2000;
-  double Tlows[Ntime+1];
-  for (int i=0;i<=Ntime;i++) {
-    Tlows[i] = -400.0+i*0.4;
-  }
-  //  
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-  if (hHit_Energy->GetEntries()==0) hHit_Energy->SetBins(Nslots,Elows);
-  if (hHit_EnergyVsSlotID->GetEntries()==0) hHit_EnergyVsSlotID->SetBins(Nslots,slots,Nslots,Elows);
-  if (hHit_TimeVsEnergy->GetEntries()==0) hHit_TimeVsEnergy->SetBins(Nslots,Elows,Ntime,Tlows);
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
-  //
-  sumCurrent = 0.0;
-  Ncurrent = 0;
-  return NOERROR;
+    const DTAGHGeometry& taghGeom = *(taghGeomVect[0]);
+    // get photon energy bin low of each counter for energy histogram binning
+    double Elows[Nslots+1];
+    double slots[Nslots+1];
+    for (int i=0;i<Nslots;i++) {
+        Elows[i] = taghGeom.getElow(Nslots-i);
+        slots[i] = 0.5+i;
+    }
+    // add the upper limit
+    Elows[Nslots] = taghGeom.getEhigh(1);
+    slots[Nslots] = 0.5+Nslots;
+    //
+    const int Ntime = 2000;
+    double Tlows[Ntime+1];
+    for (int i=0;i<=Ntime;i++) {
+        Tlows[i] = -400.0+i*0.4;
+    }
+    //
+    japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+    if (hHit_Energy->GetEntries()==0) hHit_Energy->SetBins(Nslots,Elows);
+    if (hHit_EnergyVsSlotID->GetEntries()==0) hHit_EnergyVsSlotID->SetBins(Nslots,slots,Nslots,Elows);
+    if (hHit_TimeVsEnergy->GetEntries()==0) hHit_TimeVsEnergy->SetBins(Nslots,Elows,Ntime,Tlows);
+    japp->RootUnLock(); //RELEASE ROOT LOCK!!
+    //
+    sumCurrent = 0.0;
+    Ncurrent = 0;
+    return NOERROR;
 }
 
 
@@ -267,192 +267,192 @@ jerror_t JEventProcessor_TAGH_online::brun(JEventLoop *eventLoop, int32_t runnum
 
 
 jerror_t JEventProcessor_TAGH_online::evnt(JEventLoop *eventLoop, uint64_t eventnumber) {
-  // This is called for every event. Use of common resources like writing
-  // to a file or filling a histogram should be mutex protected. Using
-  // loop-Get(...) to get reconstructed objects (and thereby activating the
-  // reconstruction algorithm) should be done outside of any mutex lock
-  // since multiple threads may call this method at the same time.
- 
-  // get TAGH hits and digihits
-  vector<const DTAGHHit*> hits;
-  eventLoop->Get(hits);
-  vector<const DTAGHDigiHit*> digihits;
-  eventLoop->Get(digihits);
-  vector<const DTAGHTDCDigiHit*> tdcdigihits;
-  eventLoop->Get(tdcdigihits);
-  // for converting f1TDC raw digihit time to time with respect to trigger in ns
-  const DTTabUtilities* ttabUtilities = NULL;
-  eventLoop->GetSingle(ttabUtilities);
-  // cache pulse pedestal and window raw data objects
-  map< const DTAGHDigiHit*, pair<const Df250PulsePedestal*, const Df250WindowRawData*> > pp_wr_cache;
-  for(unsigned int i=0; i < digihits.size(); i++) {
-    const Df250PulsePedestal* pulsePed = NULL;
-    const Df250PulseIntegral* pulseInt = NULL;
-    const Df250WindowRawData* rawData = NULL;
-    digihits[i]->GetSingle(pulsePed);
-    digihits[i]->GetSingle(pulseInt);
-    if (pulseInt) pulseInt->GetSingle(rawData);
-    pp_wr_cache[digihits[i]] = pair<const Df250PulsePedestal*, const Df250WindowRawData*>(pulsePed, rawData);
-  }
-  // get beam current
-  vector<const DEPICSvalue *> epicsVals;
-  eventLoop->Get(epicsVals);
-  double current = 0.0;
-  for(unsigned int i = 0; i < epicsVals.size(); i++){
-    if (epicsVals[i]->name == "IBCAD00CRCUR6"){
-      current = epicsVals[i]->fval;
-      break;
-    }
-  }
-  if (current>3.0&&current<2000.0) {
-    sumCurrent += current;
-    Ncurrent++;
-    current = sumCurrent/Ncurrent;
-  }
-  // fill hists
-  japp->RootWriteLock();
+    // This is called for every event. Use of common resources like writing
+    // to a file or filling a histogram should be mutex protected. Using
+    // loop-Get(...) to get reconstructed objects (and thereby activating the
+    // reconstruction algorithm) should be done outside of any mutex lock
+    // since multiple threads may call this method at the same time.
 
-  if (current>3.0&&current<2000.0) hBeamCurrent->Fill(current);
+    // get TAGH hits and digihits
+    vector<const DTAGHHit*> hits;
+    eventLoop->Get(hits);
+    vector<const DTAGHDigiHit*> digihits;
+    eventLoop->Get(digihits);
+    vector<const DTAGHTDCDigiHit*> tdcdigihits;
+    eventLoop->Get(tdcdigihits);
+    // for converting f1TDC raw digihit time to time with respect to trigger in ns
+    const DTTabUtilities* ttabUtilities = NULL;
+    eventLoop->GetSingle(ttabUtilities);
+    // cache pulse pedestal and window raw data objects
+    map< const DTAGHDigiHit*, pair<const Df250PulsePedestal*, const Df250WindowRawData*> > pp_wr_cache;
+    for(unsigned int i=0; i < digihits.size(); i++) {
+        const Df250PulsePedestal* pulsePed = NULL;
+        const Df250PulseIntegral* pulseInt = NULL;
+        const Df250WindowRawData* rawData = NULL;
+        digihits[i]->GetSingle(pulsePed);
+        digihits[i]->GetSingle(pulseInt);
+        if (pulseInt) pulseInt->GetSingle(rawData);
+        pp_wr_cache[digihits[i]] = pair<const Df250PulsePedestal*, const Df250WindowRawData*>(pulsePed, rawData);
+    }
+    // get beam current
+    vector<const DEPICSvalue *> epicsVals;
+    eventLoop->Get(epicsVals);
+    double current = 0.0;
+    for(unsigned int i = 0; i < epicsVals.size(); i++){
+        if (epicsVals[i]->name == "IBCAD00CRCUR6"){
+            current = epicsVals[i]->fval;
+            break;
+        }
+    }
+    if (current>3.0&&current<2000.0) {
+        sumCurrent += current;
+        Ncurrent++;
+        current = sumCurrent/Ncurrent;
+    }
+    // fill hists
+    japp->RootWriteLock();
 
-  if((digihits.size()>0) || (tdcdigihits.size()>0))
-	  tagh_num_events->Fill(1);
+    if (current>3.0&&current<2000.0) hBeamCurrent->Fill(current);
 
-  hHit_RawNHits->Fill(hits.size());
-  hDigiHit_NfadcHits->Fill(digihits.size());
-  hDigiHit_NtdcHits->Fill(tdcdigihits.size());
-  int NfadcHits_cut = 0;
-  int NHits_hasADC = 0;  int NHits_hasADC_us = 0;  int NHits_hasADC_ds = 0;
-  int Nadc[Nslots];
-  for (int i=0;i<Nslots;i++) Nadc[i] = 0;
-  for(unsigned int i=0; i < digihits.size(); i++) {
-    double ped = digihits[i]->pedestal/digihits[i]->nsamples_pedestal;
-    hDigiHit_NSamplesPedestal->Fill(digihits[i]->nsamples_pedestal); 
-    hDigiHit_Pedestal->Fill(ped);
-    const Df250PulsePedestal* pulsePed = pp_wr_cache[digihits[i]].first;
-    double peak = -999.0;
-    if (pulsePed) peak = pulsePed->pulse_peak; 
-    hDigiHit_RawPeak->Fill(peak);
-    if (ped==0.0||peak==0.0) continue;
-    hDigiHit_PedestalVsSlotID->Fill(digihits[i]->counter_id,ped);
-    hDigiHit_fadcOccupancy->Fill(digihits[i]->counter_id);
-    hDigiHit_RawPeakVsSlotID->Fill(digihits[i]->counter_id,peak);
-    hDigiHit_RawIntegral->Fill(digihits[i]->pulse_integral);
-    hDigiHit_RawIntegralVsSlotID->Fill(digihits[i]->counter_id,digihits[i]->pulse_integral);
-    hDigiHit_NSamplesIntegral->Fill(digihits[i]->nsamples_integral);
-    double PI = digihits[i]->pulse_integral-digihits[i]->nsamples_integral*ped; // pedestal-subtracted pulse integral
-    hDigiHit_IntegralVsSlotID->Fill(digihits[i]->counter_id,PI);
-    hDigiHit_IntegralVsPeak->Fill(peak-ped,PI);
-    hDigiHit_PeakVsSlotID->Fill(digihits[i]->counter_id,peak-ped);
-    hDigiHit_PulseTime->Fill(digihits[i]->pulse_time);
-    double t_ns = 0.0625*digihits[i]->pulse_time;
-    hDigiHit_fadcTime->Fill(t_ns);
-    hDigiHit_fadcTimeVsSlotID->Fill(digihits[i]->counter_id,t_ns);
-    hDigiHit_fadcTimeVsIntegral->Fill(PI,t_ns);
-    hDigiHit_QualityFactor->Fill(digihits[i]->QF);
-    if (pulsePed) hDigiHit_PulseNumber->Fill(pulsePed->pulse_number);
-    if (pulsePed) hDigiHit_PulseNumberVsSlotID->Fill(digihits[i]->counter_id,pulsePed->pulse_number);
-    if (PI>counts_cut)  { 
-      NfadcHits_cut++;
-      hDigiHit_fadcOccupancy_cut->Fill(digihits[i]->counter_id);
-      hDigiHit_fadcTime_cut->Fill(t_ns);
-      hDigiHit_fadcTimeVsSlotID_cut->Fill(digihits[i]->counter_id,t_ns);
-      hDigiHit_fadcTimeVsQF_cut->Fill(digihits[i]->QF,t_ns);
-    }
-    const Df250WindowRawData* rawData = pp_wr_cache[digihits[i]].second;
-    if (rawData) {
-      int prevSample = 100;
-      int Ncrosses = 0;      
-      if (!rawData->invalid_samples&&!rawData->overflow) {
-	for (unsigned int j=0;j<rawData->samples.size();j++) {
-	  int sample = rawData->samples[j];
-	  int threshold = 400; 
-	  if (sample>threshold&&prevSample<threshold) Ncrosses++;
-	  prevSample = sample;
-	}
-      }
-      Nadc[digihits[i]->counter_id-1] = Ncrosses;
-    }
-    else {
-      if (peak>400.0) Nadc[digihits[i]->counter_id-1]++;
-    }
-  }
-  int NmultiPeak = 0;
-  if (digihits.size()>0) {
-    for (int i=0;i<Nslots;i++) {
-      NmultiPeak += Nadc[i];
-      hDigiHit_NfadcHitsVsSlotID->Fill(i+1,Nadc[i]);
-    }
-  }
-  hDigiHit_NfadcHits_multiPeak->Fill(NmultiPeak);
-  hDigiHit_NfadcHits_cut->Fill(NfadcHits_cut);
-  for(unsigned int j=0; j < digihits.size(); j++) {
-    double PI = digihits[j]->pulse_integral-digihits[j]->nsamples_integral*digihits[j]->pedestal/digihits[j]->nsamples_pedestal; // pedestal-subtracted pulse integral
-    if (digihits[j]->pedestal>0.0&&PI>counts_cut) {
-      int matches = 0;
-      for(unsigned int i=0; i < tdcdigihits.size(); i++) {
-	if (digihits[j]->counter_id==tdcdigihits[i]->counter_id) {
-	  matches++;
-	  double T_tdc = ttabUtilities->Convert_DigiTimeToNs_F1TDC(tdcdigihits[i]);
-	  double T_adc = 0.0625*digihits[j]->pulse_time;
-	  hDigiHit_tdcTimeVsfadcTime->Fill(T_adc,T_tdc);
-	  hDigiHit_tdcadcTimeDiff->Fill(T_tdc-T_adc);
-	  hDigiHit_tdcadcTimeDiffVsSlotID->Fill(digihits[j]->counter_id,T_tdc-T_adc);
-	  hDigiHit_tdcadcTimeDiffVsIntegral->Fill(PI,T_tdc-T_adc);
-	}
-      }
-      hDigiHit_adctdcMatchesVsSlotID_cut->Fill(digihits[j]->counter_id,matches);
-    }
-  }
-  int Ntdc[Nslots];
-  for (int i=0;i<Nslots;i++) Ntdc[i] = 0;
-  for(unsigned int i=0; i < tdcdigihits.size(); i++) {
-    Ntdc[tdcdigihits[i]->counter_id-1]++;
-    hDigiHit_tdcOccupancy->Fill(tdcdigihits[i]->counter_id);
-    hDigiHit_tdcRawTime->Fill(tdcdigihits[i]->time);
-    double T_tdc = ttabUtilities->Convert_DigiTimeToNs_F1TDC(tdcdigihits[i]);
-    hDigiHit_tdcTime->Fill(T_tdc);
-    hDigiHit_tdcTimeVsSlotID->Fill(tdcdigihits[i]->counter_id,T_tdc);
-  }
-  if (tdcdigihits.size()>0) {
-    for (int i=0;i<Nslots;i++) {
-      hDigiHit_NtdcHitsVsSlotID->Fill(i+1,Ntdc[i]);
-    }
-  }
-  //
-  for(unsigned int i=0; i<hits.size(); i++) {
-    hHit_HasTDCvsHasADC->Fill(hits[i]->has_fADC,hits[i]->has_TDC);
-    if (hits[i]->has_fADC) {
-      NHits_hasADC++;
-      if (hits[i]->counter_id<=NupstreamCounters) NHits_hasADC_us++;
-      else NHits_hasADC_ds++;
-      hHit_Occupancy->Fill(hits[i]->counter_id);
-      int HVid = hits[i]->counter_id<=NupstreamCounters ? hits[i]->counter_id : hits[i]->counter_id-Nslots+NHVchannels;
-      hHit_HVidVsSlotID->Fill(hits[i]->counter_id,HVid);
-      hHit_Energy->Fill(hits[i]->E);
-      hHit_EnergyVsSlotID->Fill(hits[i]->counter_id,hits[i]->E);
-      hHit_Integral->Fill(hits[i]->integral);
-      hHit_IntegralVsSlotID->Fill(hits[i]->counter_id,hits[i]->integral);
-      //hHit_fadcNpe->Fill(hits[i]->npe_fadc);
-      hHit_fadcTime->Fill(hits[i]->time_fadc);
-      hHit_fadcTimeVsSlotID->Fill(hits[i]->counter_id,hits[i]->time_fadc);
-      hHit_Time->Fill(hits[i]->t);
-      hHit_TimeVsSlotID->Fill(hits[i]->counter_id,hits[i]->t);
-      hHit_TimeVsEnergy->Fill(hits[i]->E,hits[i]->t);
-      hHit_TimeVsIntegral->Fill(hits[i]->integral,hits[i]->t);
-      if (hits[i]->has_TDC) {
-	hHit_tdcTime->Fill(hits[i]->time_tdc);
-	hHit_tdcTimeVsSlotID->Fill(hits[i]->counter_id,hits[i]->time_tdc);
-	hHit_tdcadcTimeDiffVsSlotID->Fill(hits[i]->counter_id,hits[i]->time_tdc-hits[i]->time_fadc);
-	hHit_tdcadcTimeDiffVsIntegral->Fill(hits[i]->integral,hits[i]->time_tdc-hits[i]->time_fadc);
-      }
-    }
-  }
-  hHit_NHits->Fill(NHits_hasADC);
-  hHit_NHits_us->Fill(NHits_hasADC_us);
-  hHit_NHits_ds->Fill(NHits_hasADC_ds);
-  japp->RootUnLock();
+    if((digihits.size()>0) || (tdcdigihits.size()>0))
+    tagh_num_events->Fill(1);
 
-  return NOERROR;
+    hHit_RawNHits->Fill(hits.size());
+    hDigiHit_NfadcHits->Fill(digihits.size());
+    hDigiHit_NtdcHits->Fill(tdcdigihits.size());
+    int NfadcHits_cut = 0;
+    int NHits_hasADC = 0;  int NHits_hasADC_us = 0;  int NHits_hasADC_ds = 0;
+    int Nadc[Nslots];
+    for (int i=0;i<Nslots;i++) Nadc[i] = 0;
+    for(unsigned int i=0; i < digihits.size(); i++) {
+        double ped = digihits[i]->pedestal/digihits[i]->nsamples_pedestal;
+        hDigiHit_NSamplesPedestal->Fill(digihits[i]->nsamples_pedestal);
+        hDigiHit_Pedestal->Fill(ped);
+        const Df250PulsePedestal* pulsePed = pp_wr_cache[digihits[i]].first;
+        double peak = -999.0;
+        if (pulsePed) peak = pulsePed->pulse_peak;
+        hDigiHit_RawPeak->Fill(peak);
+        if (ped==0.0||peak==0.0) continue;
+        hDigiHit_PedestalVsSlotID->Fill(digihits[i]->counter_id,ped);
+        hDigiHit_fadcOccupancy->Fill(digihits[i]->counter_id);
+        hDigiHit_RawPeakVsSlotID->Fill(digihits[i]->counter_id,peak);
+        hDigiHit_RawIntegral->Fill(digihits[i]->pulse_integral);
+        hDigiHit_RawIntegralVsSlotID->Fill(digihits[i]->counter_id,digihits[i]->pulse_integral);
+        hDigiHit_NSamplesIntegral->Fill(digihits[i]->nsamples_integral);
+        double PI = digihits[i]->pulse_integral-digihits[i]->nsamples_integral*ped; // pedestal-subtracted pulse integral
+        hDigiHit_IntegralVsSlotID->Fill(digihits[i]->counter_id,PI);
+        hDigiHit_IntegralVsPeak->Fill(peak-ped,PI);
+        hDigiHit_PeakVsSlotID->Fill(digihits[i]->counter_id,peak-ped);
+        hDigiHit_PulseTime->Fill(digihits[i]->pulse_time);
+        double t_ns = 0.0625*digihits[i]->pulse_time;
+        hDigiHit_fadcTime->Fill(t_ns);
+        hDigiHit_fadcTimeVsSlotID->Fill(digihits[i]->counter_id,t_ns);
+        hDigiHit_fadcTimeVsIntegral->Fill(PI,t_ns);
+        hDigiHit_QualityFactor->Fill(digihits[i]->QF);
+        if (pulsePed) hDigiHit_PulseNumber->Fill(pulsePed->pulse_number);
+        if (pulsePed) hDigiHit_PulseNumberVsSlotID->Fill(digihits[i]->counter_id,pulsePed->pulse_number);
+        if (PI>counts_cut)  {
+            NfadcHits_cut++;
+            hDigiHit_fadcOccupancy_cut->Fill(digihits[i]->counter_id);
+            hDigiHit_fadcTime_cut->Fill(t_ns);
+            hDigiHit_fadcTimeVsSlotID_cut->Fill(digihits[i]->counter_id,t_ns);
+            hDigiHit_fadcTimeVsQF_cut->Fill(digihits[i]->QF,t_ns);
+        }
+        const Df250WindowRawData* rawData = pp_wr_cache[digihits[i]].second;
+        if (rawData) {
+            int prevSample = 100;
+            int Ncrosses = 0;
+            if (!rawData->invalid_samples&&!rawData->overflow) {
+                for (unsigned int j=0;j<rawData->samples.size();j++) {
+                    int sample = rawData->samples[j];
+                    int threshold = 400;
+                    if (sample>threshold&&prevSample<threshold) Ncrosses++;
+                    prevSample = sample;
+                }
+            }
+            Nadc[digihits[i]->counter_id-1] = Ncrosses;
+        }
+        else {
+            if (peak>400.0) Nadc[digihits[i]->counter_id-1]++;
+        }
+    }
+    int NmultiPeak = 0;
+    if (digihits.size()>0) {
+        for (int i=0;i<Nslots;i++) {
+            NmultiPeak += Nadc[i];
+            hDigiHit_NfadcHitsVsSlotID->Fill(i+1,Nadc[i]);
+        }
+    }
+    hDigiHit_NfadcHits_multiPeak->Fill(NmultiPeak);
+    hDigiHit_NfadcHits_cut->Fill(NfadcHits_cut);
+    for(unsigned int j=0; j < digihits.size(); j++) {
+        double PI = digihits[j]->pulse_integral-digihits[j]->nsamples_integral*digihits[j]->pedestal/digihits[j]->nsamples_pedestal; // pedestal-subtracted pulse integral
+        if (digihits[j]->pedestal>0.0&&PI>counts_cut) {
+            int matches = 0;
+            for(unsigned int i=0; i < tdcdigihits.size(); i++) {
+                if (digihits[j]->counter_id==tdcdigihits[i]->counter_id) {
+                    matches++;
+                    double T_tdc = ttabUtilities->Convert_DigiTimeToNs_F1TDC(tdcdigihits[i]);
+                    double T_adc = 0.0625*digihits[j]->pulse_time;
+                    hDigiHit_tdcTimeVsfadcTime->Fill(T_adc,T_tdc);
+                    hDigiHit_tdcadcTimeDiff->Fill(T_tdc-T_adc);
+                    hDigiHit_tdcadcTimeDiffVsSlotID->Fill(digihits[j]->counter_id,T_tdc-T_adc);
+                    hDigiHit_tdcadcTimeDiffVsIntegral->Fill(PI,T_tdc-T_adc);
+                }
+            }
+            hDigiHit_adctdcMatchesVsSlotID_cut->Fill(digihits[j]->counter_id,matches);
+        }
+    }
+    int Ntdc[Nslots];
+    for (int i=0;i<Nslots;i++) Ntdc[i] = 0;
+    for(unsigned int i=0; i < tdcdigihits.size(); i++) {
+        Ntdc[tdcdigihits[i]->counter_id-1]++;
+        hDigiHit_tdcOccupancy->Fill(tdcdigihits[i]->counter_id);
+        hDigiHit_tdcRawTime->Fill(tdcdigihits[i]->time);
+        double T_tdc = ttabUtilities->Convert_DigiTimeToNs_F1TDC(tdcdigihits[i]);
+        hDigiHit_tdcTime->Fill(T_tdc);
+        hDigiHit_tdcTimeVsSlotID->Fill(tdcdigihits[i]->counter_id,T_tdc);
+    }
+    if (tdcdigihits.size()>0) {
+        for (int i=0;i<Nslots;i++) {
+            hDigiHit_NtdcHitsVsSlotID->Fill(i+1,Ntdc[i]);
+        }
+    }
+    //
+    for(unsigned int i=0; i<hits.size(); i++) {
+        hHit_HasTDCvsHasADC->Fill(hits[i]->has_fADC,hits[i]->has_TDC);
+        if (hits[i]->has_fADC) {
+            NHits_hasADC++;
+            if (hits[i]->counter_id<=NupstreamCounters) NHits_hasADC_us++;
+            else NHits_hasADC_ds++;
+            hHit_Occupancy->Fill(hits[i]->counter_id);
+            int HVid = hits[i]->counter_id<=NupstreamCounters ? hits[i]->counter_id : hits[i]->counter_id-Nslots+NHVchannels;
+            hHit_HVidVsSlotID->Fill(hits[i]->counter_id,HVid);
+            hHit_Energy->Fill(hits[i]->E);
+            hHit_EnergyVsSlotID->Fill(hits[i]->counter_id,hits[i]->E);
+            hHit_Integral->Fill(hits[i]->integral);
+            hHit_IntegralVsSlotID->Fill(hits[i]->counter_id,hits[i]->integral);
+            //hHit_fadcNpe->Fill(hits[i]->npe_fadc);
+            hHit_fadcTime->Fill(hits[i]->time_fadc);
+            hHit_fadcTimeVsSlotID->Fill(hits[i]->counter_id,hits[i]->time_fadc);
+            hHit_Time->Fill(hits[i]->t);
+            hHit_TimeVsSlotID->Fill(hits[i]->counter_id,hits[i]->t);
+            hHit_TimeVsEnergy->Fill(hits[i]->E,hits[i]->t);
+            hHit_TimeVsIntegral->Fill(hits[i]->integral,hits[i]->t);
+            if (hits[i]->has_TDC) {
+                hHit_tdcTime->Fill(hits[i]->time_tdc);
+                hHit_tdcTimeVsSlotID->Fill(hits[i]->counter_id,hits[i]->time_tdc);
+                hHit_tdcadcTimeDiffVsSlotID->Fill(hits[i]->counter_id,hits[i]->time_tdc-hits[i]->time_fadc);
+                hHit_tdcadcTimeDiffVsIntegral->Fill(hits[i]->integral,hits[i]->time_tdc-hits[i]->time_fadc);
+            }
+        }
+    }
+    hHit_NHits->Fill(NHits_hasADC);
+    hHit_NHits_us->Fill(NHits_hasADC_us);
+    hHit_NHits_ds->Fill(NHits_hasADC_ds);
+    japp->RootUnLock();
+
+    return NOERROR;
 }
 
 
@@ -460,10 +460,10 @@ jerror_t JEventProcessor_TAGH_online::evnt(JEventLoop *eventLoop, uint64_t event
 
 
 jerror_t JEventProcessor_TAGH_online::erun(void) {
-  // This is called whenever the run number changes, before it is
-  // changed to give you a chance to clean up before processing
-  // events from the next run number.
-  return NOERROR;
+    // This is called whenever the run number changes, before it is
+    // changed to give you a chance to clean up before processing
+    // events from the next run number.
+    return NOERROR;
 }
 
 
@@ -471,8 +471,8 @@ jerror_t JEventProcessor_TAGH_online::erun(void) {
 
 
 jerror_t JEventProcessor_TAGH_online::fini(void) {
-  // Called before program exit after event processing is finished.
-  return NOERROR;
+    // Called before program exit after event processing is finished.
+    return NOERROR;
 }
 
 

--- a/src/plugins/monitoring/TAGH_online/JEventProcessor_TAGH_online.h
+++ b/src/plugins/monitoring/TAGH_online/JEventProcessor_TAGH_online.h
@@ -12,18 +12,18 @@
 
 
 class JEventProcessor_TAGH_online:public jana::JEventProcessor{
- public:
-  JEventProcessor_TAGH_online();
-  ~JEventProcessor_TAGH_online();
-  const char* className(void){return "JEventProcessor_TAGH_online";}
+public:
+    JEventProcessor_TAGH_online();
+    ~JEventProcessor_TAGH_online();
+    const char* className(void){return "JEventProcessor_TAGH_online";}
 
 
- private:
-  jerror_t init(void);						///< Called once at program start.
-  jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
-  jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
-  jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
-  jerror_t fini(void);						///< Called after last event of last event source has been processed.
+private:
+    jerror_t init(void); ///< Called once at program start.
+    jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber); ///< Called everytime a new run number is detected.
+    jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber); ///< Called every event.
+    jerror_t erun(void); ///< Called everytime run number changes, provided brun has been called.
+    jerror_t fini(void); ///< Called after last event of last event source has been processed.
 };
 
 #endif // _JEventProcessor_TAGH_online_

--- a/src/plugins/monitoring/TAGH_online/TAGH_hit.C
+++ b/src/plugins/monitoring/TAGH_online/TAGH_hit.C
@@ -7,56 +7,56 @@
 // hnamepath: /TAGH/Hit/Hit_Time
 // hnamepath: /TAGH/Hit/Hit_Energy
 
-{  
-  TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("TAGH/Hit");
-  if(dir) dir->cd();
+{
+    TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("TAGH/Hit");
+    if(dir) dir->cd();
 
-  TH1I* hNHits = (TH1I*)gDirectory->FindObjectAny("Hit_NHits");
-  TH1I* hOccupancy = (TH1I*)gDirectory->FindObjectAny("Hit_Occupancy");
-  TH1I* hTime = (TH1I*)gDirectory->FindObjectAny("Hit_Time");
-  TH1I* hEnergy = (TH1I*)gDirectory->FindObjectAny("Hit_Energy");
+    TH1I* hNHits = (TH1I*)gDirectory->FindObjectAny("Hit_NHits");
+    TH1I* hOccupancy = (TH1I*)gDirectory->FindObjectAny("Hit_Occupancy");
+    TH1I* hTime = (TH1I*)gDirectory->FindObjectAny("Hit_Time");
+    TH1I* hEnergy = (TH1I*)gDirectory->FindObjectAny("Hit_Energy");
 
-  if(gPad == NULL){
-    TCanvas *c1 = new TCanvas("c1","TAGH Hit Monitor I",150,10,990,660);
-    c1->cd(0);
-    c1->Draw();
-    c1->Update();
-  }
+    if(gPad == NULL){
+        TCanvas *c1 = new TCanvas("c1","TAGH Hit Monitor I",150,10,990,660);
+        c1->cd(0);
+        c1->Draw();
+        c1->Update();
+    }
+    
+    if(!gPad) return;
+    TCanvas* c1 = gPad->GetCanvas();
+    c1->Divide(2,2);
 
-  if(!gPad) return;
-  TCanvas* c1 = gPad->GetCanvas();
-  c1->Divide(2,2);
+    double tsize = 0.0475;
+    gStyle->SetOptStat("emr");
+    if(hOccupancy){
+        hOccupancy->SetFillColor(kBlue);
+        c1->cd(1);
+        hOccupancy->SetTitleSize(tsize,"xy");
+        hOccupancy->Draw();
+    }
 
-  double tsize = 0.0475;  
-  gStyle->SetOptStat("emr");
-  if(hOccupancy){
-    hOccupancy->SetFillColor(kBlue);
-    c1->cd(1);
-    hOccupancy->SetTitleSize(tsize,"xy");
-    hOccupancy->Draw();
-  }
- 
-  if(hEnergy){
-    hEnergy->SetFillColor(kBlue);
-    c1->cd(2);
-    hEnergy->SetTitleSize(tsize,"xy");
-    hEnergy->Draw();
-  }
- 
-  if(hTime){
-    hTime->SetFillColor(kBlue);
-    c1->cd(3);
-    hTime->SetTitleSize(tsize,"xy");
-    hTime->GetXaxis()->SetRange(hTime->FindFirstBinAbove(1.0),hTime->FindLastBinAbove(1.0));
-    hTime->Draw();
-  }
+    if(hEnergy){
+        hEnergy->SetFillColor(kBlue);
+        c1->cd(2);
+        hEnergy->SetTitleSize(tsize,"xy");
+        hEnergy->Draw();
+    }
 
-  if(hNHits){
-    hNHits->SetFillColor(kBlue);
-    c1->cd(4);
-    hNHits->SetTitleSize(tsize,"xy");
-    hNHits->GetXaxis()->SetRange(hNHits->FindFirstBinAbove(1.0),hNHits->FindLastBinAbove(1.0));
-    hNHits->Draw();
-  }
+    if(hTime){
+        hTime->SetFillColor(kBlue);
+        c1->cd(3);
+        hTime->SetTitleSize(tsize,"xy");
+        hTime->GetXaxis()->SetRange(hTime->FindFirstBinAbove(1.0),hTime->FindLastBinAbove(1.0));
+        hTime->Draw();
+    }
+
+    if(hNHits){
+        hNHits->SetFillColor(kBlue);
+        c1->cd(4);
+        hNHits->SetTitleSize(tsize,"xy");
+        hNHits->GetXaxis()->SetRange(hNHits->FindFirstBinAbove(1.0),hNHits->FindLastBinAbove(1.0));
+        hNHits->Draw();
+    }
 
 }

--- a/src/plugins/monitoring/TAGH_online/TAGH_hit2.C
+++ b/src/plugins/monitoring/TAGH_online/TAGH_hit2.C
@@ -9,73 +9,73 @@
 // hnamepath: /TAGH/Hit/Hit_IntegralVsSlotID
 // hnamepath: /TAGH/Hit/Hit_TimeVsIntegral
 
-{  
-  TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("TAGH/Hit");
-  if(dir) dir->cd();
+{
+    TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("TAGH/Hit");
+    if(dir) dir->cd();
 
-  TH2I* hT_tdc = (TH2I*)gDirectory->FindObjectAny("Hit_tdcTimeVsSlotID");
-  TH2F* hStat = (TH2F*)gDirectory->FindObjectAny("Hit_HasTDCvsHasADC");
-  TH2I* hT_adc = (TH2I*)gDirectory->FindObjectAny("Hit_fadcTimeVsSlotID");
-  TH2I* hTdiff = (TH2I*)gDirectory->FindObjectAny("Hit_tdcadcTimeDiffVsSlotID");
-  TH2I* hPI = (TH2I*)gDirectory->FindObjectAny("Hit_IntegralVsSlotID");
-  TH2I* hTvsPI = (TH2I*)gDirectory->FindObjectAny("Hit_TimeVsIntegral");
+    TH2I* hT_tdc = (TH2I*)gDirectory->FindObjectAny("Hit_tdcTimeVsSlotID");
+    TH2F* hStat = (TH2F*)gDirectory->FindObjectAny("Hit_HasTDCvsHasADC");
+    TH2I* hT_adc = (TH2I*)gDirectory->FindObjectAny("Hit_fadcTimeVsSlotID");
+    TH2I* hTdiff = (TH2I*)gDirectory->FindObjectAny("Hit_tdcadcTimeDiffVsSlotID");
+    TH2I* hPI = (TH2I*)gDirectory->FindObjectAny("Hit_IntegralVsSlotID");
+    TH2I* hTvsPI = (TH2I*)gDirectory->FindObjectAny("Hit_TimeVsIntegral");
 
-  if(gPad == NULL){
-    TCanvas *c1 = new TCanvas("c1","TAGH Hit Monitor II",150,10,990,660);
-    c1->cd(0);
-    c1->Draw();
-    c1->Update();
-  }
+    if(gPad == NULL){
+        TCanvas *c1 = new TCanvas("c1","TAGH Hit Monitor II",150,10,990,660);
+        c1->cd(0);
+        c1->Draw();
+        c1->Update();
+    }
 
-  if(!gPad) return;
-  TCanvas* c1 = gPad->GetCanvas();
-  c1->Divide(3,2);
+    if(!gPad) return;
+    TCanvas* c1 = gPad->GetCanvas();
+    c1->Divide(3,2);
 
-  double tsize = 0.0475;  
-  gStyle->SetOptStat("emr");
-  if(hT_tdc){
-    c1->cd(1);
-    hT_tdc->SetTitleSize(tsize,"xy");
-    hT_tdc->GetYaxis()->SetRange(hT_tdc->FindFirstBinAbove(10.0,2),hT_tdc->FindLastBinAbove(10.0,2));
-    hT_tdc->Draw("colz");
-  }
- 
-  if(hStat){
-    c1->cd(2);
-    hStat->SetTitleSize(tsize,"xy");
-    hStat->GetYaxis()->SetRange(hStat->FindFirstBinAbove(10.0,2),hStat->FindLastBinAbove(10.0,2));
-    hStat->SetMarkerColor(kRed);
-    hStat->SetMarkerSize(2.0);
-    hStat->DrawNormalized("text");
-  }
-  
-  if(hPI){
-    c1->cd(3);
-    hPI->SetTitleSize(tsize,"xy");
-    hPI->GetYaxis()->SetRange(hPI->FindFirstBinAbove(10.0,2),hPI->FindLastBinAbove(10.0,2));
-    hPI->Draw("colz");
-  }
+    double tsize = 0.0475;
+    gStyle->SetOptStat("emr");
+    if(hT_tdc){
+        c1->cd(1);
+        hT_tdc->SetTitleSize(tsize,"xy");
+        hT_tdc->GetYaxis()->SetRange(hT_tdc->FindFirstBinAbove(10.0,2),hT_tdc->FindLastBinAbove(10.0,2));
+        hT_tdc->Draw("colz");
+    }
 
-  if(hT_adc){
-    c1->cd(4);
-    hT_adc->SetTitleSize(tsize,"xy");
-    hT_adc->GetYaxis()->SetRange(hT_adc->FindFirstBinAbove(10.0,2),hT_adc->FindLastBinAbove(10.0,2));
-    hT_adc->Draw("colz");
-  }
-  
-  if(hTdiff){
-    c1->cd(5);
-    hTdiff->SetTitleSize(tsize,"xy");
-    hTdiff->GetYaxis()->SetRange(hTdiff->FindFirstBinAbove(10.0,2),hTdiff->FindLastBinAbove(10.0,2));
-    hTdiff->Draw("colz");
-  }
-  
-  if(hTvsPI){
-    c1->cd(6);
-    hTvsPI->SetTitleSize(tsize,"xy");
-    hTvsPI->GetXaxis()->SetRange(hTvsPI->FindFirstBinAbove(10.0),hTvsPI->FindLastBinAbove(10.0));
-    hTvsPI->GetYaxis()->SetRange(hTvsPI->FindFirstBinAbove(10.0,2),hTvsPI->FindLastBinAbove(10.0,2));
-    hTvsPI->Draw("colz");
-  }
+    if(hStat){
+        c1->cd(2);
+        hStat->SetTitleSize(tsize,"xy");
+        hStat->GetYaxis()->SetRange(hStat->FindFirstBinAbove(10.0,2),hStat->FindLastBinAbove(10.0,2));
+        hStat->SetMarkerColor(kRed);
+        hStat->SetMarkerSize(2.0);
+        hStat->DrawNormalized("text");
+    }
+
+    if(hPI){
+        c1->cd(3);
+        hPI->SetTitleSize(tsize,"xy");
+        hPI->GetYaxis()->SetRange(hPI->FindFirstBinAbove(10.0,2),hPI->FindLastBinAbove(10.0,2));
+        hPI->Draw("colz");
+    }
+
+    if(hT_adc){
+        c1->cd(4);
+        hT_adc->SetTitleSize(tsize,"xy");
+        hT_adc->GetYaxis()->SetRange(hT_adc->FindFirstBinAbove(10.0,2),hT_adc->FindLastBinAbove(10.0,2));
+        hT_adc->Draw("colz");
+    }
+
+    if(hTdiff){
+        c1->cd(5);
+        hTdiff->SetTitleSize(tsize,"xy");
+        hTdiff->GetYaxis()->SetRange(hTdiff->FindFirstBinAbove(10.0,2),hTdiff->FindLastBinAbove(10.0,2));
+        hTdiff->Draw("colz");
+    }
+
+    if(hTvsPI){
+        c1->cd(6);
+        hTvsPI->SetTitleSize(tsize,"xy");
+        hTvsPI->GetXaxis()->SetRange(hTvsPI->FindFirstBinAbove(10.0),hTvsPI->FindLastBinAbove(10.0));
+        hTvsPI->GetYaxis()->SetRange(hTvsPI->FindFirstBinAbove(10.0,2),hTvsPI->FindLastBinAbove(10.0,2));
+        hTvsPI->Draw("colz");
+    }
 
 }

--- a/src/plugins/monitoring/TPOL_online/JEventProcessor_TPOL_online.cc
+++ b/src/plugins/monitoring/TPOL_online/JEventProcessor_TPOL_online.cc
@@ -26,13 +26,15 @@ const int NmultBins = 25; // number of bins for multiplicity histograms
 static TH1I *tpol_num_events;
 static TH1I *hRaw_NHits;
 static TH1I *hHit_NHits;
-static TH1F *hHit_Occupancy;
+static TH1I *hHit_Occupancy;
+static TH1F *hHit_Phi;
 static TH1I *hHit_Peak;
 static TH2I *hHit_PeakVsSector;
 static TH1I *hHit_Integral;
 static TH2I *hHit_IntegralVsSector;
 static TH1I *hHit_Time;
-static TH2F *hHit_TimeVsSector;
+static TH2I *hHit_TimeVsSector;
+static TH2F *hHit_TimeVsPhi;
 static TH2I *hHit_TimeVsPeak;
 static TH2I *hHit_TimeVsIntegral;
 //
@@ -99,13 +101,15 @@ jerror_t JEventProcessor_TPOL_online::init(void) {
     // hit-level hists (after calibration)
     gDirectory->mkdir("Hit")->cd();
     hHit_NHits = new TH1I("Hit_NHits","TPOL hit multiplicity;hits;events",NmultBins,0.5,0.5+NmultBins);
-    hHit_Occupancy = new TH1F("Hit_Occupancy","TPOL occupancy;sector;hits / counter",Nsectors,0.5,0.5+Nsectors);
+    hHit_Occupancy = new TH1I("Hit_Occupancy","TPOL occupancy;sector;hits / sector",Nsectors,0.5,0.5+Nsectors);
+    hHit_Phi = new TH1F("Hit_Phi","TPOL azimuthal angle;triplet azimuthal angle [degrees];hits / sector",Nsectors,0.0,360.0);
     hHit_Peak = new TH1I("Hit_Peak","TPOL fADC pulse peak;pulse peak;hits",410,0.0,4100.0);
     hHit_PeakVsSector = new TH2I("Hit_PeakVsSector","TPOL fADC pulse peak vs. sector;sector;pulse peak",Nsectors,0.5,0.5+Nsectors,410,0.0,4100.0);
     hHit_Integral = new TH1I("Hit_Integral","TPOL fADC pulse integral;pulse integral;hits",1000,0.0,30000.0);
     hHit_IntegralVsSector = new TH2I("Hit_IntegralVsSector","TPOL fADC pulse integral vs. sector;sector;pulse integral",Nsectors,0.5,0.5+Nsectors,1000,0.0,30000.0);
     hHit_Time = new TH1I("Hit_Time","TPOL time;time [ns];hits / 800 ps",1000,-400.0,400.0);
-    hHit_TimeVsSector = new TH2F("Hit_TimeVsSector","TPOL time vs. sector;sector;time [ns]",Nsectors,0.5,0.5+Nsectors,1000,-400.0,400.0);
+    hHit_TimeVsSector = new TH2I("Hit_TimeVsSector","TPOL time vs. sector;sector;time [ns]",Nsectors,0.5,0.5+Nsectors,1000,-400.0,400.0);
+    hHit_TimeVsPhi = new TH2F("Hit_TimeVsPhi","TPOL time vs. phi;#phi [degrees];time [ns]",Nsectors,0.0,360.0,1000,-400.0,400.0);
     hHit_TimeVsIntegral = new TH2I("Hit_TimeVsIntegral","TPOL time vs. integral;pulse integral;time [ns]",500,0.0,30000.0,1000,-400.0,400.0);
     hHit_TimeVsPeak = new TH2I("Hit_TimeVsPeak","TPOL time vs. peak;pulse peak;time [ns]",410,0.0,4100.0,1000,-400.0,400.0);
     // digihit-level hists
@@ -203,9 +207,7 @@ jerror_t JEventProcessor_TPOL_online::evnt(JEventLoop *eventLoop, uint64_t event
                 NHits++;
         }
     }
-    if(NHits>0) {
-        hRaw_NHits->Fill(NHits);
-    }
+    hRaw_NHits->Fill(NHits);
     if(sdhits.size()>0) tpol_num_events->Fill(1);
     hDigiHit_NHits->Fill(sdhits.size());
     for(unsigned int i=0; i < sdhits.size(); i++) {
@@ -241,12 +243,14 @@ jerror_t JEventProcessor_TPOL_online::evnt(JEventLoop *eventLoop, uint64_t event
     hHit_NHits->Fill(hits.size());
     for(unsigned int i=0; i<hits.size(); i++) {
         hHit_Occupancy->Fill(hits[i]->sector);
+        hHit_Phi->Fill(hits[i]->phi);
         hHit_Integral->Fill(hits[i]->integral);
         hHit_IntegralVsSector->Fill(hits[i]->sector,hits[i]->integral);
         hHit_Peak->Fill(hits[i]->pulse_peak);
         hHit_PeakVsSector->Fill(hits[i]->sector,hits[i]->pulse_peak);
         hHit_Time->Fill(hits[i]->t);
         hHit_TimeVsSector->Fill(hits[i]->sector,hits[i]->t);
+        hHit_TimeVsPhi->Fill(hits[i]->phi,hits[i]->t);
         hHit_TimeVsIntegral->Fill(hits[i]->integral,hits[i]->t);
         hHit_TimeVsPeak->Fill(hits[i]->pulse_peak,hits[i]->t);
     }


### PR DESCRIPTION
The TPOL hit library needs to use waveforms for the current run period
because the pulse identification in the fADC250 firmware does not work
well for its relatively slow rise times.

TPOL monitoring histograms have been added to the PSPair plugin. One of
these can be used to extract the raw triplet asymmetry after subtracting
accidentals and combining PARA and PERP runs.
