### PR TITLE
Plugin locks

### DIFF
--- a/src/plugins/Analysis/DAQTree/JEventProcessor_DAQTree.cc
+++ b/src/plugins/Analysis/DAQTree/JEventProcessor_DAQTree.cc
@@ -264,9 +264,9 @@ jerror_t JEventProcessor_DAQTree::evnt(JEventLoop *loop, uint64_t eventnumber)
 	loop->Get(f250TriggerTime_vec);
 	sort(f250TriggerTime_vec.begin(), f250TriggerTime_vec.end(), Df250TriggerTime_cmp);
 
-	/// Trees are filled with data
-	japp->RootWriteLock();
-
+	// Trees are filled with data
+	// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+	japp->RootWriteLock(); //ACQUIRE ROOT LOCK
 
 	/// Df125WindowRawData
 	const uint32_t numDf125WRDpedsamps = 10;
@@ -962,7 +962,7 @@ jerror_t JEventProcessor_DAQTree::evnt(JEventLoop *loop, uint64_t eventnumber)
 		Df250TriggerTime_tree->Fill();
 	}
 
-	japp->RootUnLock();
+	japp->RootUnLock(); //RELEASE ROOT LOCK
 	
 	return NOERROR;
 }

--- a/src/plugins/Analysis/DAQTreeBCAL/JEventProcessor_DAQTreeBCAL.cc
+++ b/src/plugins/Analysis/DAQTreeBCAL/JEventProcessor_DAQTreeBCAL.cc
@@ -111,6 +111,13 @@ jerror_t JEventProcessor_DAQTreeBCAL::evnt(JEventLoop *loop, uint64_t eventnumbe
 	vector<const DBCALDigiHit*> bcaldigihits;
 	loop->Get(bcaldigihits);
 
+	// Get the DBCALTDCDigiHit objects
+	vector<const DBCALTDCDigiHit*> bcaltdcdigihits;
+	loop->Get(bcaltdcdigihits);
+
+	// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+	japp->RootWriteLock(); //ACQUIRE ROOT LOCK
+
 	// Loop over DBCALDigiHit objects
 	for(unsigned int i=0; i< bcaldigihits.size(); i++){
 
@@ -162,11 +169,6 @@ jerror_t JEventProcessor_DAQTreeBCAL::evnt(JEventLoop *loop, uint64_t eventnumbe
 		} catch (...) {}
 	}
 
-
-	// Get the DBCALTDCDigiHit objects
-	vector<const DBCALTDCDigiHit*> bcaltdcdigihits;
-	loop->Get(bcaltdcdigihits);
-
 	// Loop over DBCALTDCDigiHit objects
 	for(unsigned int i=0; i< bcaltdcdigihits.size(); i++){
 
@@ -191,6 +193,7 @@ jerror_t JEventProcessor_DAQTreeBCAL::evnt(JEventLoop *loop, uint64_t eventnumbe
 		BCALTDCdigi->Fill();
 	}
 
+	japp->RootUnLock(); //RELEASE ROOT LOCK
 
 	return NOERROR;
 }

--- a/src/plugins/Analysis/TPOL_tree/JEventProcessor_TPOL_tree.cc
+++ b/src/plugins/Analysis/TPOL_tree/JEventProcessor_TPOL_tree.cc
@@ -57,7 +57,7 @@ jerror_t JEventProcessor_TPOL_tree::init(void)
     //
     bool SAVE_WAVEFORMS = true;
     gPARMS->SetDefaultParameter("TPOL_tree:SAVE_WAVEFORMS",SAVE_WAVEFORMS);
-    japp->RootWriteLock();
+
     TPOL = new TTree("TPOL_tree","TPOL tree");
     TPOL->Branch("nadc",&nadc,"nadc/i");
     TPOL->Branch("eventnum",&eventnum,"eventnum/i");
@@ -86,7 +86,6 @@ jerror_t JEventProcessor_TPOL_tree::init(void)
     TPOL->Branch("t_tag",&t_tag,"t_tag/D");
     TPOL->Branch("E_diff",&E_diff,"E_diff/D");
     eventnum = 0;
-    japp->RootUnLock();
     //
     return NOERROR;
 }
@@ -143,6 +142,7 @@ jerror_t JEventProcessor_TPOL_tree::evnt(JEventLoop *loop, uint64_t eventnumber)
     loop->Get(taghhits);
     vector<const DTAGMHit*> tagmhits;
     loop->Get(tagmhits);
+
     japp->RootWriteLock();
     // PSC coincidences
     if (cpairs.size()>=1) {

--- a/src/plugins/Analysis/acceptance_hists/DEventProcessor_acceptance_hists.cc
+++ b/src/plugins/Analysis/acceptance_hists/DEventProcessor_acceptance_hists.cc
@@ -123,7 +123,7 @@ jerror_t DEventProcessor_acceptance_hists::evnt(JEventLoop *loop, uint64_t event
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	{
 		for(unsigned int i=0; i<fdchits.size(); i++){
 			if(fdchits[i]->type==0){
@@ -211,7 +211,7 @@ jerror_t DEventProcessor_acceptance_hists::evnt(JEventLoop *loop, uint64_t event
 			}
 		}
 	}
-	RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 	return NOERROR;
 }
@@ -222,13 +222,13 @@ jerror_t DEventProcessor_acceptance_hists::evnt(JEventLoop *loop, uint64_t event
 jerror_t DEventProcessor_acceptance_hists::erun(void)
 {
 	// Since we are modifying histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	{
 		CDC->Divide(thrown_charged);
 		FDC->Divide(thrown_charged);
 		CDC_FDC->Divide(thrown_charged);
 	}
-	RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 	return NOERROR;
 }

--- a/src/plugins/Analysis/b1pi_hists/DEventProcessor_b1pi_hists.cc
+++ b/src/plugins/Analysis/b1pi_hists/DEventProcessor_b1pi_hists.cc
@@ -39,7 +39,6 @@ jerror_t DEventProcessor_b1pi_hists::brun(JEventLoop *locEventLoop, int32_t runn
 	const DEventWriterROOT* locEventWriterROOT = NULL;
 	locEventLoop->GetSingle(locEventWriterROOT);
 	locEventWriterROOT->Create_DataTrees(locEventLoop);
-//	locEventWriterROOT->Create_ThrownTree("tree_b1pi_thrownmc.root");
 
 	return NOERROR;
 }
@@ -57,7 +56,6 @@ jerror_t DEventProcessor_b1pi_hists::evnt(JEventLoop *locEventLoop, uint64_t eve
 	const DEventWriterROOT* locEventWriterROOT = NULL;
 	locEventLoop->GetSingle(locEventWriterROOT);
 	locEventWriterROOT->Fill_DataTrees(locEventLoop, "b1pi_hists");
-//	locEventWriterROOT->Fill_ThrownTree(locEventLoop);
 
 	//Do Miscellaneous Cuts
 	bool locSaveEventFlag = false;

--- a/src/plugins/Analysis/bcal_calib/DEventProcessor_bcal_calib.cc
+++ b/src/plugins/Analysis/bcal_calib/DEventProcessor_bcal_calib.cc
@@ -94,6 +94,28 @@ jerror_t DEventProcessor_bcal_calib::init(void)
   DEBUG_PLOT_LINES=false;
   gPARMS->SetDefaultParameter("BCAL_CALIB:DEBUG_PLOT_LINES",DEBUG_PLOT_LINES);
 
+  if (DEBUG_HISTS){
+    
+    Hcdc_prob = (TH1F*)gROOT->FindObject("Hcdc_prob");
+    if (!Hcdc_prob){
+      Hcdc_prob=new TH1F("Hcdc_prob","Confidence level for time-based fit",100,0.0,1.); 
+    } 
+    Hcdcmatch = (TH1F*)gROOT->FindObject("Hcdcmatch");
+    if (!Hcdcmatch){
+      Hcdcmatch=new TH1F("Hcdcmatch","CDC hit matching distance",1000,0.0,50.); 
+    }
+    Hcdcmatch_stereo = (TH1F*)gROOT->FindObject("Hcdcmatch_stereo");
+    if (!Hcdcmatch_stereo){
+      Hcdcmatch_stereo=new TH1F("Hcdcmatch_stereo","CDC stereo hit matching distance",1000,0.0,50.); 
+    }
+    
+    Hbcalmatchxy=(TH2F*)gROOT->FindObject("Hbcalmatchxy");
+    if (!Hbcalmatchxy){
+      Hbcalmatchxy=new TH2F("Hbcalmatchxy","BCAL #deltay vs #deltax",400,-50.,50.,
+			    400,-50.,50.);
+    }
+  }
+
   return NOERROR;
 }
 
@@ -123,34 +145,6 @@ jerror_t DEventProcessor_bcal_calib::brun(JEventLoop *loop, int32_t runnumber)
   jcalib->Get("CDC/cdc_resolution_parms", cdc_res_parms);
   CDC_RES_PAR1 = cdc_res_parms["res_par1"];
   CDC_RES_PAR2 = cdc_res_parms["res_par2"];
-
-  dapp->Lock();
-
-  
-
-  if (DEBUG_HISTS){
-    
-    Hcdc_prob = (TH1F*)gROOT->FindObject("Hcdc_prob");
-    if (!Hcdc_prob){
-      Hcdc_prob=new TH1F("Hcdc_prob","Confidence level for time-based fit",100,0.0,1.); 
-    } 
-    Hcdcmatch = (TH1F*)gROOT->FindObject("Hcdcmatch");
-    if (!Hcdcmatch){
-      Hcdcmatch=new TH1F("Hcdcmatch","CDC hit matching distance",1000,0.0,50.); 
-    }
-    Hcdcmatch_stereo = (TH1F*)gROOT->FindObject("Hcdcmatch_stereo");
-    if (!Hcdcmatch_stereo){
-      Hcdcmatch_stereo=new TH1F("Hcdcmatch_stereo","CDC stereo hit matching distance",1000,0.0,50.); 
-    }
-    
-    Hbcalmatchxy=(TH2F*)gROOT->FindObject("Hbcalmatchxy");
-    if (!Hbcalmatchxy){
-      Hbcalmatchxy=new TH2F("Hbcalmatchxy","BCAL #deltay vs #deltax",400,-50.,50.,
-			    400,-50.,50.);
-    }
-  }
-
-  dapp->Unlock();
 
   return NOERROR;
 }

--- a/src/plugins/Analysis/bcalfcaltof_res_tree/DEventProcessor_bcalfcaltof_res_tree.cc
+++ b/src/plugins/Analysis/bcalfcaltof_res_tree/DEventProcessor_bcalfcaltof_res_tree.cc
@@ -160,7 +160,9 @@ jerror_t DEventProcessor_bcalfcaltof_res_tree::evnt(JEventLoop *loop, uint64_t e
 			locDeltaE = locBCALShower->E - locTrueE;
 			locDeltaT = locBCALShower->t - locTrueT;
 
-			LockState();
+			// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+			japp->RootWriteLock(); //ACQUIRE ROOT LOCK
+
 			dBCALMCComparison->dTrueR = locTrueR;
 			dBCALMCComparison->dTruePhi = locTruePhi;
 			dBCALMCComparison->dTrueZ = locTrueZ;
@@ -181,7 +183,7 @@ jerror_t DEventProcessor_bcalfcaltof_res_tree::evnt(JEventLoop *loop, uint64_t e
 
 			dPluginTree_BCALMCComparison->Fill();
 
-			UnlockState();
+			japp->RootUnLock(); //RELEASE ROOT LOCK
 		} //end DBCALShower loop
 
 	} //end BCAL
@@ -241,7 +243,8 @@ jerror_t DEventProcessor_bcalfcaltof_res_tree::evnt(JEventLoop *loop, uint64_t e
 			locDeltaE = locFCALShower->getEnergy() - locTrueE;
 			locDeltaT = locFCALShower->getTime() - locTrueT;
 
-			LockState();
+			// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+			japp->RootWriteLock(); //ACQUIRE ROOT LOCK
 
 			dFCALMCComparison->dTrueX = locTrueX;
 			dFCALMCComparison->dTrueY = locTrueY;
@@ -264,7 +267,7 @@ jerror_t DEventProcessor_bcalfcaltof_res_tree::evnt(JEventLoop *loop, uint64_t e
 
 			dPluginTree_FCALMCComparison->Fill();
 
-			UnlockState();
+			japp->RootUnLock(); //RELEASE ROOT LOCK
 		} //end DFCALShower loop
 
 	} //end FCAL
@@ -335,7 +338,8 @@ jerror_t DEventProcessor_bcalfcaltof_res_tree::evnt(JEventLoop *loop, uint64_t e
 				else{locVerticalPlaneFlag = true;}
 			}
 
-			LockState();
+			// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+			japp->RootWriteLock(); //ACQUIRE ROOT LOCK
 
 			dTOFMCComparison->dTrueX = locTrueX;
 			dTOFMCComparison->dTrueY = locTrueY;
@@ -352,8 +356,7 @@ jerror_t DEventProcessor_bcalfcaltof_res_tree::evnt(JEventLoop *loop, uint64_t e
 			dTOFMCComparison->dTrueBetaGamma = locTrueBetaGamma;
 			dPluginTree_TOFMCComparison->Fill();
 
-
-			UnlockState();
+			japp->RootUnLock(); //RELEASE ROOT LOCK
 		} //end DTOFPoint loop
 
 	} //end TOF

--- a/src/plugins/Analysis/candidate_tree/DEventProcessor_candidate_tree.h
+++ b/src/plugins/Analysis/candidate_tree/DEventProcessor_candidate_tree.h
@@ -47,6 +47,7 @@ class DEventProcessor_candidate_tree:public JEventProcessor{
 		
 		DCoordinateSystem target;
 		const DLorentzDeflections *lorentz_def;//< Correction to FDC cathodes due to Lorentz force
+		DMagneticFieldMap *bfield;
 
 		class hit_info_t{
 			public:
@@ -82,7 +83,6 @@ class DEventProcessor_candidate_tree:public JEventProcessor{
 		
 		int NLRbad, NLRgood, NLRfit_unknown;
 		int Nevents;
-		DReferenceTrajectory *rt;
 		
 		int Nwarnings;
 };

--- a/src/plugins/Analysis/cdc_covariance_hists/DEventProcessor_cdc_covariance_hists.h
+++ b/src/plugins/Analysis/cdc_covariance_hists/DEventProcessor_cdc_covariance_hists.h
@@ -35,7 +35,6 @@ class DEventProcessor_cdc_covariance_hists:public jana::JEventProcessor{
 		TProfile2D *cdc_cov_calc;
 		
 		const DMagneticFieldMap *bfield;
-		DReferenceTrajectory *rt;
 		
 	private:
 		jerror_t init(void);	///< Invoked via DEventProcessor virtual method

--- a/src/plugins/Analysis/cdc_hists/DEventProcessor_cdc_hists.h
+++ b/src/plugins/Analysis/cdc_hists/DEventProcessor_cdc_hists.h
@@ -57,7 +57,6 @@ class DEventProcessor_cdc_hists:public JEventProcessor{
 		pthread_mutex_t mutex;
 		
 		const DMagneticFieldMap *bfield;
-		DReferenceTrajectory *rt;
 };
 
 #endif // _DEventProcessor_cdc_hists_

--- a/src/plugins/Analysis/dc_alignment/DEventProcessor_dc_alignment.cc
+++ b/src/plugins/Analysis/dc_alignment/DEventProcessor_dc_alignment.cc
@@ -476,7 +476,7 @@ jerror_t DEventProcessor_dc_alignment::brun(JEventLoop *loop, int32_t runnumber)
     short_drift_func[2][2]=row["c3"];
   }
 
-  dapp->Lock();
+	japp->RootWriteLock(); //ACQUIRE ROOT LOCK
 
   for (int i=0;i<28;i++){
     char title[40];
@@ -617,7 +617,7 @@ jerror_t DEventProcessor_dc_alignment::brun(JEventLoop *loop, int32_t runnumber)
 
 
   
-  dapp->Unlock();
+	japp->RootUnLock(); //RELEASE ROOT LOCK
 
    // Get pointer to TrackFinder object 
   vector<const DTrackFinder *> finders;
@@ -964,13 +964,12 @@ DEventProcessor_dc_alignment::DoFilter(double t0,double OuterZ,DMatrix4x1 &S,
 		    cdc.N=myevt;
 		    
 		    
-		    // Lock mutex
-		    pthread_mutex_lock(&mutex);
+			// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+			japp->RootWriteLock(); //ACQUIRE ROOT LOCK
 		    
 		    cdctree->Fill();
 		    
-		    // Unlock mutex
-		    pthread_mutex_unlock(&mutex);
+			japp->RootUnLock(); //RELEASE ROOT LOCK
 		    
 		  }
 		}
@@ -1081,13 +1080,12 @@ DEventProcessor_dc_alignment::DoFilterCathodePlanes(double t0,double start_z,
 	    fdc_c.layer=layer+1;
 	    fdc_c.N=myevt;
 	    
-	    // Lock mutex
-	    pthread_mutex_lock(&mutex);
+		// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+		japp->RootWriteLock(); //ACQUIRE ROOT LOCK
 	    
 	    fdcCtree->Fill();
 	  
-	    // Unlock mutex
-	    pthread_mutex_unlock(&mutex);
+		japp->RootUnLock(); //RELEASE ROOT LOCK
 	  }
 	}
       }
@@ -1195,13 +1193,12 @@ DEventProcessor_dc_alignment::DoFilterAnodePlanes(double t0,double start_z,
 	    fdc.layer=layer+1;
 	    fdc.N=myevt;
 	    
-	    // Lock mutex
-	    pthread_mutex_lock(&mutex);
+		// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+		japp->RootWriteLock(); //ACQUIRE ROOT LOCK
 	    
 	    fdctree->Fill();
 	    
-	    // Unlock mutex
-	    pthread_mutex_unlock(&mutex);
+		japp->RootUnLock(); //RELEASE ROOT LOCK
 	  }
 	}
       }

--- a/src/plugins/Analysis/eloss_tree/DEventProcessor_eloss.cc
+++ b/src/plugins/Analysis/eloss_tree/DEventProcessor_eloss.cc
@@ -83,6 +83,9 @@ jerror_t DEventProcessor_eloss::evnt(JEventLoop *loop, uint64_t eventnumber)
 		return NOERROR;
 	}
 	
+	// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+	japp->RootWriteLock(); //ACQUIRE ROOT LOCK
+
 	// Fill dana tree
 	const DReferenceTrajectory::swim_step_t *step = tracks[0]->hypotheses[0]->rt->swim_steps;
 	for(int i=0; i<tracks[0]->hypotheses[0]->rt->Nswim_steps; i++, step++){
@@ -115,6 +118,8 @@ jerror_t DEventProcessor_eloss::evnt(JEventLoop *loop, uint64_t eventnumber)
 		geant_event.mech = traj->mech;
 		geant->Fill();
 	}
+
+	japp->RootUnLock(); //RELEASE ROOT LOCK
 
 	return NOERROR;
 }

--- a/src/plugins/Analysis/eta_ntuple/DEventProcessor_eta_ntuple.cc
+++ b/src/plugins/Analysis/eta_ntuple/DEventProcessor_eta_ntuple.cc
@@ -170,7 +170,8 @@ jerror_t DEventProcessor_eta_ntuple::evnt(JEventLoop *loop, uint64_t eventnumber
 		return NOERROR;
 	}
 
-	pthread_mutex_lock(&mutex);
+	// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+	japp->RootWriteLock(); //ACQUIRE ROOT LOCK
 	
 	evt->Clear();
 	evt->event = eventnumber;
@@ -211,10 +212,11 @@ jerror_t DEventProcessor_eta_ntuple::evnt(JEventLoop *loop, uint64_t eventnumber
 	evt->fcal->Sort(); // sort by cluster energy (uses fcal_t::Compare );
 	evt->sc->Sort(); // sort by phi diff (uses sc_t::Compare );
 	evt->bcal->Sort(); // sort by cluster energy (uses bcal_t::Compare );
+
 	if(make_root)tree->Fill();
 	if(make_hbook)FillNtuple();
 	
-	pthread_mutex_unlock(&mutex);
+	japp->RootUnLock(); //RELEASE ROOT LOCK
 
 	return NOERROR;
 }

--- a/src/plugins/Analysis/fcal_hists/DEventProcessor_fcal_hists.cc
+++ b/src/plugins/Analysis/fcal_hists/DEventProcessor_fcal_hists.cc
@@ -66,9 +66,7 @@ jerror_t DEventProcessor_fcal_hists::evnt(JEventLoop *loop, uint64_t eventnumber
 
 	const DFCALGeometry& fcalGeom = *(fcalGeomVect[0]);
 	if(fcalGeomVect.size()<1)return OBJECT_NOT_AVAILABLE;
-	
-	LockState();
-	
+		
 	// Create STL map of "real" hits that can be used below to match 
 	// with MC hits.
 	map<int,const DFCALHit*> hit_map;
@@ -79,6 +77,9 @@ jerror_t DEventProcessor_fcal_hists::evnt(JEventLoop *loop, uint64_t eventnumber
 		hit_map[channel] = hit;
 	}
 	
+	// Since we are modifying histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+
 	// Loop over "truth" hits and match them to real hits by using assuming
 	// one hit per channel
 	for(unsigned int i=0; i<truthhits.size(); i++){
@@ -91,7 +92,7 @@ jerror_t DEventProcessor_fcal_hists::evnt(JEventLoop *loop, uint64_t eventnumber
 		dE_over_E_vs_E->Fill(truthhit->E, deltaE/truthhit->E);
 	}
 
-	UnlockState();	
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 	return NOERROR;
 }

--- a/src/plugins/Analysis/fdc_covariance_hists/DEventProcessor_fdc_covariance_hists.cc
+++ b/src/plugins/Analysis/fdc_covariance_hists/DEventProcessor_fdc_covariance_hists.cc
@@ -89,8 +89,6 @@ jerror_t DEventProcessor_fdc_covariance_hists::brun(JEventLoop *loop, int32_t ru
 		return RESOURCE_UNAVAILABLE;
 	}
 	bfield=dapp->GetBfield(runnumber);
-	rt = new DReferenceTrajectory(bfield);
-	rt->SetDRootGeom(dapp->GetRootGeom());
 	
 	// Get z-position of most upstream FDC layer
 	vector<double> z_wires;
@@ -176,10 +174,13 @@ jerror_t DEventProcessor_fdc_covariance_hists::evnt(JEventLoop *loop, uint64_t e
 	}
 	s1 = s1_min;
 
+	DApplication* dapp = dynamic_cast<DApplication*>(loop->GetJApplication());
+	DReferenceTrajectory *rt = new DReferenceTrajectory(bfield);
+	rt->SetDRootGeom(dapp->GetRootGeom());
+	rt->Swim(pos_fdc1, mom_fdc1);
+
 	// Lock mutex
 	pthread_mutex_lock(&mutex);
-
-	rt->Swim(pos_fdc1, mom_fdc1);
 
 	// Loop over FDC hits
 	vector<double> resi_by_layer(24,-1000);
@@ -253,6 +254,8 @@ jerror_t DEventProcessor_fdc_covariance_hists::evnt(JEventLoop *loop, uint64_t e
 	// Unlock mutex
 	pthread_mutex_unlock(&mutex);
 	
+	delete rt;
+
 	return NOERROR;
 }
 

--- a/src/plugins/Analysis/fdc_covariance_hists/DEventProcessor_fdc_covariance_hists.h
+++ b/src/plugins/Analysis/fdc_covariance_hists/DEventProcessor_fdc_covariance_hists.h
@@ -35,7 +35,6 @@ class DEventProcessor_fdc_covariance_hists:public jana::JEventProcessor{
 		TProfile2D *fdc_cov_calc;
 		
 		const DMagneticFieldMap *bfield;
-		DReferenceTrajectory *rt;		
 		
 	private:
 		jerror_t init(void);	///< Invoked via DEventProcessor virtual method

--- a/src/plugins/Analysis/mc_tree/DEventProcessor_mc_tree.cc
+++ b/src/plugins/Analysis/mc_tree/DEventProcessor_mc_tree.cc
@@ -272,8 +272,8 @@ jerror_t DEventProcessor_mc_tree::evnt(JEventLoop *loop, uint64_t eventnumber) {
 		thr.richtruthhits.push_back(
 				MakeRichTruthHit((DRichTruthHit*) richtruthhits[j]));
 
-	// Lock mutex
-	pthread_mutex_lock(&mutex);
+	// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+	japp->RootWriteLock(); //ACQUIRE ROOT LOCK
 
 	// Fill in Event objects
 	evt_thrown->Clear();
@@ -291,8 +291,7 @@ jerror_t DEventProcessor_mc_tree::evnt(JEventLoop *loop, uint64_t eventnumber) {
 	evt_thrown->event = eventnumber;
 	tree_thrown->Fill();
 
-	// Unlock mutex
-	pthread_mutex_unlock(&mutex);
+	japp->RootUnLock(); //RELEASE ROOT LOCK
 
 	return NOERROR;
 }

--- a/src/plugins/Analysis/mcthrown_hists/DEventProcessor_mcthrown_hists.cc
+++ b/src/plugins/Analysis/mcthrown_hists/DEventProcessor_mcthrown_hists.cc
@@ -89,6 +89,10 @@ jerror_t DEventProcessor_mcthrown_hists::evnt(JEventLoop *loop, uint64_t eventnu
 	vector<const DMCThrown*> mcthrowns;
 	loop->Get(mcthrowns);
 	
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+
 	// Loop over thrown tracks
 	Nparticles_per_event->Fill(mcthrowns.size());
 	for(unsigned int i=0;i<mcthrowns.size();i++){
@@ -127,6 +131,8 @@ jerror_t DEventProcessor_mcthrown_hists::evnt(JEventLoop *loop, uint64_t eventnu
 				break;
 		}
 	}
+
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 	return NOERROR;
 }

--- a/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.cc
+++ b/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.cc
@@ -30,27 +30,23 @@ jerror_t DEventProcessor_monitoring_hists::init(void)
 	if(gPARMS->Exists("OUTPUT_FILENAME"))
 		gPARMS->GetParameter("OUTPUT_FILENAME", locOutputFileName);
 
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-	{
-		//go to file
-		TFile* locFile = (TFile*)gROOT->FindObject(locOutputFileName.c_str());
-		if(locFile != NULL)
-			locFile->cd("");
-		else
-			gDirectory->Cd("/");
+	//go to file
+	TFile* locFile = (TFile*)gROOT->FindObject(locOutputFileName.c_str());
+	if(locFile != NULL)
+		locFile->cd("");
+	else
+		gDirectory->Cd("/");
 
-		//go to directory
-		TDirectoryFile* locSubDirectory = static_cast<TDirectoryFile*>(gDirectory->Get("Independent"));
-		if(locSubDirectory == NULL) //else folder already created
-			locSubDirectory = new TDirectoryFile("Independent", "Independent");
-		locSubDirectory->cd();
+	//go to directory
+	TDirectoryFile* locSubDirectory = static_cast<TDirectoryFile*>(gDirectory->Get("Independent"));
+	if(locSubDirectory == NULL) //else folder already created
+		locSubDirectory = new TDirectoryFile("Independent", "Independent");
+	locSubDirectory->cd();
 
-		dHist_IsEvent = new TH1D("IsEvent", "Is the event an event?", 2, -0.5, 1.5);
-		dHist_IsEvent->GetXaxis()->SetBinLabel(1, "False");
-		dHist_IsEvent->GetXaxis()->SetBinLabel(2, "True");
-		gDirectory->cd("..");
-	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	dHist_IsEvent = new TH1D("IsEvent", "Is the event an event?", 2, -0.5, 1.5);
+	dHist_IsEvent->GetXaxis()->SetBinLabel(1, "False");
+	dHist_IsEvent->GetXaxis()->SetBinLabel(2, "True");
+	gDirectory->cd("..");
 
 	return NOERROR;
 }
@@ -94,11 +90,13 @@ jerror_t DEventProcessor_monitoring_hists::brun(JEventLoop *locEventLoop, int32_
 //------------------
 jerror_t DEventProcessor_monitoring_hists::evnt(JEventLoop *locEventLoop, uint64_t eventnumber)
 {
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	{
 		dHist_IsEvent->Fill(1);
 	}
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 	vector<const DMCThrown*> locMCThrowns;
 	locEventLoop->Get(locMCThrowns);

--- a/src/plugins/Analysis/pidstudies_tree/DEventProcessor_pidstudies_tree.cc
+++ b/src/plugins/Analysis/pidstudies_tree/DEventProcessor_pidstudies_tree.cc
@@ -107,6 +107,9 @@ jerror_t DEventProcessor_pidstudies_tree::evnt(JEventLoop *loop, uint64_t eventn
 	}
 
 	//fill information into trees
+	// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+	japp->RootWriteLock(); //ACQUIRE ROOT LOCK
+
 	dMCReconstructionStatuses->dMCReconstructionStatusVector.resize(0);
 	for(loc_i = 0; loc_i < locMCThrownVector.size(); loc_i++){
 		locMCThrown = locMCThrownVector[loc_i];
@@ -171,6 +174,8 @@ jerror_t DEventProcessor_pidstudies_tree::evnt(JEventLoop *loop, uint64_t eventn
 		dMCReconstructionStatuses->dMCReconstructionStatusVector.push_back(locMCReconstructionStatus);
 	}
 	dPluginTree_MCReconstructionStatuses->Fill();
+
+	japp->RootUnLock(); //RELEASE ROOT LOCK
 
 	return NOERROR;
 }

--- a/src/plugins/Analysis/trackeff_hists2/DEventProcessor_trackeff_hists2.cc
+++ b/src/plugins/Analysis/trackeff_hists2/DEventProcessor_trackeff_hists2.cc
@@ -139,8 +139,8 @@ jerror_t DEventProcessor_trackeff_hists2::evnt(JEventLoop *loop, uint64_t eventn
 	loop->Get(mctrajpoints);
 	loop->Get(mcthrowns);
 
-	// Lock mutex
-	pthread_mutex_lock(&mutex);
+	// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+	japp->RootWriteLock(); //ACQUIRE ROOT LOCK
 	
 	// Get hit list for all throwns
 	for(unsigned int i=0; i<mcthrowns.size(); i++){
@@ -226,8 +226,7 @@ jerror_t DEventProcessor_trackeff_hists2::evnt(JEventLoop *loop, uint64_t eventn
 		trkeff->Fill();
 	}
 
-	// Unlock mutex
-	pthread_mutex_unlock(&mutex);
+	japp->RootUnLock(); //RELEASE ROOT LOCK
 	
 	return NOERROR;
 }

--- a/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.cc
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.cc
@@ -70,6 +70,9 @@ jerror_t JEventProcessor_BCAL_TDC_Timing::init(void)
 jerror_t JEventProcessor_BCAL_TDC_Timing::brun(JEventLoop *loop, int32_t runnumber)
 {
     // This is called whenever the run number changes
+    DApplication* app = dynamic_cast<DApplication*>(loop->GetJApplication());
+    DGeometry* geom = app->GetDGeometry(runnumber);
+    geom->GetTargetZ(Z_TARGET);
     return NOERROR;
 }
 
@@ -80,11 +83,6 @@ jerror_t JEventProcessor_BCAL_TDC_Timing::evnt(JEventLoop *loop, uint64_t eventn
 {
     vector<const DBCALUnifiedHit *> bcalUnifiedHitVector;
     loop->Get(bcalUnifiedHitVector);
-
-    DApplication* app = dynamic_cast<DApplication*>(loop->GetJApplication());
-    DGeometry* geom = app->GetDGeometry(runnumber);
-    double Z_TARGET;
-    geom->GetTargetZ(Z_TARGET);
 
     /**********************************************
      _____ _                   __        __    _ _    

--- a/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.cc
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.cc
@@ -70,9 +70,6 @@ jerror_t JEventProcessor_BCAL_TDC_Timing::init(void)
 jerror_t JEventProcessor_BCAL_TDC_Timing::brun(JEventLoop *loop, int32_t runnumber)
 {
     // This is called whenever the run number changes
-    DApplication* app = dynamic_cast<DApplication*>(loop->GetJApplication());
-    DGeometry* geom = app->GetDGeometry(runnumber);
-    geom->GetTargetZ(Z_TARGET);
     return NOERROR;
 }
 
@@ -83,6 +80,11 @@ jerror_t JEventProcessor_BCAL_TDC_Timing::evnt(JEventLoop *loop, uint64_t eventn
 {
     vector<const DBCALUnifiedHit *> bcalUnifiedHitVector;
     loop->Get(bcalUnifiedHitVector);
+
+    DApplication* app = dynamic_cast<DApplication*>(loop->GetJApplication());
+    DGeometry* geom = app->GetDGeometry(runnumber);
+    double Z_TARGET;
+    geom->GetTargetZ(Z_TARGET);
 
     /**********************************************
      _____ _                   __        __    _ _    

--- a/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.h
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.h
@@ -22,6 +22,8 @@ class JEventProcessor_BCAL_TDC_Timing:public jana::JEventProcessor{
 		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+	    double Z_TARGET;
 };
 
 #endif // _JEventProcessor_BCAL_TDC_Timing_

--- a/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.h
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.h
@@ -22,7 +22,6 @@ class JEventProcessor_BCAL_TDC_Timing:public jana::JEventProcessor{
 		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
-        double Z_TARGET;
 };
 
 #endif // _JEventProcessor_BCAL_TDC_Timing_

--- a/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
+++ b/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
@@ -54,9 +54,6 @@ JEventProcessor_BCAL_attenlength_gainratio::~JEventProcessor_BCAL_attenlength_ga
 //------------------
 jerror_t JEventProcessor_BCAL_attenlength_gainratio::init(void)
 {
-	// lock all root operations
-	japp->RootWriteLock();
-
 	// Set style
 	gStyle->SetTitleOffset(1, "Y");
 	gStyle->SetTitleOffset(1.3, "z");
@@ -143,7 +140,6 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::init(void)
 	// back to main dir
 	main->cd();
 
-	japp->RootUnLock();
 	return NOERROR;
 }
 
@@ -171,7 +167,9 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::evnt(JEventLoop *loop, uint
 	vector<const DBCALPoint*> dbcalpoints;
 	loop->Get(dbcalpoints);
 
-	japp->RootWriteLock();
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
 	for(unsigned int i=0; i<dbcalpoints.size(); i++) {
 		const DBCALPoint *point = dbcalpoints[i];
@@ -236,7 +234,8 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::evnt(JEventLoop *loop, uint
 		EvsZ_all->Fill(zpos, Energy);
 		EvsZ_layer[layer-1]->Fill(zpos, Energy);
 	}
-	japp->RootUnLock();
+
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 
 	return NOERROR;
@@ -261,7 +260,10 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::fini(void)
 	// Called before program exit after event processing is finished.
 
 
-	
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+
 	// for (int module=0; module<nummodule; module++) {
 	// 	if (VERBOSE>0) printf("M%i ",module);
 	// 	for (int layer=0; layer<numlayer; layer++) {
@@ -326,6 +328,9 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::fini(void)
 	hist2D_peakgainratio->SetBinContent(0,0,1);
 	hist2D_intattenlength->SetBinContent(0,0,1);
 	hist2D_intgainratio->SetBinContent(0,0,1);
+
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
 	return NOERROR;
 }
 

--- a/src/plugins/Calibration/FCALgains/JEventProcessor_FCALgains.cc
+++ b/src/plugins/Calibration/FCALgains/JEventProcessor_FCALgains.cc
@@ -42,10 +42,8 @@ jerror_t JEventProcessor_FCALgains::init(void)
   // This is called once at program startup. If you are creating
   // and filling historgrams in this plugin, you should lock the
   // ROOT mutex like this:
-  japp->RootWriteLock();
 
   if(InvMass1 && InvMass2 && InvMass3 && InvMass4 && InvMass5!= NULL){
-    japp->RootUnLock();
     return NOERROR;
   }
 
@@ -124,8 +122,6 @@ hits2D_pi0 = new TH2F( "hits2D_pi0", "FCAL Hits Pi0; X; Y", 61, -30, 30, 61, -30
 			  m_mLt.Zero();
 			  m_event = 0;
 			  m_TotPastCuts = 0;
-
-			  japp->RootUnLock();
 
 
 			  return NOERROR;
@@ -214,11 +210,12 @@ jerror_t JEventProcessor_FCALgains::evnt(jana::JEventLoop* locEventLoop, uint64_
   DVector3 norm(0.0,0.0,-1);
   DVector3 pos,mom;
   Double_t radius = 0;
-  japp->RootWriteLock();
   Double_t p;
-  
- 
-  
+
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+    
   for (unsigned int i=0; i < locTrackTimeBased.size() ; ++i){
     for (unsigned int j=0; j< locFCALShowers.size(); ++j){
 
@@ -434,7 +431,7 @@ jerror_t JEventProcessor_FCALgains::evnt(jana::JEventLoop* locEventLoop, uint64_
       }
     }
 }
-  japp->RootUnLock();
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
   return NOERROR;
 }
 

--- a/src/plugins/Calibration/FCALpedestals/JEventProcessor_FCALpedestals.cc
+++ b/src/plugins/Calibration/FCALpedestals/JEventProcessor_FCALpedestals.cc
@@ -70,8 +70,6 @@ jerror_t JEventProcessor_FCALpedestals::init(void)
   // and filling historgrams in this plugin, you should lock the
   // ROOT mutex like this:
   //
-  japp->RootWriteLock();
-
   TDirectory *main = gDirectory;
   gDirectory->mkdir("FCAL_pedestals")->cd();
   
@@ -81,7 +79,6 @@ jerror_t JEventProcessor_FCALpedestals::init(void)
   }
 
   main->cd();
-  japp->RootUnLock();
 
   return NOERROR;
 }
@@ -134,7 +131,9 @@ jerror_t JEventProcessor_FCALpedestals::evnt(JEventLoop *eventLoop,
   vector< const DFCALDigiHit*  > digiHits;
   eventLoop->Get( digiHits );
    
-  japp->RootWriteLock();
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
   
   for( vector< const DFCALDigiHit* >::const_iterator dHitItr = digiHits.begin();
        dHitItr != digiHits.end(); ++dHitItr ){
@@ -151,9 +150,7 @@ jerror_t JEventProcessor_FCALpedestals::evnt(JEventLoop *eventLoop,
     }
   }
 
-  japp->RootUnLock(); 
-
-
+ 	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
   return NOERROR;
 }

--- a/src/plugins/Calibration/PSC_TW/JEventProcessor_PSC_TW.cc
+++ b/src/plugins/Calibration/PSC_TW/JEventProcessor_PSC_TW.cc
@@ -84,15 +84,11 @@ jerror_t JEventProcessor_PSC_TW::init(void)
 	// japp->RootUnLock();
 	//
 
-   japp->RootWriteLock();
-
    // Name histograms
    for (uint32_t i = 0; i < NMODULES; ++i) {
       h_dt_vs_pp_l[i] = new TH2F(Form("h_dt_vs_pp_l_%i",i+1),Form("Time difference vs. pulse peak for left PSC module %i",i+1),1000,0,1000,100,-5,5);
       h_dt_vs_pp_r[i] = new TH2F(Form("h_dt_vs_pp_r_%i",i+1),Form("Time difference vs. pulse peak for right PSC module %i",i+1),1000,0,1000,100,-5,5);
    }
-
-   japp->RootUnLock();
 
 	return NOERROR;
 }
@@ -150,7 +146,9 @@ jerror_t JEventProcessor_PSC_TW::evnt(JEventLoop *loop, uint64_t eventnumber)
    else
       return NOERROR;
 
-   japp->RootWriteLock();
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
    if (pairs.size() > 0) {
       psc_mod_l = pairs[0]->ee.first->module;
@@ -166,7 +164,7 @@ jerror_t JEventProcessor_PSC_TW::evnt(JEventLoop *loop, uint64_t eventnumber)
       h_dt_vs_pp_r[psc_mod_r - 1]->Fill(pp_r,tdc_r - rf_r);
    }
 
-   japp->RootUnLock();
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
    return NOERROR;
 }

--- a/src/plugins/Calibration/PS_E_calib/JEventProcessor_PS_E_calib.cc
+++ b/src/plugins/Calibration/PS_E_calib/JEventProcessor_PS_E_calib.cc
@@ -107,8 +107,6 @@ jerror_t JEventProcessor_PS_E_calib::init(void)
 	// japp->RootUnLock();
 	//
 
-   japp->RootWriteLock();
-
    // create root folder tagm
    TDirectory *tagmDir = gDirectory->mkdir("TAGM");
    TDirectory *taghDir = gDirectory->mkdir("TAGH");
@@ -136,7 +134,6 @@ jerror_t JEventProcessor_PS_E_calib::init(void)
                                         50,0,1,NEb_PS,Ebl_PS,Ebh_PS);
    }
    
-   japp->RootUnLock();
 	return NOERROR;
 }
 
@@ -195,7 +192,9 @@ jerror_t JEventProcessor_PS_E_calib::evnt(JEventLoop *loop, uint64_t eventnumber
    loop->Get(ps_pairs);
    loop->Get(psc_pairs);
 
-   japp->RootWriteLock();
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
    if (psc_pairs.size() > 0 ) {
       for (uint32_t i = 0; i < ps_pairs.size(); ++i) {
@@ -251,7 +250,8 @@ jerror_t JEventProcessor_PS_E_calib::evnt(JEventLoop *loop, uint64_t eventnumber
          }
       }
    }
-   japp->RootUnLock();
+
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 	return NOERROR;
 }

--- a/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.cc
+++ b/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.cc
@@ -58,7 +58,6 @@ jerror_t JEventProcessor_ST_Propagation_Time::init(void)
   z_upper_limit = 100.0;
   Photonspeed = 29.9792458;
   // **************** define histograms *************************
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 
   //Create root folder and cd to it, store main dir
   TDirectory *main = gDirectory;
@@ -85,7 +84,7 @@ jerror_t JEventProcessor_ST_Propagation_Time::init(void)
     }
   // cd back to main directory
   main->cd();
-  japp->RootUnLock();
+
   return NOERROR;
 }
 
@@ -175,7 +174,11 @@ jerror_t JEventProcessor_ST_Propagation_Time::evnt(JEventLoop *loop, uint64_t ev
   // Grab the associated RF bunch object
   const DEventRFBunch *thisRFBunch = NULL;
   loop->GetSingle(thisRFBunch, "Calibrations");
-  japp->RootWriteLock();
+
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+
   locTOFRFShiftedTime = 9.9E+9;
   // Loop over the charged tracks
   for (uint32_t i = 0; i < chargedTrackVector.size(); i++)
@@ -331,7 +334,9 @@ jerror_t JEventProcessor_ST_Propagation_Time::evnt(JEventLoop *loop, uint64_t ev
 	    }
    	} // sc charged tracks
     }// TOF reference time
-  japp->RootUnLock(); 
+
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
   return NOERROR;
 }
 

--- a/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.cc
+++ b/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.cc
@@ -50,7 +50,6 @@ jerror_t JEventProcessor_ST_Tresolution::init(void)
 	// japp->RootUnLock();
 	//
   // **************** define histograms *************************
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 
   //Create root folder and cd to it, store main dir
   TDirectory *main = gDirectory;
@@ -71,7 +70,6 @@ jerror_t JEventProcessor_ST_Tresolution::init(void)
 
   // cd back to main directory
   main->cd();
-  japp->RootUnLock();
 
   RF_BUNCH_TAG = "Calibrations";
   gPARMS->SetDefaultParameter("SC_TCALIB:RF_BUNCH_TAG", RF_BUNCH_TAG, "RF bunch selection tag for SC timing resolution");
@@ -171,7 +169,10 @@ jerror_t JEventProcessor_ST_Tresolution::evnt(JEventLoop *loop, uint64_t eventnu
   const DEventRFBunch *thisRFBunch = NULL;
   loop->GetSingle(thisRFBunch, RF_BUNCH_TAG.c_str());
 
-  japp->RootWriteLock();
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+
   for (uint32_t i = 0; i < chargedTrackVector.size(); i++)
     {   
       // Grab the charged track and declare time based track object
@@ -267,7 +268,9 @@ jerror_t JEventProcessor_ST_Tresolution::evnt(JEventLoop *loop, uint64_t eventnu
 	  h2_CorrectedTime_z[sc_index]->Fill(locSCzIntersection,Corr_Time_ns - SC_RFShiftedTime);
 	}
     } // sc charged tracks
-  japp->RootUnLock();
+
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
   return NOERROR;
 }
 

--- a/src/plugins/Calibration/TAGH_timewalk/JEventProcessor_TAGH_timewalk.cc
+++ b/src/plugins/Calibration/TAGH_timewalk/JEventProcessor_TAGH_timewalk.cc
@@ -56,7 +56,7 @@ jerror_t JEventProcessor_TAGH_timewalk::init(void)
     // This is called once at program startup. If you are creating
     // and filling historgrams in this plugin, you should lock the
     // ROOT mutex like this:
-    japp->RootWriteLock();
+
     const double Tl = -200.0;
     const double Th = 600.0;
     const int NTb = 8000;
@@ -75,7 +75,6 @@ jerror_t JEventProcessor_TAGH_timewalk::init(void)
         hTAGHRF_tdcTimeDiffVsPulseHeight[i] = new TH2I(name,title+";pulse height [fADC counts];time(TDC) - time(RF) [ns]",41,0,4100,50,-2.5,2.5);
     }
     mainDir->cd();
-    japp->RootUnLock();
 
     return NOERROR;
 }
@@ -111,7 +110,11 @@ jerror_t JEventProcessor_TAGH_timewalk::evnt(JEventLoop *loop, uint64_t eventnum
         rfTime = rfTimes[0];
     else
         return NOERROR;
-    japp->RootWriteLock();
+
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+
     double t_RF = rfTime->dTime;
     for(unsigned int i=0; i<taghhits.size(); i++) {
         const DTAGHHit *hit = taghhits[i];
@@ -126,7 +129,9 @@ jerror_t JEventProcessor_TAGH_timewalk::evnt(JEventLoop *loop, uint64_t eventnum
         hTAGHRF_tdcTimeDiffVsPulseHeight[0]->Fill(pulse_height,t_tdc-t_RF);
         hTAGHRF_tdcTimeDiffVsPulseHeight[id]->Fill(pulse_height,t_tdc-t_RF);
     }
-    japp->RootUnLock();
+
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
     return NOERROR;
 }
 

--- a/src/plugins/Calibration/TAGM_TW/JEventProcessor_TAGM_TW.cc
+++ b/src/plugins/Calibration/TAGM_TW/JEventProcessor_TAGM_TW.cc
@@ -78,9 +78,6 @@ JEventProcessor_TAGM_TW::~JEventProcessor_TAGM_TW()
 //------------------
 jerror_t JEventProcessor_TAGM_TW::init(void)
 {
-
-   japp->RootWriteLock();
-
    // Name histograms 
    for (uint32_t i = 0; i < NCOLUMNS; ++i) {
       h_dt_vs_pp[i] = new TH2F(Form("h_dt_vs_pp_%i",i+1),
@@ -89,7 +86,6 @@ jerror_t JEventProcessor_TAGM_TW::init(void)
                                1000,0,1000,200,-37,-17);
    }
 
-   japp->RootUnLock();
    return NOERROR;
 	
 }
@@ -147,7 +143,9 @@ jerror_t JEventProcessor_TAGM_TW::evnt(JEventLoop *loop, uint64_t eventnumber)
    else
       return NOERROR;
 
-   japp->RootWriteLock();
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
    if (psc_pairs.size() > 0 && ps_pairs.size() > 0) {
       for (uint32_t i = 0; i < hits.size(); ++i) {
@@ -181,7 +179,7 @@ jerror_t JEventProcessor_TAGM_TW::evnt(JEventLoop *loop, uint64_t eventnumber)
       }
    }
 
-   japp->RootUnLock();
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
    return NOERROR;
 }

--- a/src/plugins/Simulation/extract_ptype_hddm/JEventProcessor_extract_ptype_hddm.cc
+++ b/src/plugins/Simulation/extract_ptype_hddm/JEventProcessor_extract_ptype_hddm.cc
@@ -52,9 +52,6 @@ JEventProcessor_extract_ptype_hddm::~JEventProcessor_extract_ptype_hddm()
 //------------------
 jerror_t JEventProcessor_extract_ptype_hddm::init(void)
 {
-   // Lock mutex
-   pthread_mutex_lock(&mutex);
-
    // Get type of particle to extract
    PTYPE = Neutron;
    gPARMS->SetDefaultParameter("PTYPE", PTYPE, 
@@ -102,9 +99,6 @@ jerror_t JEventProcessor_extract_ptype_hddm::init(void)
         << std::endl;
    jout << "----------------------------------------" << std::endl;
    jout << std::endl;
-
-   // Unlock mutex
-   pthread_mutex_unlock(&mutex);
 
    return NOERROR;
 }

--- a/src/plugins/Utilities/danahddm/JEventProcessor_danahddm.cc
+++ b/src/plugins/Utilities/danahddm/JEventProcessor_danahddm.cc
@@ -78,9 +78,15 @@ jerror_t JEventProcessor_danahddm::init(void)
 //-------------------------------
 jerror_t JEventProcessor_danahddm::brun(JEventLoop *loop, int32_t runnumber)
 {
+   // get write lock
+   pthread_mutex_lock(&hddmMutex);
+
    // If file is already open, don't reopen it. Just keep adding to it.
    if (file)
+	{
+	   pthread_mutex_unlock(&hddmMutex);
       return NOERROR;
+	}
 
    // We wait until here to open the output so that we can check if the 
    // input is hddm. If it's not, tell the user and exit immediately
@@ -116,6 +122,9 @@ jerror_t JEventProcessor_danahddm::brun(JEventLoop *loop, int32_t runnumber)
    else {
       jout << " HDDM integrity checks disabled" << std::endl;
    }
+
+   // unlock
+   pthread_mutex_unlock(&hddmMutex);
 
    return NOERROR;
 }

--- a/src/plugins/Utilities/dumpcandidates/JEventProcessor_dumpcandidates.cc
+++ b/src/plugins/Utilities/dumpcandidates/JEventProcessor_dumpcandidates.cc
@@ -83,6 +83,7 @@ jerror_t JEventProcessor_dumpcandidates::brun(JEventLoop *eventLoop, int32_t run
 	vector<vector<DFDCWire *> > fdcwires;
 	dgeom->GetFDCWires(fdcwires);
 	
+	LockState();
 	// Generate map keyed by wire object's address
 	// (in the form of an unsigned long) and whose
 	// value is the index of the wire (i.e. position
@@ -105,6 +106,7 @@ jerror_t JEventProcessor_dumpcandidates::brun(JEventLoop *eventLoop, int32_t run
 			wireID[ GetFDCWireID(w) ] = index++;
 		}
 	}
+	UnlockState();
 
 	return NOERROR;
 }

--- a/src/plugins/Utilities/dumpthrowns/JEventProcessor_dumpthrowns.cc
+++ b/src/plugins/Utilities/dumpthrowns/JEventProcessor_dumpthrowns.cc
@@ -92,8 +92,10 @@ jerror_t JEventProcessor_dumpthrowns::evnt(JEventLoop *loop, uint64_t eventnumbe
 		ss << " " << thrown->px() << " " << thrown->py() << " " << thrown->pz();
 		
 		// Write thrown parameters string to file
+		LockState();
 		(*ofs) << ss.str() << endl;
 		events_written++;
+		UnlockState();
 		
 		// Sometimes, generated particles are added to the thrown
 		// particles list. We want only the first MAX_CANDIDATE_FILTER

--- a/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.cc
+++ b/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.cc
@@ -98,17 +98,20 @@ jerror_t JEventProcessor_pi0bcalskim::evnt(JEventLoop *loop, uint64_t eventnumbe
   vector<const DVertex*> kinfitVertex;
   loop->Get(kinfitVertex);
 
+	const DEventWriterEVIO* locEventWriterEVIO = NULL;
+	loop->GetSingle(locEventWriterEVIO);
+
   // always write out BOR events
   if(loop->GetJEvent().GetStatusBit(kSTATUS_BOR_EVENT)) {
       //jout << "Found BOR!" << endl;
-      dEventWriterEVIO->Write_EVIOEvent( loop, "pi0bcalskim" );
+      locEventWriterEVIO->Write_EVIOEvent( loop, "pi0bcalskim" );
       return NOERROR;
   }
 
   // write out the first few EPICS events to save run number & other meta info
   if(loop->GetJEvent().GetStatusBit(kSTATUS_EPICS_EVENT) && (num_epics_events<5)) {
       //jout << "Found EPICS!" << endl;
-      dEventWriterEVIO->Write_EVIOEvent( loop, "pi0bcalskim" );
+      locEventWriterEVIO->Write_EVIOEvent( loop, "pi0bcalskim" );
       num_epics_events++;
       return NOERROR;
   }
@@ -183,7 +186,7 @@ jerror_t JEventProcessor_pi0bcalskim::evnt(JEventLoop *loop, uint64_t eventnumbe
 	        if( WRITE_EVIO ) {
                 //	cout << " inv mass = " << inv_mass << " sh1 E = " << sh1_E << " sh2 E = " << sh2_E << " event num = " << eventnumber << endl;
                 cout << eventnumber << endl;
-     			 dEventWriterEVIO->Write_EVIOEvent( loop, "pi0bcalskim" );
+     			 locEventWriterEVIO->Write_EVIOEvent( loop, "pi0bcalskim" );
   		  }
 			}
 

--- a/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.cc
+++ b/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.cc
@@ -69,8 +69,6 @@ JEventProcessor_pi0bcalskim::~JEventProcessor_pi0bcalskim()
 //------------------
 jerror_t JEventProcessor_pi0bcalskim::init(void)
 {
-  dEventWriterEVIO = NULL;
-
   //if( ! WRITE_EVIO) cerr << " output isnt working " << endl;
 
   return NOERROR;
@@ -81,8 +79,6 @@ jerror_t JEventProcessor_pi0bcalskim::init(void)
 //------------------
 jerror_t JEventProcessor_pi0bcalskim::brun(JEventLoop *eventLoop, int32_t runnumber)
 {
-  eventLoop->GetSingle(dEventWriterEVIO);
-
   return NOERROR;
 }
 

--- a/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.h
+++ b/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.h
@@ -35,9 +35,6 @@ class JEventProcessor_pi0bcalskim:public jana::JEventProcessor{
   					///< Called after last event of last event source has been processed.
   double MIN_SH1_E;
   double MIN_SH2_E;
-
-  const DEventWriterEVIO* dEventWriterEVIO;		
-
  
   int WRITE_EVIO;
   int num_epics_events;

--- a/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.cc
+++ b/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.cc
@@ -82,8 +82,6 @@ JEventProcessor_pi0fcalskim::~JEventProcessor_pi0fcalskim()
 //------------------
 jerror_t JEventProcessor_pi0fcalskim::init(void)
 {
-  dEventWriterEVIO = NULL;
-
   num_epics_events = 0;
 /*
   if( ! ( WRITE_ROOT || WRITE_EVIO ) ){
@@ -118,8 +116,6 @@ jerror_t JEventProcessor_pi0fcalskim::init(void)
 //------------------
 jerror_t JEventProcessor_pi0fcalskim::brun(JEventLoop *eventLoop, int32_t runnumber)
 {
-  eventLoop->GetSingle(dEventWriterEVIO);
-
   return NOERROR;
 }
 
@@ -139,17 +135,20 @@ jerror_t JEventProcessor_pi0fcalskim::evnt(JEventLoop *loop, uint64_t eventnumbe
 
   vector < const DFCALShower * > matchedShowers;
 
+	const DEventWriterEVIO* locEventWriterEVIO = NULL;
+	loop->GetSingle(locEventWriterEVIO);
+
   // always write out BOR events
   if(loop->GetJEvent().GetStatusBit(kSTATUS_BOR_EVENT)) {
       //jout << "Found BOR!" << endl;
-      dEventWriterEVIO->Write_EVIOEvent( loop, "pi0fcalskim" );
+      locEventWriterEVIO->Write_EVIOEvent( loop, "pi0fcalskim" );
       return NOERROR;
   }
 
   // write out the first few EPICS events to save run number & other meta info
   if(loop->GetJEvent().GetStatusBit(kSTATUS_EPICS_EVENT) && (num_epics_events<5)) {
       //jout << "Found EPICS!" << endl;
-      dEventWriterEVIO->Write_EVIOEvent( loop, "pi0fcalskim" );
+      locEventWriterEVIO->Write_EVIOEvent( loop, "pi0fcalskim" );
       num_epics_events++;
       return NOERROR;
   }
@@ -259,7 +258,7 @@ jerror_t JEventProcessor_pi0fcalskim::evnt(JEventLoop *loop, uint64_t eventnumbe
 
     if( WRITE_EVIO ){
 
-      dEventWriterEVIO->Write_EVIOEvent( loop, "pi0fcalskim" );
+      locEventWriterEVIO->Write_EVIOEvent( loop, "pi0fcalskim" );
     }
  }
  

--- a/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.h
+++ b/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.h
@@ -34,8 +34,6 @@ class JEventProcessor_pi0fcalskim:public jana::JEventProcessor{
 
   void writeClustersToRoot( const vector< const DFCALCluster* > clusVec );
 
-  const DEventWriterEVIO* dEventWriterEVIO;		
-
   double MIN_MASS;
   double MAX_MASS;
   double MIN_E;

--- a/src/plugins/Utilities/run_summary/DEventProcessor_run_summary.cc
+++ b/src/plugins/Utilities/run_summary/DEventProcessor_run_summary.cc
@@ -79,6 +79,8 @@ jerror_t DEventProcessor_run_summary::brun(jana::JEventLoop* locEventLoop, int l
 	else //already created by another thread
 		conditions_tree = static_cast<TTree*>(gDirectory->Get("conditions"));
 
+	main_dir->cd();
+
 	japp->RootUnLock();
 
 	// reset EPICS summary info each run
@@ -86,7 +88,6 @@ jerror_t DEventProcessor_run_summary::brun(jana::JEventLoop* locEventLoop, int l
 		delete epics_info;
 	epics_info = new DEPICSstore;
 
-	main_dir->cd();
 	return NOERROR;
 }
 

--- a/src/plugins/Utilities/run_summary/DEventProcessor_run_summary.cc
+++ b/src/plugins/Utilities/run_summary/DEventProcessor_run_summary.cc
@@ -143,6 +143,9 @@ jerror_t DEventProcessor_run_summary::erun(void)
 	if(conditions_tree == NULL)
 		return NOERROR;
 
+	// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+	japp->RootWriteLock(); //ACQUIRE ROOT LOCK
+
 	// make a branch for the run number
 	TBranch *run_branch = conditions_tree->FindBranch("run_number");
 	if(run_branch == NULL)
@@ -174,6 +177,8 @@ jerror_t DEventProcessor_run_summary::erun(void)
 
 	// save the values for this run
 	conditions_tree->Fill();
+
+	japp->RootUnLock(); //RELEASE ROOT LOCK
 
 	return NOERROR;
 }

--- a/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.cc
+++ b/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.cc
@@ -110,7 +110,7 @@ jerror_t DEventProcessor_track_skimmer::evnt(jana::JEventLoop* locEventLoop, uin
 	locEventLoop->Get(locChargedTracks, "PreSelect");
 
 	//MUST LOCK AROUND MODIFICATION OF MEMBER VARIABLES IN brun() or evnt().
-	japp->WriteLock("EventStoreWriter");
+	LockState();
 	{
 		if(locChargedTracks.size() >= 2)
 			dIDXAStream_2track << locRunNumber << " " << locEventNumber << " " << locUniqueID << endl;
@@ -140,7 +140,7 @@ jerror_t DEventProcessor_track_skimmer::evnt(jana::JEventLoop* locEventLoop, uin
 				dIDXAStream_5track1pi0 << locRunNumber << " " << locEventNumber << " " << locUniqueID << endl;
 		}
 	}
-	japp->Unlock("EventStoreWriter");
+	UnlockState();
 
 	return NOERROR;
 }

--- a/src/plugins/monitoring/BCAL_LEDonline/JEventProcessor_BCAL_LEDonline.cc
+++ b/src/plugins/monitoring/BCAL_LEDonline/JEventProcessor_BCAL_LEDonline.cc
@@ -119,13 +119,7 @@ JEventProcessor_BCAL_LEDonline::~JEventProcessor_BCAL_LEDonline() {
 
 jerror_t JEventProcessor_BCAL_LEDonline::init(void) {
 	
-	// lock all root operations
-	japp->RootWriteLock();
-	
-	// First thread to get here makes all histograms. If one pointer is
-	// already not NULL, assume all histograms are defined and return now
 	if(bcal_fadc_digi_time != NULL){
-		japp->RootUnLock();
 		return NOERROR;
 	}
 	
@@ -316,10 +310,6 @@ jerror_t JEventProcessor_BCAL_LEDonline::init(void) {
 	// back to main dir
 	main->cd();
 	
-	// unlock
-	japp->RootUnLock();
-	
-	
 	return NOERROR;
 }
 
@@ -398,8 +388,9 @@ jerror_t JEventProcessor_BCAL_LEDonline::evnt(JEventLoop *loop, uint64_t eventnu
 		loop->Get(dbcaltdchits);
 		loop->Get(dbcaluhits);
 	
-		// Lock ROOT
-		japp->RootWriteLock();
+		// FILL HISTOGRAMS
+		// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+		japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
 		if( (dbcaldigihits.size() > 0) || (dbcaltdcdigihits.size() > 0) )
 			bcal_num_events->Fill(1);
@@ -585,8 +576,7 @@ jerror_t JEventProcessor_BCAL_LEDonline::evnt(JEventLoop *loop, uint64_t eventnu
 			}
 		}
 
-		// Unlock ROOT
-		japp->RootUnLock();
+		japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 	}
 	
 	return NOERROR;

--- a/src/plugins/monitoring/BCAL_inv_mass/JEventProcessor_BCAL_inv_mass.cc
+++ b/src/plugins/monitoring/BCAL_inv_mass/JEventProcessor_BCAL_inv_mass.cc
@@ -60,10 +60,8 @@ jerror_t JEventProcessor_BCAL_inv_mass::init(void)
 	// This is called once at program startup. If you are creating
 	// and filling historgrams in this plugin, you should lock the
 	// ROOT mutex like this:
-	japp->RootWriteLock();
 
 	if(bcal_diphoton_mass_500 != NULL){
-	  japp->RootUnLock();
 	  return NOERROR;
 	}
 
@@ -110,9 +108,6 @@ jerror_t JEventProcessor_BCAL_inv_mass::init(void)
 	 //	dir->cd();
 
 	main->cd();
-
-	 japp->RootUnLock();
-
 
 	return NOERROR;
 }
@@ -217,7 +212,6 @@ jerror_t JEventProcessor_BCAL_inv_mass::evnt(jana::JEventLoop* locEventLoop, uin
                   }
 	}                        
 
-	japp->RootWriteLock();
  	vector <const DChargedTrackHypothesis*> locParticles;
 	double kinfitVertexX = 0.0, kinfitVertexY = 0.0, kinfitVertexZ = 0.0;
 	for (unsigned int i = 0 ; i < kinfitVertex.size(); i++)
@@ -229,6 +223,10 @@ jerror_t JEventProcessor_BCAL_inv_mass::evnt(jana::JEventLoop* locEventLoop, uin
 		//kinfitVertexT = kinfitVertex[i]->dSpacetimeVertex.T();
 	}
 	
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+
 	for(unsigned int i=0; i<locBCALShowers.size(); i++)
 	{
 	     //   if(locDetectorMatches->Get_IsMatchedToTrack(locBCALShowers[i]))
@@ -281,7 +279,7 @@ jerror_t JEventProcessor_BCAL_inv_mass::evnt(jana::JEventLoop* locEventLoop, uin
 	}   
 
 
-	japp->RootUnLock();     
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 
 	/*

--- a/src/plugins/monitoring/BCAL_online/JEventProcessor_BCAL_online.cc
+++ b/src/plugins/monitoring/BCAL_online/JEventProcessor_BCAL_online.cc
@@ -170,13 +170,9 @@ JEventProcessor_BCAL_online::~JEventProcessor_BCAL_online() {
 
 jerror_t JEventProcessor_BCAL_online::init(void) {
 	
-	// lock all root operations
-	japp->RootWriteLock();
-	
 	// First thread to get here makes all histograms. If one pointer is
 	// already not NULL, assume all histograms are defined and return now
 	if(bcal_fadc_digi_integral != NULL){
-		japp->RootUnLock();
 		return NOERROR;
 	}
 	
@@ -437,10 +433,6 @@ jerror_t JEventProcessor_BCAL_online::init(void) {
 	// back to main dir
 	main->cd();
 	
-	// unlock
-	japp->RootUnLock();
-	
-	
 	return NOERROR;
 }
 
@@ -508,8 +500,9 @@ jerror_t JEventProcessor_BCAL_online::evnt(JEventLoop *loop, uint64_t eventnumbe
 	loop->Get(dbcalclusters);
 	loop->Get(dbcalshowers);
 	
-	// Lock ROOT
-	japp->RootWriteLock();
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
 	if( (dbcaldigihits.size() > 0) || (dbcaltdcdigihits.size() > 0) )
 		bcal_num_events->Fill(1);
@@ -761,9 +754,7 @@ jerror_t JEventProcessor_BCAL_online::evnt(JEventLoop *loop, uint64_t eventnumbe
 		bcal_shower_plane->Fill(shower->x,shower->y);
 	}
 
-
-	// Unlock ROOT
-	japp->RootUnLock();
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 	
 	return NOERROR;
 }

--- a/src/plugins/monitoring/CDC_Efficiency/JEventProcessor_CDC_Efficiency.cc
+++ b/src/plugins/monitoring/CDC_Efficiency/JEventProcessor_CDC_Efficiency.cc
@@ -86,7 +86,7 @@ jerror_t JEventProcessor_CDC_Efficiency::init(void)
     double phi[28] = {0, 0.074707844, 0.038166294, 0.096247609, 0.05966371, 0.012001551, 0.040721951, 0.001334527, 0.014963808, 0.048683644, 0.002092645, 0.031681749, 0.040719354, 0.015197341, 0.006786058, 0.030005892, 0.019704045, -0.001782064, -0.001306618, 0.018592421, 0.003686784, 0.022132975, 0.019600866, 0.002343723, 0.021301449, 0.005348855, 0.005997358, 0.021018761};
 
     // Define a different 2D histogram for each ring. X-axis is phi, Y-axis is radius (to plot correctly with "pol" option)
-    japp->RootWriteLock();
+
     // create root folder for cdc and cd to it, store main dir
     TDirectory *main = gDirectory;
     gDirectory->mkdir("CDC_Efficiency")->cd();
@@ -133,9 +133,6 @@ jerror_t JEventProcessor_CDC_Efficiency::init(void)
     if(gDirectory->Get("hResVsT") == NULL)
         hResVsT = new TH2I("hResVsT","Tracking Residual (Biased) Vs Drift Time; Drift Time [ns]; Residual [cm]", 500, 0.0, 700.0, 1000, -0.5, 0.5);
     main->cd();
-
-    japp->RootUnLock();
-
 
     return NOERROR;
 }
@@ -499,59 +496,61 @@ jerror_t JEventProcessor_CDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
                     Double_t w, v;
                     if(cdc_expected_ring[ringNum] != NULL && ringNum < 29){
                         if (distanceToWire < DOCACUT){
-                            japp->RootWriteLock();
+									// FILL HISTOGRAMS
+									// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+									japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                             w = cdc_expected_ring[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                             cdc_expected_ring[ringNum]->SetBinContent(wireNum, 1, w);
-                            japp->RootUnLock();
+									japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                         }
                         switch ( (int) (distanceToWire * 10) % 8){
                             case 0:
-                                japp->RootWriteLock();
+										japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                 w = cdc_expected_ring_DOCA0[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                 cdc_expected_ring_DOCA0[ringNum]->SetBinContent(wireNum, 1, w);
-                                japp->RootUnLock();
+										japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                 break;
                             case 1:
-                                japp->RootWriteLock();
+										japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                 w = cdc_expected_ring_DOCA1[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                 cdc_expected_ring_DOCA1[ringNum]->SetBinContent(wireNum, 1, w);
-                                japp->RootUnLock();
+										japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                 break;
                             case 2:
-                                japp->RootWriteLock();
+										japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                 w = cdc_expected_ring_DOCA2[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                 cdc_expected_ring_DOCA2[ringNum]->SetBinContent(wireNum, 1, w);
-                                japp->RootUnLock();
+										japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                 break;
                             case 3:
-                                japp->RootWriteLock();
+										japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                 w = cdc_expected_ring_DOCA3[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                 cdc_expected_ring_DOCA3[ringNum]->SetBinContent(wireNum, 1, w);
-                                japp->RootUnLock();
+										japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                 break;
                             case 4:
-                                japp->RootWriteLock();
+										japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                 w = cdc_expected_ring_DOCA4[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                 cdc_expected_ring_DOCA4[ringNum]->SetBinContent(wireNum, 1, w);
-                                japp->RootUnLock();
+										japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                 break;
                             case 5:
-                                japp->RootWriteLock();
+										japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                 w = cdc_expected_ring_DOCA5[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                 cdc_expected_ring_DOCA5[ringNum]->SetBinContent(wireNum, 1, w);
-                                japp->RootUnLock();
+										japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                 break;
                             case 6:
-                                japp->RootWriteLock();
+										japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                 w = cdc_expected_ring_DOCA6[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                 cdc_expected_ring_DOCA6[ringNum]->SetBinContent(wireNum, 1, w);
-                                japp->RootUnLock();
+										japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                 break;
                             case 7:
-                                japp->RootWriteLock();
+										japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                 w = cdc_expected_ring_DOCA7[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                 cdc_expected_ring_DOCA7[ringNum]->SetBinContent(wireNum, 1, w);
-                                japp->RootUnLock();
+										japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                 break;
                             default:
                                 cout << "Unknown DOCA Lookup?" << endl;
@@ -564,62 +563,62 @@ jerror_t JEventProcessor_CDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
                         const DCDCHit * locHit = locCDCHitVector[hitNum];
                         if(locHit->ring == ringNum && locHit->straw == wireNum){
                             if (distanceToWire < DOCACUT){
-                                japp->RootWriteLock();
+										japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                 //printf("Matching Hit!!!!!\n");
                                 v = cdc_measured_ring[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                 cdc_measured_ring[ringNum]->SetBinContent(wireNum, 1, v);
                                 double dx = thisTimeBasedTrack->rt->Straw_dx(wire, 0.78);
                                 ChargeVsTrackLength->Fill(dx,locHit->q);
-                                japp->RootUnLock();
+										japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                             }
                             switch ( (int) (distanceToWire * 10) % 8){
                                 case 0:
-                                    japp->RootWriteLock();
+											japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                     v = cdc_measured_ring_DOCA0[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                     cdc_measured_ring_DOCA0[ringNum]->SetBinContent(wireNum, 1, v);
-                                    japp->RootUnLock();
+											japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                     break;
                                 case 1:
-                                    japp->RootWriteLock();
+											japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                     v = cdc_measured_ring_DOCA1[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                     cdc_measured_ring_DOCA1[ringNum]->SetBinContent(wireNum, 1, v);
-                                    japp->RootUnLock();
+											japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                     break;
                                 case 2:
-                                    japp->RootWriteLock();
+											japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                     v = cdc_measured_ring_DOCA2[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                     cdc_measured_ring_DOCA2[ringNum]->SetBinContent(wireNum, 1, v);
-                                    japp->RootUnLock();
+											japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                     break;
                                 case 3:
-                                    japp->RootWriteLock();
+											japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                     v = cdc_measured_ring_DOCA3[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                     cdc_measured_ring_DOCA3[ringNum]->SetBinContent(wireNum, 1, v);
-                                    japp->RootUnLock();
+											japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                     break;
                                 case 4:
-                                    japp->RootWriteLock();
+											japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                     v = cdc_measured_ring_DOCA4[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                     cdc_measured_ring_DOCA4[ringNum]->SetBinContent(wireNum, 1, v);
-                                    japp->RootUnLock();
+											japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                     break;
                                 case 5:
-                                    japp->RootWriteLock();
+											japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                     v = cdc_measured_ring_DOCA5[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                     cdc_measured_ring_DOCA5[ringNum]->SetBinContent(wireNum, 1, v);
-                                    japp->RootUnLock();
+											japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                     break;
                                 case 6:
-                                    japp->RootWriteLock();
+											japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                     v = cdc_measured_ring_DOCA6[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                     cdc_measured_ring_DOCA6[ringNum]->SetBinContent(wireNum, 1, v);
-                                    japp->RootUnLock();
+											japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                     break;
                                 case 7:
-                                    japp->RootWriteLock();
+											japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
                                     v  = cdc_measured_ring_DOCA7[ringNum]->GetBinContent(wireNum, 1) + 1.0;
                                     cdc_measured_ring_DOCA7[ringNum]->SetBinContent(wireNum, 1, v);
-                                    japp->RootUnLock();
+											japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
                                     break;
                                 default:
                                     cout << "Unknown DOCA Lookup?" << endl;

--- a/src/plugins/monitoring/CDC_drift/JEventProcessor_CDC_drift.cc
+++ b/src/plugins/monitoring/CDC_drift/JEventProcessor_CDC_drift.cc
@@ -108,11 +108,6 @@ jerror_t JEventProcessor_CDC_drift::init(void) {
 
 	*/
 
-
-
-
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-
 	// create root folder for cdc and cd to it, store main dir
 	TDirectory *savedir = gDirectory;
 	gDirectory->mkdir("CDC_fits")->cd();
@@ -161,7 +156,6 @@ jerror_t JEventProcessor_CDC_drift::init(void) {
 	afit->Branch("sigma",&sigma,"sigma/D");
 
 	savedir->cd();
-	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 
 	return NOERROR;
 }
@@ -235,8 +229,8 @@ jerror_t JEventProcessor_CDC_drift::evnt(JEventLoop *eventLoop, uint64_t eventnu
 
 
 
-
-	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
+	japp->RootWriteLock(); //ACQUIRE ROOT LOCK
 
 	fithisto = kFALSE;
 
@@ -434,8 +428,6 @@ jerror_t JEventProcessor_CDC_drift::evnt(JEventLoop *eventLoop, uint64_t eventnu
 
 
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
-
-	//app->RootUnLock();
 
 	return NOERROR;
 }

--- a/src/plugins/monitoring/CDC_expert/JEventProcessor_CDC_expert.cc
+++ b/src/plugins/monitoring/CDC_expert/JEventProcessor_CDC_expert.cc
@@ -129,10 +129,6 @@ jerror_t JEventProcessor_CDC_expert::init(void) {
   // I moved all the histogram setup into the brun so that I can use different
   // scales for the later runs using the new firmware.  NSJ.
 
-  //  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-  //  japp->RootUnLock(); //RELEASE ROOT LOCK!!
-
-
   return NOERROR;
 }
 
@@ -414,8 +410,9 @@ jerror_t JEventProcessor_CDC_expert::evnt(JEventLoop *eventLoop, uint64_t eventn
   vector<const Df125WindowRawData*> wrdvector;
   eventLoop->Get(wrdvector);
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   for(uint32_t i=0; i<hits.size(); i++) {
 
@@ -588,8 +585,7 @@ jerror_t JEventProcessor_CDC_expert::evnt(JEventLoop *eventLoop, uint64_t eventn
   }
 
 
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
-
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
   return NOERROR;
 }

--- a/src/plugins/monitoring/CDC_expert_2/JEventProcessor_CDC_expert_2.cc
+++ b/src/plugins/monitoring/CDC_expert_2/JEventProcessor_CDC_expert_2.cc
@@ -128,9 +128,6 @@ JEventProcessor_CDC_expert_2::~JEventProcessor_CDC_expert_2() {
 jerror_t JEventProcessor_CDC_expert_2::init(void) {
 
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-
-
   // raw quantities for read out (fa125 new format) are
   //   time                    field max 2047   scaled x 1, units 0.8ns
   //   time qf                 field max 1 
@@ -339,8 +336,6 @@ jerror_t JEventProcessor_CDC_expert_2::init(void) {
 
   main->cd();    // back to main dir
 
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
-
   return NOERROR;
 
 
@@ -413,8 +408,9 @@ jerror_t JEventProcessor_CDC_expert_2::evnt(JEventLoop *eventLoop, uint64_t even
   eventLoop->Get(digihits);
 
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
 
   for (uint32_t i=0; i<hits.size(); i++) {
@@ -593,7 +589,7 @@ jerror_t JEventProcessor_CDC_expert_2::evnt(JEventLoop *eventLoop, uint64_t even
   } //end for each digihit
 
 
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 
   return NOERROR;

--- a/src/plugins/monitoring/CDC_online/JEventProcessor_CDC_online.cc
+++ b/src/plugins/monitoring/CDC_online/JEventProcessor_CDC_online.cc
@@ -197,7 +197,7 @@ jerror_t JEventProcessor_CDC_online::brun(JEventLoop *eventLoop, int32_t runnumb
 
 
 	if(gDirectory->Get("cdc_raw_amp_vs_n") != NULL)
-  cdc_raw_amp_vs_n = (TH1I*)gDirectory->Get("cdc_raw_amp_vs_n");
+  cdc_raw_amp_vs_n = (TH2I*)gDirectory->Get("cdc_raw_amp_vs_n");
 	else
   cdc_raw_amp_vs_n   = new TH2I("cdc_raw_amp_vs_n","CDC amplitude (ADC units, scaled) vs straw number;straw;ADC units",NSTRAWS,HALF,NSTRAWSPH,128,0,AMAX);
 
@@ -207,7 +207,7 @@ jerror_t JEventProcessor_CDC_online::brun(JEventLoop *eventLoop, int32_t runnumb
   cdc_raw_t = new TH1I("cdc_raw_t",Form("CDC raw time (units of %s); raw time (%s)",rtunits,rtunits),200,0,RTMAX);
 
 	if(gDirectory->Get("cdc_raw_t_vs_n") != NULL)
-  cdc_raw_t_vs_n = (TH1I*)gDirectory->Get("cdc_raw_t_vs_n");
+  cdc_raw_t_vs_n = (TH2I*)gDirectory->Get("cdc_raw_t_vs_n");
 	else
   cdc_raw_t_vs_n = new TH2I("cdc_raw_t_vs_n",Form("CDC raw time (units of %s) vs straw number;straw;time (%s)",rtunits,rtunits),NSTRAWS,HALF,NSTRAWSPH,100,0,RTMAX);
 
@@ -217,7 +217,7 @@ jerror_t JEventProcessor_CDC_online::brun(JEventLoop *eventLoop, int32_t runnumb
   cdc_raw_int   = new TH1I("cdc_raw_int","CDC integral (ADC units, scaled), pedestal subtracted; ADC units",200,0,IMAX);
 
 	if(gDirectory->Get("cdc_raw_int_vs_n") != NULL)
-  cdc_raw_int_vs_n = (TH1I*)gDirectory->Get("cdc_raw_int_vs_n");
+  cdc_raw_int_vs_n = (TH2I*)gDirectory->Get("cdc_raw_int_vs_n");
 	else
   cdc_raw_int_vs_n   = new TH2I("cdc_raw_int_vs_n","CDC integral (ADC units,scaled), pedestal subtracted, vs straw number;straw;ADC units",NSTRAWS,HALF,NSTRAWSPH,100,0,IMAX);
 
@@ -227,7 +227,7 @@ jerror_t JEventProcessor_CDC_online::brun(JEventLoop *eventLoop, int32_t runnumb
   cdc_raw_intpp   = new TH1I("cdc_raw_intpp","CDC integral (ADC units, scaled), includes pedestal; ADC units",200,0,IMAX);
 
 	if(gDirectory->Get("cdc_raw_intpp_vs_n") != NULL)
-  cdc_raw_intpp_vs_n = (TH1I*)gDirectory->Get("cdc_raw_intpp_vs_n");
+  cdc_raw_intpp_vs_n = (TH2I*)gDirectory->Get("cdc_raw_intpp_vs_n");
 	else
   cdc_raw_intpp_vs_n   = new TH2I("cdc_raw_intpp_vs_n","CDC integral (ADC units, scaled), including pedestal, vs straw number;straw;ADC units",NSTRAWS,HALF,NSTRAWSPH,100,0,IMAX);
 
@@ -237,7 +237,7 @@ jerror_t JEventProcessor_CDC_online::brun(JEventLoop *eventLoop, int32_t runnumb
   cdc_ped   = new TH1I("cdc_ped","CDC pedestal (ADC units);pedestal (ADC units)",(Int_t)(PMAX/2),0,PMAX);
 
 	if(gDirectory->Get("cdc_ped_vs_n") != NULL)
-  cdc_ped_vs_n = (TH1I*)gDirectory->Get("cdc_ped_vs_n");
+  cdc_ped_vs_n = (TH2I*)gDirectory->Get("cdc_ped_vs_n");
 	else
   cdc_ped_vs_n   = new TH2I("cdc_ped_vs_n","CDC pedestal (ADC units) vs straw number;straw;pedestal (ADC units)",NSTRAWS,HALF,NSTRAWSPH,(Int_t)(PMAX/4),0,PMAX);
 
@@ -247,7 +247,7 @@ jerror_t JEventProcessor_CDC_online::brun(JEventLoop *eventLoop, int32_t runnumb
   cdc_windata_ped   = new TH1I("cdc_windata_ped","CDC pedestal (ADC units) from raw window data;pedestal (ADC units)",(Int_t)(PMAX/2),0,PMAX);
 
 	if(gDirectory->Get("cdc_windata_ped_vs_n") != NULL)
-  cdc_windata_ped_vs_n = (TH1I*)gDirectory->Get("cdc_windata_ped_vs_n");
+  cdc_windata_ped_vs_n = (TH2I*)gDirectory->Get("cdc_windata_ped_vs_n");
 	else
   cdc_windata_ped_vs_n   = new TH2I("cdc_windata_ped_vs_n","CDC pedestal (ADC units) from raw window data vs straw number;straw;pedestal (ADC units)",NSTRAWS,HALF,NSTRAWSPH,(Int_t)(PMAX/4),0,PMAX);
 

--- a/src/plugins/monitoring/CDC_online/JEventProcessor_CDC_online.cc
+++ b/src/plugins/monitoring/CDC_online/JEventProcessor_CDC_online.cc
@@ -94,9 +94,6 @@ jerror_t JEventProcessor_CDC_online::init(void) {
   // scales for the later runs using the new firmware
 
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-
-
   // create root folder for cdc and cd to it, store main dir
   TDirectory *main = gDirectory;
   gDirectory->mkdir("CDC")->cd();
@@ -131,7 +128,6 @@ jerror_t JEventProcessor_CDC_online::init(void) {
   // back to main dir
   main->cd();
 
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
 
   return NOERROR;
 }
@@ -142,8 +138,6 @@ jerror_t JEventProcessor_CDC_online::init(void) {
 
 jerror_t JEventProcessor_CDC_online::brun(JEventLoop *eventLoop, int32_t runnumber) {
   // This is called whenever the run number changes
-
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 
   // max values for histogram scales, modified fa250-format readout
 
@@ -190,41 +184,76 @@ jerror_t JEventProcessor_CDC_online::brun(JEventLoop *eventLoop, int32_t runnumb
 
   japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 
-
-
-  // created root folder for cdc in init; cd to it, store main dir
-
   gDirectory->cd("CDC");
-
 
   // book histograms
 
+   //CHECK IF HISTOGRAMS ALREADY CREATED. IF SO, GRAB THEM. IF NOT, CREATE THEM
 
+	if(gDirectory->Get("cdc_raw_amp") != NULL)
+  cdc_raw_amp = (TH1I*)gDirectory->Get("cdc_raw_amp");
+	else
   cdc_raw_amp   = new TH1I("cdc_raw_amp","CDC amplitude (ADC units, scaled); ADC units",AMAX,0,AMAX);
+
+
+	if(gDirectory->Get("cdc_raw_amp_vs_n") != NULL)
+  cdc_raw_amp_vs_n = (TH1I*)gDirectory->Get("cdc_raw_amp_vs_n");
+	else
   cdc_raw_amp_vs_n   = new TH2I("cdc_raw_amp_vs_n","CDC amplitude (ADC units, scaled) vs straw number;straw;ADC units",NSTRAWS,HALF,NSTRAWSPH,128,0,AMAX);
 
+	if(gDirectory->Get("cdc_raw_t") != NULL)
+  cdc_raw_t = (TH1I*)gDirectory->Get("cdc_raw_t");
+	else
   cdc_raw_t = new TH1I("cdc_raw_t",Form("CDC raw time (units of %s); raw time (%s)",rtunits,rtunits),200,0,RTMAX);
+
+	if(gDirectory->Get("cdc_raw_t_vs_n") != NULL)
+  cdc_raw_t_vs_n = (TH1I*)gDirectory->Get("cdc_raw_t_vs_n");
+	else
   cdc_raw_t_vs_n = new TH2I("cdc_raw_t_vs_n",Form("CDC raw time (units of %s) vs straw number;straw;time (%s)",rtunits,rtunits),NSTRAWS,HALF,NSTRAWSPH,100,0,RTMAX);
 
-
-
+	if(gDirectory->Get("cdc_raw_int") != NULL)
+  cdc_raw_int = (TH1I*)gDirectory->Get("cdc_raw_int");
+	else
   cdc_raw_int   = new TH1I("cdc_raw_int","CDC integral (ADC units, scaled), pedestal subtracted; ADC units",200,0,IMAX);
+
+	if(gDirectory->Get("cdc_raw_int_vs_n") != NULL)
+  cdc_raw_int_vs_n = (TH1I*)gDirectory->Get("cdc_raw_int_vs_n");
+	else
   cdc_raw_int_vs_n   = new TH2I("cdc_raw_int_vs_n","CDC integral (ADC units,scaled), pedestal subtracted, vs straw number;straw;ADC units",NSTRAWS,HALF,NSTRAWSPH,100,0,IMAX);
 
-
+	if(gDirectory->Get("cdc_raw_intpp") != NULL)
+  cdc_raw_intpp = (TH1I*)gDirectory->Get("cdc_raw_intpp");
+	else
   cdc_raw_intpp   = new TH1I("cdc_raw_intpp","CDC integral (ADC units, scaled), includes pedestal; ADC units",200,0,IMAX);
+
+	if(gDirectory->Get("cdc_raw_intpp_vs_n") != NULL)
+  cdc_raw_intpp_vs_n = (TH1I*)gDirectory->Get("cdc_raw_intpp_vs_n");
+	else
   cdc_raw_intpp_vs_n   = new TH2I("cdc_raw_intpp_vs_n","CDC integral (ADC units, scaled), including pedestal, vs straw number;straw;ADC units",NSTRAWS,HALF,NSTRAWSPH,100,0,IMAX);
 
-
+	if(gDirectory->Get("cdc_ped") != NULL)
+  cdc_ped = (TH1I*)gDirectory->Get("cdc_ped");
+	else
   cdc_ped   = new TH1I("cdc_ped","CDC pedestal (ADC units);pedestal (ADC units)",(Int_t)(PMAX/2),0,PMAX);
+
+	if(gDirectory->Get("cdc_ped_vs_n") != NULL)
+  cdc_ped_vs_n = (TH1I*)gDirectory->Get("cdc_ped_vs_n");
+	else
   cdc_ped_vs_n   = new TH2I("cdc_ped_vs_n","CDC pedestal (ADC units) vs straw number;straw;pedestal (ADC units)",NSTRAWS,HALF,NSTRAWSPH,(Int_t)(PMAX/4),0,PMAX);
 
- 
-
+	if(gDirectory->Get("cdc_windata_ped") != NULL)
+  cdc_windata_ped = (TH1I*)gDirectory->Get("cdc_windata_ped");
+	else
   cdc_windata_ped   = new TH1I("cdc_windata_ped","CDC pedestal (ADC units) from raw window data;pedestal (ADC units)",(Int_t)(PMAX/2),0,PMAX);
+
+	if(gDirectory->Get("cdc_windata_ped_vs_n") != NULL)
+  cdc_windata_ped_vs_n = (TH1I*)gDirectory->Get("cdc_windata_ped_vs_n");
+	else
   cdc_windata_ped_vs_n   = new TH2I("cdc_windata_ped_vs_n","CDC pedestal (ADC units) from raw window data vs straw number;straw;pedestal (ADC units)",NSTRAWS,HALF,NSTRAWSPH,(Int_t)(PMAX/4),0,PMAX);
 
+  gDirectory->cd(".."); //RETURN TO MAIN FOLDER
 
+	japp->RootUnLock(); //RELEASE ROOT LOCK
 
 
   return NOERROR;
@@ -274,7 +303,9 @@ jerror_t JEventProcessor_CDC_online::evnt(JEventLoop *eventLoop, uint64_t eventn
 
 
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   if(digihits.size() > 0)
 	  cdc_num_events->Fill(1);
@@ -406,9 +437,7 @@ jerror_t JEventProcessor_CDC_online::evnt(JEventLoop *eventLoop, uint64_t eventn
 
   } //end of loop through digihits
 
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
-
-  //app->RootUnLock();
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
   return NOERROR;
 }

--- a/src/plugins/monitoring/FDC_online/JEventProcessor_FDC_online.cc
+++ b/src/plugins/monitoring/FDC_online/JEventProcessor_FDC_online.cc
@@ -70,8 +70,6 @@ jerror_t JEventProcessor_FDC_online::init(void) {
   strip_angle=15.*PI/180.; // strip angle now in rads
   cell_rot_step=60.*PI/180.; // cell rotation step now in rads
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-
   // create root folder for fdc and cd to it, store main dir
   TDirectory *main = gDirectory;
   gDirectory->mkdir("FDC")->cd();
@@ -158,8 +156,6 @@ jerror_t JEventProcessor_FDC_online::init(void) {
   // back to main dir
   main->cd();
 
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
-
   return NOERROR;
 }
 
@@ -206,7 +202,9 @@ jerror_t JEventProcessor_FDC_online::evnt(JEventLoop *eventLoop, uint64_t eventn
   vector<const DFDCCathodeDigiHit *>cathodedigis;
   eventLoop->Get(cathodedigis);
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
   
   if( (anodedigis.size()>0) || (cathodedigis.size()>0) )
 	  fdc_num_events->Fill(1);
@@ -299,7 +297,7 @@ jerror_t JEventProcessor_FDC_online::evnt(JEventLoop *eventLoop, uint64_t eventn
      } //end cell loop
   } //end package loop
   
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
   return NOERROR;
 }

--- a/src/plugins/monitoring/L3_online/JEventProcessor_L3_online.cc
+++ b/src/plugins/monitoring/L3_online/JEventProcessor_L3_online.cc
@@ -57,10 +57,6 @@ JEventProcessor_L3_online::~JEventProcessor_L3_online() {
 
 jerror_t JEventProcessor_L3_online::init(void) {
 
-  // lock all root operations
-  japp->RootWriteLock();
-
-
   // create root folder for evnt and cd to it, store main dir
   TDirectory *main = gDirectory;
   gDirectory->mkdir("l3")->cd();
@@ -72,10 +68,6 @@ jerror_t JEventProcessor_L3_online::init(void) {
 
   // back to main dir
   main->cd();
-
-
-  // unlock
-  japp->RootUnLock();
 
   return NOERROR;
 }

--- a/src/plugins/monitoring/PSC_online/JEventProcessor_PSC_online.cc
+++ b/src/plugins/monitoring/PSC_online/JEventProcessor_PSC_online.cc
@@ -117,8 +117,6 @@ JEventProcessor_PSC_online::~JEventProcessor_PSC_online() {
 
 jerror_t JEventProcessor_PSC_online::init(void) {
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-  
   // create root folder for psc and cd to it, store main dir
   TDirectory *mainDir = gDirectory;
   TDirectory *pscDir = gDirectory->mkdir("PSC");
@@ -200,8 +198,6 @@ jerror_t JEventProcessor_PSC_online::init(void) {
   // back to main dir
   mainDir->cd();
 
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
-
   return NOERROR;
 }
 
@@ -243,7 +239,9 @@ jerror_t JEventProcessor_PSC_online::evnt(JEventLoop *eventLoop, uint64_t eventn
     pp_cache[digihits[i]] = pulsePed;
   }
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   if((digihits.size()>0) || (tdcdigihits.size()>0)) psc_num_events->Fill(1);
   
@@ -347,7 +345,7 @@ jerror_t JEventProcessor_PSC_online::evnt(JEventLoop *eventLoop, uint64_t eventn
   }
   hHit_NHits->Fill(NHits[0]+NHits[1]);
   hHit_NHitsVsArm->Fill(0.,NHits[0]); hHit_NHitsVsArm->Fill(1.,NHits[1]);
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
   return NOERROR;
 }

--- a/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.cc
+++ b/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.cc
@@ -50,7 +50,6 @@ jerror_t JEventProcessor_ST_online_Tresolution::init(void)
 	// japp->RootUnLock();
 	//
   // **************** define histograms *************************
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 
   TDirectory *main = gDirectory;
   gDirectory->mkdir("st_Tresolution")->cd();
@@ -70,7 +69,7 @@ jerror_t JEventProcessor_ST_online_Tresolution::init(void)
 
   gDirectory->cd("../");
   main->cd();
-  japp->RootUnLock();
+
   return NOERROR;
 }
 
@@ -166,8 +165,10 @@ jerror_t JEventProcessor_ST_online_Tresolution::evnt(JEventLoop *loop, uint64_t 
   const DEventRFBunch *thisRFBunch = NULL;
   loop->GetSingle(thisRFBunch, "Calibrations");
   
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
-  japp->RootWriteLock();
   for (uint32_t i = 0; i < chargedTrackVector.size(); i++)
     {   
       // Grab the charged track and declare time based track object
@@ -263,7 +264,9 @@ jerror_t JEventProcessor_ST_online_Tresolution::evnt(JEventLoop *loop, uint64_t 
 	  h2_CorrectedTime_z[sc_index]->Fill(locSCzIntersection,Corr_Time_ns - SC_RFShiftedTime);
 	}
     } // sc charged tracks
-  japp->RootUnLock();
+
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
   return NOERROR;
 }
 

--- a/src/plugins/monitoring/ST_online_lowlevel/JEventProcessor_ST_online_lowlevel.cc
+++ b/src/plugins/monitoring/ST_online_lowlevel/JEventProcessor_ST_online_lowlevel.cc
@@ -61,7 +61,6 @@ jerror_t JEventProcessor_ST_online_lowlevel::init(void)
 	//  ... fill historgrams or trees ...
 	// japp->RootUnLock();
 	//
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
   
   //Create root folder for ST and cd to it, store main dir
   TDirectory *main = gDirectory;
@@ -136,7 +135,7 @@ jerror_t JEventProcessor_ST_online_lowlevel::init(void)
     }
   // cd back to main directory
   main->cd();
-  japp->RootUnLock();
+
   return NOERROR;
 }
 
@@ -201,8 +200,10 @@ jerror_t JEventProcessor_ST_online_lowlevel::evnt(JEventLoop *loop, uint64_t eve
   uint32_t TDC_hits       = dsctdcdigihits.size();
   uint32_t Hits           = dschits.size();
 
-  // Lock ROOT mutex so other threads won't interfere 
-  japp->RootWriteLock();
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+
   if( (dscdigihits.size()>0) || (dsctdcdigihits.size()>0) || (dschits.size()>0) )
     st_num_events->Fill(1);
   //******** Fill 2D multiplicity histos ********************************
@@ -438,7 +439,8 @@ jerror_t JEventProcessor_ST_online_lowlevel::evnt(JEventLoop *loop, uint64_t eve
       
     }// End Hit loop
   // Lock ROOT mutex so other threads won't interfere 
-  japp->RootUnLock();
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
   return NOERROR;
 }
 

--- a/src/plugins/monitoring/ST_online_multi/JEventProcessor_ST_online_multi.cc
+++ b/src/plugins/monitoring/ST_online_multi/JEventProcessor_ST_online_multi.cc
@@ -68,7 +68,7 @@ jerror_t JEventProcessor_ST_online_multi::init(void)
 	//  ... fill historgrams or trees ...
 	// japp->RootUnLock();
 	//
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+
   //Create root folder for ST and cd to it, store main dir
   TDirectory *main = gDirectory;
   gDirectory->mkdir("st_multiplicity")->cd();
@@ -105,7 +105,6 @@ jerror_t JEventProcessor_ST_online_multi::init(void)
  
   // cd back to main directory
   main->cd();
-  japp->RootUnLock();
   return NOERROR;
 }
 
@@ -150,9 +149,10 @@ jerror_t JEventProcessor_ST_online_multi::evnt(JEventLoop *loop, uint64_t eventn
   int FAC_hits       = Factory_Hits.size();
  
 
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
-  // Lock ROOT mutex so other threads won't interfere 
-  japp->RootWriteLock();   // Root lock when fill the histos
  //reset the counters to zero
   memset(counter_adc, 0, sizeof(counter_adc));
   memset(counter_tdc, 0, sizeof(counter_tdc));
@@ -259,8 +259,8 @@ jerror_t JEventProcessor_ST_online_multi::evnt(JEventLoop *loop, uint64_t eventn
 	}
     }
   
-  // Mutex Unlock
-  japp->RootUnLock(); //Root unlock
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
   return NOERROR;
 }
 

--- a/src/plugins/monitoring/TAGM_online/JEventProcessor_TAGM_online.cc
+++ b/src/plugins/monitoring/TAGM_online/JEventProcessor_TAGM_online.cc
@@ -164,9 +164,6 @@ JEventProcessor_TAGM_online::~JEventProcessor_TAGM_online() {
 
 jerror_t JEventProcessor_TAGM_online::init(void) {
 
-  // lock all root operations
-  japp->RootWriteLock();
-
 
   // create root folder for tagm and cd to it, store main dir
   TDirectory *main = gDirectory;
@@ -559,9 +556,6 @@ jerror_t JEventProcessor_TAGM_online::init(void) {
   // back to main dir
   main->cd();
 
-  // unlock
-  japp->RootUnLock();
-
   return NOERROR;
 }
 
@@ -592,8 +586,9 @@ jerror_t JEventProcessor_TAGM_online::evnt(JEventLoop *eventLoop, uint64_t event
   eventLoop->Get(tdcdigihits);
   eventLoop->Get(hits);
 
-  // Lock ROOT mutex so other threads won't interfere 
-  japp->RootWriteLock();
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   // Histogram the total number of events
   if( (digihits.size()>0) || (tdcdigihits.size()>0) )
@@ -866,8 +861,8 @@ jerror_t JEventProcessor_TAGM_online::evnt(JEventLoop *eventLoop, uint64_t event
     }
   }
 
-  // Lock ROOT mutex so other threads won't interfere 
-  japp->RootUnLock();
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
   return NOERROR;
 }
 

--- a/src/plugins/monitoring/TOF_TDC_shift/JEventProcessor_TOF_TDC_shift.cc
+++ b/src/plugins/monitoring/TOF_TDC_shift/JEventProcessor_TOF_TDC_shift.cc
@@ -39,8 +39,6 @@ JEventProcessor_TOF_TDC_shift::~JEventProcessor_TOF_TDC_shift() {
 
 jerror_t JEventProcessor_TOF_TDC_shift::init(void) {
   
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-
   // Create root folder for ST and cd to it, store main dir
   TDirectory *main = gDirectory;
   gDirectory->mkdir("TOF_TDC_shift")->cd();
@@ -50,8 +48,6 @@ jerror_t JEventProcessor_TOF_TDC_shift::init(void) {
 
   // cd back to main directory
   main->cd();
-
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
 
   return NOERROR;
 }
@@ -93,9 +89,9 @@ jerror_t JEventProcessor_TOF_TDC_shift::evnt(JEventLoop *eventLoop, uint64_t eve
     }
   }
 
-  // Lock ROOT mutex so other threads won't interfere 
-  japp->RootWriteLock();
-
+	// FILL HISTOGRAMS
+	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   // Fill histogram of TI % 6 vs (ADC time - TDC time)
   for(UInt_t tof = 0;tof<dtofdigihits.size();tof++){
@@ -113,8 +109,8 @@ jerror_t JEventProcessor_TOF_TDC_shift::evnt(JEventLoop *eventLoop, uint64_t eve
       }
     }
   }
-  // Lock ROOT mutex so other threads won't interfere 
-  japp->RootUnLock();
+
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
   return NOERROR;
 }

--- a/src/plugins/monitoring/pedestal_online/JEventProcessor_pedestal_online.cc
+++ b/src/plugins/monitoring/pedestal_online/JEventProcessor_pedestal_online.cc
@@ -86,9 +86,6 @@ jerror_t JEventProcessor_pedestal_online::init(void)
 {
 	if (VERBOSE>=1) printf("JEventProcessor_pedestal_online::init()\n");
 
-	// lock all root operations
-	japp->RootWriteLock();
-		
 	// create root folder for DAQ and cd to it, store main dir
 	maindir = gDirectory;
 	peddir = maindir->mkdir("pedestal");
@@ -103,9 +100,6 @@ jerror_t JEventProcessor_pedestal_online::init(void)
 	
 	// back to main dir
 	maindir->cd();
-	
-	// unlock
-	japp->RootUnLock();
 
 	return NOERROR;
 }
@@ -146,7 +140,7 @@ jerror_t JEventProcessor_pedestal_online::evnt(JEventLoop *loop, uint64_t eventn
 	loop->Get(f250PIs);
 	loop->Get(f125PIs);
 	
-	// Lock ROOT
+	// Although we are only filling objects local to this plugin, the directory changes: Global ROOT lock
 	japp->RootWriteLock();
 
 	if (peddir!=NULL) peddir->cd();


### PR DESCRIPTION
Went through ALL plugins in sim-recon and updated/fixed them:

1) When filling histograms, use new JApplication::RootFillLock() function. This compartmentalizes the locking: don't prevent other plugins from filling their histograms. 
2) Removed nested locks where possible.
3) When writing to TTree in hd_root.root, grab GLOBAL root lock, not plugin-local-lock (TTree::Fill() writes to file).
4) Fix instances where returning from function without releasing lock.
5) Fix one instance of double-lock (and no unlock)
6) No longer swimming reference trajectories inside of a lock (ugh).
7) No longer call JEventLoop::Get() within a lock (yikes!).
8) Consistently use the JANA global root lock when creating hists / trees in brun(), NOT the dapp lock.
9) Remove all locking from JEventProcessor::init(): guaranteed to be single-threaded environment.
10) Other miscellaneous fixes. 

Note that 1) REQUIRES the very-latest version of JANA: 0.7.5p1. You must upgrade to continue updating sim-recon. 
