### PR TITLE
Rootwriter lock

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisAction.cc
+++ b/src/libraries/ANALYSIS/DAnalysisAction.cc
@@ -24,6 +24,7 @@ dPerformAntiCut(false), dReaction(locReaction), dActionName(locActionBaseName), 
 	dOutputFileName = "hd_root.root";
 	if(gPARMS->Exists("OUTPUT_FILENAME"))
 		gPARMS->GetParameter("OUTPUT_FILENAME", dOutputFileName);
+
 	dNumPreviousParticleCombos = 0;
 	dNumParticleCombos = 0;
 

--- a/src/libraries/ANALYSIS/DChargedTrackHypothesis_factory_Combo.h
+++ b/src/libraries/ANALYSIS/DChargedTrackHypothesis_factory_Combo.h
@@ -35,20 +35,19 @@ class DChargedTrackHypothesis_factory_Combo : public jana::JFactory<DChargedTrac
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
-		void Create_PIDsAsNeeded(JEventLoop* locEventLoop, const DReaction* locReaction, const DEventRFBunch* locEventRFBunch, const DChargedTrack* locChargedTrack, set<Particle_t>& locPIDs);
+		void Build_RFPIDMap(map<Particle_t, vector<const DReaction*> >& locPIDMap, map<const DReaction*, set<const DEventRFBunch*> >& locRFBunchReactionMap, map<Particle_t, set<const DEventRFBunch*> >& locRFBunchPIDMap);
+		void Create_TrackHypos(JEventLoop* locEventLoop, const DChargedTrack* locChargedTrack, map<Particle_t, vector<const DReaction*> >& locPIDMap, map<Particle_t, set<const DEventRFBunch*> >& locRFBunchPIDMap);
+		DChargedTrackHypothesis* Create_TrackHypo(JEventLoop* locEventLoop, const DEventRFBunch* locEventRFBunch, const DChargedTrack* locChargedTrack, Particle_t locPID);
 
 		DChargedTrackHypothesis_factory* dChargedTrackHypothesisFactory;
-
 		const DDetectorMatches* dDetectorMatches;
 		vector<const DReaction*> dReactions;
-		map<const DReaction*, set<Particle_t> > dPositivelyChargedPIDs;
-		map<const DReaction*, set<Particle_t> > dNegativelyChargedPIDs;
-
-		map<const DEventRFBunch*, map<const DChargedTrack*, set<Particle_t> > > dCreatedParticleMap;
 		map<pair<const DChargedTrack*, Particle_t>, const DTrackTimeBased*> dTimeBasedSourceMap;
+
+		map<Particle_t, vector<const DReaction*> > dPositivelyChargedPIDs; //vector: reactions for which they are needed
+		map<Particle_t, vector<const DReaction*> > dNegativelyChargedPIDs; //vector: reactions for which they are needed
 
 		string dTrackSelectionTag;
 };
 
 #endif // _DChargedTrackHypothesis_factory_Combo_
-

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -35,129 +35,119 @@ DEventWriterROOT::DEventWriterROOT(JEventLoop* locEventLoop)
 		dCutActionMap_BDTSignalCombo[locReactions[loc_i]]->Initialize(locEventLoop);
 	}
 
-	japp->RootWriteLock();
+	dWriterLock = japp->WriteLock("DEventWriterROOT"); //will create if doesn't exist, else returns it
 	{
 		++Get_NumEventWriterThreads();
 	}
-	japp->RootUnLock();
+	Unlock_Writer();
 }
 
 DEventWriterROOT::~DEventWriterROOT(void)
 {
-	japp->RootWriteLock();
+	Lock_Writer();
 	{
 		--Get_NumEventWriterThreads();
 		if(Get_NumEventWriterThreads() != 0)
 		{
-			japp->RootUnLock();
+			Unlock_Writer();
 			return;
 		}
-		for(size_t loc_i = 0; loc_i < Get_OutputROOTFiles().size(); ++loc_i)
+		map<string, TFile*>& locFileMap = Get_OutputROOTFileMap();
+		map<string, TFile*>::iterator locFileIterator = locFileMap.begin();
+		for(; locFileIterator != locFileMap.end(); ++locFileIterator)
 		{
-			Get_OutputROOTFiles()[loc_i]->Write(0, TObject::kOverwrite);
-			Get_OutputROOTFiles()[loc_i]->Close();
-			delete Get_OutputROOTFiles()[loc_i];
+			TFile* locFile = locFileIterator->second;
+			locFile->Write(0, TObject::kOverwrite);
+			locFile->Close();
+			delete locFile;
 		}
-		Get_OutputROOTFiles().clear();
+		locFileMap.clear();
 	}
-	japp->RootUnLock();
+	Unlock_Writer();
 }
 
-// ALL must be external locks: all read, and read value may not be accurate otherwise
-
-// must be read/used entirely within writer lock
 int& DEventWriterROOT::Get_NumEventWriterThreads(void) const
 {
+	// must be read/used entirely within writer lock
 	static int locNumEventWriterThreads = 0;
 	return locNumEventWriterThreads;
 }
 
-//store ttree itself rather than string: too late to change once it's created
-//once you have it, can release writer lock and retrieve file-lock. 
-string& DEventWriterROOT::Get_ThrownTreeFileName(void) const
+pair<string, TTree*>& DEventWriterROOT::Get_ThrownTreePair(void) const
 {
-	//static so that it's not a member: can be changed in a call to a const function //object is const when the user gets it
-	static string locThrownTreeFileName = "";
-	return locThrownTreeFileName;
+	// read/modify within writer lock, but fill TTree in file-lock
+	// when creating TTree, don't release lock until TTree fully initialized
+	static pair<string, TTree*> locThrownTreePair("", NULL); //string is file name
+	return locThrownTreePair;
 }
 
-//use writer-lock to get map for this tree (by reference!), then use file-lock to modify
 map<TTree*, map<string, TClonesArray*> >& DEventWriterROOT::Get_ClonesArrayMap(void) const
 {
+	// read/modify within writer lock, but read/modify value map in file-lock
 	static map<TTree*, map<string, TClonesArray*> > locClonesArrayMap;
 	return locClonesArrayMap;
 }
 
-//use writer-lock to get map for this tree (by reference!), then use file-lock to modify
 map<TTree*, map<string, TObject*> >& DEventWriterROOT::Get_TObjectMap(void) const
 {
+	// read/modify within writer lock, but read/modify value map in file-lock
 	static map<TTree*, map<string, TObject*> > locTObjectMap;
 	return locTObjectMap;
 }
 
-//use writer-lock to get map for this tree (by reference!), then use file-lock to modify
 map<TTree*, map<string, unsigned int> >& DEventWriterROOT::Get_FundamentalArraySizeMap(void) const
 {
+	// read/modify within writer lock, but read/modify value map in file-lock
 	static map<TTree*, map<string, unsigned int> > locFundamentalArraySizeMap;
 	return locFundamentalArraySizeMap;
 }
 
-// must be read/used entirely within writer lock
-	//only release lock AFTER TTree is created AND added to new TTree map
-//convert to map<string, TFile*> instead
-deque<TFile*>& DEventWriterROOT::Get_OutputROOTFiles(void) const
+map<string, TFile*>& DEventWriterROOT::Get_OutputROOTFileMap(void) const
 {
-	static deque<TFile*> locOutputROOTFiles;
-	return locOutputROOTFiles;
+	// must be read/used entirely within writer lock
+	static map<string, TFile*> locOutputROOTFileMap; //string: file name
+	return locOutputROOTFileMap;
 }
 
-//add static map<string, TTree*>: use writer-lock to get tree, then grab file-lock to modify
-
-//when creating:
-	//writer lock
-	//check for file/tree existence: create, register
-	//setup tree //must do HERE, else another thread may see an incomplete tree: no gap between creation -> registration -> setup
-	//release writer lock
-
-//when filling:
-	//writer-lock
-	//pre-get everything
-	//release writer lock
-	//acquire file-lock
-	//fill everything
-	//release file lock
+map<string, TTree*>& DEventWriterROOT::Get_TTreeMap(void) const
+{
+	// read/modify within writer lock, but fill TTree in file-lock
+	// when creating TTree, don't release lock until TTree fully initialized
+	static map<string, TTree*> locTTreeMap; //string: file name
+	return locTTreeMap;
+}
 
 //memory maps: must hold onto them, pass them DIRECTLY through ALL functions, and into the header file fill functions
 	//create a struct to hold them, so they're easier to pass
 
 void DEventWriterROOT::Create_ThrownTree(string locOutputFileName) const
 {
-	japp->RootWriteLock();
+	Lock_Writer();
 	{
-		if(Get_ThrownTreeFileName() != "")
+		//see if ttree already exists
+		pair<string, TTree*> locThrownTreePair = DEventWriterROOT::Get_ThrownTreePair();
+		if(locThrownTreePair.second != NULL)
 		{
-			japp->RootUnLock();
+			Unlock_Writer();
 			return; //already created
 		}
-		Get_ThrownTreeFileName() = locOutputFileName;
 
 		//create ROOT file if it doesn't exist already
-		TFile* locFile = (TFile*)gROOT->FindObject(locOutputFileName.c_str());
-		if(locFile == NULL)
+		map<string, TFile*>& locFileMap = Get_OutputROOTFileMap();
+		map<string, TFile*>::iterator locFileIterator = locFileMap.find(locOutputFileName);
+		if(locFileIterator == locFileMap.end())
 		{
-			locFile = new TFile(locOutputFileName.c_str(), "RECREATE");
-			Get_OutputROOTFiles().push_back(locFile);
+			TFile* locFile = new TFile(locOutputFileName.c_str(), "RECREATE");
+			locFileMap.insert(pair<string, TFile*>(locOutputFileName, locFile));
 		}
+		else
+			locFileIterator->second->cd();
+		locThrownTreePair.first = locOutputFileName;
 
-		//create tree if it doesn't exist already
+		//create ttree
 		string locTreeName = "Thrown_Tree";
-		locFile->cd();
-		if(gDirectory->Get(locTreeName.c_str()) != NULL)
-		{
-			japp->RootUnLock();
-			return; //already created by another thread
-		}
 		TTree* locTree = new TTree(locTreeName.c_str(), locTreeName.c_str());
+		locThrownTreePair.second = locTree;
 
 		/******************************************************************** Create Branches ********************************************************************/
 
@@ -171,7 +161,7 @@ void DEventWriterROOT::Create_ThrownTree(string locOutputFileName) const
 		//CUSTOM
 		Create_CustomBranches_ThrownTree(locTree);
 	}
-	japp->RootUnLock();
+	Unlock_Writer();
 }
 
 void DEventWriterROOT::Create_DataTrees(JEventLoop* locEventLoop) const
@@ -189,7 +179,7 @@ void DEventWriterROOT::Create_DataTrees(JEventLoop* locEventLoop) const
 	locGeometry->GetTargetZ(locTargetCenterZ);
 
 	//CREATE TTREES
-	japp->RootWriteLock();
+	Lock_Writer();
 	{
 		for(size_t loc_i = 0; loc_i < locReactions.size(); ++loc_i)
 		{
@@ -197,28 +187,35 @@ void DEventWriterROOT::Create_DataTrees(JEventLoop* locEventLoop) const
 				Create_DataTree(locReactions[loc_i], !locMCThrowns.empty(), locTargetCenterZ);
 		}
 	}
-	japp->RootUnLock();
+	Unlock_Writer();
 }
 
 void DEventWriterROOT::Create_DataTree(const DReaction* locReaction, bool locIsMCDataFlag, double locTargetCenterZ) const
 {
 	string locReactionName = locReaction->Get_ReactionName();
+	string locOutputFileName = locReaction->Get_TTreeOutputFileName();
+	string locTreeName = locReactionName + string("_Tree");
+
+	//If tree already exists, return
+	map<string, TTree*>& locTreeMap = Get_TTreeMap();
+	map<string, TTree*>::iterator locTreeIterator = locTreeMap.find(locTreeName);
+	if(locTreeIterator != locTreeMap.end())
+		return; //already created by another thread
 
 	//create ROOT file if it doesn't exist already
-	string locOutputFileName = locReaction->Get_TTreeOutputFileName();
-	TFile* locFile = (TFile*)gROOT->FindObject(locOutputFileName.c_str());
-	if(locFile == NULL)
+	map<string, TFile*>& locFileMap = Get_OutputROOTFileMap();
+	map<string, TFile*>::iterator locFileIterator = locFileMap.find(locOutputFileName);
+	if(locFileIterator == locFileMap.end())
 	{
-		locFile = new TFile(locOutputFileName.c_str(), "RECREATE");
-		Get_OutputROOTFiles().push_back(locFile);
+		TFile* locFile = new TFile(locOutputFileName.c_str(), "RECREATE");
+		locFileMap.insert(pair<string, TFile*>(locOutputFileName, locFile));
 	}
+	else
+		locFileIterator->second->cd();
 
-	//create tree if it doesn't exist already
-	string locTreeName = locReactionName + string("_Tree");
-	locFile->cd();
-	if(gDirectory->Get(locTreeName.c_str()) != NULL)
-		return; //already created by another thread
+	//create tree
 	TTree* locTree = new TTree(locTreeName.c_str(), locTreeName.c_str());
+	locTreeMap.insert(pair<string, TTree*>(locTreeName, locTree));
 
 	//find the # particles of each pid
 	map<Particle_t, unsigned int> locParticleNumberMap;
@@ -944,30 +941,37 @@ void DEventWriterROOT::Fill_ThrownTree(JEventLoop* locEventLoop) const
 	map<const DMCThrown*, unsigned int> locThrownIndexMap;
 	Group_ThrownParticles(locMCThrowns_FinalState, locMCThrowns_Decaying, locMCThrownsToSave, locThrownIndexMap);
 
-	string locTreeName = "Thrown_Tree";
-	japp->RootWriteLock();
+	//GET TTREE, FILE NAME, AND MEMORY MAPS
+	TTree* locTree = NULL;
+	string locOutputFileName = "";
+	DBranchMemoryMaps locMemoryMaps;
+	Lock_Writer();
 	{
-		if(Get_ThrownTreeFileName() == "")
+		//TTree, file name
+		pair<string, TTree*> locThrownTreePair = DEventWriterROOT::Get_ThrownTreePair();
+		if(locThrownTreePair.second == NULL)
 		{
-			japp->RootUnLock();
+			cout << "ERROR: OUTPUT ROOT TREE NOT CREATED (in DEventWriterROOT::Fill_DataTree()). SKIP FILLING. " << endl;
+			Unlock_Writer();
 			return;
 		}
+		locOutputFileName = locThrownTreePair.first;
+		locTree = locTreeIterator.second;
 
-		//get the tree
-		TFile* locFile = (TFile*)gROOT->FindObject(Get_ThrownTreeFileName().c_str());
-		locFile->cd("/");
-		TTree* locTree = (TTree*)gDirectory->Get(locTreeName.c_str());
-		if(locTree == NULL)
-		{
-			cout << "ERROR: OUTPUT ROOT TREE NOT CREATED (in DEventWriterROOT::Fill_ThrownTree()). SKIP FILLING. " << endl;
-			japp->RootUnLock();
-			return;
-		}
+		//memory maps
+		locMemoryMaps.dFundamentalArraySizeMap = &(Get_FundamentalArraySizeMap()[locTree]);
+		locMemoryMaps.dTObjectMap = &(Get_TObjectMap()[locTree]);
+		locMemoryMaps.dClonesArrayMap = &(Get_ClonesArrayMap()[locTree]);
+	}
+	Unlock_Writer();
 
+	//Lock on the file name: TTree::Fill() can flush to file.
+	//However, it won't interfere with tree fills to other files.
+	japp->WriteLock(locOutputFileName);
+	{
 		//clear the tclonesarry's
-		map<string, TClonesArray*>& locTreeMap_ClonesArray = Get_ClonesArrayMap()[locTree];
-		map<string, TClonesArray*>::iterator locClonesArrayMapIterator;
-		for(locClonesArrayMapIterator = locTreeMap_ClonesArray.begin(); locClonesArrayMapIterator != locTreeMap_ClonesArray.end(); ++locClonesArrayMapIterator)
+		map<string, TClonesArray*>::iterator locClonesArrayMapIterator = locMemoryMaps.dClonesArrayMap->begin();
+		for(; locClonesArrayMapIterator != locMemoryMaps.dClonesArrayMap->end(); ++locClonesArrayMapIterator)
 			locClonesArrayMapIterator->second->Clear();
 
 		//setup target info, if not done already
@@ -980,14 +984,14 @@ void DEventWriterROOT::Fill_ThrownTree(JEventLoop* locEventLoop) const
 		Fill_FundamentalData<ULong64_t>(locTree, "EventNumber", locEventLoop->GetJEvent().GetEventNumber());
 
 		//throwns
-		Fill_ThrownInfo(locTree, locMCReaction, locMCThrownsToSave, locThrownIndexMap, locNumPIDThrown_FinalState, locPIDThrown_Decaying);
+		Fill_ThrownInfo(locTree, locMCReaction, locMCThrownsToSave, locThrownIndexMap, locNumPIDThrown_FinalState, locPIDThrown_Decaying, locMemoryMaps);
 
 		//Custom Branches
 		Fill_CustomBranches_ThrownTree(locTree, locMCReaction, locMCThrownsToSave);
 
 		locTree->Fill();
 	}
-	japp->RootUnLock();
+	japp->Unlock(locOutputFileName);
 }
 
 void DEventWriterROOT::Fill_DataTrees(JEventLoop* locEventLoop, string locDReactionTag) const
@@ -1172,30 +1176,35 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 	string locOutputFileName = locReaction->Get_TTreeOutputFileName();
 	string locTreeName = locReaction->Get_ReactionName() + string("_Tree");
 
-	japp->RootWriteLock();
+	//GET TTREE AND MEMORY MAPS
+	TTree* locTree = NULL;
+	DBranchMemoryMaps locMemoryMaps;
+	Lock_Writer();
 	{
-		TFile* locFile = (TFile*)gROOT->FindObject(locOutputFileName.c_str());
-		if(locFile == NULL)
-		{
-			cout << "ERROR: OUTPUT ROOT TREE FILE NOT CREATED (in DEventWriterROOT::Fill_DataTree()). SKIP FILLING. " << endl;
-			japp->RootUnLock();
-			return;
-		}
-
-		//get the tree info
-		locFile->cd("/");
-		TTree* locTree = (TTree*)gDirectory->Get(locTreeName.c_str());
-		if(locTree == NULL)
+		map<string, TTree*>& locTreeMap = Get_TTreeMap();
+		map<string, TTree*>::iterator locTreeIterator = locTreeMap.find(locTreeName);
+		if(locTreeIterator == locTreeMap.end())
 		{
 			cout << "ERROR: OUTPUT ROOT TREE NOT CREATED (in DEventWriterROOT::Fill_DataTree()). SKIP FILLING. " << endl;
-			japp->RootUnLock();
+			Unlock_Writer();
 			return;
 		}
+		locTree = locTreeIterator->second;
 
+		//memory maps
+		locMemoryMaps.dFundamentalArraySizeMap = &(Get_FundamentalArraySizeMap()[locTree]);
+		locMemoryMaps.dTObjectMap = &(Get_TObjectMap()[locTree]);
+		locMemoryMaps.dClonesArrayMap = &(Get_ClonesArrayMap()[locTree]);
+	}
+	Unlock_Writer();
+
+	//Lock on the file name: TTree::Fill() can flush to file.
+	//However, it won't interfere with tree fills to other files.
+	japp->WriteLock(locOutputFileName);
+	{
 		//clear the tclonesarry's
-		map<string, TClonesArray*>& locTreeMap_ClonesArray = Get_ClonesArrayMap()[locTree];
-		map<string, TClonesArray*>::iterator locClonesArrayMapIterator;
-		for(locClonesArrayMapIterator = locTreeMap_ClonesArray.begin(); locClonesArrayMapIterator != locTreeMap_ClonesArray.end(); ++locClonesArrayMapIterator)
+		map<string, TClonesArray*>::iterator locClonesArrayMapIterator = locMemoryMaps.dClonesArrayMap->begin();
+		for(; locClonesArrayMapIterator != locMemoryMaps.dClonesArrayMap->end(); ++locClonesArrayMapIterator)
 			locClonesArrayMapIterator->second->Clear();
 
 		//PRIMARY EVENT INFO
@@ -1205,12 +1214,12 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 		//PRODUCTION X4
 		DLorentzVector locProductionX4 = locVertex->dSpacetimeVertex;
 		TLorentzVector locProductionTX4(locProductionX4.X(), locProductionX4.Y(), locProductionX4.Z(), locProductionX4.T());
-		Fill_TObjectData<TLorentzVector>(locTree, "X4_Production", locProductionTX4);
+		Fill_TObjectData<TLorentzVector>(locTree, "X4_Production", locProductionTX4, locMemoryMaps);
 
 		//THROWN INFORMATION
 		if(locMCReaction != NULL)
 		{
-			Fill_ThrownInfo(locTree, locMCReaction, locMCThrownsToSave, locThrownIndexMap, locNumPIDThrown_FinalState, locPIDThrown_Decaying, locMCThrownMatching, locObjectToArrayIndexMap);
+			Fill_ThrownInfo(locTree, locMCReaction, locMCThrownsToSave, locThrownIndexMap, locNumPIDThrown_FinalState, locPIDThrown_Decaying, locMCThrownMatching, locObjectToArrayIndexMap, locMemoryMaps);
 			Fill_FundamentalData<Bool_t>(locTree, "IsThrownTopology", locIsThrownTopologyFlag);
 		}
 
@@ -1220,28 +1229,28 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 			//however, only fill with beam particles that are in the combos
 			Fill_FundamentalData<UInt_t>(locTree, "NumBeam", locBeamPhotons.size());
 			for(size_t loc_i = 0; loc_i < locBeamPhotons.size(); ++loc_i)
-				Fill_BeamData(locTree, loc_i, locBeamPhotons[loc_i], locVertex, locMCThrownMatching);
+				Fill_BeamData(locTree, loc_i, locBeamPhotons[loc_i], locVertex, locMCThrownMatching, locMemoryMaps);
 		}
 
 		//INDEPENDENT CHARGED TRACKS
 		Fill_FundamentalData<UInt_t>(locTree, "NumChargedHypos", locIndependentChargedTrackHypotheses.size());
 		for(size_t loc_i = 0; loc_i < locIndependentChargedTrackHypotheses.size(); ++loc_i)
-			Fill_ChargedHypo(locTree, loc_i, locIndependentChargedTrackHypotheses[loc_i], locMCThrownMatching, locThrownIndexMap, locDetectorMatches);
+			Fill_ChargedHypo(locTree, loc_i, locIndependentChargedTrackHypotheses[loc_i], locMCThrownMatching, locThrownIndexMap, locDetectorMatches, locMemoryMaps);
 
 		//INDEPENDENT NEUTRAL PARTICLES
 		Fill_FundamentalData<UInt_t>(locTree, "NumNeutralHypos", locIndependentNeutralParticleHypotheses.size());
 		for(size_t loc_i = 0; loc_i < locIndependentNeutralParticleHypotheses.size(); ++loc_i)
-			Fill_NeutralHypo(locTree, loc_i, locIndependentNeutralParticleHypotheses[loc_i], locMCThrownMatching, locThrownIndexMap, locDetectorMatches);
+			Fill_NeutralHypo(locTree, loc_i, locIndependentNeutralParticleHypotheses[loc_i], locMCThrownMatching, locThrownIndexMap, locDetectorMatches, locMemoryMaps);
 
 		//COMBOS
 		Fill_FundamentalData<UInt_t>(locTree, "NumCombos", locParticleCombos.size());
 		for(size_t loc_i = 0; loc_i < locParticleCombos.size(); ++loc_i)
 		{
-			Fill_ComboData(locTree, locParticleCombos[loc_i], loc_i, locObjectToArrayIndexMap);
+			Fill_ComboData(locTree, locParticleCombos[loc_i], loc_i, locObjectToArrayIndexMap, locMemoryMaps);
 			if(locMCReaction != NULL)
 			{
-				Fill_FundamentalData<Bool_t>(locTree, "IsTrueCombo", locIsTrueComboFlags[loc_i], loc_i);
-				Fill_FundamentalData<Bool_t>(locTree, "IsBDTSignalCombo", locIsBDTSignalComboFlags[loc_i], loc_i);
+				Fill_FundamentalData<Bool_t>(locTree, "IsTrueCombo", locIsTrueComboFlags[loc_i], loc_i, locMemoryMaps);
+				Fill_FundamentalData<Bool_t>(locTree, "IsBDTSignalCombo", locIsBDTSignalComboFlags[loc_i], loc_i, locMemoryMaps);
 			}
 		}
 
@@ -1251,7 +1260,7 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 		//FILL
 		locTree->Fill();
 	}
-	japp->RootUnLock();
+	japp->Unlock(locOutputFileName);
 }
 
 ULong64_t DEventWriterROOT::Calc_ParticleMultiplexID(Particle_t locPID) const
@@ -1320,13 +1329,13 @@ void DEventWriterROOT::Group_ThrownParticles(const vector<const DMCThrown*>& loc
 		locThrownIndexMap[locMCThrownsToSave[loc_i]] = loc_i;
 }
 
-void DEventWriterROOT::Fill_ThrownInfo(TTree* locTree, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying) const
+void DEventWriterROOT::Fill_ThrownInfo(TTree* locTree, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying, DBranchMemoryMaps locMemoryMaps) const
 {
 	map<string, map<oid_t, int> > locObjectToArrayIndexMap;
-	Fill_ThrownInfo(locTree, locMCReaction, locMCThrowns, locThrownIndexMap, locNumPIDThrown_FinalState, locPIDThrown_Decaying, NULL, locObjectToArrayIndexMap);
+	Fill_ThrownInfo(locTree, locMCReaction, locMCThrowns, locThrownIndexMap, locNumPIDThrown_FinalState, locPIDThrown_Decaying, NULL, locObjectToArrayIndexMap, locMemoryMaps);
 }
 
-void DEventWriterROOT::Fill_ThrownInfo(TTree* locTree, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying, const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const
+void DEventWriterROOT::Fill_ThrownInfo(TTree* locTree, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying, const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap, DBranchMemoryMaps locMemoryMaps) const
 {
 	//THIS MUST BE CALLED FROM WITHIN A LOCK, SO DO NOT PASS IN JEVENTLOOP! //TOO TEMPTING TO DO SOMETHING BAD
 
@@ -1338,23 +1347,23 @@ void DEventWriterROOT::Fill_ThrownInfo(TTree* locTree, const DMCReaction* locMCR
 
 	DVector3 locThrownBeamX3 = locMCReaction->beam.position();
 	TLorentzVector locThrownBeamTX4(locThrownBeamX3.X(), locThrownBeamX3.Y(), locThrownBeamX3.Z(), locMCReaction->beam.time());
-	Fill_TObjectData<TLorentzVector>(locTree, "ThrownBeam", "X4", locThrownBeamTX4);
+	Fill_TObjectData<TLorentzVector>(locTree, "ThrownBeam", "X4", locThrownBeamTX4, locMemoryMaps);
 
 	DLorentzVector locThrownBeamP4 = locMCReaction->beam.lorentzMomentum();
 	TLorentzVector locThrownBeamTP4(locThrownBeamP4.Px(), locThrownBeamP4.Py(), locThrownBeamP4.Pz(), locThrownBeamP4.E());
-	Fill_TObjectData<TLorentzVector>(locTree, "ThrownBeam", "P4", locThrownBeamTP4);
+	Fill_TObjectData<TLorentzVector>(locTree, "ThrownBeam", "P4", locThrownBeamTP4, locMemoryMaps);
 
 	//THROWN PRODUCTS
 	Fill_FundamentalData<UInt_t>(locTree, "NumThrown", locMCThrowns.size());
 	for(size_t loc_i = 0; loc_i < locMCThrowns.size(); ++loc_i)
-		Fill_ThrownParticleData(locTree, loc_i, locMCThrowns[loc_i], locThrownIndexMap, locMCThrownMatching, locObjectToArrayIndexMap);
+		Fill_ThrownParticleData(locTree, loc_i, locMCThrowns[loc_i], locThrownIndexMap, locMCThrownMatching, locObjectToArrayIndexMap, locMemoryMaps);
 
 	//PID INFO
 	Fill_FundamentalData<ULong64_t>(locTree, "NumPIDThrown_FinalState", locNumPIDThrown_FinalState); //19 digits
 	Fill_FundamentalData<ULong64_t>(locTree, "PIDThrown_Decaying", locPIDThrown_Decaying);
 }
 
-void DEventWriterROOT::Fill_ThrownParticleData(TTree* locTree, unsigned int locArrayIndex, const DMCThrown* locMCThrown, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const
+void DEventWriterROOT::Fill_ThrownParticleData(TTree* locTree, unsigned int locArrayIndex, const DMCThrown* locMCThrown, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap, DBranchMemoryMaps locMemoryMaps) const
 {
 	string locParticleBranchName = "Thrown";
 
@@ -1368,8 +1377,8 @@ void DEventWriterROOT::Fill_ThrownParticleData(TTree* locTree, unsigned int locA
 		locParentIndex = locIterator->second;
 		break;
 	}
-	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "ParentIndex", locParentIndex, locArrayIndex);
-	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "PID", locMCThrown->pdgtype, locArrayIndex);
+	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "ParentIndex", locParentIndex, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "PID", locMCThrown->pdgtype, locArrayIndex, locMemoryMaps);
 
 	//MATCHING
 	if(locMCThrownMatching != NULL)
@@ -1390,29 +1399,29 @@ void DEventWriterROOT::Fill_ThrownParticleData(TTree* locTree, unsigned int locA
 			if(locNeutralShower != NULL)
 				locMatchID = locNeutralShower->dShowerID;
 		}
-		Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "MatchID", locMatchID, locArrayIndex);
-		Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "MatchFOM", locMatchFOM, locArrayIndex);
+		Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "MatchID", locMatchID, locArrayIndex, locMemoryMaps);
+		Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "MatchFOM", locMatchFOM, locArrayIndex, locMemoryMaps);
 	}
 
 	//KINEMATICS: THROWN //at the production vertex
 	TLorentzVector locX4_Thrown(locMCThrown->position().X(), locMCThrown->position().Y(), locMCThrown->position().Z(), locMCThrown->time());
-	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4", locX4_Thrown, locArrayIndex);
+	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4", locX4_Thrown, locArrayIndex, locMemoryMaps);
 	TLorentzVector locP4_Thrown(locMCThrown->momentum().X(), locMCThrown->momentum().Y(), locMCThrown->momentum().Z(), locMCThrown->energy());
-	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4", locP4_Thrown, locArrayIndex);
+	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4", locP4_Thrown, locArrayIndex, locMemoryMaps);
 }
 
-void DEventWriterROOT::Fill_BeamData(TTree* locTree, unsigned int locArrayIndex, const DBeamPhoton* locBeamPhoton, const DVertex* locVertex, const DMCThrownMatching* locMCThrownMatching) const
+void DEventWriterROOT::Fill_BeamData(TTree* locTree, unsigned int locArrayIndex, const DBeamPhoton* locBeamPhoton, const DVertex* locVertex, const DMCThrownMatching* locMCThrownMatching, DBranchMemoryMaps locMemoryMaps) const
 {
 	string locParticleBranchName = "Beam";
 
 	//IDENTIFIER
-	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "PID", PDGtype(locBeamPhoton->PID()), locArrayIndex);
+	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "PID", PDGtype(locBeamPhoton->PID()), locArrayIndex, locMemoryMaps);
 
 	//MATCHING
 	if(locMCThrownMatching != NULL)
 	{
 		Bool_t locIsGeneratorFlag = (locMCThrownMatching->Get_ReconMCGENBeamPhoton() == locBeamPhoton) ? kTRUE : kFALSE;
-		Fill_FundamentalData<Bool_t>(locTree, locParticleBranchName, "IsGenerator", locIsGeneratorFlag, locArrayIndex);
+		Fill_FundamentalData<Bool_t>(locTree, locParticleBranchName, "IsGenerator", locIsGeneratorFlag, locArrayIndex, locMemoryMaps);
 	}
 
 	//KINEMATICS: MEASURED
@@ -1426,14 +1435,14 @@ void DEventWriterROOT::Fill_BeamData(TTree* locTree, unsigned int locArrayIndex,
 	double locTime = locBeamPhoton->time() + locDeltaT;
 
 	TLorentzVector locX4_Measured(locProductionVertex.X(), locProductionVertex.Y(), locProductionVertex.Z(), locTime);
-	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_Measured", locX4_Measured, locArrayIndex);
+	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_Measured", locX4_Measured, locArrayIndex, locMemoryMaps);
 
 	DLorentzVector locDP4 = locBeamPhoton->lorentzMomentum();
 	TLorentzVector locP4_Measured(locDP4.Px(), locDP4.Py(), locDP4.Pz(), locDP4.E());
-	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_Measured", locP4_Measured, locArrayIndex);
+	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_Measured", locP4_Measured, locArrayIndex, locMemoryMaps);
 }
 
-void DEventWriterROOT::Fill_ChargedHypo(TTree* locTree, unsigned int locArrayIndex, const DChargedTrackHypothesis* locChargedTrackHypothesis, const DMCThrownMatching* locMCThrownMatching, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DDetectorMatches* locDetectorMatches) const
+void DEventWriterROOT::Fill_ChargedHypo(TTree* locTree, unsigned int locArrayIndex, const DChargedTrackHypothesis* locChargedTrackHypothesis, const DMCThrownMatching* locMCThrownMatching, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DDetectorMatches* locDetectorMatches, DBranchMemoryMaps locMemoryMaps) const
 {
 	string locParticleBranchName = "ChargedHypo";
 
@@ -1450,8 +1459,8 @@ void DEventWriterROOT::Fill_ChargedHypo(TTree* locTree, unsigned int locArrayInd
 		locFCALShower = locChargedTrackHypothesis->Get_FCALShowerMatchParams()->dFCALShower;
 
 	//IDENTIFIERS
-	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "TrackID", locChargedTrackHypothesis->candidateid, locArrayIndex);
-	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "PID", PDGtype(locChargedTrackHypothesis->PID()), locArrayIndex);
+	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "TrackID", locChargedTrackHypothesis->candidateid, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "PID", PDGtype(locChargedTrackHypothesis->PID()), locArrayIndex, locMemoryMaps);
 
 	//MATCHING
 	if(locMCThrownMatching != NULL)
@@ -1461,46 +1470,46 @@ void DEventWriterROOT::Fill_ChargedHypo(TTree* locTree, unsigned int locArrayInd
 		const DMCThrown* locMCThrown = locMCThrownMatching->Get_MatchingMCThrown(locChargedTrackHypothesis, locMatchFOM);
 		if(locMCThrown != NULL)
 			locThrownIndex = locThrownIndexMap.find(locMCThrown)->second;
-		Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "ThrownIndex", locThrownIndex, locArrayIndex);
+		Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "ThrownIndex", locThrownIndex, locArrayIndex, locMemoryMaps);
 	}
 
 	//KINEMATICS: MEASURED
 	DVector3 locPosition = locChargedTrackHypothesis->position();
 	TLorentzVector locTX4_Measured(locPosition.X(), locPosition.Y(), locPosition.Z(), locChargedTrackHypothesis->time());
-	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_Measured", locTX4_Measured, locArrayIndex);
+	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_Measured", locTX4_Measured, locArrayIndex, locMemoryMaps);
 
 	DLorentzVector locDP4 = locChargedTrackHypothesis->lorentzMomentum();
 	TLorentzVector locP4_Measured(locDP4.Px(), locDP4.Py(), locDP4.Pz(), locDP4.E());
-	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_Measured", locP4_Measured, locArrayIndex);
+	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_Measured", locP4_Measured, locArrayIndex, locMemoryMaps);
 
 	//TRACKING INFO
-	Fill_FundamentalData<UInt_t>(locTree, locParticleBranchName, "NDF_Tracking", locChargedTrackHypothesis->dNDF_Track, locArrayIndex);
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_Tracking", locChargedTrackHypothesis->dChiSq_Track, locArrayIndex);
-	Fill_FundamentalData<UInt_t>(locTree, locParticleBranchName, "NDF_DCdEdx", locChargedTrackHypothesis->dNDF_DCdEdx, locArrayIndex);
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_DCdEdx", locChargedTrackHypothesis->dChiSq_DCdEdx, locArrayIndex);
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "dEdx_CDC", locTrackTimeBased->ddEdx_CDC, locArrayIndex);
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "dEdx_FDC", locTrackTimeBased->ddEdx_FDC, locArrayIndex);
+	Fill_FundamentalData<UInt_t>(locTree, locParticleBranchName, "NDF_Tracking", locChargedTrackHypothesis->dNDF_Track, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_Tracking", locChargedTrackHypothesis->dChiSq_Track, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<UInt_t>(locTree, locParticleBranchName, "NDF_DCdEdx", locChargedTrackHypothesis->dNDF_DCdEdx, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_DCdEdx", locChargedTrackHypothesis->dChiSq_DCdEdx, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "dEdx_CDC", locTrackTimeBased->ddEdx_CDC, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "dEdx_FDC", locTrackTimeBased->ddEdx_FDC, locArrayIndex, locMemoryMaps);
 
 	//HIT ENERGY
 	double locTOFdEdx = (locChargedTrackHypothesis->Get_TOFHitMatchParams() != NULL) ? locChargedTrackHypothesis->Get_TOFHitMatchParams()->dEdx : 0.0;
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "dEdx_TOF", locTOFdEdx, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "dEdx_TOF", locTOFdEdx, locArrayIndex, locMemoryMaps);
 	double locSCdEdx = (locChargedTrackHypothesis->Get_SCHitMatchParams() != NULL) ? locChargedTrackHypothesis->Get_SCHitMatchParams()->dEdx : 0.0;
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "dEdx_ST", locSCdEdx, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "dEdx_ST", locSCdEdx, locArrayIndex, locMemoryMaps);
 	double locBCALEnergy = (locBCALShower != NULL) ? locBCALShower->E : 0.0;
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Energy_BCAL", locBCALEnergy, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Energy_BCAL", locBCALEnergy, locArrayIndex, locMemoryMaps);
 	double locFCALEnergy = (locFCALShower != NULL) ? locFCALShower->getEnergy() : 0.0;
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Energy_FCAL", locFCALEnergy, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Energy_FCAL", locFCALEnergy, locArrayIndex, locMemoryMaps);
 
 	//TIMING INFO
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "HitTime", locChargedTrackHypothesis->t1(), locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "HitTime", locChargedTrackHypothesis->t1(), locArrayIndex, locMemoryMaps);
 	double locStartTimeError = locChargedTrackHypothesis->t0_err();
 	double locRFDeltaTVariance = (locChargedTrackHypothesis->errorMatrix())(6, 6) + locStartTimeError*locStartTimeError;
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "RFDeltaTVar", locRFDeltaTVariance, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "RFDeltaTVar", locRFDeltaTVariance, locArrayIndex, locMemoryMaps);
 
 	//MEASURED PID INFO
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Beta_Timing", locChargedTrackHypothesis->measuredBeta(), locArrayIndex);
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_Timing", locChargedTrackHypothesis->dChiSq_Timing, locArrayIndex);
-	Fill_FundamentalData<UInt_t>(locTree, locParticleBranchName, "NDF_Timing", locChargedTrackHypothesis->dNDF_Timing, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Beta_Timing", locChargedTrackHypothesis->measuredBeta(), locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_Timing", locChargedTrackHypothesis->dChiSq_Timing, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<UInt_t>(locTree, locParticleBranchName, "NDF_Timing", locChargedTrackHypothesis->dNDF_Timing, locArrayIndex, locMemoryMaps);
 
 	//SHOWER MATCHING: BCAL
 	double locTrackBCAL_DeltaPhi = 999.0, locTrackBCAL_DeltaZ = 999.0;
@@ -1509,17 +1518,17 @@ void DEventWriterROOT::Fill_ChargedHypo(TTree* locTree, unsigned int locArrayInd
 		locTrackBCAL_DeltaPhi = locChargedTrackHypothesis->Get_BCALShowerMatchParams()->dDeltaPhiToShower;
 		locTrackBCAL_DeltaZ = locChargedTrackHypothesis->Get_BCALShowerMatchParams()->dDeltaZToShower;
 	}
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "TrackBCAL_DeltaPhi", locTrackBCAL_DeltaPhi, locArrayIndex);
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "TrackBCAL_DeltaZ", locTrackBCAL_DeltaZ, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "TrackBCAL_DeltaPhi", locTrackBCAL_DeltaPhi, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "TrackBCAL_DeltaZ", locTrackBCAL_DeltaZ, locArrayIndex, locMemoryMaps);
 
 	//SHOWER MATCHING: FCAL
 	double locDOCAToShower_FCAL = 999.0;
 	if(locChargedTrackHypothesis->Get_FCALShowerMatchParams() != NULL)
 		locDOCAToShower_FCAL = locChargedTrackHypothesis->Get_FCALShowerMatchParams()->dDOCAToShower;
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "TrackFCAL_DOCA", locDOCAToShower_FCAL, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "TrackFCAL_DOCA", locDOCAToShower_FCAL, locArrayIndex, locMemoryMaps);
 }
 
-void DEventWriterROOT::Fill_NeutralHypo(TTree* locTree, unsigned int locArrayIndex, const DNeutralParticleHypothesis* locNeutralParticleHypothesis, const DMCThrownMatching* locMCThrownMatching, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DDetectorMatches* locDetectorMatches) const
+void DEventWriterROOT::Fill_NeutralHypo(TTree* locTree, unsigned int locArrayIndex, const DNeutralParticleHypothesis* locNeutralParticleHypothesis, const DMCThrownMatching* locMCThrownMatching, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DDetectorMatches* locDetectorMatches, DBranchMemoryMaps locMemoryMaps) const
 {
 	string locParticleBranchName = "NeutralHypo";
 	const DNeutralShower* locNeutralShower = NULL;
@@ -1533,8 +1542,8 @@ void DEventWriterROOT::Fill_NeutralHypo(TTree* locTree, unsigned int locArrayInd
 
 	//IDENTIFIERS
 	Particle_t locPID = locNeutralParticleHypothesis->PID();
-	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "NeutralID", locNeutralShower->dShowerID, locArrayIndex);
-	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "PID", PDGtype(locPID), locArrayIndex);
+	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "NeutralID", locNeutralShower->dShowerID, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "PID", PDGtype(locPID), locArrayIndex, locMemoryMaps);
 
 	//MATCHING
 	if(locMCThrownMatching != NULL)
@@ -1544,33 +1553,33 @@ void DEventWriterROOT::Fill_NeutralHypo(TTree* locTree, unsigned int locArrayInd
 		const DMCThrown* locMCThrown = locMCThrownMatching->Get_MatchingMCThrown(locNeutralParticleHypothesis, locMatchFOM);
 		if(locMCThrown != NULL)
 			locThrownIndex = locThrownIndexMap.find(locMCThrown)->second;
-		Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "ThrownIndex", locThrownIndex, locArrayIndex);
+		Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "ThrownIndex", locThrownIndex, locArrayIndex, locMemoryMaps);
 	}
 
 	//KINEMATICS: MEASURED
 	DVector3 locPosition = locNeutralParticleHypothesis->position();
 	TLorentzVector locX4_Measured(locPosition.X(), locPosition.Y(), locPosition.Z(), locNeutralParticleHypothesis->time());
-	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_Measured", locX4_Measured, locArrayIndex);
+	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_Measured", locX4_Measured, locArrayIndex, locMemoryMaps);
 
 	DLorentzVector locDP4 = locNeutralParticleHypothesis->lorentzMomentum();
 	TLorentzVector locP4_Measured(locDP4.Px(), locDP4.Py(), locDP4.Pz(), locDP4.E());
-	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_Measured", locP4_Measured, locArrayIndex);
+	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_Measured", locP4_Measured, locArrayIndex, locMemoryMaps);
 
 	//MEASURED PID INFO
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Beta_Timing", locNeutralParticleHypothesis->measuredBeta(), locArrayIndex);
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_Timing", locNeutralParticleHypothesis->dChiSq, locArrayIndex);
-	Fill_FundamentalData<UInt_t>(locTree, locParticleBranchName, "NDF_Timing", locNeutralParticleHypothesis->dNDF, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Beta_Timing", locNeutralParticleHypothesis->measuredBeta(), locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_Timing", locNeutralParticleHypothesis->dChiSq, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<UInt_t>(locTree, locParticleBranchName, "NDF_Timing", locNeutralParticleHypothesis->dNDF, locArrayIndex, locMemoryMaps);
 
 	//SHOWER ENERGY
 	double locBCALEnergy = (locNeutralShower->dDetectorSystem == SYS_BCAL) ? locNeutralShower->dEnergy : 0.0;
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Energy_BCAL", locBCALEnergy, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Energy_BCAL", locBCALEnergy, locArrayIndex, locMemoryMaps);
 	double locFCALEnergy = (locNeutralShower->dDetectorSystem == SYS_FCAL) ? locNeutralShower->dEnergy : 0.0;
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Energy_FCAL", locFCALEnergy, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Energy_FCAL", locFCALEnergy, locArrayIndex, locMemoryMaps);
 
 	//SHOWER POSITION
 	DLorentzVector locHitDX4 = locNeutralShower->dSpacetimeVertex;
 	TLorentzVector locTX4_Shower(locHitDX4.X(), locHitDX4.Y(), locHitDX4.Z(), locHitDX4.T());
-	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_Shower", locTX4_Shower, locArrayIndex);
+	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_Shower", locTX4_Shower, locArrayIndex, locMemoryMaps);
 
 	//Track DOCA to Shower - BCAL
 	double locNearestTrackBCALDeltaPhi = 999.0, locNearestTrackBCALDeltaZ = 999.0;
@@ -1587,8 +1596,8 @@ void DEventWriterROOT::Fill_NeutralHypo(TTree* locTree, unsigned int locArrayInd
 			locNearestTrackBCALDeltaZ = 999.0;
 		}
 	}
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "TrackBCAL_DeltaPhi", locNearestTrackBCALDeltaPhi, locArrayIndex);
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "TrackBCAL_DeltaZ", locNearestTrackBCALDeltaZ, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "TrackBCAL_DeltaPhi", locNearestTrackBCALDeltaPhi, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "TrackBCAL_DeltaZ", locNearestTrackBCALDeltaZ, locArrayIndex, locMemoryMaps);
 
 	//Track DOCA to Shower - FCAL
 	double locDistanceToNearestTrack_FCAL = 999.0;
@@ -1599,17 +1608,17 @@ void DEventWriterROOT::Fill_NeutralHypo(TTree* locTree, unsigned int locArrayInd
 		if(locDistanceToNearestTrack_FCAL > 999.0)
 			locDistanceToNearestTrack_FCAL = 999.0;
 	}
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "TrackFCAL_DOCA", locDistanceToNearestTrack_FCAL, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "TrackFCAL_DOCA", locDistanceToNearestTrack_FCAL, locArrayIndex, locMemoryMaps);
 
 	//PHOTON PID INFO
 	double locStartTimeError = locNeutralParticleHypothesis->t0_err();
 	double locPhotonRFDeltaTVar = (locNeutralParticleHypothesis->errorMatrix())(6, 6) + locStartTimeError*locStartTimeError;
 	if(locPID != Gamma)
 		locPhotonRFDeltaTVar = 0.0;
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "PhotonRFDeltaTVar", locPhotonRFDeltaTVar, locArrayIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "PhotonRFDeltaTVar", locPhotonRFDeltaTVar, locArrayIndex, locMemoryMaps);
 }
 
-void DEventWriterROOT::Fill_ComboData(TTree* locTree, const DParticleCombo* locParticleCombo, unsigned int locComboIndex, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const
+void DEventWriterROOT::Fill_ComboData(TTree* locTree, const DParticleCombo* locParticleCombo, unsigned int locComboIndex, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap, DBranchMemoryMaps locMemoryMaps) const
 {
 	//MAIN CLASSES
 	const DReaction* locReaction = locParticleCombo->Get_Reaction();
@@ -1617,11 +1626,11 @@ void DEventWriterROOT::Fill_ComboData(TTree* locTree, const DParticleCombo* locP
 	const DEventRFBunch* locEventRFBunch = locParticleCombo->Get_EventRFBunch();
 
 	//IS COMBO CUT
-	Fill_FundamentalData<Bool_t>(locTree, "IsComboCut", kFALSE, locComboIndex);
+	Fill_FundamentalData<Bool_t>(locTree, "IsComboCut", kFALSE, locComboIndex, locMemoryMaps);
 
 	//RF INFO
 	double locRFTime = (locEventRFBunch != NULL) ? locEventRFBunch->dTime : numeric_limits<double>::quiet_NaN();
-	Fill_FundamentalData<Float_t>(locTree, "RFTime_Measured", locRFTime, locComboIndex);
+	Fill_FundamentalData<Float_t>(locTree, "RFTime_Measured", locRFTime, locComboIndex, locMemoryMaps);
 
 	//KINFIT INFO
 	DKinFitType locKinFitType = locReaction->Get_KinFitType();
@@ -1630,29 +1639,29 @@ void DEventWriterROOT::Fill_ComboData(TTree* locTree, const DParticleCombo* locP
 	{
 		if(locKinFitResults != NULL)
 		{
-			Fill_FundamentalData<Float_t>(locTree, "ChiSq_KinFit", locKinFitResults->Get_ChiSq(), locComboIndex);
-			Fill_FundamentalData<UInt_t>(locTree, "NDF_KinFit", locKinFitResults->Get_NDF(), locComboIndex);
+			Fill_FundamentalData<Float_t>(locTree, "ChiSq_KinFit", locKinFitResults->Get_ChiSq(), locComboIndex, locMemoryMaps);
+			Fill_FundamentalData<UInt_t>(locTree, "NDF_KinFit", locKinFitResults->Get_NDF(), locComboIndex, locMemoryMaps);
 			if((locKinFitType == d_SpacetimeFit) || (locKinFitType == d_P4AndSpacetimeFit))
 			{
 				double locRFTime_KinFit = -9.9E9; //NOT IMPLEMENTED YET
-				Fill_FundamentalData<Float_t>(locTree, "RFTime_KinFit", locRFTime_KinFit, locComboIndex);
+				Fill_FundamentalData<Float_t>(locTree, "RFTime_KinFit", locRFTime_KinFit, locComboIndex, locMemoryMaps);
 			}
 		}
 		else
 		{
-			Fill_FundamentalData<Float_t>(locTree, "ChiSq_KinFit", 0.0, locComboIndex);
-			Fill_FundamentalData<UInt_t>(locTree, "NDF_KinFit", 0, locComboIndex);
+			Fill_FundamentalData<Float_t>(locTree, "ChiSq_KinFit", 0.0, locComboIndex, locMemoryMaps);
+			Fill_FundamentalData<UInt_t>(locTree, "NDF_KinFit", 0, locComboIndex, locMemoryMaps);
 			if((locKinFitType == d_SpacetimeFit) || (locKinFitType == d_P4AndSpacetimeFit))
-				Fill_FundamentalData<Float_t>(locTree, "RFTime_KinFit", -9.9E9, locComboIndex);
+				Fill_FundamentalData<Float_t>(locTree, "RFTime_KinFit", -9.9E9, locComboIndex, locMemoryMaps);
 		}
 	}
 
 	//STEP DATA
 	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
-		Fill_ComboStepData(locTree, locParticleCombo, loc_i, locComboIndex, locKinFitType, locObjectToArrayIndexMap);
+		Fill_ComboStepData(locTree, locParticleCombo, loc_i, locComboIndex, locKinFitType, locObjectToArrayIndexMap, locMemoryMaps);
 }
 
-void DEventWriterROOT::Fill_ComboStepData(TTree* locTree, const DParticleCombo* locParticleCombo, unsigned int locStepIndex, unsigned int locComboIndex, DKinFitType locKinFitType, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const
+void DEventWriterROOT::Fill_ComboStepData(TTree* locTree, const DParticleCombo* locParticleCombo, unsigned int locStepIndex, unsigned int locComboIndex, DKinFitType locKinFitType, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap, DBranchMemoryMaps locMemoryMaps) const
 {
 	TList* locUserInfo = locTree->GetUserInfo();
 	TMap* locPositionToNameMap = (TMap*)locUserInfo->FindObject("PositionToNameMap");
@@ -1670,13 +1679,13 @@ void DEventWriterROOT::Fill_ComboStepData(TTree* locTree, const DParticleCombo* 
 		const DKinematicData* locInitParticleMeasured = locParticleComboStep->Get_InitialParticle_Measured();
 		const DBeamPhoton* locMeasuredBeamPhoton = dynamic_cast<const DBeamPhoton*>(locInitParticleMeasured);
 		int locBeamIndex = locObjectToArrayIndexMap.find("DBeamPhoton")->second.find(locMeasuredBeamPhoton->id)->second;
-		Fill_ComboBeamData(locTree, locComboIndex, locBeamPhoton, locBeamIndex, locKinFitType);
+		Fill_ComboBeamData(locTree, locComboIndex, locBeamPhoton, locBeamIndex, locKinFitType, locMemoryMaps);
 	}
 	else //decaying
 	{
 		string locParticleBranchName = string("Decaying") + Convert_ToBranchName(ParticleType(locInitialPID));
 		if((locStepIndex == 0) || IsDetachedVertex(locInitialPID))
-			Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4", locStepTX4, locComboIndex);
+			Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4", locStepTX4, locComboIndex, locMemoryMaps);
 		if(IsFixedMass(locInitialPID) && ((locKinFitType == d_P4Fit) || (locKinFitType == d_P4AndVertexFit) || (locKinFitType == d_P4AndSpacetimeFit)))
 		{
 			TLorentzVector locDecayP4;
@@ -1689,7 +1698,7 @@ void DEventWriterROOT::Fill_ComboStepData(TTree* locTree, const DParticleCombo* 
 			}
 			else
 				locDecayP4.SetPxPyPzE(locInitialParticle->momentum().X(), locInitialParticle->momentum().Y(), locInitialParticle->momentum().Z(), locInitialParticle->energy());
-			Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_KinFit", locDecayP4, locComboIndex);
+			Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_KinFit", locDecayP4, locComboIndex, locMemoryMaps);
 		}
 	}
 
@@ -1721,7 +1730,7 @@ void DEventWriterROOT::Fill_ComboStepData(TTree* locTree, const DParticleCombo* 
 				else
 					locMissingP4.SetPxPyPzE(locKinematicData->momentum().X(), locKinematicData->momentum().Y(), locKinematicData->momentum().Z(), locKinematicData->energy());
 
-				Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_KinFit", locMissingP4, locComboIndex);
+				Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_KinFit", locMissingP4, locComboIndex, locMemoryMaps);
 			}
 			continue;
 		}
@@ -1744,7 +1753,7 @@ void DEventWriterROOT::Fill_ComboStepData(TTree* locTree, const DParticleCombo* 
 			const map<oid_t, int>& locObjectIDMap = locObjectToArrayIndexMap.find("DNeutralParticleHypothesis")->second;
 			int locNeutralIndex = locObjectIDMap.find(locAssociatedNeutralHypo->id)->second;
 
-			Fill_ComboNeutralData(locTree, locComboIndex, locParticleBranchName, locMeasuredNeutralHypo, locNeutralHypo, locNeutralIndex, locKinFitType);
+			Fill_ComboNeutralData(locTree, locComboIndex, locParticleBranchName, locMeasuredNeutralHypo, locNeutralHypo, locNeutralIndex, locKinFitType, locMemoryMaps);
 		}
 		else
 		{
@@ -1767,17 +1776,17 @@ void DEventWriterROOT::Fill_ComboStepData(TTree* locTree, const DParticleCombo* 
 			if(locChargedIndex == -1)
 				locChargedIndex = locObjectIDMap.find(locMeasuredChargedHypo->id)->second;
 
-			Fill_ComboChargedData(locTree, locComboIndex, locParticleBranchName, locMeasuredChargedHypo, locChargedHypo, locChargedIndex, locKinFitType);
+			Fill_ComboChargedData(locTree, locComboIndex, locParticleBranchName, locMeasuredChargedHypo, locChargedHypo, locChargedIndex, locKinFitType, locMemoryMaps);
 		}
 	}
 }
 
-void DEventWriterROOT::Fill_ComboBeamData(TTree* locTree, unsigned int locComboIndex, const DBeamPhoton* locBeamPhoton, unsigned int locBeamIndex, DKinFitType locKinFitType) const
+void DEventWriterROOT::Fill_ComboBeamData(TTree* locTree, unsigned int locComboIndex, const DBeamPhoton* locBeamPhoton, unsigned int locBeamIndex, DKinFitType locKinFitType, DBranchMemoryMaps locMemoryMaps) const
 {
 	string locParticleBranchName = "ComboBeam";
 
 	//IDENTIFIER
-	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "BeamIndex", locBeamIndex, locComboIndex);
+	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "BeamIndex", locBeamIndex, locComboIndex, locMemoryMaps);
 
 	//KINEMATICS: KINFIT
 	if(locKinFitType != d_NoFit)
@@ -1786,7 +1795,7 @@ void DEventWriterROOT::Fill_ComboBeamData(TTree* locTree, unsigned int locComboI
 		{
 			DVector3 locPosition = locBeamPhoton->position();
 			TLorentzVector locX4_KinFit(locPosition.X(), locPosition.Y(), locPosition.Z(), locBeamPhoton->time());
-			Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_KinFit", locX4_KinFit, locComboIndex);
+			Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_KinFit", locX4_KinFit, locComboIndex, locMemoryMaps);
 		}
 
 		//if charged, bends in b-field, update p4 when vertex changes
@@ -1794,15 +1803,15 @@ void DEventWriterROOT::Fill_ComboBeamData(TTree* locTree, unsigned int locComboI
 		{
 			DLorentzVector locDP4 = locBeamPhoton->lorentzMomentum();
 			TLorentzVector locP4_KinFit(locDP4.Px(), locDP4.Py(), locDP4.Pz(), locDP4.E());
-			Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_KinFit", locP4_KinFit, locComboIndex);
+			Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_KinFit", locP4_KinFit, locComboIndex, locMemoryMaps);
 		}
 	}
 }
 
-void DEventWriterROOT::Fill_ComboChargedData(TTree* locTree, unsigned int locComboIndex, string locParticleBranchName, const DChargedTrackHypothesis* locMeasuredChargedHypo, const DChargedTrackHypothesis* locChargedHypo, unsigned int locChargedIndex, DKinFitType locKinFitType) const
+void DEventWriterROOT::Fill_ComboChargedData(TTree* locTree, unsigned int locComboIndex, string locParticleBranchName, const DChargedTrackHypothesis* locMeasuredChargedHypo, const DChargedTrackHypothesis* locChargedHypo, unsigned int locChargedIndex, DKinFitType locKinFitType, DBranchMemoryMaps locMemoryMaps) const
 {
 	//IDENTIFIER
-	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "ChargedIndex", locChargedIndex, locComboIndex);
+	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "ChargedIndex", locChargedIndex, locComboIndex, locMemoryMaps);
 
 	//KINFIT
 	if(locKinFitType != d_NoFit)
@@ -1812,41 +1821,41 @@ void DEventWriterROOT::Fill_ComboChargedData(TTree* locTree, unsigned int locCom
 		{
 			DVector3 locPosition = locChargedHypo->position();
 			TLorentzVector locX4_KinFit(locPosition.X(), locPosition.Y(), locPosition.Z(), locChargedHypo->time());
-			Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_KinFit", locX4_KinFit, locComboIndex);
+			Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_KinFit", locX4_KinFit, locComboIndex, locMemoryMaps);
 		}
 
 		//update even if vertex-only fit, because charged momentum propagated through b-field
 		DLorentzVector locDP4 = locChargedHypo->lorentzMomentum();
 		TLorentzVector locP4_KinFit(locDP4.Px(), locDP4.Py(), locDP4.Pz(), locDP4.E());
-		Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_KinFit", locP4_KinFit, locComboIndex);
+		Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_KinFit", locP4_KinFit, locComboIndex, locMemoryMaps);
 
 		//PID INFO
 		if(locKinFitType != d_P4Fit)
 		{
-			Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Beta_Timing_KinFit", locChargedHypo->measuredBeta(), locComboIndex);
-			Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_Timing_KinFit", locChargedHypo->dChiSq_Timing, locComboIndex);
+			Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Beta_Timing_KinFit", locChargedHypo->measuredBeta(), locComboIndex, locMemoryMaps);
+			Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_Timing_KinFit", locChargedHypo->dChiSq_Timing, locComboIndex, locMemoryMaps);
 		}
 	}
 }
 
-void DEventWriterROOT::Fill_ComboNeutralData(TTree* locTree, unsigned int locComboIndex, string locParticleBranchName, const DNeutralParticleHypothesis* locMeasuredNeutralHypo, const DNeutralParticleHypothesis* locNeutralHypo, unsigned int locNeutralIndex, DKinFitType locKinFitType) const
+void DEventWriterROOT::Fill_ComboNeutralData(TTree* locTree, unsigned int locComboIndex, string locParticleBranchName, const DNeutralParticleHypothesis* locMeasuredNeutralHypo, const DNeutralParticleHypothesis* locNeutralHypo, unsigned int locNeutralIndex, DKinFitType locKinFitType, DBranchMemoryMaps locMemoryMaps) const
 {
 	//IDENTIFIER
-	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "NeutralIndex", locNeutralIndex, locComboIndex);
+	Fill_FundamentalData<Int_t>(locTree, locParticleBranchName, "NeutralIndex", locNeutralIndex, locComboIndex, locMemoryMaps);
 
 	//KINEMATICS: MEASURED
 	DVector3 locPosition = locMeasuredNeutralHypo->position();
 	TLorentzVector locX4_Measured(locPosition.X(), locPosition.Y(), locPosition.Z(), locMeasuredNeutralHypo->time());
-	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_Measured", locX4_Measured, locComboIndex);
+	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_Measured", locX4_Measured, locComboIndex, locMemoryMaps);
 
 	DLorentzVector locDP4 = locMeasuredNeutralHypo->lorentzMomentum();
 	TLorentzVector locP4_Measured(locDP4.Px(), locDP4.Py(), locDP4.Pz(), locDP4.E());
-	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_Measured", locP4_Measured, locComboIndex);
+	Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_Measured", locP4_Measured, locComboIndex, locMemoryMaps);
 
 	//MEASURED PID INFO
-	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Beta_Timing_Measured", locMeasuredNeutralHypo->measuredBeta(), locComboIndex);
+	Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Beta_Timing_Measured", locMeasuredNeutralHypo->measuredBeta(), locComboIndex, locMemoryMaps);
 	if(locParticleBranchName.substr(0, 6) == "Photon")
-		Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_Timing_Measured", locMeasuredNeutralHypo->dChiSq, locComboIndex);
+		Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_Timing_Measured", locMeasuredNeutralHypo->dChiSq, locComboIndex, locMemoryMaps);
 
 	//KINFIT
 	if(locKinFitType != d_NoFit)
@@ -1856,21 +1865,20 @@ void DEventWriterROOT::Fill_ComboNeutralData(TTree* locTree, unsigned int locCom
 		{
 			DVector3 locPosition = locNeutralHypo->position();
 			TLorentzVector locX4_KinFit(locPosition.X(), locPosition.Y(), locPosition.Z(), locNeutralHypo->time());
-			Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_KinFit", locX4_KinFit, locComboIndex);
+			Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "X4_KinFit", locX4_KinFit, locComboIndex, locMemoryMaps);
 		}
 
 		//update even if vertex-only fit, because neutral momentum defined by vertex
 		DLorentzVector locDP4 = locNeutralHypo->lorentzMomentum();
 		TLorentzVector locP4_KinFit(locDP4.Px(), locDP4.Py(), locDP4.Pz(), locDP4.E());
-		Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_KinFit", locP4_KinFit, locComboIndex);
+		Fill_ClonesData<TLorentzVector>(locTree, locParticleBranchName, "P4_KinFit", locP4_KinFit, locComboIndex, locMemoryMaps);
 
 		//PID INFO
 		if(locKinFitType != d_P4Fit)
 		{
-			Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Beta_Timing_KinFit", locNeutralHypo->measuredBeta(), locComboIndex);
+			Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "Beta_Timing_KinFit", locNeutralHypo->measuredBeta(), locComboIndex, locMemoryMaps);
 			if(locParticleBranchName.substr(0, 6) == "Photon")
-				Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_Timing_KinFit", locNeutralHypo->dChiSq, locComboIndex);
+				Fill_FundamentalData<Float_t>(locTree, locParticleBranchName, "ChiSq_Timing_KinFit", locNeutralHypo->dChiSq, locComboIndex, locMemoryMaps);
 		}
 	}
 }
-

--- a/src/libraries/ANALYSIS/DEventWriterROOT.h
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.h
@@ -67,7 +67,7 @@ class DEventWriterROOT : public JObject
 		virtual void Fill_CustomBranches_DataTree(TTree* locTree, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns,
 				const DMCThrownMatching* locMCThrownMatching, const DDetectorMatches* locDetectorMatches,
 				const vector<const DBeamPhoton*>& locBeamPhotons, const vector<const DChargedTrackHypothesis*>& locChargedHypos,
-				const vector<const DNeutralParticle*>& locNeutralParticles, const deque<const DParticleCombo*>& locParticleCombos) const{};
+				const vector<const DNeutralParticleHypothesis*>& locNeutralHypos, const deque<const DParticleCombo*>& locParticleCombos) const{};
 
 		//UTILITY FUNCTIONS
 		string Convert_ToBranchName(string locInputName) const;
@@ -195,6 +195,10 @@ class DEventWriterROOT : public JObject
 				const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const;
 		void Fill_ThrownParticleData(TTree* locTree, unsigned int locArrayIndex, const DMCThrown* locMCThrown, const map<const DMCThrown*, unsigned int>& locThrownIndexMap,
 				const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const;
+
+		//TREE FILLING: GET HYPOTHESES
+		vector<const DChargedTrackHypothesis*> Get_ChargedHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs) const;
+		vector<const DNeutralParticleHypothesis*> Get_NeutralHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs) const;
 
 		//TREE FILLING: INDEPENDENT PARTICLES
 		void Fill_BeamData(TTree* locTree, unsigned int locArrayIndex, const DBeamPhoton* locBeamPhoton, const DVertex* locVertex, const DMCThrownMatching* locMCThrownMatching) const;

--- a/src/libraries/ANALYSIS/DEventWriterROOT.h
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.h
@@ -159,6 +159,10 @@ class DEventWriterROOT : public JObject
 		//keep track of the output files
 		deque<TFile*>& Get_OutputROOTFiles(void) const;
 
+		// When creating ROOT histograms, should still acquire JANA-wide ROOT lock (e.g. modifying gDirectory)
+		// This mutex is shared by every DEventWriterROOT object. This is used to control access to these static member functions. 
+		pthread_rwlock_t* dWriterLock;
+
 		/****************************************************************************************************************************************/
 
 		void Get_Reactions(jana::JEventLoop* locEventLoop, vector<const DReaction*>& locReactions) const;

--- a/src/libraries/ANALYSIS/DEventWriterROOT.h
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.h
@@ -89,15 +89,15 @@ class DEventWriterROOT : public JObject
 
 		//BRANCH FILLING: //with the full branch name
 		template <typename DType> void Fill_FundamentalData(TTree* locTree, string locBranchName, DType locValue) const;
-		template <typename DType> void Fill_FundamentalData(TTree* locTree, string locBranchName, DType locValue, unsigned int locArrayIndex, DBranchMemoryMaps locMemoryMaps) const;
-		template <typename DType> void Fill_ClonesData(TTree* locTree, string locBranchName, DType& locObject, unsigned int locArrayIndex, DBranchMemoryMaps locMemoryMaps) const;
-		template <typename DType> void Fill_TObjectData(TTree* locTree, string locBranchName, DType& locObject, DBranchMemoryMaps locMemoryMaps) const;
+		template <typename DType> void Fill_FundamentalData(TTree* locTree, string locBranchName, DType locValue, unsigned int locArrayIndex) const;
+		template <typename DType> void Fill_ClonesData(TTree* locTree, string locBranchName, DType& locObject, unsigned int locArrayIndex) const;
+		template <typename DType> void Fill_TObjectData(TTree* locTree, string locBranchName, DType& locObject) const;
 
 		//BRANCH FILLING: //with separate particle & variable names (from which the branch name is made)
 		template <typename DType> void Fill_FundamentalData(TTree* locTree, string locParticleBranchName, string locVariableName, DType locValue) const;
-		template <typename DType> void Fill_FundamentalData(TTree* locTree, string locParticleBranchName, string locVariableName, DType locValue, unsigned int locArrayIndex, DBranchMemoryMaps locMemoryMaps) const;
-		template <typename DType> void Fill_ClonesData(TTree* locTree, string locParticleBranchName, string locVariableName, DType& locObject, unsigned int locArrayIndex, DBranchMemoryMaps locMemoryMaps) const;
-		template <typename DType> void Fill_TObjectData(TTree* locTree, string locParticleBranchName, string locVariableName, DType& locObject, DBranchMemoryMaps locMemoryMaps) const;
+		template <typename DType> void Fill_FundamentalData(TTree* locTree, string locParticleBranchName, string locVariableName, DType locValue, unsigned int locArrayIndex) const;
+		template <typename DType> void Fill_ClonesData(TTree* locTree, string locParticleBranchName, string locVariableName, DType& locObject, unsigned int locArrayIndex) const;
+		template <typename DType> void Fill_TObjectData(TTree* locTree, string locParticleBranchName, string locVariableName, DType& locObject) const;
 
 		const DAnalysisUtilities* dAnalysisUtilities;
 
@@ -161,25 +161,6 @@ class DEventWriterROOT : public JObject
 		//keep track of the ttrees
 		map<string, TTree*>& Get_TTreeMap(void) const;
 
-		// When creating ROOT histograms, should still acquire JANA-wide ROOT lock (e.g. modifying gDirectory)
-		// This mutex is shared by every DEventWriterROOT object. This is used to control access to these static member functions. 
-		pthread_rwlock_t* dWriterLock;
-		void Lock_Writer(void);
-		void Unlock_Writer(void);
-
-		//The above memory maps must be passed into the branch fill functions
-		//They keep track of the memory locations & array sizes for the branch memory
-		//The fill functions cannot grab them directly from the static maps because:
-			//You need a writer-lock to access the static maps, and the fill functions are already in a file-lock: deadlock
-		//However, the create functions can access the maps directly, because those are called from within the writer-lock
-		struct DBranchMemoryMaps
-		{
-			//for a given TTree //string is branch name
-			map<string, unsigned int>* dFundamentalArraySizeMap;
-			map<string, TObject*>* dTObjectMap;
-			map<string, TClonesArray*>* dClonesArrayMap;
-		};
-
 		/****************************************************************************************************************************************/
 
 		void Get_Reactions(jana::JEventLoop* locEventLoop, vector<const DReaction*>& locReactions) const;
@@ -208,31 +189,31 @@ class DEventWriterROOT : public JObject
 		void Group_ThrownParticles(const vector<const DMCThrown*>& locMCThrowns_FinalState, const vector<const DMCThrown*>& locMCThrowns_Decaying,
 				vector<const DMCThrown*>& locMCThrownsToSave, map<const DMCThrown*, unsigned int>& locThrownIndexMap) const;
 		void Fill_ThrownInfo(TTree* locTree, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns,
-				const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying, DBranchMemoryMaps locMemoryMaps) const;
+				const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying) const;
 		void Fill_ThrownInfo(TTree* locTree, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns,
 				const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying,
-				const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap, DBranchMemoryMaps locMemoryMaps) const;
+				const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const;
 		void Fill_ThrownParticleData(TTree* locTree, unsigned int locArrayIndex, const DMCThrown* locMCThrown, const map<const DMCThrown*, unsigned int>& locThrownIndexMap,
-				const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap, DBranchMemoryMaps locMemoryMaps) const;
+				const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const;
 
 		//TREE FILLING: INDEPENDENT PARTICLES
-		void Fill_BeamData(TTree* locTree, unsigned int locArrayIndex, const DBeamPhoton* locBeamPhoton, const DVertex* locVertex, const DMCThrownMatching* locMCThrownMatching, DBranchMemoryMaps locMemoryMaps) const;
+		void Fill_BeamData(TTree* locTree, unsigned int locArrayIndex, const DBeamPhoton* locBeamPhoton, const DVertex* locVertex, const DMCThrownMatching* locMCThrownMatching) const;
 		void Fill_ChargedHypo(TTree* locTree, unsigned int locArrayIndex, const DChargedTrackHypothesis* locChargedTrackHypothesis, const DMCThrownMatching* locMCThrownMatching,
-				const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DDetectorMatches* locDetectorMatches, DBranchMemoryMaps locMemoryMaps) const;
+				const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DDetectorMatches* locDetectorMatches) const;
 		void Fill_NeutralHypo(TTree* locTree, unsigned int locArrayIndex, const DNeutralParticleHypothesis* locPhotonHypothesis, const DMCThrownMatching* locMCThrownMatching,
-				const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DDetectorMatches* locDetectorMatches, DBranchMemoryMaps locMemoryMaps) const;
+				const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DDetectorMatches* locDetectorMatches) const;
 
 		//TREE FILLING: COMBO
-		void Fill_ComboData(TTree* locTree, const DParticleCombo* locParticleCombo, unsigned int locComboIndex, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap, DBranchMemoryMaps locMemoryMaps) const;
+		void Fill_ComboData(TTree* locTree, const DParticleCombo* locParticleCombo, unsigned int locComboIndex, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const;
 		void Fill_ComboStepData(TTree* locTree, const DParticleCombo* locParticleCombo, unsigned int locStepIndex, unsigned int locComboIndex,
-				DKinFitType locKinFitType, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap, DBranchMemoryMaps locMemoryMaps) const;
+				DKinFitType locKinFitType, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const;
 
 		//TREE FILLING: COMBO PARTICLES
-		void Fill_ComboBeamData(TTree* locTree, unsigned int locComboIndex, const DBeamPhoton* locBeamPhoton, unsigned int locBeamIndex, DKinFitType locKinFitType, DBranchMemoryMaps locMemoryMaps) const;
+		void Fill_ComboBeamData(TTree* locTree, unsigned int locComboIndex, const DBeamPhoton* locBeamPhoton, unsigned int locBeamIndex, DKinFitType locKinFitType) const;
 		void Fill_ComboChargedData(TTree* locTree, unsigned int locComboIndex, string locParticleBranchName, const DChargedTrackHypothesis* locMeasuredChargedHypo,
-				const DChargedTrackHypothesis* locChargedHypo, unsigned int locChargedIndex, DKinFitType locKinFitType, DBranchMemoryMaps locMemoryMaps) const;
+				const DChargedTrackHypothesis* locChargedHypo, unsigned int locChargedIndex, DKinFitType locKinFitType) const;
 		void Fill_ComboNeutralData(TTree* locTree, unsigned int locComboIndex, string locParticleBranchName, const DNeutralParticleHypothesis* locMeasuredNeutralHypo,
-				const DNeutralParticleHypothesis* locNeutralHypo, unsigned int locNeutralIndex, DKinFitType locKinFitType, DBranchMemoryMaps locMemoryMaps) const;
+				const DNeutralParticleHypothesis* locNeutralHypo, unsigned int locNeutralIndex, DKinFitType locKinFitType) const;
 
 		//For ROOT type string for fundamental data variables
 			//Defined in https://root.cern.ch/root/htmldoc/TTree.html
@@ -253,16 +234,6 @@ template<> struct DEventWriterROOT::DROOTTypeString<Double_t> { static const cha
 template<> struct DEventWriterROOT::DROOTTypeString<Long64_t> { static const char* GetTypeString() {return "L";} };
 template<> struct DEventWriterROOT::DROOTTypeString<ULong64_t> { static const char* GetTypeString() {return "l";} };
 template<> struct DEventWriterROOT::DROOTTypeString<Bool_t> { static const char* GetTypeString() {return "O";} };
-
-inline void DEventWriterROOT::Lock_Writer(void)
-{
-	pthread_rwlock_wrlock(dWriterLock);
-}
-
-inline void DEventWriterROOT::Unlock_Writer(void)
-{
-	pthread_rwlock_unlock(dWriterLock);
-}
 
 //BRANCH CREATION: //with separate particle & variable names (from which the branch name is made)
 template <typename DType> void DEventWriterROOT::Create_Branch_Fundamental(TTree* locTree, string locParticleBranchName, string locVariableName) const
@@ -324,24 +295,24 @@ template <typename DType> void DEventWriterROOT::Fill_FundamentalData(TTree* loc
 	Fill_FundamentalData<DType>(locTree, locBranchName, locValue);
 }
 
-template <typename DType> void DEventWriterROOT::Fill_FundamentalData(TTree* locTree, string locParticleBranchName, string locVariableName, DType locValue, unsigned int locArrayIndex, DBranchMemoryMaps locMemoryMaps) const
+template <typename DType> void DEventWriterROOT::Fill_FundamentalData(TTree* locTree, string locParticleBranchName, string locVariableName, DType locValue, unsigned int locArrayIndex) const
 {
 	string locBranchName = Build_BranchName(locParticleBranchName, locVariableName);
-	Fill_FundamentalData<DType>(locTree, locBranchName, locValue, locArrayIndex, locMemoryMaps);
+	Fill_FundamentalData<DType>(locTree, locBranchName, locValue, locArrayIndex);
 }
 
-template <typename DType> void DEventWriterROOT::Fill_ClonesData(TTree* locTree, string locParticleBranchName, string locVariableName, DType& locObject, unsigned int locArrayIndex, DBranchMemoryMaps locMemoryMaps) const
+template <typename DType> void DEventWriterROOT::Fill_ClonesData(TTree* locTree, string locParticleBranchName, string locVariableName, DType& locObject, unsigned int locArrayIndex) const
 {
 	//only call for objects inheriting from TObject*!!!
 	string locBranchName = Build_BranchName(locParticleBranchName, locVariableName);
-	Fill_ClonesData<DType>(locTree, locBranchName, locObject, locArrayIndex, locMemoryMaps);
+	Fill_ClonesData<DType>(locTree, locBranchName, locObject, locArrayIndex);
 }
 
-template <typename DType> void DEventWriterROOT::Fill_TObjectData(TTree* locTree, string locParticleBranchName, string locVariableName, DType& locObject, DBranchMemoryMaps locMemoryMaps) const
+template <typename DType> void DEventWriterROOT::Fill_TObjectData(TTree* locTree, string locParticleBranchName, string locVariableName, DType& locObject) const
 {
 	//only call for objects inheriting from TObject*!!!
 	string locBranchName = Build_BranchName(locParticleBranchName, locVariableName);
-	Fill_TObjectData<DType>(locTree, locBranchName, locObject, locMemoryMaps);
+	Fill_TObjectData<DType>(locTree, locBranchName, locObject);
 }
 
 //BRANCH FILLING: //with the full branch name
@@ -351,10 +322,10 @@ template <typename DType> void DEventWriterROOT::Fill_FundamentalData(TTree* loc
 	*locBranchPointer = locValue;
 }
 
-template <typename DType> void DEventWriterROOT::Fill_FundamentalData(TTree* locTree, string locBranchName, DType locValue, unsigned int locArrayIndex, DBranchMemoryMaps locMemoryMaps) const
+template <typename DType> void DEventWriterROOT::Fill_FundamentalData(TTree* locTree, string locBranchName, DType locValue, unsigned int locArrayIndex) const
 {
 	//create a new, larger array if the current one is too small
-	unsigned int& locCurrentArraySize = locMemoryMaps.dFundamentalArraySizeMap->find(locBranchName)->second;
+	unsigned int& locCurrentArraySize = Get_FundamentalArraySizeMap()[locTree][locBranchName];
 	DType* locBranchPointer = (DType*)locTree->GetBranch(locBranchName.c_str())->GetAddress();
 	if(locArrayIndex >= locCurrentArraySize)
 	{
@@ -371,18 +342,18 @@ template <typename DType> void DEventWriterROOT::Fill_FundamentalData(TTree* loc
 	locBranchPointer[locArrayIndex] = locValue;
 }
 
-template <typename DType> void DEventWriterROOT::Fill_ClonesData(TTree* locTree, string locBranchName, DType& locObject, unsigned int locArrayIndex, DBranchMemoryMaps locMemoryMaps) const
+template <typename DType> void DEventWriterROOT::Fill_ClonesData(TTree* locTree, string locBranchName, DType& locObject, unsigned int locArrayIndex) const
 {
 	//only call for objects inheriting from TObject*!!!
-	TClonesArray* locClonesArray = locMemoryMaps.dClonesArrayMap->find(locBranchName)->second;
+	TClonesArray* locClonesArray = Get_ClonesArrayMap()[locTree][locBranchName];
 	DType* locConstructedObject = (DType*)locClonesArray->ConstructedAt(locArrayIndex);
 	*locConstructedObject = locObject;
 }
 
-template <typename DType> void DEventWriterROOT::Fill_TObjectData(TTree* locTree, string locBranchName, DType& locObject, DBranchMemoryMaps locMemoryMaps) const
+template <typename DType> void DEventWriterROOT::Fill_TObjectData(TTree* locTree, string locBranchName, DType& locObject) const
 {
 	//only call for objects inheriting from TObject*!!!
-	DType* locDType = (DType*)locMemoryMaps.dTObjectMap->find(locBranchName)->second;
+	DType* locDType = (DType*)Get_TObjectMap()[locTree][locBranchName];
 	*locDType = locObject;
 }
 

--- a/src/libraries/ANALYSIS/DEventWriterROOT.h
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.h
@@ -167,7 +167,7 @@ class DEventWriterROOT : public JObject
 
 		//TREE CREATION:
 		void Create_DataTree(const DReaction* locReaction, bool locIsMCDataFlag, double locTargetCenterZ) const;
-		void Create_UserInfoMaps(TTree* locTree, const DReaction* locReaction, map<Particle_t, unsigned int>& locParticleNumberMap, double locTargetCenterZ) const;
+		TMap* Create_UserInfoMaps(TTree* locTree, const DReaction* locReaction, double locTargetCenterZ) const;
 		void Create_UserTargetInfo(TTree* locTree, Particle_t locTargetPID, double locTargetCenterZ) const;
 		void Create_Branches_Thrown(TTree* locTree, bool locIsOnlyThrownFlag) const;
 
@@ -178,7 +178,8 @@ class DEventWriterROOT : public JObject
 		void Create_Branches_ChargedHypotheses(TTree* locTree, bool locIsMCDataFlag) const;
 
 		//TREE CREATION: COMBO INFO
-		void Create_Branches_Combo(TTree* locTree, const DReaction* locReaction, bool locIsMCDataFlag, const map<Particle_t, unsigned int>& locParticleNumberMap) const;
+			//TMap is locPositionToNameMap
+		void Create_Branches_Combo(TTree* locTree, const DReaction* locReaction, bool locIsMCDataFlag, TMap* locPositionToNameMap) const;
 		void Create_Branches_BeamComboParticle(TTree* locTree, Particle_t locBeamPID, DKinFitType locKinFitType) const;
 		void Create_Branches_ComboTrack(TTree* locTree, string locParticleBranchName, DKinFitType locKinFitType) const;
 		void Create_Branches_ComboNeutral(TTree* locTree, string locParticleBranchName, DKinFitType locKinFitType) const;

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -512,7 +512,7 @@ void DHistogramAction_TrackVertexComparison::Initialize(JEventLoop* locEventLoop
 	deque<deque<Particle_t> > locDetectedChargedPIDs_HasDupes;
 	Get_Reaction()->Get_DetectedFinalPIDs(locDetectedChargedPIDs_HasDupes, 1, true);
 
-	string locHistName, locHistTitle, locStepName, locStepROOTName, locParticleName, locParticleROOTName;
+	string locHistName, locHistTitle, locStepROOTName, locParticleName, locParticleROOTName;
 	Particle_t locPID, locHigherMassPID, locLowerMassPID;
 	string locHigherMassParticleName, locLowerMassParticleName, locHigherMassParticleROOTName, locLowerMassParticleROOTName;
 
@@ -540,9 +540,10 @@ void DHistogramAction_TrackVertexComparison::Initialize(JEventLoop* locEventLoop
 				continue;
 
 			const DReactionStep* locReactionStep = Get_Reaction()->Get_ReactionStep(loc_i);
-			locStepName = locReactionStep->Get_StepName();
+			ostringstream locStepName;
+			locStepName << "Step" << loc_i << "__" << locReactionStep->Get_StepName();
 			locStepROOTName = locReactionStep->Get_StepROOTName();
-			CreateAndChangeTo_Directory(locStepName, locStepName);
+			CreateAndChangeTo_Directory(locStepName.str(), locStepName.str());
 
 			// Max Track DeltaZ
 			locHistName = "MaxTrackDeltaZ";
@@ -753,7 +754,7 @@ void DHistogramAction_ParticleComboKinematics::Initialize(JEventLoop* locEventLo
 	vector<const DParticleID*> locParticleIDs;
 	locEventLoop->Get(locParticleIDs);
 
-	string locHistName, locHistTitle, locStepName, locStepROOTName, locParticleName, locParticleROOTName;
+	string locHistName, locHistTitle, locStepROOTName, locParticleName, locParticleROOTName;
 	Particle_t locPID;
 
 	size_t locNumSteps = Get_Reaction()->Get_NumReactionSteps();
@@ -853,7 +854,8 @@ void DHistogramAction_ParticleComboKinematics::Initialize(JEventLoop* locEventLo
 		for(size_t loc_i = 0; loc_i < locNumSteps; ++loc_i)
 		{
 			const DReactionStep* locReactionStep = Get_Reaction()->Get_ReactionStep(loc_i);
-			locStepName = locReactionStep->Get_StepName();
+			ostringstream locStepName;
+			locStepName << "Step" << loc_i << "__" << locReactionStep->Get_StepName();
 			locStepROOTName = locReactionStep->Get_StepROOTName();
 
 			Particle_t locInitialPID = locReactionStep->Get_InitialParticleID();
@@ -879,7 +881,7 @@ void DHistogramAction_ParticleComboKinematics::Initialize(JEventLoop* locEventLo
 
 				if(!locDirectoryCreatedFlag)
 				{
-					CreateAndChangeTo_Directory(locStepName, locStepName);
+					CreateAndChangeTo_Directory(locStepName.str(), locStepName.str());
 					locDirectoryCreatedFlag = true;
 				}
 
@@ -945,7 +947,7 @@ void DHistogramAction_ParticleComboKinematics::Initialize(JEventLoop* locEventLo
 			{
 				if(!locDirectoryCreatedFlag)
 				{
-					CreateAndChangeTo_Directory(locStepName, locStepName);
+					CreateAndChangeTo_Directory(locStepName.str(), locStepName.str());
 					locDirectoryCreatedFlag = true;
 				}
 
@@ -967,7 +969,7 @@ void DHistogramAction_ParticleComboKinematics::Initialize(JEventLoop* locEventLo
 			{
 				if(!locDirectoryCreatedFlag)
 				{
-					CreateAndChangeTo_Directory(locStepName, locStepName);
+					CreateAndChangeTo_Directory(locStepName.str(), locStepName.str());
 					locDirectoryCreatedFlag = true;
 				}
 
@@ -1637,7 +1639,8 @@ void DHistogramAction_KinFitResults::Initialize(JEventLoop* locEventLoop)
 		for(size_t loc_i = 0; loc_i < Get_Reaction()->Get_NumReactionSteps(); ++loc_i)
 		{
 			const DReactionStep* locReactionStep = Get_Reaction()->Get_ReactionStep(loc_i);
-			string locStepName = locReactionStep->Get_StepName();
+			ostringstream locStepName;
+			locStepName << "Step" << loc_i << "__" << locReactionStep->Get_StepName();
 			string locStepROOTName = locReactionStep->Get_StepROOTName();
 
 			deque<Particle_t> locPIDs;
@@ -1715,7 +1718,7 @@ void DHistogramAction_KinFitResults::Initialize(JEventLoop* locEventLoop)
 					continue; //vertex-only fit: neutral shower does not constrain: no pulls
 
 				if(locPIDSet.empty()) //first call
-					CreateAndChangeTo_Directory(locStepName, locStepName);
+					CreateAndChangeTo_Directory(locStepName.str(), locStepName.str());
 
 				string locParticleName = ParticleType(locPID);
 				CreateAndChangeTo_Directory(locParticleName, locParticleName);

--- a/src/libraries/ANALYSIS/DNeutralParticleHypothesis_factory_Combo.cc
+++ b/src/libraries/ANALYSIS/DNeutralParticleHypothesis_factory_Combo.cc
@@ -42,7 +42,7 @@ jerror_t DNeutralParticleHypothesis_factory_Combo::brun(jana::JEventLoop *locEve
 	// DReaction objects. (A simpler way to do this would be to
 	// just use locEventLoop->Get(...), but then only one plugin could
 	// be used at a time.)
-	vector<const DReaction*> locReactions;
+	dReactions.clear();
 	vector<JFactory_base*> locFactories = locEventLoop->GetFactories();
 	for(size_t loc_i = 0; loc_i < locFactories.size(); ++loc_i)
 	{
@@ -57,16 +57,16 @@ jerror_t DNeutralParticleHypothesis_factory_Combo::brun(jana::JEventLoop *locEve
 		// overall list.
 		vector<const DReaction*> locReactionsSubset;
 		locFactory->Get(locReactionsSubset);
-		locReactions.insert(locReactions.end(), locReactionsSubset.begin(), locReactionsSubset.end());
+		dReactions.insert(dReactions.end(), locReactionsSubset.begin(), locReactionsSubset.end());
 	}
 
 	//build list of all needed neutral PIDs
-	for(size_t loc_i = 0; loc_i < locReactions.size(); ++loc_i)
+	for(size_t loc_i = 0; loc_i < dReactions.size(); ++loc_i)
 	{
 		deque<Particle_t> locDetectedNeutralPIDs;
-		locReactions[loc_i]->Get_DetectedFinalPIDs(locDetectedNeutralPIDs, 2, false);
+		dReactions[loc_i]->Get_DetectedFinalPIDs(locDetectedNeutralPIDs, 2, false);
 		for(size_t loc_j = 0; loc_j < locDetectedNeutralPIDs.size(); ++loc_j)
-			dNeutralPIDs.insert(locDetectedNeutralPIDs[loc_j]);
+			dNeutralPIDs[locDetectedNeutralPIDs[loc_j]].push_back(dReactions[loc_i]);
 	}
 
 	return NOERROR;
@@ -84,11 +84,28 @@ jerror_t DNeutralParticleHypothesis_factory_Combo::evnt(jana::JEventLoop *locEve
 	vector<const DEventRFBunch*> locEventRFBunches;
 	locEventLoop->Get(locEventRFBunches, "Combo");
 
-	vector<const DNeutralShower*> locNeutralShowers;
-	locEventLoop->Get(locNeutralShowers, dShowerSelectionTag.c_str());
+	vector<const DNeutralParticle*> locNeutralParticles;
+	locEventLoop->Get(locNeutralParticles, dShowerSelectionTag.c_str());
+
+	vector<const DNeutralParticleHypothesis*> locOrigNeutralParticleHypotheses;
+	locEventLoop->Get(locOrigNeutralParticleHypotheses);
 
 	const DVertex* locVertex = NULL;
 	locEventLoop->GetSingle(locVertex);
+
+	//pre-sort rf bunches
+	//for each PID, what are the rf bunches that I need? determined via links to reactions
+	map<const DReaction*, set<const DEventRFBunch*> > locRFBunchReactionMap;
+	for(size_t loc_i = 0; loc_i < dReactions.size(); ++loc_i)
+	{
+		for(size_t loc_j = 0; loc_j < locEventRFBunches.size(); ++loc_j)
+		{
+			if(locEventRFBunches[loc_j]->IsAssociated(dReactions[loc_i]))
+				locRFBunchReactionMap[dReactions[loc_i]].insert(locEventRFBunches[loc_j]);
+		}
+	}
+	map<Particle_t, set<const DEventRFBunch*> > locRFBunchPIDMap;
+	Build_RFPIDMap(dNeutralPIDs, locRFBunchReactionMap, locRFBunchPIDMap);
 
 	//assume that: for each RF bunch, must calculate each PID FOM for each shower
 		//is true unless: somehow for a given combination of the above, it always fails an invariant mass cut
@@ -96,24 +113,55 @@ jerror_t DNeutralParticleHypothesis_factory_Combo::evnt(jana::JEventLoop *locEve
 		//and it's WAY faster than looping over EVERY blueprint and checking what the exceptions are
 			//scales much better this way
 
-	set<Particle_t>::iterator locIterator = dNeutralPIDs.begin();
-	for(; locIterator != dNeutralPIDs.end(); ++locIterator)
+	for(size_t loc_j = 0; loc_j < locNeutralParticles.size(); ++loc_j)
 	{
-		for(size_t loc_i = 0; loc_i < locEventRFBunches.size(); ++loc_i)
+		map<Particle_t, vector<const DReaction*> >::const_iterator locPIDIterator = dNeutralPIDs.begin();
+		for(; locPIDIterator != dNeutralPIDs.end(); ++locPIDIterator)
 		{
-			for(size_t loc_j = 0; loc_j < locNeutralShowers.size(); ++loc_j)
+			Particle_t locPID = locPIDIterator->first;
+			vector<const DReaction*> locReactions = locPIDIterator->second;
+
+			//loop over rf bunches for this PID
+			set<const DEventRFBunch*> locRFBunches = locRFBunchPIDMap[locPID];
+			set<const DEventRFBunch*>::const_iterator locRFIterator = locRFBunches.begin();
+			for(; locRFIterator != locRFBunches.end(); ++locRFIterator)
 			{
-				//create the objects
-				DNeutralParticleHypothesis* locNeutralParticleHypothesis = dNeutralParticleHypothesisFactory->Create_DNeutralParticleHypothesis(locNeutralShowers[loc_j], *locIterator, locEventRFBunches[loc_i], locVertex);
+				//create
+				const DNeutralShower* locNeutralShower = locNeutralParticles[loc_j]->dNeutralShower;
+				DNeutralParticleHypothesis* locNeutralParticleHypothesis = dNeutralParticleHypothesisFactory->Create_DNeutralParticleHypothesis(locNeutralShower, locPID, *locRFIterator, locVertex);
 				if(locNeutralParticleHypothesis == NULL)
 					continue;
-				locNeutralParticleHypothesis->AddAssociatedObject(locEventRFBunches[loc_i]);
+
+				locNeutralParticleHypothesis->AddAssociatedObject(locNeutralParticles[loc_j]);
+				locNeutralParticleHypothesis->AddAssociatedObject(*locRFIterator);
+				for(size_t loc_k = 0; loc_k < locReactions.size(); ++loc_k)
+					locNeutralParticleHypothesis->AddAssociatedObject(locReactions[loc_k]);
+
+				const DNeutralParticleHypothesis* locOrigNeutralParticleHypothesis = locNeutralParticles[loc_j]->Get_Hypothesis(locPID);
+				if(locOrigNeutralParticleHypothesis != NULL)
+					locNeutralParticleHypothesis->AddAssociatedObject(locOrigNeutralParticleHypothesis);
+
 				_data.push_back(locNeutralParticleHypothesis);
 			}
 		}
 	}
 
 	return NOERROR;
+}
+
+void DNeutralParticleHypothesis_factory_Combo::Build_RFPIDMap(map<Particle_t, vector<const DReaction*> >& locPIDMap, map<const DReaction*, set<const DEventRFBunch*> >& locRFBunchReactionMap, map<Particle_t, set<const DEventRFBunch*> >& locRFBunchPIDMap)
+{
+	map<Particle_t, vector<const DReaction*> >::const_iterator locIterator = locPIDMap.begin();
+	for(; locIterator != locPIDMap.end(); ++locIterator)
+	{
+		Particle_t locPID = locIterator->first;
+		vector<const DReaction*> locReactions = locIterator->second;
+		for(size_t loc_i = 0; loc_i < locReactions.size(); ++loc_i)
+		{
+			set<const DEventRFBunch*>& locRFBunches = locRFBunchReactionMap[locReactions[loc_i]];
+			locRFBunchPIDMap[locPID].insert(locRFBunches.begin(), locRFBunches.end());
+		}
+	}
 }
 
 //------------------

--- a/src/libraries/ANALYSIS/DNeutralParticleHypothesis_factory_Combo.h
+++ b/src/libraries/ANALYSIS/DNeutralParticleHypothesis_factory_Combo.h
@@ -14,6 +14,7 @@
 #include <PID/DNeutralParticleHypothesis.h>
 #include "PID/DNeutralParticleHypothesis_factory.h"
 #include <PID/DNeutralShower.h>
+#include <PID/DNeutralParticle.h>
 #include <PID/DEventRFBunch.h>
 
 #include "ANALYSIS/DParticleComboBlueprint.h"
@@ -32,9 +33,12 @@ class DNeutralParticleHypothesis_factory_Combo:public jana::JFactory<DNeutralPar
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
+		void Build_RFPIDMap(map<Particle_t, vector<const DReaction*> >& locPIDMap, map<const DReaction*, set<const DEventRFBunch*> >& locRFBunchReactionMap, map<Particle_t, set<const DEventRFBunch*> >& locRFBunchPIDMap);
+
 		DNeutralParticleHypothesis_factory* dNeutralParticleHypothesisFactory;
 
-		set<Particle_t> dNeutralPIDs;
+		vector<const DReaction*> dReactions;
+		map<Particle_t, vector<const DReaction*> > dNeutralPIDs; //vector: reactions for which they are needed
 		string dShowerSelectionTag;
 };
 

--- a/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.cc
+++ b/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.cc
@@ -33,7 +33,7 @@ jerror_t DParticleComboBlueprint_factory::init(void)
 	{
 		locMassStream << hypotheses[loc_i];
 		if(loc_i != (hypotheses.size() - 1))
-			locMassStream << ", ";
+			locMassStream << ",";
 	}
 
 	string HYPOTHESES = locMassStream.str();

--- a/src/libraries/ANALYSIS/DReaction.cc
+++ b/src/libraries/ANALYSIS/DReaction.cc
@@ -41,7 +41,8 @@ string DReaction::Get_DetectedParticlesROOTName(void) const
 				continue; //missing particle
 
 			//see if this pid is a parent in a future step
-			if(Check_IsDecayingParticle(locPID, loc_i + 1))
+			int locDecayStepIndex = Get_DecayStepIndex(loc_i, loc_j);
+			if(locDecayStepIndex >= 0)
 				continue;
 
 			locDetectedParticlesROOTName += ParticleName_ROOT(locPID);
@@ -120,7 +121,8 @@ void DReaction::Get_DetectedFinalPIDs(deque<Particle_t>& locDetectedPIDs, int lo
 				continue; //wrong charge
 
 			//see if this pid is a parent in a future step
-			if(Check_IsDecayingParticle(locPID, loc_i + 1))
+			int locDecayStepIndex = Get_DecayStepIndex(loc_i, loc_j);
+			if(locDecayStepIndex >= 0)
 				continue;
 
 			if(!locIncludeDuplicatesFlag)
@@ -165,7 +167,8 @@ void DReaction::Get_DetectedFinalPIDs(deque<deque<Particle_t> >& locDetectedPIDs
 				continue; //wrong charge
 
 			//see if this pid is a parent in a future step
-			if(Check_IsDecayingParticle(locPID, loc_i + 1))
+			int locDecayStepIndex = Get_DecayStepIndex(loc_i, loc_j);
+			if(locDecayStepIndex >= 0)
 				continue;
 
 			if(!locIncludeDuplicatesFlag)
@@ -200,7 +203,8 @@ void DReaction::Get_FinalStatePIDs(deque<Particle_t>& locFinalStatePIDs, bool lo
 			locPID = dReactionSteps[loc_i]->Get_FinalParticleID(loc_j);
 
 			//see if this pid is a parent in a future step
-			if(Check_IsDecayingParticle(locPID, loc_i + 1))
+			int locDecayStepIndex = Get_DecayStepIndex(loc_i, loc_j);
+			if(locDecayStepIndex >= 0)
 				continue;
 
 			//see if this PID is already stored

--- a/src/libraries/ANALYSIS/DReaction.h
+++ b/src/libraries/ANALYSIS/DReaction.h
@@ -113,7 +113,6 @@ class DReaction : public JObject
 		bool Get_EnableTTreeOutputFlag(void) const{return dEnableTTreeOutputFlag;}
 
 		// OTHER:
-		bool Check_IsDecayingParticle(Particle_t locPID, size_t locSearchStartIndex = 1) const;
 		bool Check_AreStepsIdentical(const DReaction* locReaction) const;
 
 	private:
@@ -196,17 +195,6 @@ inline string DReaction::Get_DecayChainFinalParticlesROOTNames(Particle_t locIni
 		return Get_DecayChainFinalParticlesROOTNames(loc_i, locUpToStepIndex, locUpThroughPIDs, locKinFitResultsFlag, false);
 	}
 	return string("");
-}
-
-inline bool DReaction::Check_IsDecayingParticle(Particle_t locPID, size_t locSearchStartIndex) const
-{
-	//see if this pid is a parent in a future step
-	for(size_t loc_k = locSearchStartIndex; loc_k < dReactionSteps.size(); ++loc_k)
-	{
-		if(dReactionSteps[loc_k]->Get_InitialParticleID() == locPID)
-			return true;
-	}
-	return false;
 }
 
 inline void DReaction::Get_ReactionSteps(Particle_t locInitialPID, deque<const DReactionStep*>& locReactionSteps) const

--- a/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.cc
+++ b/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.cc
@@ -91,7 +91,7 @@ jerror_t DTrackTimeBased_factory_Combo::init(void)
 	{
 		locMassStream << hypotheses[loc_i];
 		if(loc_i != (hypotheses.size() - 1))
-			locMassStream << ", ";
+			locMassStream << ",";
 	}
 
 	string HYPOTHESES = locMassStream.str();

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -105,7 +105,7 @@ jerror_t DTrackTimeBased_factory::init(void)
 	{
 		locMassStream << hypotheses[loc_i];
 		if(loc_i != (hypotheses.size() - 1))
-			locMassStream << ", ";
+			locMassStream << ",";
 	}
 
 	string HYPOTHESES = locMassStream.str();

--- a/src/libraries/TRACKING/DTrackWireBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackWireBased_factory.cc
@@ -94,7 +94,7 @@ jerror_t DTrackWireBased_factory::init(void)
 		{
 			locMassStream << hypotheses[loc_i];
 			if(loc_i != (hypotheses.size() - 1))
-				locMassStream << ", ";
+				locMassStream << ",";
 		}
 
 		string HYPOTHESES = locMassStream.str();

--- a/src/libraries/include/particleType.h
+++ b/src/libraries/include/particleType.h
@@ -213,11 +213,11 @@ inline static char* ParticleType(Particle_t p)
   case RhoMinus:
     return (char*)"Rho-";
   case omega:
-    return (char*)"omega";
+    return (char*)"Omega";
   case EtaPrime:
     return (char*)"EtaPrime";
   case phiMeson:
-    return (char*)"phiMeson";
+    return (char*)"Phi";
   case a0_980:
     return (char*)"a0(980)";
   case f0_980:
@@ -501,11 +501,11 @@ inline static Particle_t ParticleEnum(const char* locParticleName)
     return RhoPlus;
   else if(strcmp(locParticleName, "Rho-") == 0)
     return RhoMinus;
-  else if(strcmp(locParticleName, "omega") == 0)
+  else if(strcmp(locParticleName, "Omega") == 0)
     return omega;
   else if(strcmp(locParticleName, "EtaPrime") == 0)
     return EtaPrime;
-  else if(strcmp(locParticleName, "phiMeson") == 0)
+  else if(strcmp(locParticleName, "Phi") == 0)
     return phiMeson;
   else if(strcmp(locParticleName, "a0(980)") == 0)
     return a0_980;


### PR DESCRIPTION
Compartmentalize locks during ROOT TTree filling: Unique lock per output file (TTree::Fill() flushes to file occasionally).  

Fixed bugs such that proper charged & neutral hypos are saved to the TTree. 

Fixed TTree, histogram bugs related to having multiple steps with the same decaying particle. 
