### PR TITLE
Action lock

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisAction.cc
+++ b/src/libraries/ANALYSIS/DAnalysisAction.cc
@@ -26,6 +26,13 @@ dPerformAntiCut(false), dReaction(locReaction), dActionName(locActionBaseName), 
 		gPARMS->GetParameter("OUTPUT_FILENAME", dOutputFileName);
 	dNumPreviousParticleCombos = 0;
 	dNumParticleCombos = 0;
+
+	string locLockName = dActionName;
+	if(dReaction != NULL)
+		locLockName += string("_") + dReaction->Get_ReactionName();
+
+	dActionLock = japp->ReadLock(locLockName); //will create if doesn't exist, else returns it
+	pthread_rwlock_unlock(dActionLock); //unlock
 }
 
 void DAnalysisAction::operator()(JEventLoop* locEventLoop, set<const DParticleCombo*>& locSurvivingParticleCombos)
@@ -78,3 +85,4 @@ TDirectoryFile* DAnalysisAction::CreateAndChangeTo_ActionDirectory(void)
 	locDirTitle = locActionName;
 	return CreateAndChangeTo_Directory(locDirectory, locDirName, locDirTitle);
 }
+

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -81,6 +81,7 @@ void DHistogramAction_ObjectMemory::Initialize(JEventLoop* locEventLoop)
 	locBinLabels.push_back("DParticleCombo");
 
 	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		CreateAndChangeTo_ActionDirectory();
@@ -259,7 +260,11 @@ bool DHistogramAction_ObjectMemory::Perform_Action(JEventLoop* locEventLoop, con
 	locTotalMemory /= (1024.0*1024.0); //convert to MB
 
 	map<int, size_t>::iterator locIterator = locNumObjectsMap.begin();
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		++dEventCounter;
 		if(dEventCounter <= dMaxNumEvents)
@@ -277,7 +282,7 @@ bool DHistogramAction_ObjectMemory::Perform_Action(JEventLoop* locEventLoop, con
 			dHist_TotalMemory->SetBinContent(dEventCounter, locTotalMemory);
 		}
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return true;
 }
@@ -297,6 +302,8 @@ void DHistogramAction_Reconstruction::Initialize(JEventLoop* locEventLoop)
 	vector<const DMCThrown*> locMCThrowns;
 	locEventLoop->Get(locMCThrowns);
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
@@ -523,8 +530,10 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 		locWireToTimeBasedTrackMap[locTrackWireBased] = locTrackTimeBasedVector[loc_i];
 	}
 
-	//Fill Histograms
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		for(size_t loc_i = 0; loc_i < locFCALShowers.size(); ++loc_i)
 		{
@@ -686,7 +695,7 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 			dHist_MCMatchedHitsVsP->Fill(locTrackTimeBased->momentum().Mag(), locHitFraction);
 		}
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }
@@ -702,6 +711,8 @@ void DHistogramAction_DetectorMatching::Initialize(JEventLoop* locEventLoop)
 
 	bool locIsRESTEvent = (string(locEventLoop->GetJEvent().GetJEventSource()->className()) == string("DEventSourceREST"));
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
@@ -1141,10 +1152,11 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 		}
 	}
 	
-	//Fill Histograms
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
-
 		/********************************************************** MATCHING DISTANCE **********************************************************/
 
 		//BCAL
@@ -1392,7 +1404,7 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 				dHistMap_TrackPVsTheta_NoHitMatch[locIsTimeBased]->Fill(locTheta, locP);
 		}
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 }
 
 void DHistogramAction_DetectorPID::Initialize(JEventLoop* locEventLoop)
@@ -1411,6 +1423,8 @@ void DHistogramAction_DetectorPID::Initialize(JEventLoop* locEventLoop)
 	if(gPARMS->Exists("COMBO:SHOWER_SELECT_TAG"))
 		gPARMS->GetParameter("COMBO:SHOWER_SELECT_TAG", locShowerSelectionTag);
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//So: Default tag is "", User can set it to something else
@@ -1733,8 +1747,10 @@ bool DHistogramAction_DetectorPID::Perform_Action(JEventLoop* locEventLoop, cons
 	const DParticleID* locParticleID = NULL;
 	locEventLoop->GetSingle(locParticleID);
 
-	//Fill Histograms
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		if(locEventRFBunch->dTimeSource != SYS_NULL) //only histogram beta for neutrals if the t0 is well known
 		{
@@ -1888,7 +1904,7 @@ bool DHistogramAction_DetectorPID::Perform_Action(JEventLoop* locEventLoop, cons
 			}
 		}
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }
@@ -1908,6 +1924,8 @@ void DHistogramAction_Neutrals::Initialize(JEventLoop* locEventLoop)
 	double locTargetZCenter = 0.0;
 	locGeometry->GetTargetZ(locTargetZCenter);
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
@@ -1970,8 +1988,10 @@ bool DHistogramAction_Neutrals::Perform_Action(JEventLoop* locEventLoop, const D
 	locEventLoop->Get(locEventRFBunches);
 	double locStartTime = locEventRFBunches.empty() ? 0.0 : locEventRFBunches[0]->dTime;
 
-	//Fill Histograms
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		for(size_t loc_i = 0; loc_i < locNeutralShowers.size(); ++loc_i)
 		{
@@ -2013,7 +2033,7 @@ bool DHistogramAction_Neutrals::Perform_Action(JEventLoop* locEventLoop, const D
 			}
 		}
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }
@@ -2041,6 +2061,8 @@ void DHistogramAction_DetectorMatchParams::Initialize(JEventLoop* locEventLoop)
 	if(gPARMS->Exists("COMBO:TRACK_SELECT_TAG"))
 		gPARMS->GetParameter("COMBO:TRACK_SELECT_TAG", locTrackSelectionTag);
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//So: Default tag is "", User can set it to something else
@@ -2164,8 +2186,10 @@ void DHistogramAction_DetectorMatchParams::Fill_Hists(JEventLoop* locEventLoop, 
 	const DEventRFBunch* locEventRFBunch = NULL;
 	locEventLoop->GetSingle(locEventRFBunch);
 
-	//Fill Histograms
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		for(size_t loc_i = 0; loc_i < locChargedTracks.size(); ++loc_i)
 		{
@@ -2237,7 +2261,7 @@ void DHistogramAction_DetectorMatchParams::Fill_Hists(JEventLoop* locEventLoop, 
 			}
 		}
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 }
 
 void DHistogramAction_EventVertex::Initialize(JEventLoop* locEventLoop)
@@ -2248,6 +2272,8 @@ void DHistogramAction_EventVertex::Initialize(JEventLoop* locEventLoop)
 	if(gPARMS->Exists("COMBO:TRACK_SELECT_TAG"))
 		gPARMS->GetParameter("COMBO:TRACK_SELECT_TAG", locTrackSelectionTag);
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//So: Default tag is "", User can set it to something else
@@ -2399,7 +2425,10 @@ bool DHistogramAction_EventVertex::Perform_Action(JEventLoop* locEventLoop, cons
 	}
 
 	//Event Vertex
-	japp->RootWriteLock();
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action();
 	{
 		for(size_t loc_i = 0; loc_i < locChargedTracks.size(); ++loc_i)
 		{
@@ -2420,14 +2449,17 @@ bool DHistogramAction_EventVertex::Perform_Action(JEventLoop* locEventLoop, cons
 			dEventVertexT_2OrMoreGoodTracks->Fill(locVertex->dSpacetimeVertex.T());
 		}
 	}
-	japp->RootUnLock();
+	Unlock_Action();
 
 	if(locVertex->dKinFitNDF == 0)
 		return true; //kin fit not performed or didn't converge: no results to histogram
 
 	double locConfidenceLevel = TMath::Prob(locVertex->dKinFitChiSq, locVertex->dKinFitNDF);
 
-	japp->RootWriteLock();
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action();
 	{
 		dHist_KinFitConfidenceLevel->Fill(locConfidenceLevel);
 
@@ -2452,7 +2484,7 @@ bool DHistogramAction_EventVertex::Perform_Action(JEventLoop* locEventLoop, cons
 			}
 		}
 	}
-	japp->RootUnLock();
+	Unlock_Action();
 
 	return true;
 }
@@ -2468,6 +2500,8 @@ void DHistogramAction_DetectedParticleKinematics::Initialize(JEventLoop* locEven
 	if(gPARMS->Exists("COMBO:SHOWER_SELECT_TAG"))
 		gPARMS->GetParameter("COMBO:SHOWER_SELECT_TAG", locShowerSelectionTag);
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//So: Default tag is "", User can set it to something else
@@ -2577,12 +2611,16 @@ bool DHistogramAction_DetectedParticleKinematics::Perform_Action(JEventLoop* loc
 
 	vector<const DBeamPhoton*> locBeamPhotons;
 	locEventLoop->Get(locBeamPhotons);
-	japp->RootWriteLock();
+
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action();
 	{
 		for(size_t loc_i = 0; loc_i < locBeamPhotons.size(); ++loc_i)
 			dBeamParticle_P->Fill(locBeamPhotons[loc_i]->energy());
 	}
-	japp->RootUnLock();
+	Unlock_Action();
 
 	vector<const DChargedTrack*> locPreSelectChargedTracks;
 	locEventLoop->Get(locPreSelectChargedTracks, dTrackSelectionTag.c_str());
@@ -2599,12 +2637,15 @@ bool DHistogramAction_DetectedParticleKinematics::Perform_Action(JEventLoop* loc
 		if(dHistMap_QBetaVsP.find(locCharge) == dHistMap_QBetaVsP.end())
 			continue;
 
-		japp->RootWriteLock();
+		//FILL HISTOGRAMS
+		//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+		//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+		Lock_Action();
 		{
 			//Extremely inefficient, I know ...
 			dHistMap_QBetaVsP[locCharge]->Fill(locP, locBeta_Timing);
 		}
-		japp->RootUnLock();
+		Unlock_Action();
 	}
 
 	for(size_t loc_i = 0; loc_i < locPreSelectChargedTracks.size(); ++loc_i)
@@ -2622,7 +2663,10 @@ bool DHistogramAction_DetectedParticleKinematics::Perform_Action(JEventLoop* loc
 		if(dHistMap_P.find(locPID) == dHistMap_P.end())
 			continue; //not interested in histogramming
 
-		japp->RootWriteLock();
+		//FILL HISTOGRAMS
+		//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+		//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+		Lock_Action();
 		{
 			dHistMap_P[locPID]->Fill(locP);
 			dHistMap_Phi[locPID]->Fill(locPhi);
@@ -2635,7 +2679,7 @@ bool DHistogramAction_DetectedParticleKinematics::Perform_Action(JEventLoop* loc
 			dHistMap_VertexYVsX[locPID]->Fill(locChargedTrackHypothesis->position().X(), locChargedTrackHypothesis->position().Y());
 			dHistMap_VertexT[locPID]->Fill(locChargedTrackHypothesis->time());
 		}
-		japp->RootUnLock();
+		Unlock_Action();
 	}
 
 	vector<const DNeutralParticle*> locNeutralParticles;
@@ -2673,7 +2717,10 @@ bool DHistogramAction_DetectedParticleKinematics::Perform_Action(JEventLoop* loc
 		double locBeta_Timing = locNeutralParticleHypothesis->measuredBeta();
 		double locDeltaBeta = locNeutralParticleHypothesis->deltaBeta();
 
-		japp->RootWriteLock();
+		//FILL HISTOGRAMS
+		//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+		//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+		Lock_Action();
 		{
 			dHistMap_P[locPID]->Fill(locP);
 			dHistMap_Phi[locPID]->Fill(locPhi);
@@ -2686,7 +2733,7 @@ bool DHistogramAction_DetectedParticleKinematics::Perform_Action(JEventLoop* loc
 			dHistMap_VertexYVsX[locPID]->Fill(locNeutralParticleHypothesis->position().X(), locNeutralParticleHypothesis->position().Y());
 			dHistMap_VertexT[locPID]->Fill(locNeutralParticleHypothesis->time());
 		}
-		japp->RootUnLock();
+		Unlock_Action();
 	}
 	return true;
 }
@@ -2698,6 +2745,7 @@ void DHistogramAction_NumReconstructedObjects::Initialize(JEventLoop* locEventLo
 	bool locIsRESTEvent = (string(locEventLoop->GetJEvent().GetJEventSource()->className()) == string("DEventSourceREST"));
 
 	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		CreateAndChangeTo_ActionDirectory();
@@ -2910,7 +2958,10 @@ bool DHistogramAction_NumReconstructedObjects::Perform_Action(JEventLoop* locEve
 		}
 	}
 
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		//# High-Level Objects
 		dHist_NumHighLevelObjects->Fill(1, (Double_t)locRFTimes.size());
@@ -3043,7 +3094,7 @@ bool DHistogramAction_NumReconstructedObjects::Perform_Action(JEventLoop* locEve
 			dHist_NumRFSignals->Fill((Double_t)(locRFDigiTimes.size() + locRFTDCDigiTimes.size()));
 		}
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return true;
 }
@@ -3056,6 +3107,8 @@ void DHistogramAction_TrackMultiplicity::Initialize(JEventLoop* locEventLoop)
 	if(gPARMS->Exists("COMBO:SHOWER_SELECT_TAG"))
 		gPARMS->GetParameter("COMBO:SHOWER_SELECT_TAG", locShowerSelectionTag);
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//So: Default tag is "", User can set it to something else
@@ -3212,7 +3265,11 @@ bool DHistogramAction_TrackMultiplicity::Perform_Action(JEventLoop* locEventLoop
 	}
 
 	size_t locNumGoodTracks = locNumGoodPositiveTracks + locNumGoodNegativeTracks;
-	japp->RootWriteLock();
+
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action();
 	{
 		dHist_NumReconstructedParticles->Fill(0.0, (Double_t)(locChargedTracks.size() + locNeutralParticles.size()));
 		dHist_NumReconstructedParticles->Fill(1.0, (Double_t)locChargedTracks.size());
@@ -3230,7 +3287,7 @@ bool DHistogramAction_TrackMultiplicity::Perform_Action(JEventLoop* locEventLoop
 		for(size_t loc_i = 0; loc_i < dFinalStatePIDs.size(); ++loc_i)
 			dHist_NumGoodReconstructedParticles->Fill(5.0 + (Double_t)loc_i, (Double_t)locNumGoodTracksByPID[dFinalStatePIDs[loc_i]]);
 	}
-	japp->RootUnLock();
+	Unlock_Action();
 
 	return true;
 }

--- a/src/plugins/Analysis/b1pi_hists/DCustomAction_HistMass_X_2000.cc
+++ b/src/plugins/Analysis/b1pi_hists/DCustomAction_HistMass_X_2000.cc
@@ -13,6 +13,8 @@ void DCustomAction_HistMass_X_2000::Initialize(JEventLoop* locEventLoop)
 	//Create any histograms/trees/etc. within a ROOT lock. 
 		//This is so that when running multithreaded, only one thread is writing to the ROOT file at a time. 
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		// Optional: Useful utility functions.
@@ -101,13 +103,15 @@ bool DCustomAction_HistMass_X_2000::Perform_Action(JEventLoop* locEventLoop, con
 	}*/
 	double locInvariantMass = locP4.M();
 
-	//Optional: Fill histograms
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		// Fill any histograms here
 		dMassHist->Fill(locInvariantMass);
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }

--- a/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_hists.cc
+++ b/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_hists.cc
@@ -35,6 +35,8 @@ void DCustomAction_p2gamma_hists::Initialize(JEventLoop* locEventLoop)
         min2gMassCut = 0.10;
         max2gMassCut = 0.16;
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
@@ -138,7 +140,10 @@ bool DCustomAction_p2gamma_hists::Perform_Action(JEventLoop* locEventLoop, const
 	TLorentzVector locDelta = (locProtonP4 - locProtonP4Init);
 	double t = locDelta.M2();
 	
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		// Fill histograms here
 		dEgamma->Fill(locBeamPhotonEnergy);
@@ -192,7 +197,7 @@ bool DCustomAction_p2gamma_hists::Perform_Action(JEventLoop* locEventLoop, const
 			}
 		}
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }

--- a/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_unusedHists.cc
+++ b/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_unusedHists.cc
@@ -15,6 +15,8 @@ void DCustomAction_p2gamma_unusedHists::Initialize(JEventLoop* locEventLoop)
         locEventLoop->GetSingle(locParticleID);
 	dParticleID = locParticleID;
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
@@ -232,11 +234,14 @@ bool DCustomAction_p2gamma_unusedHists::Perform_Action(JEventLoop* locEventLoop,
 		}	
 	}
 	
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		dNShowerBCAL_FCAL->Fill(nUnmatchedFCAL, nUnmatchedBCAL);
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }
@@ -260,7 +265,10 @@ void DCustomAction_p2gamma_unusedHists::FillTrack(const DChargedTrack* locCharge
 	  else cout<<nPoss<<" "<<nHits<<endl;
 	*/
 
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		dHistMap_TrackNhits_Theta[locMatch][locCharge]->Fill(locTrackTimeBased->momentum().Theta()*180/TMath::Pi(), nHits);
 		dHistMap_TrackChiSq_Theta[locMatch][locCharge]->Fill(locTrackTimeBased->momentum().Theta()*180/TMath::Pi(), locTrackTimeBased->chisq);
@@ -272,7 +280,7 @@ void DCustomAction_p2gamma_unusedHists::FillTrack(const DChargedTrack* locCharge
 		//dHistMap_TrackNposs_Theta[locMatch][locCharge]->Fill(locTrackTimeBased->momentum().Theta()*180/TMath::Pi(), nPoss);
 		//dHistMap_TrackHitFrac_Theta[locMatch][locCharge]->Fill(locTrackTimeBased->momentum().Theta()*180/TMath::Pi(), fitFrac);
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return;
 }
@@ -320,12 +328,15 @@ void DCustomAction_p2gamma_unusedHists::FillShower(const DNeutralShower* locNeut
 
 		const DBCALShower* locBCALShower = NULL;
 		locNeutralShower->GetSingleT(locBCALShower);
-		
-		japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+
+		//FILL HISTOGRAMS
+		//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+		//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+		Lock_Action(); //ACQUIRE ROOT LOCK!!
 		{
 			dHistMap_BCALShowerNcell[locMatch]->Fill(locBCALShower->N_cell);
 		}
-		japp->RootUnLock(); //RELEASE ROOT LOCK!!
+		Unlock_Action(); //RELEASE ROOT LOCK!!
 
 		vector<const DBCALCluster*> locBCALClusters;
 		locBCALShower->Get(locBCALClusters);
@@ -351,7 +362,10 @@ void DCustomAction_p2gamma_unusedHists::FillShower(const DNeutralShower* locNeut
 		}
 	}
 
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		dHistMap_ShowerEnergy_Theta[locMatch][locSystem]->Fill(locPosition.Theta()*180./TMath::Pi(), locEnergy);
 		dHistMap_ShowerPhi_Theta[locMatch][locSystem]->Fill(locPosition.Theta()*180./TMath::Pi(), locPosition.Phi()*180./TMath::Pi());
@@ -374,7 +388,7 @@ void DCustomAction_p2gamma_unusedHists::FillShower(const DNeutralShower* locNeut
 		}
 
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return;
 }

--- a/src/plugins/Analysis/p2k_hists/DCustomAction_p2k_hists.cc
+++ b/src/plugins/Analysis/p2k_hists/DCustomAction_p2k_hists.cc
@@ -9,7 +9,8 @@
 
 void DCustomAction_p2k_hists::Initialize(JEventLoop* locEventLoop)
 {
-
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
@@ -125,7 +126,10 @@ bool DCustomAction_p2k_hists::Perform_Action(JEventLoop* locEventLoop, const DPa
 
 	double dEdxCut = 2.2;
 
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		// Fill histograms here
 		dEgamma->Fill(locBeamPhotonEnergy);
@@ -177,7 +181,8 @@ bool DCustomAction_p2k_hists::Perform_Action(JEventLoop* locEventLoop, const DPa
 			dKminus_Beta_P_RhoTag->Fill(locParticles[1]->lorentzMomentum().Vect().Mag(), kminus_beta);
 		}
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }
+

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.cc
@@ -53,6 +53,8 @@ void DCustomAction_p2pi_hists::Initialize(JEventLoop* locEventLoop)
 	// check if a particle is missing
 	Get_Reaction()->Get_MissingPID(dMissingPID);
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
@@ -171,7 +173,10 @@ bool DCustomAction_p2pi_hists::Perform_Action(JEventLoop* locEventLoop, const DP
 	if(locPsi < -1*TMath::Pi()) locPsi += 2*TMath::Pi();
         if(locPsi > TMath::Pi()) locPsi -= 2*TMath::Pi();
 
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		// Fill histograms here
 		dEgamma->Fill(locBeamPhotonEnergy);
@@ -237,7 +242,7 @@ bool DCustomAction_p2pi_hists::Perform_Action(JEventLoop* locEventLoop, const DP
 			}
 		}
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraPi0.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraPi0.cc
@@ -9,6 +9,8 @@
 
 void DCustomAction_CutExtraPi0::Initialize(JEventLoop* locEventLoop)
 {
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		// Optional: Useful utility functions.
@@ -58,13 +60,15 @@ bool DCustomAction_CutExtraPi0::Perform_Action(JEventLoop* locEventLoop, const D
 		}
 	}
 
-	//Optional: Fill histograms
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		for(size_t loc_i = 0; loc_i < locInvariantMasses.size(); ++loc_i)
 			dHist_Pi0InvariantMass->Fill(locInvariantMasses[loc_i]);
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return locPassesCutFlag; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_dEdxCut.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_dEdxCut.cc
@@ -13,6 +13,8 @@ void DCustomAction_dEdxCut::Initialize(JEventLoop* locEventLoop)
 	//Create any histograms/trees/etc. within a ROOT lock. 
 		//This is so that when running multithreaded, only one thread is writing to the ROOT file at a time. 
 
+	//CREATE THE FUNCTIONS
+	//Since we are creating functions, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		string locFuncName = "df_dEdxCut_SelectHeavy"; //e.g. proton

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_p3pi_hists.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_p3pi_hists.cc
@@ -102,7 +102,11 @@ bool DCustomAction_p3pi_hists::Perform_Action(JEventLoop* locEventLoop, const DP
 		dDeltaPhi_M3pi->Fill(locOmegaP4.M(), locDeltaPhi);
 		
 		// require proton and omega are back-to-back
-		if(locDeltaPhi < 175. || locDeltaPhi > 185.) return true;
+		if(locDeltaPhi < 175. || locDeltaPhi > 185.)
+		{
+			Unlock_Action(); //RELEASE ROOT LOCK!!
+			return true;
+		}
 		dMM2_M3pi_CoplanarTag->Fill(locOmegaP4.M(), locMissingP4.M2());
 		dDeltaE_M3pi_CoplanarTag->Fill(locOmegaP4.M(),locMissingP4.E());
 		if(locOmegaP4.M() > 0.7 && locOmegaP4.M() < 0.9)

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_p3pi_hists.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_p3pi_hists.cc
@@ -9,7 +9,8 @@
 
 void DCustomAction_p3pi_hists::Initialize(JEventLoop* locEventLoop)
 {
-
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
@@ -83,7 +84,10 @@ bool DCustomAction_p3pi_hists::Perform_Action(JEventLoop* locEventLoop, const DP
 
 	double dEdxCut = 2.2;
 
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		// Fill histograms here
 		dEgamma->Fill(locBeamPhotonEnergy);
@@ -130,7 +134,7 @@ bool DCustomAction_p3pi_hists::Perform_Action(JEventLoop* locEventLoop, const DP
 			
 		}
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }

--- a/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_ppi0gamma_hists.cc
+++ b/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_ppi0gamma_hists.cc
@@ -9,6 +9,8 @@
 
 void DCustomAction_ppi0gamma_hists::Initialize(JEventLoop* locEventLoop)
 {
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
@@ -73,7 +75,10 @@ bool DCustomAction_ppi0gamma_hists::Perform_Action(JEventLoop* locEventLoop, con
 
 	double dEdxCut = 2.2;
 	
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		// Fill histograms here
 		dEgamma->Fill(locBeamPhotonEnergy);
@@ -121,11 +126,11 @@ bool DCustomAction_ppi0gamma_hists::Perform_Action(JEventLoop* locEventLoop, con
 			
 			}
 			
-			japp->RootUnLock();
+			Unlock_Action(); //RELEASE ROOT LOCK!!
 			return true;
 		}
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_CutExtraPi0.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_CutExtraPi0.cc
@@ -9,6 +9,8 @@
 
 void DCustomAction_CutExtraPi0::Initialize(JEventLoop* locEventLoop)
 {
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		// Optional: Useful utility functions.
@@ -58,13 +60,15 @@ bool DCustomAction_CutExtraPi0::Perform_Action(JEventLoop* locEventLoop, const D
 		}
 	}
 
-	//Optional: Fill histograms
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
 		for(size_t loc_i = 0; loc_i < locInvariantMasses.size(); ++loc_i)
 			dHist_Pi0InvariantMass->Fill(locInvariantMasses[loc_i]);
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	Unlock_Action(); //RELEASE ROOT LOCK!!
 
 	return locPassesCutFlag; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_dEdxCut.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_dEdxCut.cc
@@ -13,6 +13,8 @@ void DCustomAction_dEdxCut::Initialize(JEventLoop* locEventLoop)
 	//Create any histograms/trees/etc. within a ROOT lock. 
 		//This is so that when running multithreaded, only one thread is writing to the ROOT file at a time. 
 
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		string locFuncName = "df_dEdxCut_SelectHeavy"; //e.g. proton


### PR DESCRIPTION
Each analysis action now has it's own lock.  This way, instead of locking all of ROOT when you want to fill histograms, you just acquire the action lock, so that different actions can fill without interfering with each other. You still need the global ROOT lock when creating histograms. 

Also, fix several deadlock-causing bugs in some of the custom actions in the DReaction plugins in sim-recon, where "return" was called without first unlocking. 
