### PR TITLE
Fix bug when calculating, using time for NEW time-based tracks.

### DIFF
--- a/src/libraries/ANALYSIS/DDetectorMatches_factory_Combo.h
+++ b/src/libraries/ANALYSIS/DDetectorMatches_factory_Combo.h
@@ -38,6 +38,9 @@ class DDetectorMatches_factory_Combo : public jana::JFactory<DDetectorMatches>
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
+		pair<double, double> Calc_EnergyRatio(const DTrackTimeBased* locTrackTimeBased, const DTrackTimeBased* locOriginalTrackTimeBased) const;
+		double Calc_PVariance(const DTrackTimeBased* locTrack) const;
+
 		DDetectorMatches_factory* dDetectorMatchesFactory;
 };
 

--- a/src/libraries/ANALYSIS/DEventRFBunch_factory_Combo.cc
+++ b/src/libraries/ANALYSIS/DEventRFBunch_factory_Combo.cc
@@ -221,6 +221,9 @@ jerror_t DEventRFBunch_factory_Combo::evnt(jana::JEventLoop *locEventLoop, uint6
 	const DVertex* locVertex = NULL;
 	locEventLoop->GetSingle(locVertex);
 
+	const DDetectorMatches* locDetectorMatches = NULL;
+	locEventLoop->GetSingle(locDetectorMatches, "Combo");
+
 	map<pair<int, int>, DEventRFBunch*> locComboRFBunchMap; //key pair ints are: num-rf-bunch-shifts, num-votes
 
 	//pre-sort time-based tracks
@@ -257,7 +260,7 @@ jerror_t DEventRFBunch_factory_Combo::evnt(jana::JEventLoop *locEventLoop, uint6
 	for(size_t loc_i = 0; loc_i < locTrackTimeBasedVector.size(); ++loc_i)
 	{
 		double locStartTime = 0.0;
-		if(!Get_StartTime(locEventLoop, locTrackTimeBasedVector[loc_i], locStartTime))
+		if(!Get_StartTime(locDetectorMatches, locTrackTimeBasedVector[loc_i], locStartTime))
 			continue;
 		double locPropagatedTime = locStartTime + (dTargetCenterZ - locTrackTimeBasedVector[loc_i]->z())/29.9792458;
 		dPropagatedStartTimes_TimeBased[locTrackTimeBasedVector[loc_i]] = locPropagatedTime;
@@ -376,11 +379,8 @@ jerror_t DEventRFBunch_factory_Combo::evnt(jana::JEventLoop *locEventLoop, uint6
 	return NOERROR;
 }
 
-bool DEventRFBunch_factory_Combo::Get_StartTime(JEventLoop* locEventLoop, const DTrackTimeBased* locTrackTimeBased, double& locStartTime)
+bool DEventRFBunch_factory_Combo::Get_StartTime(const DDetectorMatches* locDetectorMatches, const DTrackTimeBased* locTrackTimeBased, double& locStartTime)
 {
-	const DDetectorMatches* locDetectorMatches = NULL;
-	locEventLoop->GetSingle(locDetectorMatches);
-
 	// Use time-based tracking time as initial guess
 	locStartTime = 0.0;
 

--- a/src/libraries/ANALYSIS/DEventRFBunch_factory_Combo.h
+++ b/src/libraries/ANALYSIS/DEventRFBunch_factory_Combo.h
@@ -69,7 +69,7 @@ class DEventRFBunch_factory_Combo:public jana::JFactory<DEventRFBunch>
 		double dTargetCenterZ;
 		double dMinThrownMatchFOM;
 
-		bool Get_StartTime(JEventLoop* locEventLoop, const DTrackTimeBased* locTrackTimeBased, double& locStartTime);
+		bool Get_StartTime(const DDetectorMatches* locDetectorMatches, const DTrackTimeBased* locTrackTimeBased, double& locStartTime);
 		double Calc_StartTime(const DNeutralShower* locNeutralShower, const DVertex* locVertex);
 		int Find_BestRFBunchShift(double locRFHitTime, const vector<double>& locTimes, int& locBestNumVotes);
 


### PR DESCRIPTION
New: Not created during track reconstruction, but during combo-creation.
E.g. Electron, positron.
