### PR TITLE
* Df250EmulatorAlgorithm_v1.cc [rtj]

### DIFF
--- a/src/libraries/DAQ/JEventSource_EVIO.cc
+++ b/src/libraries/DAQ/JEventSource_EVIO.cc
@@ -1920,10 +1920,17 @@ void JEventSource_EVIO::EmulateDf250Firmware(JEvent &event, vector<JObject*> &wr
                         pt_hw->time_emulated = pt_em->time_emulated;
                         pt_hw->quality_factor_emulated = pt_em->quality_factor_emulated;
                     }
-                    if ((VERBOSE > 0 && pt_hw->time != pt_hw->time_emulated) || VERBOSE > 3)
-                        jout << " comparing f250 hw and emulation pulse times for ROC/slot/chan "
-                             << pt_hw->rocid << "/" << pt_hw->slot << "/" << pt_hw->channel << ": "
-                             << pt_hw->time << " vs " << pt_hw->time_emulated << endl;
+                    if ((VERBOSE > 0 && pt_hw->time != pt_hw->time_emulated) || VERBOSE > 3) {
+                        // implement special exceptions for early pulse times in mode 8 data
+                        if (VERBOSE > 3 || !(pt_hw->time == 0 && 
+                            (pt_hw->time_emulated == 64 || pt_hw->time_emulated == 128 ||
+                             pt_hw->time_emulated == 192 || pt_hw->time_emulated == 256)) )
+                        {
+                            jout << " comparing f250 hw and emulation pulse times for ROC/slot/chan "
+                                 << pt_hw->rocid << "/" << pt_hw->slot << "/" << pt_hw->channel << ": "
+                                 << pt_hw->time << " vs " << pt_hw->time_emulated << endl;
+                        }
+                    }
                     pt_objs.erase(pt_objs.begin() + i);
                     delete pt_em;
                     pt_em = 0;


### PR DESCRIPTION
- fix bug reported by Mike Staib, where premature continue statements
   were preventing emulated objects from being generated in exceptional
   cases.
- added new code to make the emulated pulse objects agree with the
   mode 8 data in these exceptional cases.
- implement mode 7 behavior in the case where the pulse begins inside
   the pedestal window, which is the first 4 bytes of the sample series.
- JEventSource_EVIO.cc [rtj]
  - add special code to account for known differences between mode 7
    and mode 8 timing algorithms, so that the consistency checks being
    performed when emulating mode 7 behavior with mode 8 raw data does
    not falsely report an inconsistency with VERBOSE=1 set.
