### PR TITLE
SC Propagation time updates

### DIFF
--- a/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.cc
+++ b/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.cc
@@ -50,12 +50,12 @@ jerror_t JEventProcessor_ST_Propagation_Time::init(void)
 	// japp->RootUnLock();
 	//
   //****** Define Some Constants*********************************
-  NoBins_time = 200;
-  NoBins_z = 300;
-  time_lower_limit = -10.0;      
-  time_upper_limit =  10.0;
-  z_lower_limit = 0.0;
-  z_upper_limit = 60.0;
+  int NoBins_time = 200;
+  int NoBins_z = 300;
+  double time_lower_limit = -10.0;      
+  double time_upper_limit =  10.0;
+  double z_lower_limit = 0.0;
+  double z_upper_limit = 60.0;
   Photonspeed = 29.9792458;
   
   // **************** define histograms *************************
@@ -131,11 +131,21 @@ jerror_t JEventProcessor_ST_Propagation_Time::brun(JEventLoop *eventLoop, int32_
   if(!dapp)
     _DBG_<<"Cannot get DApplication from JEventLoop! (are you using a JApplication based program?)"<<endl; 
   DGeometry* locGeometry = dapp->GetDGeometry(eventLoop->GetJEvent().GetRunNumber());
-  locGeometry->GetStartCounterGeom(sc_pos, sc_norm);
+  sc_angle_corr = 1.;
+  if(locGeometry->GetStartCounterGeom(sc_pos, sc_norm)) {
+      double theta = sc_norm[0][sc_norm[0].size()-2].Theta(); 
+      sc_angle_corr = 1./cos(M_PI_2 - theta);
+  }  
+
   // Propagation Time constant
   if(eventLoop->GetCalib("START_COUNTER/propagation_time_corr", propagation_time_corr))
     jout << "Error loading /START_COUNTER/propagation_time_corr !" << endl;
+
+  // configure parameters
+  trackingFOMCut = 0.0027;  // 3 sigma cut
+
   return NOERROR;
+
 }
 
 //------------------
@@ -179,21 +189,20 @@ jerror_t JEventProcessor_ST_Propagation_Time::evnt(JEventLoop *loop, uint64_t ev
   
   // Grab the associated RF bunch object
   const DEventRFBunch *thisRFBunch = NULL;
-  loop->GetSingle(thisRFBunch, "Calibrations");
+  loop->GetSingle(thisRFBunch);
 
-	// FILL HISTOGRAMS
-	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
-
-  locTOFRFShiftedTime = 9.9E+9;
+  double locTOFRFShiftedTime = 9.9E+9;
   // Loop over the charged tracks
   for (uint32_t i = 0; i < chargedTrackVector.size(); i++)
     {   
+      DSCHitMatchParams  locSCHitMatchParams; 
+      DTOFHitMatchParams locTOFHitMatchParams;
+        
       // Grab the charged track and declare time based track object
       const DChargedTrack   *thisChargedTrack = chargedTrackVector[i];
       const DTrackTimeBased *timeBasedTrack;
       // Grab associated time based track object by selecting charged track with best FOM
-       thisChargedTrack->Get_BestTrackingFOM()->GetSingle(timeBasedTrack);
+      thisChargedTrack->Get_BestTrackingFOM()->GetSingle(timeBasedTrack);
 
       // if (thisChargedTrack->Get_Hypothesis(PiMinus) == NULL) continue;
       // thisChargedTrack->Get_Hypothesis(PiMinus)->GetSingle(timeBasedTrack);
@@ -201,39 +210,38 @@ jerror_t JEventProcessor_ST_Propagation_Time::evnt(JEventLoop *loop, uint64_t ev
       // if (timeBasedTrack->pmag() < pim_pmag_cut) continue;
 
       // Implement quality cuts for the time based tracks 
-      trackingFOMCut = 0.0027;  // 3 sigma cut
       if(timeBasedTrack->FOM  < trackingFOMCut) continue;
   
       // Define vertex vector and cut on target/scattering chamber geometry
-      vertex = timeBasedTrack->position();
-      z_v = vertex.z();
-      r_v = vertex.Perp();
-      z_vertex_cut = fabs(z_target_center - z_v) <= 15.0;
-      r_vertex_cut = r_v < 0.5;
+      DVector3 vertex = timeBasedTrack->position();
+      double z_v = vertex.z();
+      double r_v = vertex.Perp();
+      bool z_vertex_cut = fabs(z_target_center - z_v) <= 15.0;
+      bool r_vertex_cut = r_v < 0.5;
       // Apply  vertex cut
       if (!z_vertex_cut) continue;
       if (!r_vertex_cut) continue;
 
       // Grab the TOF hit match params object and cut on tracks matched to the TOF
       // Want to use TOF/RF time for t0 for SC hit time
-      foundTOF = dParticleID->Get_BestTOFMatchParams(timeBasedTrack, locDetectorMatches, locTOFHitMatchParams);
+      bool foundTOF = dParticleID->Get_BestTOFMatchParams(timeBasedTrack, locDetectorMatches, locTOFHitMatchParams);
       if (!foundTOF) continue;
       
       // If there is a matched track to the SC then skip this track (avoid bias in calibration)
-      foundSCandTOF = dParticleID->Get_BestSCMatchParams(timeBasedTrack, locDetectorMatches, locSCHitMatchParams);
+      bool foundSCandTOF = dParticleID->Get_BestSCMatchParams(timeBasedTrack, locDetectorMatches, locSCHitMatchParams);
       if (foundSCandTOF) continue;
       
       // Cut on the number of particle votes to find the best RF time
       if (thisRFBunch->dNumParticleVotes < 1) continue;
       // Calculate the TOF estimate of the target time
-      locTOFHitTime                 = locTOFHitMatchParams.dHitTime;    // Corrected for timewalk and propagation time 
-      locTOFTrackFlightTime         = locTOFHitMatchParams.dFlightTime;
-      locFlightTimeCorrectedTOFTime = locTOFHitTime - locTOFTrackFlightTime;
+      double locTOFHitTime                 = locTOFHitMatchParams.dHitTime;    // Corrected for timewalk and propagation time 
+      double locTOFTrackFlightTime         = locTOFHitMatchParams.dFlightTime;
+      double locFlightTimeCorrectedTOFTime = locTOFHitTime - locTOFTrackFlightTime;
       
       // Calculate the RF estimate of the target time
-      locCenteredRFTime       = thisRFTime->dTime;                                         // RF time at center of target
-      locCenterToVertexRFTime = (timeBasedTrack->z() - z_target_center)*(1.0/Photonspeed);  // Time correction for photon from target center to vertex of track
-      locVertexRFTime         = locCenteredRFTime + locCenterToVertexRFTime;               // RF time progated to vertex time
+      double locCenteredRFTime       = thisRFTime->dTime;                                         // RF time at center of target
+      double locCenterToVertexRFTime = (timeBasedTrack->z() - z_target_center)*(1.0/Photonspeed);  // Time correction for photon from target center to vertex of track
+      double locVertexRFTime         = locCenteredRFTime + locCenterToVertexRFTime;               // RF time progated to vertex time
       // Correlate the proper RF target time with the TOF "target time"
       locTOFRFShiftedTime = dRFTimeFactory->Step_TimeToNearInputTime(locVertexRFTime, locFlightTimeCorrectedTOFTime);
       if (locTOFRFShiftedTime != 9.9E+9)
@@ -243,167 +251,179 @@ jerror_t JEventProcessor_ST_Propagation_Time::evnt(JEventLoop *loop, uint64_t ev
     {
       // Loop over the charged tracks
       for (uint32_t i = 0; i < chargedTrackVector.size(); i++)
-	{
-	  // Grab the charged track and declare time based track object
-	  const DChargedTrack   *thisChargedTrack = chargedTrackVector[i];
-	  const DTrackTimeBased *timeBasedTrack;
-	  // Grab associated time based track object by selecting charged track with best FOM
-	  thisChargedTrack->Get_BestTrackingFOM()->GetSingle(timeBasedTrack);
+      {
+          DSCHitMatchParams  locSCHitMatchParams; 
+          //DTOFHitMatchParams locTOFHitMatchParams;
+
+          // Grab the charged track and declare time based track object
+          const DChargedTrack   *thisChargedTrack = chargedTrackVector[i];
+          const DTrackTimeBased *timeBasedTrack;
+          // Grab associated time based track object by selecting charged track with best FOM
+          thisChargedTrack->Get_BestTrackingFOM()->GetSingle(timeBasedTrack);
 	  
-	  // Implement quality cuts for the time based tracks 
-	  trackingFOMCut = 0.0027;  // 3 sigma cut
-	  if(timeBasedTrack->FOM  < trackingFOMCut) continue;
+          // Implement quality cuts for the time based tracks 
+          if(timeBasedTrack->FOM  < trackingFOMCut) continue;
+          
+          // Define vertex vector and cut on target/scattering chamber geometry
+          DVector3 vertex = timeBasedTrack->position();
+          double z_v = vertex.z();
+          double r_v = vertex.Perp();
+          bool z_vertex_cut = fabs(z_target_center - z_v) <= 15.0;
+          bool r_vertex_cut = r_v < 0.5;
+          // Apply  vertex cut
+          if (!z_vertex_cut) continue;
+          if (!r_vertex_cut) continue;
+          // Grab the ST hit match params object and cut on tracks matched to the ST
+          bool foundSC = dParticleID->Get_BestSCMatchParams(timeBasedTrack, locDetectorMatches, locSCHitMatchParams);
+          if (!foundSC) continue;
 	  
-	  // Define vertex vector and cut on target/scattering chamber geometry
-	  vertex = timeBasedTrack->position();
-	  z_v = vertex.z();
-	  r_v = vertex.Perp();
-	  z_vertex_cut = fabs(z_target_center - z_v) <= 15.0;
-	  r_vertex_cut = r_v < 0.5;
-// Apply  vertex cut
-	  if (!z_vertex_cut) continue;
-	  if (!r_vertex_cut) continue;
-	  // Grab the ST hit match params object and cut on tracks matched to the ST
-	  foundSC = dParticleID->Get_BestSCMatchParams(timeBasedTrack, locDetectorMatches, locSCHitMatchParams);
-	  if (!foundSC) continue;
+          // Define sector array index
+          int sc_index = locSCHitMatchParams.dSCHit->sector - 1;
+          // Start Counter geometry in hall coordinates 
+          double sc_pos_soss = sc_pos[sc_index][0].z();   // Start of straight section
+          double sc_pos_eoss = sc_pos[sc_index][1].z();   // End of straight section
+          double sc_pos_eobs = sc_pos[sc_index][11].z();  // End of bend section
+          double sc_pos_eons = sc_pos[sc_index][12].z();  // End of nose section
+          
+          vector<DSCHitMatchParams> st_params;
+          bool sc_match = locDetectorMatches->Get_SCMatchParams(timeBasedTrack, st_params); 
+          // If st_match = true, there is a match between this track and the ST
+          if (!sc_match) continue;
+          DVector3 IntersectionPoint;
+          DVector3 IntersectionDir;
+          bool sc_match_pid = dParticleID->MatchToSC(timeBasedTrack, 
+                                                timeBasedTrack->rt, 
+                                                st_params[0].dSCHit, 
+                                                st_params[0].dSCHit->t, 
+                                                locSCHitMatchParams, 
+                                                true,
+                                                &IntersectionPoint, &IntersectionDir);      
+          if(!sc_match_pid) continue;
+          // For each paddle calculate the hit time, flight time, intersection point (z), and t0 from TOF
+          // For each hit we want to calculate thit - tflight - t0 from TOF
+          // Then correlate with hit position along z
 	  
-	  // Define sector array index
-	  sc_index = locSCHitMatchParams.dSCHit->sector - 1;
-	  // Start Counter geometry in hall coordinates 
-	  sc_pos_soss = sc_pos[sc_index][0].z();   // Start of straight section
-	  sc_pos_eoss = sc_pos[sc_index][1].z();   // End of straight section
-	  sc_pos_eobs = sc_pos[sc_index][11].z();  // End of bend section
-	  sc_pos_eons = sc_pos[sc_index][12].z();  // End of nose section
+          double locSCHitTime                 = st_params[0].dSCHit->t; //Only corrected for time walk
+          double locSCTrackFlightTime         = locSCHitMatchParams.dFlightTime;  
+          double locFlightTimeCorrectedSCTime = locSCHitTime - locSCTrackFlightTime;
 	  
-	  sc_match = locDetectorMatches->Get_SCMatchParams(timeBasedTrack, st_params); 
-	  // If st_match = true, there is a match between this track and the ST
-	  if (!sc_match) continue;
-	  sc_match_pid = dParticleID->MatchToSC(timeBasedTrack, 
-	  					timeBasedTrack->rt, 
-	  					st_params[0].dSCHit, 
-	  					st_params[0].dSCHit->t, 
-	  					locSCHitMatchParams, 
-	  					true,
-	  					&IntersectionPoint, &IntersectionDir);      
-	  if(!sc_match_pid) continue;
-	  // For each paddle calculate the hit time, flight time, intersection point (z), and t0 from TOF
-	  // For each hit we want to calculate thit - tflight - t0 from TOF
-	  // Then correlate with hit position along z
-	  
-	  locSCHitTime                 = st_params[0].dSCHit->t; //Only corrected for time walk
-	  locSCTrackFlightTime         = locSCHitMatchParams.dFlightTime;  
-	  locFlightTimeCorrectedSCTime = locSCHitTime - locSCTrackFlightTime;
-	  
-	  locSCPropTime = locFlightTimeCorrectedSCTime - locTOFRFShiftedTime;
-	  // Z intersection of charged track and SC 
-	  locSCzIntersection = IntersectionPoint.z();
-	  // Calculate the path along the paddle
-	  //Define some parameters
-	  double Radius = 12.0;
-	  double pi = 3.14159265358979323846;
-	  double theta  = 18.5 * pi/180.0;
-	  double path_ss,path_bs,path_ns; 
-	  double SS_Length = sc_pos_eoss - sc_pos_soss;// same for along z or along the paddle
-	  double BS_Length = Radius *  theta ; // along the paddle
-	  double NS_Length = (sc_pos_eons - sc_pos_eobs)/cos(theta);// along the paddle
-	  double Paddle_Length = SS_Length + BS_Length + NS_Length; // total paddle length
-	  double SC_Length_AlongZ = sc_pos_eons - sc_pos_soss; // SC length along z which is shorter than the total paddle length
-	  //=================================================================================================
-	  // I tested the calculation of the path along the paddle between the equal signs ========= comments
-	  //from line 303 to line 339
-	  // cout <<" ========== This is event number " << eventnumber <<"==========="<<endl;
-	  // cout << "Length of straight section              = "  << SS_Length << endl;
-	  // cout << "Length of bend section along the paddle = "  << BS_Length  << endl;
-	  // cout << "Length of nose section along the paddle = "  << NS_Length << endl;
-	  // cout << "Total Paddle_Length  = "  << Paddle_Length << endl;
-	  // cout << "-----------------"<<endl;
-	  // cout << "   SC_Length_AlongZ  = "  << SC_Length_AlongZ << endl;
-	  // // cout << "Start of straight section = "  << sc_pos_soss << endl;
-	  // // cout << "End of straight section = "  << sc_pos_eoss << endl;
-	  // // cout << "End of bend section = "  << sc_pos_eobs << endl;
-	  // // cout << "End of nose section = "  << sc_pos_eons << endl;
-	  // cout << " ========================================================="<<endl;
-	  // cout << "                   next z coordiate is                    "<<endl;
-	  // cout << " ========================================================="<<endl;
-	  // cout << "Z along the beam line = "  << IntersectionPoint.z() << endl;
-	  // if (locSCzIntersection > sc_pos_soss && locSCzIntersection <= sc_pos_eoss)
-	  //   {
-	  //     // Path along the paddle for straight section the 
-	  //     path_ss = IntersectionPoint.z() - sc_pos_soss;
-	  //     //   cout << "$$$$$$$ Path along paddle for  SS  = "  << path_ss << endl;
-	  //   }
-	  // if(locSCzIntersection > sc_pos_eoss && locSCzIntersection <= sc_pos_eobs)
-	  //   {
-	  //     //  Path along the paddle for the bend section 
-	  //     path_bs = SS_Length + Radius * asin((IntersectionPoint.z()- sc_pos_eoss)/Radius);
-	  //     // cout << "$$$$$$$ Path along paddle for BS  = "  << path_bs << endl;
-	  //   }
-	  // if(locSCzIntersection > sc_pos_eobs && locSCzIntersection <= sc_pos_eons)
-	  //   { 
-	  //     //  Path along the paddle for the nose section 
-	  //     path_ns = SS_Length + BS_Length +((IntersectionPoint.z() - sc_pos_eobs)/cos(theta));
-	  //     //  cout << "$$$$$$$ Path along paddle for NS  = "  << path_ns << endl;
-	  //   }
-	  //========================================================================================================	  
-	  /////////////////////////////////////////////
-	  // Fill the histograms before corrections////
-	  ////////////////////////////////////////////
-	  // Straight Sections
-	  if (locSCzIntersection > sc_pos_soss && locSCzIntersection <= sc_pos_eoss)
-	    {
-	      path_ss = IntersectionPoint.z() - sc_pos_soss;
-	      h2_PropTime_z_SS_chan[sc_index]->Fill(path_ss,locSCPropTime);
-	      h2_PpropTime_z[sc_index]->Fill(path_ss,locSCPropTime);
-	    }
-	  // Bend Sections
-	  if(locSCzIntersection > sc_pos_eoss && locSCzIntersection <= sc_pos_eobs)
-	    {
-	      path_bs = SS_Length + Radius * asin((IntersectionPoint.z()- sc_pos_eoss)/Radius);
-	      h2_PropTime_z_BS_chan[sc_index]->Fill(path_bs,locSCPropTime);
-	      h2_PpropTime_z[sc_index]->Fill(path_bs,locSCPropTime);
-	    }
-	  // Nose Sections
-	  if(locSCzIntersection > sc_pos_eobs && locSCzIntersection <= sc_pos_eons) 
-	    {
-	      path_ns = SS_Length + BS_Length +((IntersectionPoint.z() - sc_pos_eobs)/cos(theta));
-	      h2_PropTime_z_NS_chan[sc_index]->Fill(path_ns,locSCPropTime);
-	      h2_PpropTime_z[sc_index]->Fill(path_ns,locSCPropTime);
-	    }
-	  ///////////////////////////////////////////////////////////////////
-	  /// Fill the propagation time corrected histograms////////////////
-	  /////////////////////////////////////////////////////////////////
-	  // Read the constants from CCDB
-	  double incpt_ss   = propagation_time_corr[sc_index][0];
-	  double slope_ss   = propagation_time_corr[sc_index][1];
-	  double incpt_bs   = propagation_time_corr[sc_index][2];
-	  double slope_bs   = propagation_time_corr[sc_index][3];
-	  double incpt_ns   = propagation_time_corr[sc_index][4];
-	  double slope_ns   = propagation_time_corr[sc_index][5];
-	  // Straight Sections
-	  if (sc_pos_soss < locSCzIntersection  && locSCzIntersection <= sc_pos_eoss)
-	    {
-	      Corr_Time_ss = locSCPropTime - (incpt_ss + (slope_ss *  path_ss));
-	      h2_PropTimeCorr_z_SS_chan[sc_index]->Fill(path_ss,Corr_Time_ss);
-	      h2_CorrectedTime_z[sc_index]->Fill(path_ss,Corr_Time_ss);
-	    }
-	  // Bend Sections
-	  if( sc_pos_eoss < locSCzIntersection  && locSCzIntersection <= sc_pos_eobs)
-	    {
-	      Corr_Time_bs = locSCPropTime - (incpt_bs + (slope_bs *  path_bs));
-	      h2_PropTimeCorr_z_BS_chan[sc_index]->Fill(path_bs,Corr_Time_bs);
-	      h2_CorrectedTime_z[sc_index]->Fill(path_bs,Corr_Time_bs);
-	    }
-	  // Nose Sections
-	  if(sc_pos_eobs < locSCzIntersection   && locSCzIntersection <= sc_pos_eons)
-	    { 
-	      Corr_Time_ns = locSCPropTime - (incpt_ns + (slope_ns *  path_ns));
-	      h2_PropTimeCorr_z_NS_chan[sc_index]->Fill(path_ns,Corr_Time_ns);
-	      h2_CorrectedTime_z[sc_index]->Fill(path_ns,Corr_Time_ns);
-	    }
+          double locSCPropTime = locFlightTimeCorrectedSCTime - locTOFRFShiftedTime;
+          // Z intersection of charged track and SC 
+          double locSCzIntersection = IntersectionPoint.z();
+          // Calculate the path along the paddle
+          //Define some parameters
+          //double Radius = 12.0;
+          //double pi = 3.14159265358979323846;
+          //double theta  = 18.5 * pi/180.0;
+          double path_ss=0.,path_bs=0.,path_ns=0.; 
+          double SS_Length = sc_pos_eoss - sc_pos_soss;// same for along z or along the paddle
+          //double BS_Length = Radius *  theta ; // along the paddle
+          //double NS_Length = (sc_pos_eons - sc_pos_eobs)/cos(theta);// along the paddle
+          //double Paddle_Length = SS_Length + BS_Length + NS_Length; // total paddle length
+          //double SC_Length_AlongZ = sc_pos_eons - sc_pos_soss; // SC length along z which is shorter than the total paddle length
+          //=================================================================================================
+          // I tested the calculation of the path along the paddle between the equal signs ========= comments
+          //from line 303 to line 339
+          // cout <<" ========== This is event number " << eventnumber <<"==========="<<endl;
+          // cout << "Length of straight section              = "  << SS_Length << endl;
+          // cout << "Length of bend section along the paddle = "  << BS_Length  << endl;
+          // cout << "Length of nose section along the paddle = "  << NS_Length << endl;
+          // cout << "Total Paddle_Length  = "  << Paddle_Length << endl;
+          // cout << "-----------------"<<endl;
+          // cout << "   SC_Length_AlongZ  = "  << SC_Length_AlongZ << endl;
+          // // cout << "Start of straight section = "  << sc_pos_soss << endl;
+          // // cout << "End of straight section = "  << sc_pos_eoss << endl;
+          // // cout << "End of bend section = "  << sc_pos_eobs << endl;
+          // // cout << "End of nose section = "  << sc_pos_eons << endl;
+          // cout << " ========================================================="<<endl;
+          // cout << "                   next z coordiate is                    "<<endl;
+          // cout << " ========================================================="<<endl;
+          // cout << "Z along the beam line = "  << IntersectionPoint.z() << endl;
+          // if (locSCzIntersection > sc_pos_soss && locSCzIntersection <= sc_pos_eoss)
+          //   {
+          //     // Path along the paddle for straight section the 
+          //     path_ss = IntersectionPoint.z() - sc_pos_soss;
+          //     //   cout << "$$$$$$$ Path along paddle for  SS  = "  << path_ss << endl;
+          //   }
+          // if(locSCzIntersection > sc_pos_eoss && locSCzIntersection <= sc_pos_eobs)
+          //   {
+          //     //  Path along the paddle for the bend section 
+          //     path_bs = SS_Length + Radius * asin((IntersectionPoint.z()- sc_pos_eoss)/Radius);
+          //     // cout << "$$$$$$$ Path along paddle for BS  = "  << path_bs << endl;
+          //   }
+          // if(locSCzIntersection > sc_pos_eobs && locSCzIntersection <= sc_pos_eons)
+          //   { 
+          //     //  Path along the paddle for the nose section 
+          //     path_ns = SS_Length + BS_Length +((IntersectionPoint.z() - sc_pos_eobs)/cos(theta));
+          //     //  cout << "$$$$$$$ Path along paddle for NS  = "  << path_ns << endl;
+          //   }
+          //========================================================================================================	  
+          /////////////////////////////////////////////
+          // Fill the histograms before corrections////
+          ////////////////////////////////////////////
+          // FILL HISTOGRAMS
+          // Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+          japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+          
+          // Straight Sections
+          if (locSCzIntersection > sc_pos_soss && locSCzIntersection <= sc_pos_eoss)
+          {
+              path_ss = IntersectionPoint.z() - sc_pos_soss;
+              h2_PropTime_z_SS_chan[sc_index]->Fill(path_ss,locSCPropTime);
+              h2_PpropTime_z[sc_index]->Fill(path_ss,locSCPropTime);
+          }
+          // Bend Sections
+          if(locSCzIntersection > sc_pos_eoss && locSCzIntersection <= sc_pos_eobs)
+          {
+              //path_bs = SS_Length + Radius * asin((IntersectionPoint.z()- sc_pos_eoss)/Radius);
+              path_bs = SS_Length +  (locSCzIntersection - sc_pos_eoss)*sc_angle_corr;;
+              h2_PropTime_z_BS_chan[sc_index]->Fill(path_bs,locSCPropTime);
+              h2_PpropTime_z[sc_index]->Fill(path_bs,locSCPropTime);
+          }
+          // Nose Sections
+          if(locSCzIntersection > sc_pos_eobs && locSCzIntersection <= sc_pos_eons) 
+          {
+              //path_ns = SS_Length + BS_Length +((IntersectionPoint.z() - sc_pos_eobs)/cos(theta));
+              path_ns = SS_Length +  (locSCzIntersection - sc_pos_eoss)*sc_angle_corr;;
+              h2_PropTime_z_NS_chan[sc_index]->Fill(path_ns,locSCPropTime);
+              h2_PpropTime_z[sc_index]->Fill(path_ns,locSCPropTime);
+          }
+          ///////////////////////////////////////////////////////////////////
+          /// Fill the propagation time corrected histograms////////////////
+          /////////////////////////////////////////////////////////////////
+          // Read the constants from CCDB
+          double incpt_ss   = propagation_time_corr[sc_index][0];
+          double slope_ss   = propagation_time_corr[sc_index][1];
+          double incpt_bs   = propagation_time_corr[sc_index][2];
+          double slope_bs   = propagation_time_corr[sc_index][3];
+          double incpt_ns   = propagation_time_corr[sc_index][4];
+          double slope_ns   = propagation_time_corr[sc_index][5];
+          // Straight Sections
+          if (sc_pos_soss < locSCzIntersection  && locSCzIntersection <= sc_pos_eoss)
+          {
+              double Corr_Time_ss = locSCPropTime - (incpt_ss + (slope_ss *  path_ss));
+              h2_PropTimeCorr_z_SS_chan[sc_index]->Fill(path_ss,Corr_Time_ss);
+              h2_CorrectedTime_z[sc_index]->Fill(path_ss,Corr_Time_ss);
+          }
+          // Bend Sections
+          if( sc_pos_eoss < locSCzIntersection  && locSCzIntersection <= sc_pos_eobs)
+          {
+              double Corr_Time_bs = locSCPropTime - (incpt_bs + (slope_bs *  path_bs));
+              h2_PropTimeCorr_z_BS_chan[sc_index]->Fill(path_bs,Corr_Time_bs);
+              h2_CorrectedTime_z[sc_index]->Fill(path_bs,Corr_Time_bs);
+          }
+          // Nose Sections
+          if(sc_pos_eobs < locSCzIntersection   && locSCzIntersection <= sc_pos_eons)
+          { 
+              double Corr_Time_ns = locSCPropTime - (incpt_ns + (slope_ns *  path_ns));
+              h2_PropTimeCorr_z_NS_chan[sc_index]->Fill(path_ns,Corr_Time_ns);
+              h2_CorrectedTime_z[sc_index]->Fill(path_ns,Corr_Time_ns);
+          }
+          japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
    	} // sc charged tracks
     }// TOF reference time
 
-	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
   return NOERROR;
 }

--- a/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.h
+++ b/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.h
@@ -102,7 +102,8 @@ class JEventProcessor_ST_Propagation_Time:public jana::JEventProcessor{
 		TH2I **h2_PropTime_z_SS_chan;
 		TH2I **h2_PropTime_z_BS_chan;
 		TH2I **h2_PropTime_z_NS_chan;
-				
+		TH2I **h2_PpropTime_z;
+		
 		TH2I **h2_PropTimeCorr_z_SS_chan;
 		TH2I **h2_PropTimeCorr_z_BS_chan;
 		TH2I **h2_PropTimeCorr_z_NS_chan;

--- a/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.h
+++ b/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.h
@@ -62,42 +62,43 @@ class JEventProcessor_ST_Propagation_Time:public jana::JEventProcessor{
 		double z_target_center;  // Target center along z
 		double dRFBunchPeriod;   // RF bunch period from CCDBr
 		//////////////////////////////////
-		double locSCHitTime,       locSCTrackFlightTime,   locFlightTimeCorrectedSCTime;
-		double locTOFHitTime,      locTOFTrackFlightTime,  locFlightTimeCorrectedTOFTime;
-		double locCenteredRFTime,  locCenterToVertexRFTime,  locVertexRFTime, locPeriod;
-		double locTOFRFShiftedTime;
-		double locSCzIntersection;
-		double locSCPropTime;
-		double sc_pos_soss, sc_pos_eoss, sc_pos_eobs, sc_pos_eons;
-		double  Corr_Time,Corr_Time_ss,Corr_Time_bs,Corr_Time_ns, Corr_Time_bn;
-		double time_lower_limit, time_upper_limit, z_lower_limit, z_upper_limit;
-		int NoBins_time, NoBins_z;
+		//double locSCHitTime,       locSCTrackFlightTime,   locFlightTimeCorrectedSCTime;
+		//double locTOFHitTime,      locTOFTrackFlightTime,  locFlightTimeCorrectedTOFTime;
+		//double locCenteredRFTime,  locCenterToVertexRFTime,  locVertexRFTime, locPeriod;
+		//double locTOFRFShiftedTime;
+		///double locSCzIntersection;
+		//double locSCPropTime;
+		//double sc_pos_soss, sc_pos_eoss, sc_pos_eobs, sc_pos_eons;
+		//double  Corr_Time,Corr_Time_ss,Corr_Time_bs,Corr_Time_ns, Corr_Time_bn;
+		//double time_lower_limit, time_upper_limit, z_lower_limit, z_upper_limit;
+		//int NoBins_time, NoBins_z;
 
 		vector<vector<DVector3> >sc_pos;   // SC geometry vector
 		vector<vector<DVector3> >sc_norm;  
 		// Grab match track detector parameters
-		DTOFHitMatchParams locTOFHitMatchParams;  // TOF
-		DSCHitMatchParams  locSCHitMatchParams;   // SC
+		//DTOFHitMatchParams locTOFHitMatchParams;  // TOF
+		//DSCHitMatchParams  locSCHitMatchParams;   // SC
 		// Declare event vertex vector
-		DVector3 vertex;
+		//DVector3 vertex;
 		// Declare a vector which quantizes the point of the intersection of a charged particle 
 		//   with a plane in the middle of the scintillator 
-		DVector3 IntersectionPoint;
+		//DVector3 IntersectionPoint;
 		// Declare a vector which quantizes the unit vector of the charged particle track traversing
 		//   through the scintillator with its origin at the intersection point
-		DVector3 IntersectionDir;
+		//DVector3 IntersectionDir;
 		// Grab the paramteres associated to a track matched to the ST
-		vector<DSCHitMatchParams> st_params;
+		//vector<DSCHitMatchParams> st_params;
 		// Declare r and z coord. of track vertex, sc array index
-		double z_v, r_v;
-		int sc_index;
+		//double z_v, r_v;
+		//int sc_index;
 		double Photonspeed;
 		// Cuts
 		double trackingFOMCut;
 		double pim_pmag_cut;
-		bool z_vertex_cut, r_vertex_cut;
-		bool foundTOF, foundSC, foundSCandTOF;
-		bool sc_match, sc_match_pid;
+        double sc_angle_corr;
+		//bool z_vertex_cut, r_vertex_cut;
+		//bool foundTOF, foundSC, foundSCandTOF;
+		//bool sc_match, sc_match_pid;
 		// ******************* 2D histos **************
 		TH2I **h2_PropTime_z_SS_chan;
 		TH2I **h2_PropTime_z_BS_chan;

--- a/src/plugins/Calibration/ST_Propagation_Time/macros/st_prop_time_corr_v1.C
+++ b/src/plugins/Calibration/ST_Propagation_Time/macros/st_prop_time_corr_v1.C
@@ -69,16 +69,18 @@ void st_prop_time_corr_v1(char*input_filename)
       //Create the canvas
       PT_can[j] = new TCanvas( Form("PT_can_%i",j+1), Form("PT_can_%i",j+1), 800, 450);
       PT_can[j]->Divide(2, 2);
+      // The top directory 
+      TopDirectory = (TDirectory*) df->FindObjectAny("ST_Propagation_Time"); 
+      TopDirectory->cd();
       // Grab the histograms 
       char* ss = Form("h2_PropTimeCorr_z_SS_chan_%i",j+1);
-      TH2I* h2_ss = (TH2I*) df->Get(ss);
+      h2_ss = (TH2I*) TopDirectory->FindObjectAny(ss);
       char* bs = Form("h2_PropTimeCorr_z_BS_chan_%i",j+1);
-      TH2I* h2_bs = (TH2I*) df->Get(bs);
+      h2_bs = (TH2I*) TopDirectory->FindObjectAny(bs);
       char* ns = Form("h2_PropTimeCorr_z_NS_chan_%i",j+1);
-      TH2I* h2_ns = (TH2I*) df->Get(ns);
+      h2_ns = (TH2I*) TopDirectory->FindObjectAny(ns);
       char* total = Form("h2_CorrectedTime_z_%i",j+1);
-      TH2I* h2_total = (TH2I*) df->Get(total);
-      
+      h2_total = (TH2I*) TopDirectory->FindObjectAny(total);      
       //*****************************************************************
       //***********  Plot stt vs z SS                  ******************
       //*****************************************************************
@@ -89,12 +91,12 @@ void st_prop_time_corr_v1(char*input_filename)
       gPad->SetTicks();
       gPad->SetGrid();
       h2_ss->Draw("colz");
-      h2_ss->SetTitle("SS Corrected Time");
+      h2_ss->SetTitle("Straight Section Corrected Time");
       h2_ss->SetXTitle("Z (cm)");
       h2_ss->SetYTitle("SC Time (ns)");
       h2_ss->GetZaxis()->SetRangeUser(0,4);
-      h2_ss->GetXaxis()->SetRangeUser(45,98);
-      h2_ss->GetYaxis()->SetRangeUser(-3.0,3.0);
+      h2_ss->GetXaxis()->SetRangeUser(0,40);
+      h2_ss->GetYaxis()->SetRangeUser(-5.0,5.0);
       gPad->Update();
       //*****************************************************************
       //***********  Plot stt vs z BS                  ******************
@@ -106,12 +108,12 @@ void st_prop_time_corr_v1(char*input_filename)
       gPad->SetGrid();
             
       h2_bs->Draw("colz");
-      h2_bs->SetTitle("BS Corrected Time");
+      h2_bs->SetTitle("Bend Section Corrected Time");
       h2_bs->SetXTitle("Z (cm)");
       h2_bs->SetYTitle("SC Time (ns)");
       h2_bs->GetZaxis()->SetRangeUser(0,4);
-      h2_bs->GetXaxis()->SetRangeUser(45,98);
-      h2_bs->GetYaxis()->SetRangeUser(-3.0,3.0);
+      h2_bs->GetXaxis()->SetRangeUser(39,43);
+      h2_bs->GetYaxis()->SetRangeUser(-5.0,5.0);
       gPad->Update();
       //*****************************************************************
       //***********  Plot stt vs z NS                  ******************
@@ -123,12 +125,12 @@ void st_prop_time_corr_v1(char*input_filename)
       gPad->SetGrid();
       
       h2_ns->Draw("colz");
-      h2_ns->SetTitle("NS Corrected Time");
+      h2_ns->SetTitle("Nose Section Corrected Time");
       h2_ns->SetXTitle("Z (cm)");
       h2_ns->SetYTitle("SC Time (ns)");
       h2_ns->GetZaxis()->SetRangeUser(0,4);
-      h2_ns->GetXaxis()->SetRangeUser(45,98);
-      h2_ns->GetYaxis()->SetRangeUser(-3.0,3.0);
+      h2_ns->GetXaxis()->SetRangeUser(43,60);
+      h2_ns->GetYaxis()->SetRangeUser(-5.0,5.0);
       gPad->Update();
       //*****************************************************************
       //***********  Plot Total corrected time from each division *******
@@ -144,8 +146,8 @@ void st_prop_time_corr_v1(char*input_filename)
       h2_total->SetXTitle("Z (cm)");
       h2_total->SetYTitle("SC Time (ns)");
       h2_total->GetZaxis()->SetRangeUser(0,4);
-      h2_total->GetXaxis()->SetRangeUser(45,98);
-      h2_total->GetYaxis()->SetRangeUser(-3.0,3.0);
+      h2_total->GetXaxis()->SetRangeUser(0,60);
+      h2_total->GetYaxis()->SetRangeUser(-5.0,5.0);
       gPad->Update();
     }
   // Close the output file

--- a/src/plugins/Calibration/ST_Propagation_Time/macros/st_prop_time_v1.C
+++ b/src/plugins/Calibration/ST_Propagation_Time/macros/st_prop_time_v1.C
@@ -36,7 +36,7 @@ Double_t t_z_ns_fit_slope[NCHANNELS][3];
 Double_t t_z_ns_fit_slope_err[NCHANNELS][3];
 Double_t t_z_ns_fit_intercept[NCHANNELS][3];
 Double_t t_z_ns_fit_intercept_err[NCHANNELS][3];
-const int NOXbins = 1300;
+const int NOXbins = 300;
 const int NOYbins = 200;
 int sss[NCHANNELS][NOXbins][NOYbins];
 Double_t binsss[NCHANNELS][NOXbins][NOYbins];
@@ -59,14 +59,17 @@ void st_prop_time_v1(char*input_filename)
       //Create the canvas
       PT_can[j] = new TCanvas( Form("PT_can_%i",j+1),  Form("PT_can_%i",j+1), 800, 450);
       PT_can[j]->Divide(3, 1);
-	  
+      // The top directory 
+      TopDirectory = (TDirectory*) df->FindObjectAny("ST_Propagation_Time"); 
+      TopDirectory->cd();
       // Grab the histograms 
       char* ss = Form("h2_PropTime_z_SS_chan_%i",j+1);
-      TH1I* h2_ss = (TH1I*) df->Get(ss);
+      //  TH1I* h2_ss = (TH1I*) df->Get(ss);
+      h2_ss = (TH1I*) TopDirectory->FindObjectAny(ss);
       char* bs = Form("h2_PropTime_z_BS_chan_%i",j+1);
-      TH1I* h2_bs = (TH1I*) df->Get(bs);
+      h2_bs = (TH1I*) TopDirectory->FindObjectAny(bs);
       char* ns = Form("h2_PropTime_z_NS_chan_%i",j+1);
-      TH1I* h2_ns = (TH1I*) df->Get(ns);
+      h2_ns = (TH1I*) TopDirectory->FindObjectAny(ns);
       
       cout << "==================================================" << endl;
       cout << "Processing Channel " << j+1 << endl;
@@ -79,11 +82,12 @@ void st_prop_time_v1(char*input_filename)
       gStyle->SetErrorX(0); 
       gPad->SetTicks();
       gPad->SetGrid();
-      h2_ss->SetTitle("SS ST Time Vs Z");
+      h2_ss->SetTitle("Straight Section");
       h2_ss->GetZaxis()->SetRangeUser(0,4);
-      h2_ss->GetYaxis()->SetRangeUser(0.,4.);
-      h2_ss->GetYaxis()->SetTitle("ST Time (ns)");
-      h2_ss->GetXaxis()->SetRangeUser(50.,78.0);
+      h2_ss->GetYaxis()->SetRangeUser(0.,5.);
+      h2_ss->GetYaxis()->SetTitle("ST Propagation Time (ns)");
+      h2_ss->GetXaxis()->SetTitle("Path Length (cm)");
+      h2_ss->GetXaxis()->SetRangeUser(0.,40.0);
       h2_ss->Draw("colz");
       h2_ss->Fit("pol1");		
       t_z_ss_fit_slope[j][1] = pol1->GetParameter(1);
@@ -98,11 +102,12 @@ void st_prop_time_v1(char*input_filename)
       gPad->SetTicks();
       gPad->SetGrid();
       h2_bs->Draw("colz"); 
-      h2_bs->SetTitle("BS ST Time Vs Z");
+      h2_bs->SetTitle("Bend Section");
       h2_bs->GetZaxis()->SetRangeUser(0,4);
-      h2_bs->GetYaxis()->SetRangeUser(0.,4.);
-      h2_bs->GetYaxis()->SetTitle("ST Time (ns)");
-      h2_bs->GetXaxis()->SetRangeUser(77.,81.0);
+      h2_bs->GetYaxis()->SetRangeUser(0.,5.);
+      h2_bs->GetYaxis()->SetTitle("ST Propagation Time (ns)");
+      h2_bs->GetXaxis()->SetTitle("Path Length (cm)");
+      h2_bs->GetXaxis()->SetRangeUser(39.,43.0);
      
 
       h2_bs->Fit("pol1");
@@ -119,11 +124,12 @@ void st_prop_time_v1(char*input_filename)
       gPad->SetTicks();
       gPad->SetGrid();
       h2_ns->Draw("colz");
-      h2_ns->SetTitle("NS ST Time Vs Z");
+      h2_ns->SetTitle("Nose Section");
       h2_ns->GetZaxis()->SetRangeUser(0,4);
-      h2_ns->GetYaxis()->SetRangeUser(0.,4.);
-      h2_ns->GetYaxis()->SetTitle("ST Time (ns)");
-      h2_ns->GetXaxis()->SetRangeUser(80.,98.0);
+      h2_ns->GetYaxis()->SetRangeUser(0.,5.);
+      h2_ns->GetYaxis()->SetTitle("ST  Propagation Time (ns)");
+      h2_ns->GetXaxis()->SetTitle("Path Length (cm)");
+      h2_ns->GetXaxis()->SetRangeUser(43.,60.0);
       h2_ns->Fit("pol1");
       t_z_ns_fit_slope[j][1] = pol1->GetParameter(1);
       t_z_ns_fit_slope_err[j][1] = pol1->GetParError(1);

--- a/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.h
+++ b/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.h
@@ -61,47 +61,46 @@ class JEventProcessor_ST_Tresolution:public jana::JEventProcessor{
 		double z_target_center;  // Target center along z
 		double dRFBunchPeriod;   // RF bunch period from CCDBr
 		//////////////////////////////////
-		double locSCHitTime,       locSCTrackFlightTime,   locFlightTimeCorrectedSCTime;
-		double locTOFHitTime,      locTOFTrackFlightTime,  locFlightTimeCorrectedTOFTime;
-		double locCenteredRFTime,  locCenterToVertexRFTime,  locVertexRFTime, locPeriod;
-		double SC_RFShiftedTime;
-		double locSCzIntersection;
-		double locSCPropTime;
-		double sc_pos_soss, sc_pos_eoss, sc_pos_eobs, sc_pos_eons;
-		double  Corr_Time,Corr_Time_ss,Corr_Time_bs,Corr_Time_ns, Corr_Time_bn;
-		double time_lower_limit, time_upper_limit, z_lower_limit, z_upper_limit;
-		int NoBins_time, NoBins_z;
-		double st_time, FlightTime, st_corr_FlightTime; 
+		//double locSCHitTime,       locSCTrackFlightTime,   locFlightTimeCorrectedSCTime;
+		//double locTOFHitTime,      locTOFTrackFlightTime,  locFlightTimeCorrectedTOFTime;
+		//double locCenteredRFTime,  locCenterToVertexRFTime,  locVertexRFTime, locPeriod;
+		//double SC_RFShiftedTime;
+		//double locSCzIntersection;
+		//double locSCPropTime;
+		//double sc_pos_soss, sc_pos_eoss, sc_pos_eobs, sc_pos_eons;
+		//double  Corr_Time,Corr_Time_ss,Corr_Time_bs,Corr_Time_ns, Corr_Time_bn;
+		//double time_lower_limit, time_upper_limit, z_lower_limit, z_upper_limit;
+		//int NoBins_time, NoBins_z;
+		//double st_time, FlightTime, st_corr_FlightTime; 
 		vector<vector<DVector3> >sc_pos;   // SC geometry vector
 		vector<vector<DVector3> >sc_norm;  
 		// Grab match track detector parameters
-		DTOFHitMatchParams locTOFHitMatchParams;  // TOF
-		DSCHitMatchParams  locSCHitMatchParams;   // SC
+		//DTOFHitMatchParams locTOFHitMatchParams;  // TOF
+		//DSCHitMatchParams  locSCHitMatchParams;   // SC
 		// Declare event vertex vector
-		DVector3 vertex;
+		//DVector3 vertex;
 		// Declare a vector which quantizes the point of the intersection of a charged particle 
 		//   with a plane in the middle of the scintillator 
-		DVector3 IntersectionPoint;
+		//DVector3 IntersectionPoint;
 		// Declare a vector which quantizes the unit vector of the charged particle track traversing
 	//   through the scintillator with its origin at the intersection point
-		DVector3 IntersectionDir;
+		//DVector3 IntersectionDir;
 		// Grab the paramteres associated to a track matched to the ST
-		vector<DSCHitMatchParams> st_params;
+		//vector<DSCHitMatchParams> st_params;
 		// Declare r and z coord. of track vertex, sc array index
-		double z_v, r_v;
-		int sc_index;
+		//double z_v, r_v;
+		//int sc_index;
 		// Cuts
 		double trackingFOMCut;
 		double pim_pmag_cut;
-		bool z_vertex_cut, r_vertex_cut;
-		bool foundTOF, foundSC, foundSCandTOF;
-		bool sc_match, sc_match_pid;
+        double sc_angle_corr;
+		//bool z_vertex_cut, r_vertex_cut;
+		//bool foundTOF, foundSC, foundSCandTOF;
+		//bool sc_match, sc_match_pid;
 		// ******************* 2D histos **************
 		TH2I **h2_CorrectedTime_z;
 		//Define Calibration parameters variable called from CCDB
 		vector<vector<double> >propagation_time_corr;
-
-        string RF_BUNCH_TAG;
 };
 
 #endif // _JEventProcessor_ST_Tresolution_

--- a/src/plugins/Calibration/ST_Tresolution/macros/st_time_resolution.C
+++ b/src/plugins/Calibration/ST_Tresolution/macros/st_time_resolution.C
@@ -92,10 +92,12 @@ void st_time_resolution(char*input_filename)
       //Create the canvas
       PT_can[j] = new TCanvas( Form("PT_can_%i",j+1), Form("PT_can_%i",j+1), 800, 450);
       PT_can[j]->Divide(2, 1);
-	  
+	 // The top directory 
+      TopDirectory = (TDirectory*) df->FindObjectAny("ST_Tresolution"); 
+      TopDirectory->cd(); 
       // Grab the histograms
       char* total = Form("h2_CorrectedTime_z_%i",j+1);
-      TH2I* h2_total = (TH2I*) df->Get(total);
+      h2_total = (TH2I*) TopDirectory->FindObjectAny(total);
       char* pj = Form("py_%i",j+1);
       TH1D* pytotal = (TH1D*)pj;
       


### PR DESCRIPTION
- Make propagation time corrections be consistently defined in terms of path length through scintillator
- Rewrite plugins to pull expensive calculations outside of locks
- Other minor changes
