### PR TITLE
Convert global variables to function-scope statics, within private member functions.

### DIFF
--- a/src/libraries/HDDM/DEventWriterREST.h
+++ b/src/libraries/HDDM/DEventWriterREST.h
@@ -3,6 +3,7 @@
 
 #include <math.h>
 #include <vector>
+#include <string>
 
 #include <HDDM/hddm_r.hpp>
 
@@ -43,6 +44,10 @@ class DEventWriterREST : public JObject
 
 	private:
 		bool Write_RESTEvent(string locOutputFileName, hddm_r::HDDM& locRecord) const;
+
+		//contains static variables shared amongst threads
+		int& Get_NumEventWriterThreads(void) const; //acquire RESTWriter lock before modifying
+		map<string, pair<ofstream*, hddm_r::ostream*> >& Get_RESTOutputFilePointers(void) const;
 
 		string dOutputFileBaseName;
 		bool HDDM_USE_COMPRESSION;

--- a/src/plugins/Utilities/evio_writer/DEventWriterEVIO.h
+++ b/src/plugins/Utilities/evio_writer/DEventWriterEVIO.h
@@ -1,6 +1,7 @@
 #ifndef _DEventWriterEVIO_
 #define _DEventWriterEVIO_
 
+#include <map>
 #include <vector>
 #include <string>
 
@@ -38,6 +39,8 @@
 #include <DAQ/DEventTag.h>
 
 #include <DANA/DStatusBits.h>
+
+#include "HDEVIOWriter.h"
 
 using namespace std;
 using namespace jana;
@@ -100,6 +103,13 @@ class DEventWriterEVIO : public JObject
         
 		std::ofstream *ofs_debug_input;
 		std::ofstream *ofs_debug_output;
+
+	private:
+
+		//contain static variables shared amongst threads: acquire "EVIOWriter" write lock before calling
+		size_t& Get_NumEVIOOutputThreads(void) const;
+		map<string, HDEVIOWriter*>& Get_EVIOOutputters(void) const;
+		map<string, pthread_t>& Get_EVIOOutputThreads(void) const;
 
 };
 


### PR DESCRIPTION
Functionality is unchanged, this is just better coding practice. 
