### PR TITLE
Factory locks

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisResults_factory.cc
+++ b/src/libraries/ANALYSIS/DAnalysisResults_factory.cc
@@ -18,6 +18,11 @@ jerror_t DAnalysisResults_factory::init(void)
 {
 	dDebugLevel = 0;
 	dMinThrownMatchFOM = 5.73303E-7;
+
+	string locLockName = string(GetDataClassName()) + string("__") + string(Tag());
+	dFactoryLock = japp->ReadLock(locLockName); //will create if doesn't exist, else returns it
+	pthread_rwlock_unlock(dFactoryLock); //unlock
+
 	return NOERROR;
 }
 
@@ -47,104 +52,98 @@ jerror_t DAnalysisResults_factory::brun(jana::JEventLoop *locEventLoop, int32_t 
 
 	dApplication->RootWriteLock(); //to prevent undefined behavior due to directory changes, etc.
 	{
+		//get and change to the base (file/global) directory
 		string locOutputFileName = "hd_root.root";
 		if(gPARMS->Exists("OUTPUT_FILENAME"))
 			gPARMS->GetParameter("OUTPUT_FILENAME", locOutputFileName);
+
+		TDirectory* locCurrentDir = gDirectory;
 		TFile* locFile = (TFile*)gROOT->FindObject(locOutputFileName.c_str());
-		if(locFile == NULL)
-		{
-			root_hists_created = false; // this is redundant since it's already set in the constructor
-			static bool warning_issued = false;
-			if(!warning_issued){
-				cout << "WARNING: output histogram file " << locOutputFileName << " not found in DAnalysisResults_factory::brun()." << endl;
-				cout << "         some functionality disabled." << endl;
-				warning_issued = true;
-			}
-		}else{
+		if(locFile != NULL)
 			locFile->cd("");
+		else
+			gDirectory->cd("/");
 
-			for(size_t loc_i = 0; loc_i < locReactions.size(); ++loc_i)
+		for(size_t loc_i = 0; loc_i < locReactions.size(); ++loc_i)
+		{
+			locReaction = locReactions[loc_i];
+			locReactionName = locReaction->Get_ReactionName();
+			locNumActions = locReaction->Get_NumAnalysisActions();
+
+			deque<string> locActionNames;
+			for(size_t loc_j = 0; loc_j < locNumActions; ++loc_j)
+				locActionNames.push_back(locReaction->Get_AnalysisAction(loc_j)->Get_ActionName());
+
+			const char* locDirName = locReactionName.c_str();
+			locFile->cd();
+			locDirectoryFile = static_cast<TDirectoryFile*>(locFile->GetDirectory(locDirName));
+			if(locDirectoryFile == NULL)
+				locDirectoryFile = new TDirectoryFile(locDirName, locDirName);
+			locDirectoryFile->cd();
+
+			locHistName = "NumEventsSurvivedAction";
+			loc1DHist = static_cast<TH1D*>(locDirectoryFile->Get(locHistName.c_str()));
+			if(loc1DHist == NULL)
 			{
-				locReaction = locReactions[loc_i];
-				locReactionName = locReaction->Get_ReactionName();
-				locNumActions = locReaction->Get_NumAnalysisActions();
+				locHistTitle = locReactionName + string(";;# Events Survived Action");
+				loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 2, -0.5, locNumActions + 2.0 - 0.5); //+2 for input & # tracks
+				loc1DHist->GetXaxis()->SetBinLabel(1, "Input"); // a new event
+				loc1DHist->GetXaxis()->SetBinLabel(2, "Has Particle Combos"); // at least one DParticleCombo object before any actions
+				for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
+					loc1DHist->GetXaxis()->SetBinLabel(3 + loc_j, locActionNames[loc_j].c_str());
+			}
+			dHistMap_NumEventsSurvivedAction_All[locReaction] = loc1DHist;
 
-				deque<string> locActionNames;
-				for(size_t loc_j = 0; loc_j < locNumActions; ++loc_j)
-					locActionNames.push_back(locReaction->Get_AnalysisAction(loc_j)->Get_ActionName());
-
-				const char* locDirName = locReactionName.c_str();
-				locFile->cd();
-				locDirectoryFile = static_cast<TDirectoryFile*>(locFile->GetDirectory(locDirName));
-				if(locDirectoryFile == NULL)
-					locDirectoryFile = new TDirectoryFile(locDirName, locDirName);
-				locDirectoryFile->cd();
-
-				locHistName = "NumEventsSurvivedAction";
+			if(!locMCThrowns.empty())
+			{
+				locHistName = "NumEventsWhereTrueComboSurvivedAction";
 				loc1DHist = static_cast<TH1D*>(locDirectoryFile->Get(locHistName.c_str()));
 				if(loc1DHist == NULL)
 				{
-					locHistTitle = locReactionName + string(";;# Events Survived Action");
-					loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 2, -0.5, locNumActions + 2.0 - 0.5); //+2 for input & # tracks
-					loc1DHist->GetXaxis()->SetBinLabel(1, "Input"); // a new event
-					loc1DHist->GetXaxis()->SetBinLabel(2, "Has Particle Combos"); // at least one DParticleCombo object before any actions
-					for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
-						loc1DHist->GetXaxis()->SetBinLabel(3 + loc_j, locActionNames[loc_j].c_str());
-				}
-				dHistMap_NumEventsSurvivedAction_All[locReaction] = loc1DHist;
-
-				if(!locMCThrowns.empty())
-				{
-					locHistName = "NumEventsWhereTrueComboSurvivedAction";
-					loc1DHist = static_cast<TH1D*>(locDirectoryFile->Get(locHistName.c_str()));
-					if(loc1DHist == NULL)
-					{
-						locHistTitle = locReactionName + string(";;# Events Where True Combo Survived Action");
-						loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 1, -0.5, locNumActions + 1.0 - 0.5); //+1 for # tracks
-						loc1DHist->GetXaxis()->SetBinLabel(1, "Has Particle Combos"); // at least one DParticleCombo object before any actions
-						for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
-							loc1DHist->GetXaxis()->SetBinLabel(2 + loc_j, locActionNames[loc_j].c_str());
-					}
-					dHistMap_NumEventsWhereTrueComboSurvivedAction[locReaction] = loc1DHist;
-				}
-
-				locHistName = "NumCombosSurvivedAction";
-				loc2DHist = static_cast<TH2D*>(locDirectoryFile->Get(locHistName.c_str()));
-				if(loc2DHist == NULL)
-				{
-					double* locBinArray = new double[55];
-					for(unsigned int loc_j = 0; loc_j < 6; ++loc_j)
-					{
-						for(unsigned int loc_k = 1; loc_k <= 9; ++loc_k)
-							locBinArray[loc_j*9 + loc_k - 1] = double(loc_k)*pow(10.0, double(loc_j));
-					}
-					locBinArray[54] = 1.0E6;
-
-					locHistTitle = locReactionName + string(";;# Particle Combos Survived Action");
-					loc2DHist = new TH2D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 1, -0.5, locNumActions + 1 - 0.5, 54, locBinArray); //+1 for # tracks
-					delete[] locBinArray;
-					loc2DHist->GetXaxis()->SetBinLabel(1, "Has Particle Combos"); // at least one DParticleCombo object before any actions
-					for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
-						loc2DHist->GetXaxis()->SetBinLabel(2 + loc_j, locActionNames[loc_j].c_str());
-				}
-				dHistMap_NumCombosSurvivedAction[locReaction] = loc2DHist;
-
-				locHistName = "NumCombosSurvivedAction1D";
-				loc1DHist = static_cast<TH1D*>(locDirectoryFile->Get(locHistName.c_str()));
-				if(loc1DHist == NULL)
-				{
-					locHistTitle = locReactionName + string(";;# Particle Combos Survived Action");
-					loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 1, -0.5, locNumActions + 1 - 0.5); //+1 for # tracks
-					loc1DHist->GetXaxis()->SetBinLabel(1, "Minimum # Tracks"); // at least one DParticleCombo object before any actions
+					locHistTitle = locReactionName + string(";;# Events Where True Combo Survived Action");
+					loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 1, -0.5, locNumActions + 1.0 - 0.5); //+1 for # tracks
+					loc1DHist->GetXaxis()->SetBinLabel(1, "Has Particle Combos"); // at least one DParticleCombo object before any actions
 					for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
 						loc1DHist->GetXaxis()->SetBinLabel(2 + loc_j, locActionNames[loc_j].c_str());
 				}
-				dHistMap_NumCombosSurvivedAction1D[locReaction] = loc1DHist;
-				locDirectoryFile->cd("..");
+				dHistMap_NumEventsWhereTrueComboSurvivedAction[locReaction] = loc1DHist;
 			}
-			locFile->cd(""); //return to base directory
-			root_hists_created = true;
-		} // if(locFile == NULL)
+
+			locHistName = "NumCombosSurvivedAction";
+			loc2DHist = static_cast<TH2D*>(locDirectoryFile->Get(locHistName.c_str()));
+			if(loc2DHist == NULL)
+			{
+				double* locBinArray = new double[55];
+				for(unsigned int loc_j = 0; loc_j < 6; ++loc_j)
+				{
+					for(unsigned int loc_k = 1; loc_k <= 9; ++loc_k)
+						locBinArray[loc_j*9 + loc_k - 1] = double(loc_k)*pow(10.0, double(loc_j));
+				}
+				locBinArray[54] = 1.0E6;
+
+				locHistTitle = locReactionName + string(";;# Particle Combos Survived Action");
+				loc2DHist = new TH2D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 1, -0.5, locNumActions + 1 - 0.5, 54, locBinArray); //+1 for # tracks
+				delete[] locBinArray;
+				loc2DHist->GetXaxis()->SetBinLabel(1, "Has Particle Combos"); // at least one DParticleCombo object before any actions
+				for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
+					loc2DHist->GetXaxis()->SetBinLabel(2 + loc_j, locActionNames[loc_j].c_str());
+			}
+			dHistMap_NumCombosSurvivedAction[locReaction] = loc2DHist;
+
+			locHistName = "NumCombosSurvivedAction1D";
+			loc1DHist = static_cast<TH1D*>(locDirectoryFile->Get(locHistName.c_str()));
+			if(loc1DHist == NULL)
+			{
+				locHistTitle = locReactionName + string(";;# Particle Combos Survived Action");
+				loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 1, -0.5, locNumActions + 1 - 0.5); //+1 for # tracks
+				loc1DHist->GetXaxis()->SetBinLabel(1, "Minimum # Tracks"); // at least one DParticleCombo object before any actions
+				for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
+					loc1DHist->GetXaxis()->SetBinLabel(2 + loc_j, locActionNames[loc_j].c_str());
+			}
+			dHistMap_NumCombosSurvivedAction1D[locReaction] = loc1DHist;
+			locDirectoryFile->cd("..");
+		}
+		locCurrentDir->cd();
 	}
 	dApplication->RootUnLock(); //unlock
 
@@ -312,24 +311,22 @@ jerror_t DAnalysisResults_factory::evnt(jana::JEventLoop* locEventLoop, uint64_t
 			locAnalysisResults->Add_PassedParticleCombo(*locIterator);
 
 		//fill histograms & trees
-		if(root_hists_created){
-			dApplication->RootWriteLock();
+		Lock_Factory();
+		{
+			for(size_t loc_j = 0; loc_j < locNumParticleCombosSurvivedActions.size(); ++loc_j)
 			{
-				for(size_t loc_j = 0; loc_j < locNumParticleCombosSurvivedActions.size(); ++loc_j)
+				if(locNumParticleCombosSurvivedActions[loc_j] > 0)
 				{
-					if(locNumParticleCombosSurvivedActions[loc_j] > 0)
-					{
-						dHistMap_NumEventsSurvivedAction_All[locReaction]->Fill(loc_j + locNumPreKinFitActions + 2); //+2 because 0 is initial (no cuts at all), and 1 is min #tracks
-						dHistMap_NumCombosSurvivedAction[locReaction]->Fill(loc_j + locNumPreKinFitActions + 1, locNumParticleCombosSurvivedActions[loc_j]); //+1 because 0 is min #tracks
-					}
-					for(size_t loc_k = 0; loc_k < locNumParticleCombosSurvivedActions[loc_j]; ++loc_k)
-						dHistMap_NumCombosSurvivedAction1D[locReaction]->Fill(loc_j + locNumPreKinFitActions + 1); //+1 because 0 is min #tracks
+					dHistMap_NumEventsSurvivedAction_All[locReaction]->Fill(loc_j + locNumPreKinFitActions + 2); //+2 because 0 is initial (no cuts at all), and 1 is min #tracks
+					dHistMap_NumCombosSurvivedAction[locReaction]->Fill(loc_j + locNumPreKinFitActions + 1, locNumParticleCombosSurvivedActions[loc_j]); //+1 because 0 is min #tracks
 				}
-				for(int loc_j = 0; loc_j <= locLastActionTrueComboSurvives; ++loc_j)
-					dHistMap_NumEventsWhereTrueComboSurvivedAction[locReaction]->Fill(loc_j + locNumPreKinFitActions + 1); //+1 because 0 is min #tracks
+				for(size_t loc_k = 0; loc_k < locNumParticleCombosSurvivedActions[loc_j]; ++loc_k)
+					dHistMap_NumCombosSurvivedAction1D[locReaction]->Fill(loc_j + locNumPreKinFitActions + 1); //+1 because 0 is min #tracks
 			}
-			dApplication->RootUnLock();
-		} // root_hists_created
+			for(int loc_j = 0; loc_j <= locLastActionTrueComboSurvives; ++loc_j)
+				dHistMap_NumEventsWhereTrueComboSurvivedAction[locReaction]->Fill(loc_j + locNumPreKinFitActions + 1); //+1 because 0 is min #tracks
+		}
+		Unlock_Factory();
 
 		_data.push_back(locAnalysisResults);
 	}

--- a/src/libraries/ANALYSIS/DAnalysisResults_factory.h
+++ b/src/libraries/ANALYSIS/DAnalysisResults_factory.h
@@ -35,7 +35,7 @@ using namespace std;
 class DAnalysisResults_factory : public jana::JFactory<DAnalysisResults>
 {
 	public:
-		DAnalysisResults_factory():root_hists_created(false){};
+		DAnalysisResults_factory(){};
 		~DAnalysisResults_factory(){};
 
 	private:

--- a/src/libraries/ANALYSIS/DAnalysisResults_factory.h
+++ b/src/libraries/ANALYSIS/DAnalysisResults_factory.h
@@ -47,10 +47,17 @@ class DAnalysisResults_factory : public jana::JFactory<DAnalysisResults>
 
 		void Get_Reactions(jana::JEventLoop* locEventLoop, vector<const DReaction*>& locReactions) const;
 
+		// in case you need to do anything with this factory that is shared amongst threads
+			// e.g. filling histograms
+			// When creating ROOT histograms, should still acquire JANA-wide ROOT lock (e.g. modifying gDirectory)
+		// this mutex is unique to this combination of: factory name & tag
+		pthread_rwlock_t* dFactoryLock;
+		void Lock_Factory(void);
+		void Unlock_Factory(void);
+
 		unsigned int dDebugLevel;
 		DApplication* dApplication;
 		double dMinThrownMatchFOM;
-		bool root_hists_created;
 
 		map<const DReaction*, bool> dMCReactionExactMatchFlags;
 		map<const DReaction*, DCutAction_TrueCombo*> dTrueComboCuts;
@@ -60,6 +67,16 @@ class DAnalysisResults_factory : public jana::JFactory<DAnalysisResults>
 		map<const DReaction*, TH2D*> dHistMap_NumCombosSurvivedAction;
 		map<const DReaction*, TH1D*> dHistMap_NumCombosSurvivedAction1D;
 };
+
+inline void DAnalysisResults_factory::Lock_Factory(void)
+{
+	pthread_rwlock_wrlock(dFactoryLock);
+}
+
+inline void DAnalysisResults_factory::Unlock_Factory(void)
+{
+	pthread_rwlock_unlock(dFactoryLock);
+}
 
 #endif // _DAnalysisResults_factory_
 

--- a/src/libraries/ANALYSIS/DAnalysisResults_factory_PreKinFit.cc
+++ b/src/libraries/ANALYSIS/DAnalysisResults_factory_PreKinFit.cc
@@ -18,6 +18,11 @@ jerror_t DAnalysisResults_factory_PreKinFit::init(void)
 {
 	dDebugLevel = 0;
 	dMinThrownMatchFOM = 5.73303E-7;
+
+	string locLockName = string(GetDataClassName()) + string("__") + string(Tag());
+	dFactoryLock = japp->ReadLock(locLockName); //will create if doesn't exist, else returns it
+	pthread_rwlock_unlock(dFactoryLock); //unlock
+
 	return NOERROR;
 }
 
@@ -49,124 +54,117 @@ jerror_t DAnalysisResults_factory_PreKinFit::brun(jana::JEventLoop *locEventLoop
 
 	dApplication->RootWriteLock(); //to prevent undefined behavior due to directory changes, etc.
 	{
+		//get and change to the base (file/global) directory
 		string locOutputFileName = "hd_root.root";
 		if(gPARMS->Exists("OUTPUT_FILENAME"))
 			gPARMS->GetParameter("OUTPUT_FILENAME", locOutputFileName);
+
+		TDirectory* locCurrentDir = gDirectory;
 		TFile* locFile = (TFile*)gROOT->FindObject(locOutputFileName.c_str());
-		if(locFile == NULL)
-		{
-			root_hists_created = false; // this is redundant since it's already set in the constructor
-			static bool warning_issued = false;
-			if(!warning_issued){
-				cout << "WARNING: output histogram file " << locOutputFileName << " not found in DAnalysisResults_factory_PreKinFit::brun()." << endl;
-				cout << "         some functionality disabled." << endl;
-				warning_issued = true;
-			}
-		}else{
+		if(locFile != NULL)
 			locFile->cd("");
+		else
+			gDirectory->cd("/");
 
-			for(size_t loc_i = 0; loc_i < locReactions.size(); ++loc_i)
+		for(size_t loc_i = 0; loc_i < locReactions.size(); ++loc_i)
+		{
+			locReaction = locReactions[loc_i];
+			locReactionName = locReaction->Get_ReactionName();
+			locNumActions = locReaction->Get_NumAnalysisActions();
+
+			deque<string> locActionNames;
+			for(size_t loc_j = 0; loc_j < locNumActions; ++loc_j)
+				locActionNames.push_back(locReaction->Get_AnalysisAction(loc_j)->Get_ActionName());
+
+			locDirName = locReactionName;
+			locDirTitle = locReactionName;
+			locFile->cd();
+			locDirectoryFile = static_cast<TDirectoryFile*>(locFile->GetDirectory(locDirName.c_str()));
+			if(locDirectoryFile == NULL)
+				locDirectoryFile = new TDirectoryFile(locDirName.c_str(), locDirTitle.c_str());
+			locDirectoryFile->cd();
+
+			locHistName = "NumParticleCombos";
+			loc1DHist = static_cast<TH1D*>(locDirectoryFile->Get(locHistName.c_str()));
+			if(loc1DHist == NULL)
 			{
-				locReaction = locReactions[loc_i];
-				locReactionName = locReaction->Get_ReactionName();
-				locNumActions = locReaction->Get_NumAnalysisActions();
+				double* locBinArray = new double[55];
+				for(unsigned int loc_j = 0; loc_j < 6; ++loc_j)
+				{
+					for(unsigned int loc_k = 1; loc_k <= 9; ++loc_k)
+						locBinArray[loc_j*9 + loc_k - 1] = double(loc_k)*pow(10.0, double(loc_j));
+				}
+				locBinArray[54] = 1.0E6;
+				locHistTitle = locReactionName + string(";# Particle Combinations;# Events");
+				loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), 54, locBinArray);
+				delete[] locBinArray;
+			}
+			dHistMap_NumParticleCombos[locReaction] = loc1DHist;
 
-				deque<string> locActionNames;
-				for(size_t loc_j = 0; loc_j < locNumActions; ++loc_j)
-					locActionNames.push_back(locReaction->Get_AnalysisAction(loc_j)->Get_ActionName());
+			locHistName = "NumEventsSurvivedAction";
+			loc1DHist = static_cast<TH1D*>(locDirectoryFile->Get(locHistName.c_str()));
+			if(loc1DHist == NULL)
+			{
+				locHistTitle = locReactionName + string(";;# Events Survived Action");
+				loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 2, -0.5, locNumActions + 2.0 - 0.5); //+2 for input & # tracks
+				loc1DHist->GetXaxis()->SetBinLabel(1, "Input"); // a new event
+				loc1DHist->GetXaxis()->SetBinLabel(2, "Has Particle Combos"); // at least one DParticleCombo object before any actions
+				for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
+					loc1DHist->GetXaxis()->SetBinLabel(3 + loc_j, locActionNames[loc_j].c_str());
+			}
+			dHistMap_NumEventsSurvivedAction_All[locReaction] = loc1DHist;
 
-				locDirName = locReactionName;
-				locDirTitle = locReactionName;
-				locFile->cd();
-				locDirectoryFile = static_cast<TDirectoryFile*>(locFile->GetDirectory(locDirName.c_str()));
-				if(locDirectoryFile == NULL)
-					locDirectoryFile = new TDirectoryFile(locDirName.c_str(), locDirTitle.c_str());
-				locDirectoryFile->cd();
-
-				locHistName = "NumParticleCombos";
+			if(!locMCThrowns.empty())
+			{
+				locHistName = "NumEventsWhereTrueComboSurvivedAction";
 				loc1DHist = static_cast<TH1D*>(locDirectoryFile->Get(locHistName.c_str()));
 				if(loc1DHist == NULL)
 				{
-					double* locBinArray = new double[55];
-					for(unsigned int loc_j = 0; loc_j < 6; ++loc_j)
-					{
-						for(unsigned int loc_k = 1; loc_k <= 9; ++loc_k)
-							locBinArray[loc_j*9 + loc_k - 1] = double(loc_k)*pow(10.0, double(loc_j));
-					}
-					locBinArray[54] = 1.0E6;
-					locHistTitle = locReactionName + string(";# Particle Combinations;# Events");
-					loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), 54, locBinArray);
-					delete[] locBinArray;
-				}
-				dHistMap_NumParticleCombos[locReaction] = loc1DHist;
-
-				locHistName = "NumEventsSurvivedAction";
-				loc1DHist = static_cast<TH1D*>(locDirectoryFile->Get(locHistName.c_str()));
-				if(loc1DHist == NULL)
-				{
-					locHistTitle = locReactionName + string(";;# Events Survived Action");
-					loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 2, -0.5, locNumActions + 2.0 - 0.5); //+2 for input & # tracks
-					loc1DHist->GetXaxis()->SetBinLabel(1, "Input"); // a new event
-					loc1DHist->GetXaxis()->SetBinLabel(2, "Has Particle Combos"); // at least one DParticleCombo object before any actions
-					for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
-						loc1DHist->GetXaxis()->SetBinLabel(3 + loc_j, locActionNames[loc_j].c_str());
-				}
-				dHistMap_NumEventsSurvivedAction_All[locReaction] = loc1DHist;
-
-				if(!locMCThrowns.empty())
-				{
-					locHistName = "NumEventsWhereTrueComboSurvivedAction";
-					loc1DHist = static_cast<TH1D*>(locDirectoryFile->Get(locHistName.c_str()));
-					if(loc1DHist == NULL)
-					{
-						locHistTitle = locReactionName + string(";;# Events Where True Combo Survived Action");
-						loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 1, -0.5, locNumActions + 1.0 - 0.5); //+1 for # tracks
-						loc1DHist->GetXaxis()->SetBinLabel(1, "Has Particle Combos"); // at least one DParticleCombo object before any actions
-						for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
-							loc1DHist->GetXaxis()->SetBinLabel(2 + loc_j, locActionNames[loc_j].c_str());
-					}
-					dHistMap_NumEventsWhereTrueComboSurvivedAction[locReaction] = loc1DHist;
-				}
-
-				locHistName = "NumCombosSurvivedAction";
-				loc2DHist = static_cast<TH2D*>(locDirectoryFile->Get(locHistName.c_str()));
-				if(loc2DHist == NULL)
-				{
-					double* locBinArray = new double[55];
-					for(unsigned int loc_j = 0; loc_j < 6; ++loc_j)
-					{
-						for(unsigned int loc_k = 1; loc_k <= 9; ++loc_k)
-							locBinArray[loc_j*9 + loc_k - 1] = double(loc_k)*pow(10.0, double(loc_j));
-					}
-					locBinArray[54] = 1.0E6;
-
-					locHistTitle = locReactionName + string(";;# Particle Combos Survived Action");
-					loc2DHist = new TH2D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 1, -0.5, locNumActions + 1 - 0.5, 54, locBinArray); //+1 for # tracks
-					delete[] locBinArray;
-					loc2DHist->GetXaxis()->SetBinLabel(1, "Has Particle Combos"); // at least one DParticleCombo object before any actions
-					for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
-						loc2DHist->GetXaxis()->SetBinLabel(2 + loc_j, locActionNames[loc_j].c_str());
-				}
-				dHistMap_NumCombosSurvivedAction[locReaction] = loc2DHist;
-
-				locHistName = "NumCombosSurvivedAction1D";
-				loc1DHist = static_cast<TH1D*>(locDirectoryFile->Get(locHistName.c_str()));
-				if(loc1DHist == NULL)
-				{
-					locHistTitle = locReactionName + string(";;# Particle Combos Survived Action");
-					loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 1, -0.5, locNumActions + 1 - 0.5); //+1 for # tracks
-					loc1DHist->GetXaxis()->SetBinLabel(1, "Minimum # Tracks"); // at least one DParticleCombo object before any actions
+					locHistTitle = locReactionName + string(";;# Events Where True Combo Survived Action");
+					loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 1, -0.5, locNumActions + 1.0 - 0.5); //+1 for # tracks
+					loc1DHist->GetXaxis()->SetBinLabel(1, "Has Particle Combos"); // at least one DParticleCombo object before any actions
 					for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
 						loc1DHist->GetXaxis()->SetBinLabel(2 + loc_j, locActionNames[loc_j].c_str());
 				}
-				dHistMap_NumCombosSurvivedAction1D[locReaction] = loc1DHist;
-
-				locDirectoryFile->cd("..");
+				dHistMap_NumEventsWhereTrueComboSurvivedAction[locReaction] = loc1DHist;
 			}
 
-			locFile->cd(""); //return to base directory
-			root_hists_created = true;
-		} // if(locFile == NULL)
+			locHistName = "NumCombosSurvivedAction";
+			loc2DHist = static_cast<TH2D*>(locDirectoryFile->Get(locHistName.c_str()));
+			if(loc2DHist == NULL)
+			{
+				double* locBinArray = new double[55];
+				for(unsigned int loc_j = 0; loc_j < 6; ++loc_j)
+				{
+					for(unsigned int loc_k = 1; loc_k <= 9; ++loc_k)
+						locBinArray[loc_j*9 + loc_k - 1] = double(loc_k)*pow(10.0, double(loc_j));
+				}
+				locBinArray[54] = 1.0E6;
+
+				locHistTitle = locReactionName + string(";;# Particle Combos Survived Action");
+				loc2DHist = new TH2D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 1, -0.5, locNumActions + 1 - 0.5, 54, locBinArray); //+1 for # tracks
+				delete[] locBinArray;
+				loc2DHist->GetXaxis()->SetBinLabel(1, "Has Particle Combos"); // at least one DParticleCombo object before any actions
+				for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
+					loc2DHist->GetXaxis()->SetBinLabel(2 + loc_j, locActionNames[loc_j].c_str());
+			}
+			dHistMap_NumCombosSurvivedAction[locReaction] = loc2DHist;
+
+			locHistName = "NumCombosSurvivedAction1D";
+			loc1DHist = static_cast<TH1D*>(locDirectoryFile->Get(locHistName.c_str()));
+			if(loc1DHist == NULL)
+			{
+				locHistTitle = locReactionName + string(";;# Particle Combos Survived Action");
+				loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locNumActions + 1, -0.5, locNumActions + 1 - 0.5); //+1 for # tracks
+				loc1DHist->GetXaxis()->SetBinLabel(1, "Minimum # Tracks"); // at least one DParticleCombo object before any actions
+				for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
+					loc1DHist->GetXaxis()->SetBinLabel(2 + loc_j, locActionNames[loc_j].c_str());
+			}
+			dHistMap_NumCombosSurvivedAction1D[locReaction] = loc1DHist;
+
+			locDirectoryFile->cd("..");
+		}
+		locCurrentDir->cd();
 	}
 	dApplication->RootUnLock(); //unlock
 
@@ -278,11 +276,11 @@ jerror_t DAnalysisResults_factory_PreKinFit::evnt(jana::JEventLoop* locEventLoop
 
 		if(dCombosByReaction.find(locReaction) == dCombosByReaction.end())
 		{
-			dApplication->RootWriteLock();
+			Lock_Factory();
 			{
 				dHistMap_NumEventsSurvivedAction_All[locReaction]->Fill(0); //initial: a new event
 			}
-			dApplication->RootUnLock();
+			Unlock_Factory();
 			_data.push_back(locAnalysisResults);
 			continue;
 		}
@@ -347,29 +345,27 @@ jerror_t DAnalysisResults_factory_PreKinFit::evnt(jana::JEventLoop* locEventLoop
 		}
 
 		//fill histograms
-		if(root_hists_created){
-			dApplication->RootWriteLock();
+		dApplication->Lock_Factory();
+		{
+			dHistMap_NumEventsSurvivedAction_All[locReaction]->Fill(0); //initial: a new event
+			if(locNumParticleCombosSurvivedActions[0] > 0)
+				dHistMap_NumParticleCombos[locReaction]->Fill(locNumParticleCombosSurvivedActions[0]);
+			for(size_t loc_j = 0; loc_j < locNumParticleCombosSurvivedActions.size(); ++loc_j)
 			{
-				dHistMap_NumEventsSurvivedAction_All[locReaction]->Fill(0); //initial: a new event
-				if(locNumParticleCombosSurvivedActions[0] > 0)
-					dHistMap_NumParticleCombos[locReaction]->Fill(locNumParticleCombosSurvivedActions[0]);
-				for(size_t loc_j = 0; loc_j < locNumParticleCombosSurvivedActions.size(); ++loc_j)
+				if(locNumParticleCombosSurvivedActions[loc_j] > 0)
 				{
-					if(locNumParticleCombosSurvivedActions[loc_j] > 0)
-					{
-						dHistMap_NumEventsSurvivedAction_All[locReaction]->Fill(loc_j + 1); //+1 because 0 is initial (no cuts at all)
-						dHistMap_NumCombosSurvivedAction[locReaction]->Fill(loc_j, locNumParticleCombosSurvivedActions[loc_j]);
-					}
-					for(size_t loc_k = 0; loc_k < locNumParticleCombosSurvivedActions[loc_j]; ++loc_k)
-						dHistMap_NumCombosSurvivedAction1D[locReaction]->Fill(loc_j);
+					dHistMap_NumEventsSurvivedAction_All[locReaction]->Fill(loc_j + 1); //+1 because 0 is initial (no cuts at all)
+					dHistMap_NumCombosSurvivedAction[locReaction]->Fill(loc_j, locNumParticleCombosSurvivedActions[loc_j]);
 				}
-				for(size_t loc_j = locNumParticleCombosSurvivedActions.size(); loc_j < (locNumAnalysisActions + 1); ++loc_j)
-					dHistMap_NumCombosSurvivedAction[locReaction]->Fill(loc_j, 0);
-				for(int loc_j = -1; loc_j <= locLastActionTrueComboSurvives; ++loc_j) //-1/-2: combo does/does-not exist
-					dHistMap_NumEventsWhereTrueComboSurvivedAction[locReaction]->Fill(loc_j + 1);
+				for(size_t loc_k = 0; loc_k < locNumParticleCombosSurvivedActions[loc_j]; ++loc_k)
+					dHistMap_NumCombosSurvivedAction1D[locReaction]->Fill(loc_j);
 			}
-		dApplication->RootUnLock();
-		} // root_hists_created
+			for(size_t loc_j = locNumParticleCombosSurvivedActions.size(); loc_j < (locNumAnalysisActions + 1); ++loc_j)
+				dHistMap_NumCombosSurvivedAction[locReaction]->Fill(loc_j, 0);
+			for(int loc_j = -1; loc_j <= locLastActionTrueComboSurvives; ++loc_j) //-1/-2: combo does/does-not exist
+				dHistMap_NumEventsWhereTrueComboSurvivedAction[locReaction]->Fill(loc_j + 1);
+		}
+		Unlock_Factory();
 
 		_data.push_back(locAnalysisResults);
 	}
@@ -393,5 +389,4 @@ jerror_t DAnalysisResults_factory_PreKinFit::fini(void)
 {
 	return NOERROR;
 }
-
 

--- a/src/libraries/ANALYSIS/DAnalysisResults_factory_PreKinFit.cc
+++ b/src/libraries/ANALYSIS/DAnalysisResults_factory_PreKinFit.cc
@@ -345,7 +345,7 @@ jerror_t DAnalysisResults_factory_PreKinFit::evnt(jana::JEventLoop* locEventLoop
 		}
 
 		//fill histograms
-		dApplication->Lock_Factory();
+		Lock_Factory();
 		{
 			dHistMap_NumEventsSurvivedAction_All[locReaction]->Fill(0); //initial: a new event
 			if(locNumParticleCombosSurvivedActions[0] > 0)

--- a/src/libraries/ANALYSIS/DAnalysisResults_factory_PreKinFit.h
+++ b/src/libraries/ANALYSIS/DAnalysisResults_factory_PreKinFit.h
@@ -35,7 +35,7 @@ using namespace std;
 class DAnalysisResults_factory_PreKinFit : public jana::JFactory<DAnalysisResults>
 {
 	public:
-		DAnalysisResults_factory_PreKinFit():root_hists_created(false){};
+		DAnalysisResults_factory_PreKinFit(){};
 		~DAnalysisResults_factory_PreKinFit(){};
 		const char* Tag(void){return "PreKinFit";}
 

--- a/src/libraries/ANALYSIS/DAnalysisResults_factory_PreKinFit.h
+++ b/src/libraries/ANALYSIS/DAnalysisResults_factory_PreKinFit.h
@@ -48,11 +48,18 @@ class DAnalysisResults_factory_PreKinFit : public jana::JFactory<DAnalysisResult
 
 		void Get_Reactions(jana::JEventLoop* locEventLoop, vector<const DReaction*>& locReactions) const;
 
+		// in case you need to do anything with this factory that is shared amongst threads
+			// e.g. filling histograms
+			// When creating ROOT histograms, should still acquire JANA-wide ROOT lock (e.g. modifying gDirectory)
+		// this mutex is unique to this combination of: factory name & tag
+		pthread_rwlock_t* dFactoryLock;
+		void Lock_Factory(void);
+		void Unlock_Factory(void);
+
 		unsigned int dDebugLevel;
 		DApplication* dApplication;
 		double dMinThrownMatchFOM;
 		const DAnalysisUtilities* dAnalysisUtilities;
-		bool root_hists_created;
 
 		map<const DReaction*, bool> dMCReactionExactMatchFlags;
 		map<const DReaction*, DCutAction_TrueCombo*> dTrueComboCuts;
@@ -63,6 +70,16 @@ class DAnalysisResults_factory_PreKinFit : public jana::JFactory<DAnalysisResult
 		map<const DReaction*, TH2D*> dHistMap_NumCombosSurvivedAction;
 		map<const DReaction*, TH1D*> dHistMap_NumCombosSurvivedAction1D;
 };
+
+inline void DAnalysisResults_factory_PreKinFit::Lock_Factory(void)
+{
+	pthread_rwlock_wrlock(dFactoryLock);
+}
+
+inline void DAnalysisResults_factory_PreKinFit::Unlock_Factory(void)
+{
+	pthread_rwlock_unlock(dFactoryLock);
+}
 
 #endif // _DAnalysisResults_factory_PreKinFit_
 

--- a/src/libraries/ANALYSIS/DEventRFBunch_factory_Combo.cc
+++ b/src/libraries/ANALYSIS/DEventRFBunch_factory_Combo.cc
@@ -19,6 +19,11 @@ jerror_t DEventRFBunch_factory_Combo::init(void)
 	dShowerSelectionTag = "PreSelect";
 	dTrackSelectionTag = "PreSelect";
 	dMinThrownMatchFOM = 5.73303E-7;
+
+	string locLockName = string(GetDataClassName()) + string("__") + string(Tag());
+	dFactoryLock = japp->ReadLock(locLockName); //will create if doesn't exist, else returns it
+	pthread_rwlock_unlock(dFactoryLock); //unlock
+
 	return NOERROR;
 }
 
@@ -87,13 +92,17 @@ jerror_t DEventRFBunch_factory_Combo::brun(jana::JEventLoop *locEventLoop, int32
 	//Create Diagnostic Histograms
 	japp->RootWriteLock();
 	{
+		//get and change to the base (file/global) directory
 		string locOutputFileName = "hd_root.root";
 		if(gPARMS->Exists("OUTPUT_FILENAME"))
 			gPARMS->GetParameter("OUTPUT_FILENAME", locOutputFileName);
+
+		TDirectory* locCurrentDir = gDirectory;
 		TFile* locFile = (TFile*)gROOT->FindObject(locOutputFileName.c_str());
-		if(locFile == NULL)
-			return NOERROR;
-		locFile->cd("");
+		if(locFile != NULL)
+			locFile->cd("");
+		else
+			gDirectory->cd("/");
 
 		for(size_t loc_i = 0; loc_i < locReactions.size(); ++loc_i)
 		{
@@ -151,6 +160,8 @@ jerror_t DEventRFBunch_factory_Combo::brun(jana::JEventLoop *locEventLoop, int32
 				dHistMap_DeltaRFTime_TruePID[locReaction] = loc1IHist;
 			}
 		}
+
+		locCurrentDir->cd();
 	}
 	japp->RootUnLock(); //unlock
 
@@ -337,7 +348,7 @@ jerror_t DEventRFBunch_factory_Combo::evnt(jana::JEventLoop *locEventLoop, uint6
 		if(locThrownEventRFBunch != NULL)
 			locIsAllTruePID = Is_AllTruePID(locMCThrownMatching, locParticleComboBlueprint);
 		const DReaction* locReaction = locParticleComboBlueprint->Get_Reaction();
-		japp->RootWriteLock();
+		Lock_Factory();
 		{
 			for(size_t loc_j = 0; loc_j < locPropagatedTimes.size(); ++loc_j)
 			{
@@ -353,7 +364,7 @@ jerror_t DEventRFBunch_factory_Combo::evnt(jana::JEventLoop *locEventLoop, uint6
 					dHistMap_DeltaRFTime_TruePID[locReaction]->Fill(locDeltaT); //diff between selected & true RF times (all combos)
 			}
 		}
-		japp->RootUnLock(); //unlock
+		Unlock_Factory(); //unlock
 
 		// Create new RF Bunch if doesn't already exist
 		pair<int, int> locVoteResultPair(locNumBunchShifts, locNumParticleVotes); //pair ints are: num-rf-bunch-shifts, num-votes

--- a/src/libraries/ANALYSIS/DEventRFBunch_factory_Combo.h
+++ b/src/libraries/ANALYSIS/DEventRFBunch_factory_Combo.h
@@ -57,6 +57,14 @@ class DEventRFBunch_factory_Combo:public jana::JFactory<DEventRFBunch>
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
+		// in case you need to do anything with this factory that is shared amongst threads
+			// e.g. filling histograms
+			// When creating ROOT histograms, should still acquire JANA-wide ROOT lock (e.g. modifying gDirectory)
+		// this mutex is unique to this combination of: factory name & tag
+		pthread_rwlock_t* dFactoryLock;
+		void Lock_Factory(void);
+		void Unlock_Factory(void);
+
 		DEventRFBunch_factory* dEventRFBunchFactory;
 		DRFTime_factory* dRFTimeFactory;
 
@@ -80,6 +88,16 @@ class DEventRFBunch_factory_Combo:public jana::JFactory<DEventRFBunch>
 		map<const DReaction*, TH1I*> dHistMap_DeltaRFTime_TruePID; //given that the PIDs are all correct, diff between selected & true RF times
 		map<const DReaction*, TH1I*> dHistMap_DeltaRFTime; //diff between selected & true RF times (all combos)
 };
+
+inline void DEventRFBunch_factory_Combo::Lock_Factory(void)
+{
+	pthread_rwlock_wrlock(dFactoryLock);
+}
+
+inline void DEventRFBunch_factory_Combo::Unlock_Factory(void)
+{
+	pthread_rwlock_unlock(dFactoryLock);
+}
 
 #endif // _DEventRFBunch_factory_Combo_
 

--- a/src/libraries/ANALYSIS/DParticleCombo_factory_PreKinFit.cc
+++ b/src/libraries/ANALYSIS/DParticleCombo_factory_PreKinFit.cc
@@ -30,6 +30,10 @@ jerror_t DParticleCombo_factory_PreKinFit::init(void)
 	dMinThrownMatchFOM = 5.73303E-7;
 	dDebugLevel = 0;
 
+	string locLockName = string(GetDataClassName()) + string("__") + string(Tag());
+	dFactoryLock = japp->ReadLock(locLockName); //will create if doesn't exist, else returns it
+	pthread_rwlock_unlock(dFactoryLock); //unlock
+
 	return NOERROR;
 }
 
@@ -130,77 +134,104 @@ jerror_t DParticleCombo_factory_PreKinFit::brun(jana::JEventLoop *locEventLoop, 
 	//Create Diagnostic Histograms
 	japp->RootWriteLock();
 	{
+		//get and change to the base (file/global) directory
 		string locOutputFileName = "hd_root.root";
 		if(gPARMS->Exists("OUTPUT_FILENAME"))
 			gPARMS->GetParameter("OUTPUT_FILENAME", locOutputFileName);
+
+		TDirectory* locCurrentDir = gDirectory;
 		TFile* locFile = (TFile*)gROOT->FindObject(locOutputFileName.c_str());
-		if(locFile == NULL)
-		{
-			root_hists_created = false; // this is redundant since it's already set in the constructor
-			static bool warning_issued = false;
-			if(!warning_issued){
-				cout << "WARNING: output histogram file " << locOutputFileName << " not found in DParticleCombo_factory_PreKinFit::brun()." << endl;
-				cout << "         some functionality disabled." << endl;
-				warning_issued = true;
-			}
-		}else{
+		if(locFile != NULL)
 			locFile->cd("");
+		else
+			gDirectory->cd("/");
 
-			for(size_t loc_i = 0; loc_i < dReactions.size(); ++loc_i)
+		for(size_t loc_i = 0; loc_i < dReactions.size(); ++loc_i)
+		{
+			const DReaction* locReaction = dReactions[loc_i];
+
+			//get to the correct directory
+			string locReactionName = locReaction->Get_ReactionName();
+			string locDirName = locReactionName;
+			string locDirTitle = locReactionName;
+
+			//get action names
+			vector<string> locActionNames;
+			for(size_t loc_j = 0; loc_j < locReaction->Get_NumComboPreSelectionActions(); ++loc_j)
 			{
-				const DReaction* locReaction = dReactions[loc_i];
+				DAnalysisAction* locAction = locReaction->Get_ComboPreSelectionAction(loc_j);
+				if(locAction->Get_UseKinFitResultsFlag())
+					continue;
+				locActionNames.push_back(locAction->Get_ActionName());
+			}
+			dNumGoodPreComboSelectionActions[locReaction] = locActionNames.size();
 
-				//get to the correct directory
-				string locReactionName = locReaction->Get_ReactionName();
-				string locDirName = locReactionName;
-				string locDirTitle = locReactionName;
+			//Determine if cuts are used or not
+			pair<bool, double> locMinChargedPIDFOM = dMinChargedPIDFOM.first ? dMinChargedPIDFOM : locReaction->Get_MinChargedPIDFOM();
+			pair<bool, double> locMinPhotonPIDFOM = dMinPhotonPIDFOM.first ? dMinPhotonPIDFOM : locReaction->Get_MinPhotonPIDFOM();
+			pair<bool, size_t> locMaxNumBeamPhotonsInBunch = dMaxNumBeamPhotonsInBunch.first ? dMaxNumBeamPhotonsInBunch : locReaction->Get_MaxNumBeamPhotonsInBunch();
+			pair<bool, double> locMaxPhotonRFDeltaT = dMaxPhotonRFDeltaT.first ? dMaxPhotonRFDeltaT : locReaction->Get_MaxPhotonRFDeltaT();
 
-				//get action names
-				vector<string> locActionNames;
-				for(size_t loc_j = 0; loc_j < locReaction->Get_NumComboPreSelectionActions(); ++loc_j)
-				{
-					DAnalysisAction* locAction = locReaction->Get_ComboPreSelectionAction(loc_j);
-					if(locAction->Get_UseKinFitResultsFlag())
-						continue;
-					locActionNames.push_back(locAction->Get_ActionName());
-				}
-				dNumGoodPreComboSelectionActions[locReaction] = locActionNames.size();
+			unsigned int locNumCutHistBins = locActionNames.size();
+			if(locMaxPhotonRFDeltaT.first)
+				++locNumCutHistBins;
+			if(locMaxNumBeamPhotonsInBunch.first)
+				++locNumCutHistBins;
+			if(locMinChargedPIDFOM.first || locMinPhotonPIDFOM.first)
+				++locNumCutHistBins;
 
-				//Determine if cuts are used or not
-				pair<bool, double> locMinChargedPIDFOM = dMinChargedPIDFOM.first ? dMinChargedPIDFOM : locReaction->Get_MinChargedPIDFOM();
-				pair<bool, double> locMinPhotonPIDFOM = dMinPhotonPIDFOM.first ? dMinPhotonPIDFOM : locReaction->Get_MinPhotonPIDFOM();
-				pair<bool, size_t> locMaxNumBeamPhotonsInBunch = dMaxNumBeamPhotonsInBunch.first ? dMaxNumBeamPhotonsInBunch : locReaction->Get_MaxNumBeamPhotonsInBunch();
-				pair<bool, double> locMaxPhotonRFDeltaT = dMaxPhotonRFDeltaT.first ? dMaxPhotonRFDeltaT : locReaction->Get_MaxPhotonRFDeltaT();
+			//action directory
+			locFile->cd();
+			TDirectoryFile* locDirectoryFile = static_cast<TDirectoryFile*>(locFile->GetDirectory(locDirName.c_str()));
+			if(locDirectoryFile == NULL)
+				locDirectoryFile = new TDirectoryFile(locDirName.c_str(), locDirTitle.c_str());
+			locDirectoryFile->cd();
 
-				unsigned int locNumCutHistBins = locActionNames.size();
+			//pre-combo directory
+			locDirName = "Hist_ComboConstruction";
+			locDirectoryFile = static_cast<TDirectoryFile*>(gDirectory->GetDirectory(locDirName.c_str()));
+			if(locDirectoryFile == NULL)
+				locDirectoryFile = new TDirectoryFile(locDirName.c_str(), locDirTitle.c_str());
+			locDirectoryFile->cd();
+
+			//# Events Survived
+			locHistName = "NumEventsSurvivedCut";
+			loc1DHist = static_cast<TH1D*>(gDirectory->Get(locHistName.c_str()));
+			if(loc1DHist == NULL)
+			{
+				locHistTitle = locReactionName + string(";;# Events Survived Cut");
+				loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), 2 + locNumCutHistBins, 0.5, 2.5 + float(locNumCutHistBins));
+				loc1DHist->GetXaxis()->SetBinLabel(1, "Input"); // a new event
+				loc1DHist->GetXaxis()->SetBinLabel(2, "Has Particle Combo Blueprints");
+				unsigned int locBinIndex = 3;
 				if(locMaxPhotonRFDeltaT.first)
-					++locNumCutHistBins;
+				{
+					loc1DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut Beam, RF #Deltat");
+					++locBinIndex;
+				}
 				if(locMaxNumBeamPhotonsInBunch.first)
-					++locNumCutHistBins;
+				{
+					loc1DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut # Beam Photons");
+					++locBinIndex;
+				}
 				if(locMinChargedPIDFOM.first || locMinPhotonPIDFOM.first)
-					++locNumCutHistBins;
+				{
+					loc1DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut Particle PID");
+					++locBinIndex;
+				}
+				for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
+					loc1DHist->GetXaxis()->SetBinLabel(locBinIndex + loc_j, locActionNames[loc_j].c_str());
+			}
+			dHistMap_NumEventsSurvivedCut_All[locReaction] = loc1DHist;
 
-				//action directory
-				locFile->cd();
-				TDirectoryFile* locDirectoryFile = static_cast<TDirectoryFile*>(locFile->GetDirectory(locDirName.c_str()));
-				if(locDirectoryFile == NULL)
-					locDirectoryFile = new TDirectoryFile(locDirName.c_str(), locDirTitle.c_str());
-				locDirectoryFile->cd();
-
-				//pre-combo directory
-				locDirName = "Hist_ComboConstruction";
-				locDirectoryFile = static_cast<TDirectoryFile*>(gDirectory->GetDirectory(locDirName.c_str()));
-				if(locDirectoryFile == NULL)
-					locDirectoryFile = new TDirectoryFile(locDirName.c_str(), locDirTitle.c_str());
-				locDirectoryFile->cd();
-
-				//# Events Survived
-				locHistName = "NumEventsSurvivedCut";
+			if(!locMCThrowns.empty())
+			{
+				locHistName = "NumTrueEventsSurvivedCut";
 				loc1DHist = static_cast<TH1D*>(gDirectory->Get(locHistName.c_str()));
 				if(loc1DHist == NULL)
 				{
 					locHistTitle = locReactionName + string(";;# Events Survived Cut");
-					loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), 2 + locNumCutHistBins, 0.5, 2.5 + float(locNumCutHistBins));
+					loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), 3 + locNumCutHistBins, 0.5, 3.5 + float(locNumCutHistBins));
 					loc1DHist->GetXaxis()->SetBinLabel(1, "Input"); // a new event
 					loc1DHist->GetXaxis()->SetBinLabel(2, "Has Particle Combo Blueprints");
 					unsigned int locBinIndex = 3;
@@ -221,171 +252,138 @@ jerror_t DParticleCombo_factory_PreKinFit::brun(jana::JEventLoop *locEventLoop, 
 					}
 					for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
 						loc1DHist->GetXaxis()->SetBinLabel(locBinIndex + loc_j, locActionNames[loc_j].c_str());
+					loc1DHist->GetXaxis()->SetBinLabel(locBinIndex + locActionNames.size(), "Has True Combo (Not a Cut)");
 				}
-				dHistMap_NumEventsSurvivedCut_All[locReaction] = loc1DHist;
+				dHistMap_NumEventsSurvivedCut_True[locReaction] = loc1DHist;
+			}
 
-				if(!locMCThrowns.empty())
+			//# Blueprints Survived
+			locHistName = "NumBlueprintsSurvivedCut";
+			loc2DHist = static_cast<TH2D*>(gDirectory->Get(locHistName.c_str()));
+			if(loc2DHist == NULL)
+			{
+				locHistTitle = locReactionName + string(";;# Combo Blueprints Survived Cut");
+
+				double* locBinArray = new double[55];
+				for(unsigned int loc_j = 0; loc_j < 6; ++loc_j)
 				{
-					locHistName = "NumTrueEventsSurvivedCut";
-					loc1DHist = static_cast<TH1D*>(gDirectory->Get(locHistName.c_str()));
-					if(loc1DHist == NULL)
-					{
-						locHistTitle = locReactionName + string(";;# Events Survived Cut");
-						loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), 3 + locNumCutHistBins, 0.5, 3.5 + float(locNumCutHistBins));
-						loc1DHist->GetXaxis()->SetBinLabel(1, "Input"); // a new event
-						loc1DHist->GetXaxis()->SetBinLabel(2, "Has Particle Combo Blueprints");
-						unsigned int locBinIndex = 3;
-						if(locMaxPhotonRFDeltaT.first)
-						{
-							loc1DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut Beam, RF #Deltat");
-							++locBinIndex;
-						}
-						if(locMaxNumBeamPhotonsInBunch.first)
-						{
-							loc1DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut # Beam Photons");
-							++locBinIndex;
-						}
-						if(locMinChargedPIDFOM.first || locMinPhotonPIDFOM.first)
-						{
-							loc1DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut Particle PID");
-							++locBinIndex;
-						}
-						for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
-							loc1DHist->GetXaxis()->SetBinLabel(locBinIndex + loc_j, locActionNames[loc_j].c_str());
-						loc1DHist->GetXaxis()->SetBinLabel(locBinIndex + locActionNames.size(), "Has True Combo (Not a Cut)");
-					}
-					dHistMap_NumEventsSurvivedCut_True[locReaction] = loc1DHist;
+					for(unsigned int loc_k = 1; loc_k <= 9; ++loc_k)
+						locBinArray[loc_j*9 + loc_k - 1] = double(loc_k)*pow(10.0, double(loc_j));
 				}
+				locBinArray[54] = 1.0E6;
 
-				//# Blueprints Survived
-				locHistName = "NumBlueprintsSurvivedCut";
-				loc2DHist = static_cast<TH2D*>(gDirectory->Get(locHistName.c_str()));
-				if(loc2DHist == NULL)
+				loc2DHist = new TH2D(locHistName.c_str(), locHistTitle.c_str(), 1 + locNumCutHistBins, 0.5, 1.5 + float(locNumCutHistBins), 54, locBinArray);
+				delete[] locBinArray;
+				loc2DHist->GetXaxis()->SetBinLabel(1, "Has Particle Combo Blueprints");
+				unsigned int locBinIndex = 2;
+				if(locMaxPhotonRFDeltaT.first)
 				{
-					locHistTitle = locReactionName + string(";;# Combo Blueprints Survived Cut");
-
-					double* locBinArray = new double[55];
-					for(unsigned int loc_j = 0; loc_j < 6; ++loc_j)
-					{
-						for(unsigned int loc_k = 1; loc_k <= 9; ++loc_k)
-							locBinArray[loc_j*9 + loc_k - 1] = double(loc_k)*pow(10.0, double(loc_j));
-					}
-					locBinArray[54] = 1.0E6;
-
-					loc2DHist = new TH2D(locHistName.c_str(), locHistTitle.c_str(), 1 + locNumCutHistBins, 0.5, 1.5 + float(locNumCutHistBins), 54, locBinArray);
-					delete[] locBinArray;
-					loc2DHist->GetXaxis()->SetBinLabel(1, "Has Particle Combo Blueprints");
-					unsigned int locBinIndex = 2;
-					if(locMaxPhotonRFDeltaT.first)
-					{
-						loc2DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut Beam, RF #Deltat");
-						++locBinIndex;
-					}
-					if(locMaxNumBeamPhotonsInBunch.first)
-					{
-						loc2DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut # Beam Photons");
-						++locBinIndex;
-					}
-					if(locMinChargedPIDFOM.first || locMinPhotonPIDFOM.first)
-					{
-						loc2DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut Particle PID");
-						++locBinIndex;
-					}
-					for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
-						loc2DHist->GetXaxis()->SetBinLabel(locBinIndex + loc_j, locActionNames[loc_j].c_str());
+					loc2DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut Beam, RF #Deltat");
+					++locBinIndex;
 				}
-				dHistMap_NumBlueprintsSurvivedCut[locReaction] = loc2DHist;
-
-				locHistName = "NumBlueprintsSurvivedCut1D";
-				loc1DHist = static_cast<TH1D*>(gDirectory->Get(locHistName.c_str()));
-				if(loc1DHist == NULL)
+				if(locMaxNumBeamPhotonsInBunch.first)
 				{
-					locHistTitle = locReactionName + string(";;# Combo Blueprints Survived Cut");
-					loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), 1 + locNumCutHistBins, 0.5, 1.5 + float(locNumCutHistBins));
-					loc1DHist->GetXaxis()->SetBinLabel(1, "Has Particle Combo Blueprints");
-					unsigned int locBinIndex = 2;
-					if(locMaxPhotonRFDeltaT.first)
-					{
-						loc1DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut Beam, RF #Deltat");
-						++locBinIndex;
-					}
-					if(locMaxNumBeamPhotonsInBunch.first)
-					{
-						loc1DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut # Beam Photons");
-						++locBinIndex;
-					}
-					if(locMinChargedPIDFOM.first || locMinPhotonPIDFOM.first)
-					{
-						loc1DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut Particle PID");
-						++locBinIndex;
-					}
-					for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
-						loc1DHist->GetXaxis()->SetBinLabel(locBinIndex + loc_j, locActionNames[loc_j].c_str());
+					loc2DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut # Beam Photons");
+					++locBinIndex;
 				}
-				dHistMap_NumBlueprintsSurvivedCut1D[locReaction] = loc1DHist;
+				if(locMinChargedPIDFOM.first || locMinPhotonPIDFOM.first)
+				{
+					loc2DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut Particle PID");
+					++locBinIndex;
+				}
+				for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
+					loc2DHist->GetXaxis()->SetBinLabel(locBinIndex + loc_j, locActionNames[loc_j].c_str());
+			}
+			dHistMap_NumBlueprintsSurvivedCut[locReaction] = loc2DHist;
 
-				//Beam, RF Delta-t
-				locHistName = "BeamPhotonRFDeltaT";
+			locHistName = "NumBlueprintsSurvivedCut1D";
+			loc1DHist = static_cast<TH1D*>(gDirectory->Get(locHistName.c_str()));
+			if(loc1DHist == NULL)
+			{
+				locHistTitle = locReactionName + string(";;# Combo Blueprints Survived Cut");
+				loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), 1 + locNumCutHistBins, 0.5, 1.5 + float(locNumCutHistBins));
+				loc1DHist->GetXaxis()->SetBinLabel(1, "Has Particle Combo Blueprints");
+				unsigned int locBinIndex = 2;
+				if(locMaxPhotonRFDeltaT.first)
+				{
+					loc1DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut Beam, RF #Deltat");
+					++locBinIndex;
+				}
+				if(locMaxNumBeamPhotonsInBunch.first)
+				{
+					loc1DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut # Beam Photons");
+					++locBinIndex;
+				}
+				if(locMinChargedPIDFOM.first || locMinPhotonPIDFOM.first)
+				{
+					loc1DHist->GetXaxis()->SetBinLabel(locBinIndex, "Cut Particle PID");
+					++locBinIndex;
+				}
+				for(size_t loc_j = 0; loc_j < locActionNames.size(); ++loc_j)
+					loc1DHist->GetXaxis()->SetBinLabel(locBinIndex + loc_j, locActionNames[loc_j].c_str());
+			}
+			dHistMap_NumBlueprintsSurvivedCut1D[locReaction] = loc1DHist;
+
+			//Beam, RF Delta-t
+			locHistName = "BeamPhotonRFDeltaT";
+			loc1IHist = static_cast<TH1I*>(gDirectory->Get(locHistName.c_str()));
+			if(loc1IHist == NULL)
+			{
+				locHistTitle = locReactionName + string(";#Deltat_{Beam #gamma - RF} (ns)");
+				loc1IHist = new TH1I(locHistName.c_str(), locHistTitle.c_str(), 220, -11.0, 11.0);
+			}
+			dHistMap_PhotonRFDeltaT_All[locReaction] = loc1IHist;
+
+			if(!locMCThrowns.empty())
+			{
+				locHistName = "BeamPhotonRFDeltaT_TrueCombo";
 				loc1IHist = static_cast<TH1I*>(gDirectory->Get(locHistName.c_str()));
 				if(loc1IHist == NULL)
 				{
-					locHistTitle = locReactionName + string(";#Deltat_{Beam #gamma - RF} (ns)");
-					loc1IHist = new TH1I(locHistName.c_str(), locHistTitle.c_str(), 220, -11.0, 11.0);
+					loc1IHist = (TH1I*)dHistMap_PhotonRFDeltaT_All[locReaction]->Clone(locHistName.c_str());
+					locHistTitle = locReactionName + string(", True Combo");
+					loc1IHist->SetTitle(locHistTitle.c_str());
 				}
-				dHistMap_PhotonRFDeltaT_All[locReaction] = loc1IHist;
+				dHistMap_PhotonRFDeltaT_True[locReaction] = loc1IHist;
+			}
+
+			//Num Beam Photons Per Blueprint
+			locHistName = "NumSurvivingBeamParticles";
+			loc1DHist = static_cast<TH1D*>(gDirectory->Get(locHistName.c_str()));
+			if(loc1DHist == NULL)
+			{
+				locHistTitle = locReactionName + string(";# Surviving Beam Particles");
+				loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), 10, 0.5, 10.5);
+			}
+			dHistMap_NumSurvivingBeamParticles[locReaction] = loc1DHist;
+
+			//PID FOM
+			deque<Particle_t> locDetectedPIDs;
+			locReaction->Get_DetectedFinalPIDs(locDetectedPIDs);
+			for(size_t loc_j = 0; loc_j < locDetectedPIDs.size(); ++loc_j)
+			{
+				Particle_t locPID = locDetectedPIDs[loc_j];
+				string locParticleName = ParticleType(locPID);
+				string locParticleROOTName = ParticleName_ROOT(locPID);
+
+				locHistName = string("PIDConfidenceLevel_") + locParticleName;
+				locHistTitle = locParticleROOTName + string(";PID Confidence Level");
+				if(gDirectory->Get(locHistName.c_str()) != NULL) //already created by another thread, or directory name is duplicate (e.g. two identical steps)
+					dHistMap_PIDFOM_All[locReaction][locPID] = static_cast<TH1I*>(gDirectory->Get(locHistName.c_str()));
+				else
+					dHistMap_PIDFOM_All[locReaction][locPID] = new TH1I(locHistName.c_str(), locHistTitle.c_str(), 200, 0.0, 1.0);
 
 				if(!locMCThrowns.empty())
 				{
-					locHistName = "BeamPhotonRFDeltaT_TrueCombo";
-					loc1IHist = static_cast<TH1I*>(gDirectory->Get(locHistName.c_str()));
-					if(loc1IHist == NULL)
-					{
-						loc1IHist = (TH1I*)dHistMap_PhotonRFDeltaT_All[locReaction]->Clone(locHistName.c_str());
-						locHistTitle = locReactionName + string(", True Combo");
-						loc1IHist->SetTitle(locHistTitle.c_str());
-					}
-					dHistMap_PhotonRFDeltaT_True[locReaction] = loc1IHist;
-				}
-
-				//Num Beam Photons Per Blueprint
-				locHistName = "NumSurvivingBeamParticles";
-				loc1DHist = static_cast<TH1D*>(gDirectory->Get(locHistName.c_str()));
-				if(loc1DHist == NULL)
-				{
-					locHistTitle = locReactionName + string(";# Surviving Beam Particles");
-					loc1DHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), 10, 0.5, 10.5);
-				}
-				dHistMap_NumSurvivingBeamParticles[locReaction] = loc1DHist;
-
-				//PID FOM
-				deque<Particle_t> locDetectedPIDs;
-				locReaction->Get_DetectedFinalPIDs(locDetectedPIDs);
-				for(size_t loc_j = 0; loc_j < locDetectedPIDs.size(); ++loc_j)
-				{
-					Particle_t locPID = locDetectedPIDs[loc_j];
-					string locParticleName = ParticleType(locPID);
-					string locParticleROOTName = ParticleName_ROOT(locPID);
-
-					locHistName = string("PIDConfidenceLevel_") + locParticleName;
-					locHistTitle = locParticleROOTName + string(";PID Confidence Level");
+					locHistName = string("PIDConfidenceLevel_True") + locParticleName;
 					if(gDirectory->Get(locHistName.c_str()) != NULL) //already created by another thread, or directory name is duplicate (e.g. two identical steps)
-						dHistMap_PIDFOM_All[locReaction][locPID] = static_cast<TH1I*>(gDirectory->Get(locHistName.c_str()));
+						dHistMap_PIDFOM_True[locReaction][locPID] = static_cast<TH1I*>(gDirectory->Get(locHistName.c_str()));
 					else
-						dHistMap_PIDFOM_All[locReaction][locPID] = new TH1I(locHistName.c_str(), locHistTitle.c_str(), 200, 0.0, 1.0);
-
-					if(!locMCThrowns.empty())
-					{
-						locHistName = string("PIDConfidenceLevel_True") + locParticleName;
-						if(gDirectory->Get(locHistName.c_str()) != NULL) //already created by another thread, or directory name is duplicate (e.g. two identical steps)
-							dHistMap_PIDFOM_True[locReaction][locPID] = static_cast<TH1I*>(gDirectory->Get(locHistName.c_str()));
-						else
-							dHistMap_PIDFOM_True[locReaction][locPID] = (TH1I*)dHistMap_PIDFOM_All[locReaction][locPID]->Clone(locHistName.c_str());
-					}
+						dHistMap_PIDFOM_True[locReaction][locPID] = (TH1I*)dHistMap_PIDFOM_All[locReaction][locPID]->Clone(locHistName.c_str());
 				}
 			}
-			locFile->cd(""); //return to base directory
-			root_hists_created = true;
-		} // if(locFile == NULL)
+		}
+		locCurrentDir->cd();
 	}
 	japp->RootUnLock(); //unlock
 
@@ -488,18 +486,16 @@ jerror_t DParticleCombo_factory_PreKinFit::evnt(jana::JEventLoop *locEventLoop, 
 	}
 
 	//fill histograms
-	if(root_hists_created){
-		japp->RootWriteLock();
+	Lock_Factory();
+	{
+		for(size_t loc_i = 0; loc_i < dReactions.size(); ++loc_i)
 		{
-			for(size_t loc_i = 0; loc_i < dReactions.size(); ++loc_i)
-			{
-				vector<double>& locDeltaTs = locDeltaTMap[dReactions[loc_i]];
-				for(size_t loc_j = 0; loc_j < locDeltaTs.size(); ++loc_j)
-					dHistMap_PhotonRFDeltaT_All[dReactions[loc_i]]->Fill(locDeltaTs[loc_j]);
-			}
+			vector<double>& locDeltaTs = locDeltaTMap[dReactions[loc_i]];
+			for(size_t loc_j = 0; loc_j < locDeltaTs.size(); ++loc_j)
+				dHistMap_PhotonRFDeltaT_All[dReactions[loc_i]]->Fill(locDeltaTs[loc_j]);
 		}
-		japp->RootUnLock();
 	}
+	Unlock_Factory();
 
 	//pre-sort/select valid neutral/charged particles for each reaction //pre-cut (& histogram) PID
 	map<const DReaction*, map<Particle_t, vector<double> > > dPIDFOMMap; //will histogram at the end
@@ -580,30 +576,28 @@ jerror_t DParticleCombo_factory_PreKinFit::evnt(jana::JEventLoop *locEventLoop, 
 	}
 
 	//fill histograms
-	if(root_hists_created){
-		japp->RootWriteLock();
+	Lock_Factory();
+	{
+		for(size_t loc_i = 0; loc_i < dReactions.size(); ++loc_i)
 		{
-			for(size_t loc_i = 0; loc_i < dReactions.size(); ++loc_i)
+			deque<Particle_t> locDetectedPIDs;
+			dReactions[loc_i]->Get_DetectedFinalPIDs(locDetectedPIDs, 0); //all pids
+			for(size_t loc_j = 0; loc_j < locDetectedPIDs.size(); ++loc_j)
 			{
-				deque<Particle_t> locDetectedPIDs;
-				dReactions[loc_i]->Get_DetectedFinalPIDs(locDetectedPIDs, 0); //all pids
-				for(size_t loc_j = 0; loc_j < locDetectedPIDs.size(); ++loc_j)
-				{
-					Particle_t locPID = locDetectedPIDs[loc_j];
-					vector<double>& locPIDFOMs = dPIDFOMMap[dReactions[loc_i]][locPID];
-					for(size_t loc_k = 0; loc_k < locPIDFOMs.size(); ++loc_k)
-						dHistMap_PIDFOM_All[dReactions[loc_i]][locPID]->Fill(locPIDFOMs[loc_k]);
+				Particle_t locPID = locDetectedPIDs[loc_j];
+				vector<double>& locPIDFOMs = dPIDFOMMap[dReactions[loc_i]][locPID];
+				for(size_t loc_k = 0; loc_k < locPIDFOMs.size(); ++loc_k)
+					dHistMap_PIDFOM_All[dReactions[loc_i]][locPID]->Fill(locPIDFOMs[loc_k]);
 
-					if(locMCThrownMatching == NULL)
-						continue;
-					vector<double>& locTruePIDFOMs = dTruePIDFOMMap[dReactions[loc_i]][locPID];
-					for(size_t loc_k = 0; loc_k < locTruePIDFOMs.size(); ++loc_k)
-						dHistMap_PIDFOM_True[dReactions[loc_i]][locPID]->Fill(locTruePIDFOMs[loc_k]);
-				}
+				if(locMCThrownMatching == NULL)
+					continue;
+				vector<double>& locTruePIDFOMs = dTruePIDFOMMap[dReactions[loc_i]][locPID];
+				for(size_t loc_k = 0; loc_k < locTruePIDFOMs.size(); ++loc_k)
+					dHistMap_PIDFOM_True[dReactions[loc_i]][locPID]->Fill(locTruePIDFOMs[loc_k]);
 			}
 		}
-		japp->RootUnLock();
 	}
+	Unlock_Factory();
 
 	//finally, now build the combos
 	map<const DReaction*, deque<size_t> > locNumBlueprintsSurvivedCuts;
@@ -707,11 +701,11 @@ jerror_t DParticleCombo_factory_PreKinFit::evnt(jana::JEventLoop *locEventLoop, 
 				}
 
 				//hist # photons
-				japp->RootWriteLock();
+				Lock_Factory();
 				{
 					dHistMap_NumSurvivingBeamParticles[locReaction]->Fill(locCandidatePhotons[locReactionRFPair].size());
 				}
-				japp->RootUnLock();
+				Unlock_Factory();
 
 				if(!Cut_NumBeamPhotonsInBunch(locReaction, locCandidatePhotons[locReactionRFPair].size()))
 				{
@@ -793,11 +787,11 @@ jerror_t DParticleCombo_factory_PreKinFit::evnt(jana::JEventLoop *locEventLoop, 
 					if(!((*dTrueComboCuts[locReaction])(locEventLoop, locBuiltParticleCombos[loc_j])))
 						continue; //is not the true combo
 					double locDeltaT = locBuiltParticleCombos[loc_j]->Get_ParticleComboStep(0)->Get_InitialParticle()->time() - locEventRFBunch->dTime;
-					japp->RootWriteLock();
+					Lock_Factory();
 					{
 						dHistMap_PhotonRFDeltaT_True[locReaction]->Fill(locDeltaT);
 					}
-					japp->RootUnLock();
+					Unlock_Factory();
 					break;
 				}
 			}
@@ -884,42 +878,40 @@ jerror_t DParticleCombo_factory_PreKinFit::evnt(jana::JEventLoop *locEventLoop, 
 	}
 
 	//fill passed-cut histograms
-	if(root_hists_created){
-		japp->RootWriteLock();
+	Lock_Factory();
+	{
+		for(size_t loc_i = 0; loc_i < dReactions.size(); ++loc_i)
 		{
-			for(size_t loc_i = 0; loc_i < dReactions.size(); ++loc_i)
+			const DReaction* locReaction = dReactions[loc_i];
+
+			bool locIsThrownMatchFlag = false;
+			if(locMCThrownMatching != NULL)
 			{
-				const DReaction* locReaction = dReactions[loc_i];
+				if(dAnalysisUtilities->Check_ThrownsMatchReaction(locEventLoop, locReaction, dMCReactionExactMatchFlags[locReaction]))
+					locIsThrownMatchFlag = true;
+			}
 
-				bool locIsThrownMatchFlag = false;
-				if(locMCThrownMatching != NULL)
+			dHistMap_NumEventsSurvivedCut_All[locReaction]->Fill(1); //input event (+1 because binning begins at 1)
+			if(locIsThrownMatchFlag)
+				dHistMap_NumEventsSurvivedCut_True[locReaction]->Fill(1); //input event (+1 because binning begins at 1)
+			if(locTrueComboSurvivedReactions.find(locReaction) != locTrueComboSurvivedReactions.end())
+				dHistMap_NumEventsSurvivedCut_True[locReaction]->Fill(dHistMap_NumEventsSurvivedCut_True[locReaction]->GetNbinsX()); //true combo
+
+			for(size_t loc_j = 0; loc_j < locNumBlueprintsSurvivedCuts[locReaction].size(); ++loc_j)
+			{
+				if(locNumBlueprintsSurvivedCuts[locReaction][loc_j] > 0)
 				{
-					if(dAnalysisUtilities->Check_ThrownsMatchReaction(locEventLoop, locReaction, dMCReactionExactMatchFlags[locReaction]))
-						locIsThrownMatchFlag = true;
+					dHistMap_NumEventsSurvivedCut_All[locReaction]->Fill(loc_j + 2); //+2 because binning begins at 1, and 0 is input event
+					if(locIsThrownMatchFlag)
+						dHistMap_NumEventsSurvivedCut_True[locReaction]->Fill(loc_j + 2); //+2 because binning begins at 1, and 0 is input event
+					dHistMap_NumBlueprintsSurvivedCut[locReaction]->Fill(loc_j + 1, locNumBlueprintsSurvivedCuts[locReaction][loc_j]); //+1 because 0 is has blueprint
 				}
-
-				dHistMap_NumEventsSurvivedCut_All[locReaction]->Fill(1); //input event (+1 because binning begins at 1)
-				if(locIsThrownMatchFlag)
-					dHistMap_NumEventsSurvivedCut_True[locReaction]->Fill(1); //input event (+1 because binning begins at 1)
-				if(locTrueComboSurvivedReactions.find(locReaction) != locTrueComboSurvivedReactions.end())
-					dHistMap_NumEventsSurvivedCut_True[locReaction]->Fill(dHistMap_NumEventsSurvivedCut_True[locReaction]->GetNbinsX()); //true combo
-
-				for(size_t loc_j = 0; loc_j < locNumBlueprintsSurvivedCuts[locReaction].size(); ++loc_j)
-				{
-					if(locNumBlueprintsSurvivedCuts[locReaction][loc_j] > 0)
-					{
-						dHistMap_NumEventsSurvivedCut_All[locReaction]->Fill(loc_j + 2); //+2 because binning begins at 1, and 0 is input event
-						if(locIsThrownMatchFlag)
-							dHistMap_NumEventsSurvivedCut_True[locReaction]->Fill(loc_j + 2); //+2 because binning begins at 1, and 0 is input event
-						dHistMap_NumBlueprintsSurvivedCut[locReaction]->Fill(loc_j + 1, locNumBlueprintsSurvivedCuts[locReaction][loc_j]); //+1 because 0 is has blueprint
-					}
-					for(size_t loc_k = 0; loc_k < locNumBlueprintsSurvivedCuts[locReaction][loc_j]; ++loc_k)
-						dHistMap_NumBlueprintsSurvivedCut1D[locReaction]->Fill(loc_j + 1); //+1 because 0 is has blueprint
-				}
+				for(size_t loc_k = 0; loc_k < locNumBlueprintsSurvivedCuts[locReaction][loc_j]; ++loc_k)
+					dHistMap_NumBlueprintsSurvivedCut1D[locReaction]->Fill(loc_j + 1); //+1 because 0 is has blueprint
 			}
 		}
-		japp->RootUnLock();
 	}
+	Unlock_Factory();
 
 	return NOERROR;
 }

--- a/src/libraries/ANALYSIS/DParticleCombo_factory_PreKinFit.h
+++ b/src/libraries/ANALYSIS/DParticleCombo_factory_PreKinFit.h
@@ -37,7 +37,7 @@
 class DParticleCombo_factory_PreKinFit : public jana::JFactory<DParticleCombo>
 {
 	public:
-		DParticleCombo_factory_PreKinFit():root_hists_created(false){};
+		DParticleCombo_factory_PreKinFit(){};
 		~DParticleCombo_factory_PreKinFit(){};
 		const char* Tag(void){return "PreKinFit";}
 

--- a/src/libraries/ANALYSIS/DParticleCombo_factory_PreKinFit.h
+++ b/src/libraries/ANALYSIS/DParticleCombo_factory_PreKinFit.h
@@ -53,6 +53,14 @@ class DParticleCombo_factory_PreKinFit : public jana::JFactory<DParticleCombo>
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
+		// in case you need to do anything with this factory that is shared amongst threads
+			// e.g. filling histograms
+			// When creating ROOT histograms, should still acquire JANA-wide ROOT lock (e.g. modifying gDirectory)
+		// this mutex is unique to this combination of: factory name & tag
+		pthread_rwlock_t* dFactoryLock;
+		void Lock_Factory(void);
+		void Unlock_Factory(void);
+
 		const DKinematicData* Get_DetectedParticle(const DReaction* locReaction, const DEventRFBunch* locEventRFBunch, const DParticleComboBlueprintStep* locParticleComboBlueprintStep, size_t locParticleIndex);
 		DKinematicData* Create_Target(Particle_t locPID);
 
@@ -95,7 +103,6 @@ class DParticleCombo_factory_PreKinFit : public jana::JFactory<DParticleCombo>
 		double dTargetCenterZ;
 		double dMinThrownMatchFOM;
 		const DAnalysisUtilities* dAnalysisUtilities;
-		bool root_hists_created;
 
 		vector<const DReaction*> dReactions;
 		map<const DReaction*, bool> dMCReactionExactMatchFlags;
@@ -119,6 +126,16 @@ class DParticleCombo_factory_PreKinFit : public jana::JFactory<DParticleCombo>
 		map<const DReaction*, TH1D*> dHistMap_NumEventsSurvivedCut_All;
 		map<const DReaction*, TH1D*> dHistMap_NumEventsSurvivedCut_True;
 };
+
+inline void DParticleCombo_factory_PreKinFit::Lock_Factory(void)
+{
+	pthread_rwlock_wrlock(dFactoryLock);
+}
+
+inline void DParticleCombo_factory_PreKinFit::Unlock_Factory(void)
+{
+	pthread_rwlock_unlock(dFactoryLock);
+}
 
 #endif // _DParticleCombo_factory_PreKinFit_
 


### PR DESCRIPTION
Apply factory-local locks when filling histograms within a factory. Also, fix output-root-file checking: maintain full functionality without breaking RootSpy.
