### PR TITLE
Skimmer Overhaul

### DIFF
--- a/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.cc
+++ b/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.cc
@@ -39,6 +39,9 @@ jerror_t DParticleComboBlueprint_factory::init(void)
 	string HYPOTHESES = locMassStream.str();
 	gPARMS->SetDefaultParameter("TRKFIT:HYPOTHESES", HYPOTHESES);
 
+	dMaxNumNeutralShowers = 20;
+	gPARMS->SetDefaultParameter("COMBO:MAX_NEUTRALS", dMaxNumNeutralShowers);
+
 	// Parse MASS_HYPOTHESES strings to make list of masses to try
 	hypotheses.clear();
 	SplitString(HYPOTHESES, hypotheses, ",");
@@ -129,6 +132,9 @@ jerror_t DParticleComboBlueprint_factory::evnt(JEventLoop *locEventLoop, uint64_
 
 	locEventLoop->Get(dChargedTracks, dTrackSelectionTag.c_str());
 	locEventLoop->Get(dNeutralShowers, dShowerSelectionTag.c_str());
+
+	if(dNeutralShowers.size() > dMaxNumNeutralShowers)
+		return NOERROR; //don't even try
 
 	//sort charged particles into +/-
 	//Note that a DChargedTrack object can sometimes contain both positively and negatively charged hypotheses simultaneously: sometimes the tracking flips the sign of the track

--- a/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.h
+++ b/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.h
@@ -97,6 +97,8 @@ class DParticleComboBlueprint_factory : public jana::JFactory<DParticleComboBlue
 		map<DParticleComboBlueprintStep, DParticleComboBlueprintStep*> dBlueprintStepMap;
 
 		DTrackTimeBased_factory_Combo* dTrackTimeBasedFactory_Combo;
+
+		size_t dMaxNumNeutralShowers;
 };
 
 #endif // _DParticleComboBlueprint_factory_

--- a/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.cc
+++ b/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.cc
@@ -327,7 +327,7 @@ jerror_t DEventProcessor_track_skimmer::fini(void)
 	//Close streams
 	map<string, ofstream*>::iterator locStreamIterator = dIDXAStreamMap.begin();
 	for(; locStreamIterator != dIDXAStreamMap.end(); ++locStreamIterator)
-		locStreamIterator->second.close();
+		locStreamIterator->second->close();
 
 	return NOERROR;
 }

--- a/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.cc
+++ b/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.cc
@@ -33,29 +33,65 @@ jerror_t DEventProcessor_track_skimmer::init(void)
 	// japp->RootUnLock();
 	//
 
-	dIDXAStream_2track.open("eventlist_2track.idxa");
-	dIDXAStream_2track << "IDXA" << endl;
+	//CREATE STREAMS
 
-	dIDXAStream_2track1pi0.open("eventlist_2track1pi0.idxa");
-	dIDXAStream_2track1pi0 << "IDXA" << endl;
+	//# Tracks
+	dIDXAStreamMap["q+"] = new ofstream("q+.idxa");
+	dIDXAStreamMap["2q+"] = new ofstream("2q+.idxa");
+	dIDXAStreamMap["3q+"] = new ofstream("3q+.idxa");
+	dIDXAStreamMap["q-"] = new ofstream("q-.idxa");
+	dIDXAStreamMap["2q-"] = new ofstream("2q-.idxa");
 
-	dIDXAStream_3track.open("eventlist_3track.idxa");
-	dIDXAStream_3track << "IDXA" << endl;
+	//# Showers
+	dIDXAStreamMap["q0"] = new ofstream("q0.idxa");
+	dIDXAStreamMap["2q0"] = new ofstream("2q0.idxa");
+	dIDXAStreamMap["3q0"] = new ofstream("3q0.idxa");
+	dIDXAStreamMap["4q0"] = new ofstream("4q0.idxa");
+	dIDXAStreamMap["5q0"] = new ofstream("5q0.idxa");
+	dIDXAStreamMap["6q0"] = new ofstream("6q0.idxa");
 
-	dIDXAStream_3track1pi0.open("eventlist_3track1pi0.idxa");
-	dIDXAStream_3track1pi0 << "IDXA" << endl;
+	//# pi0s
+	dIDXAStreamMap["pi0"] = new ofstream("pi0.idxa");
+	dIDXAStreamMap["2pi0"] = new ofstream("2pi0.idxa");
+	dIDXAStreamMap["3pi0"] = new ofstream("3pi0.idxa");
 
-	dIDXAStream_4track.open("eventlist_4track.idxa");
-	dIDXAStream_4track << "IDXA" << endl;
+	//KShort
+	dIDXAStreamMap["ks_2piq"] = new ofstream("ks_2piq.idxa");
+	dIDXAStreamMap["ks_2pi0"] = new ofstream("ks_2pi0.idxa");
 
-	dIDXAStream_4track1pi0.open("eventlist_4track1pi0.idxa");
-	dIDXAStream_4track1pi0 << "IDXA" << endl;
+	//Eta
+	dIDXAStreamMap["eta_2g"] = new ofstream("eta_2g.idxa");
+	dIDXAStreamMap["eta_3pi0"] = new ofstream("eta_3pi0.idxa");
+	dIDXAStreamMap["eta_3piq"] = new ofstream("eta_3piq.idxa");
 
-	dIDXAStream_5track.open("eventlist_5track.idxa");
-	dIDXAStream_5track << "IDXA" << endl;
+	//Omega
+	dIDXAStreamMap["omega_3piq"] = new ofstream("omega_3piq.idxa");
+	dIDXAStreamMap["omega_pi0g"] = new ofstream("omega_pi0g.idxa");
 
-	dIDXAStream_5track1pi0.open("eventlist_5track1pi0.idxa");
-	dIDXAStream_5track1pi0 << "IDXA" << endl;
+	//EtaPrime
+	dIDXAStreamMap["etaprm_2piqeta_2g"] = new ofstream("etaprm_2piqeta_2g.idxa");
+	dIDXAStreamMap["etaprm_2piqeta_3pi0"] = new ofstream("etaprm_2piqeta_3pi0.idxa");
+	dIDXAStreamMap["etaprm_2piqeta_3piq"] = new ofstream("etaprm_2piqeta_3piq.idxa");
+	dIDXAStreamMap["etaprm_2piqg"] = new ofstream("etaprm_2piqg.idxa");
+	dIDXAStreamMap["etaprm_2pi0eta_2g"] = new ofstream("etaprm_2pi0eta_2g.idxa");
+	dIDXAStreamMap["etaprm_2pi0eta_3pi0"] = new ofstream("etaprm_2pi0eta_3pi0.idxa");
+	dIDXAStreamMap["etaprm_2pi0eta_3piq"] = new ofstream("etaprm_2pi0eta_3piq.idxa");
+
+	//Phi
+	dIDXAStreamMap["phi_2kq"] = new ofstream("phi_2kq.idxa");
+	dIDXAStreamMap["phi_3piq"] = new ofstream("phi_3piq.idxa");
+
+	//Strange Baryons
+	dIDXAStreamMap["lambda"] = new ofstream("lambda.idxa");
+	dIDXAStreamMap["sigma0"] = new ofstream("sigma0.idxa");
+	dIDXAStreamMap["sigma+"] = new ofstream("sigma+.idxa");
+	dIDXAStreamMap["xi-"] = new ofstream("xi-.idxa");
+	dIDXAStreamMap["xi0"] = new ofstream("xi0.idxa");
+
+	//First line
+	map<string, ofstream*>::iterator locStreamIterator = dIDXAStreamMap.begin();
+	for(; locStreamIterator != dIDXAStreamMap.end(); ++locStreamIterator)
+		*(locStreamIterator->second) << "IDXA" << endl;
 
 	return NOERROR;
 }
@@ -100,45 +136,140 @@ jerror_t DEventProcessor_track_skimmer::evnt(jana::JEventLoop* locEventLoop, uin
 	unsigned int locRunNumber = locEventLoop->GetJEvent().GetRunNumber();
 	unsigned int locUniqueID = locMCThrowns.empty() ? 1 : Get_FileNumber(locEventLoop);
 
+	//Default Tag: No PreSelect!! // Definition of PreSelect may change, and these skims are intended to be universal
+	vector<const DChargedTrack*> locChargedTracks;
+	locEventLoop->Get(locChargedTracks);
+	size_t locNumQPlus = 0, locNumQMinus = 0;
+	for(size_t loc_i = 0; loc_i < locChargedTracks.size(); ++loc_i)
+	{
+		if(locChargedTracks[loc_i]->Contains_Charge(1))
+			++locNumQPlus;
+		if(locChargedTracks[loc_i]->Contains_Charge(-1)) //intentionally NOT "else if"!!! //can have a track with both charges!
+			++locNumQMinus;
+	}
+
+	//Default Tag: No PreSelect!! // Definition of PreSelect may change, and these skims are intended to be universal
+	vector<const DNeutralShower*> locNeutralShowers;
+	locEventLoop->Get(locNeutralShowers);
+
+	//Find which skims are satisfied by this event
+	set<ofstream*> locSaveSkimStreams;
+
+	//# Tracks
+	if(locNumQPlus >= 1)
+		locSaveSkimStreams.insert(dIDXAStreamMap["q+"]);
+	if(locNumQPlus >= 2)
+		locSaveSkimStreams.insert(dIDXAStreamMap["2q+"]);
+	if(locNumQPlus >= 3)
+		locSaveSkimStreams.insert(dIDXAStreamMap["3q+"]);
+	if(locNumQMinus >= 1)
+		locSaveSkimStreams.insert(dIDXAStreamMap["q-"]);
+	if(locNumQMinus >= 2)
+		locSaveSkimStreams.insert(dIDXAStreamMap["2q-"]);
+
+	//# Showers
+	if(locNeutralShowers.size() >= 1)
+		locSaveSkimStreams.insert(dIDXAStreamMap["q0"]);
+	if(locNeutralShowers.size() >= 2)
+		locSaveSkimStreams.insert(dIDXAStreamMap["2q0"]);
+	if(locNeutralShowers.size() >= 3)
+		locSaveSkimStreams.insert(dIDXAStreamMap["3q0"]);
+	if(locNeutralShowers.size() >= 4)
+		locSaveSkimStreams.insert(dIDXAStreamMap["4q0"]);
+	if(locNeutralShowers.size() >= 5)
+		locSaveSkimStreams.insert(dIDXAStreamMap["5q0"]);
+	if(locNeutralShowers.size() >= 6)
+		locSaveSkimStreams.insert(dIDXAStreamMap["6q0"]);
+
 	//Get the analysis results for all DReactions. 
 		//Getting these objects triggers the analysis, if it wasn't performed already. 
 		//These objects contain the DParticleCombo objects that survived the DAnalysisAction cuts that were added to the DReactions
 	vector<const DAnalysisResults*> locAnalysisResultsVector;
 	locEventLoop->Get(locAnalysisResultsVector);
 
-	vector<const DChargedTrack*> locChargedTracks;
-	locEventLoop->Get(locChargedTracks, "PreSelect");
+	//DECAYING PARTICLES
+	for(size_t loc_i = 0; loc_i < locAnalysisResultsVector.size(); ++loc_i)
+	{
+		const DAnalysisResults* locAnalysisResults = locAnalysisResultsVector[loc_i];
+		if(locAnalysisResults->Get_NumPassedParticleCombos() == 0)
+			continue; // no combos passed
 
-	//MUST LOCK AROUND MODIFICATION OF MEMBER VARIABLES IN brun() or evnt().
+		string locReactionName = locAnalysisResults->Get_Reaction()->Get_ReactionName();
+
+		//# Pi0
+		if(locReactionName == "skim_pi0")
+			locSaveSkimStreams.insert(dIDXAStreamMap["pi0"]);
+		else if(locReactionName == "skim_2pi0")
+			locSaveSkimStreams.insert(dIDXAStreamMap["2pi0"]);
+		else if(locReactionName == "skim_3pi0")
+			locSaveSkimStreams.insert(dIDXAStreamMap["3pi0"]);
+
+		//KShort
+		else if(locReactionName == "skim_ks_2piq")
+			locSaveSkimStreams.insert(dIDXAStreamMap["ks_2piq"]);
+		else if(locReactionName == "skim_ks_2pi0")
+			locSaveSkimStreams.insert(dIDXAStreamMap["ks_2pi0"]);
+
+		//Eta
+		else if(locReactionName == "skim_eta_2g")
+			locSaveSkimStreams.insert(dIDXAStreamMap["eta_2g"]);
+		else if(locReactionName == "skim_eta_3pi0")
+			locSaveSkimStreams.insert(dIDXAStreamMap["eta_3pi0"]);
+		else if(locReactionName == "skim_eta_3piq")
+			locSaveSkimStreams.insert(dIDXAStreamMap["eta_3piq"]);
+
+		//Omega
+		else if(locReactionName == "skim_omega_3piq")
+			locSaveSkimStreams.insert(dIDXAStreamMap["omega_3piq"]);
+		else if(locReactionName == "skim_omega_pi0g")
+			locSaveSkimStreams.insert(dIDXAStreamMap["omega_pi0g"]);
+
+		//EtaPrime
+		else if(locReactionName == "skim_etaprm_2piqeta_2g")
+			locSaveSkimStreams.insert(dIDXAStreamMap["etaprm_2piqeta_2g"]);
+		else if(locReactionName == "skim_etaprm_2piqeta_3pi0")
+			locSaveSkimStreams.insert(dIDXAStreamMap["etaprm_2piqeta_3pi0"]);
+		else if(locReactionName == "skim_etaprm_2piqeta_3piq")
+			locSaveSkimStreams.insert(dIDXAStreamMap["etaprm_2piqeta_3piq"]);
+		else if(locReactionName == "skim_etaprm_2piqg")
+			locSaveSkimStreams.insert(dIDXAStreamMap["etaprm_2piqg"]);
+		else if(locReactionName == "skim_etaprm_2pi0eta_2g")
+			locSaveSkimStreams.insert(dIDXAStreamMap["etaprm_2pi0eta_2g"]);
+		else if(locReactionName == "skim_etaprm_2pi0eta_3pi0")
+			locSaveSkimStreams.insert(dIDXAStreamMap["etaprm_2pi0eta_3pi0"]);
+		else if(locReactionName == "skim_etaprm_2pi0eta_3piq")
+			locSaveSkimStreams.insert(dIDXAStreamMap["etaprm_2pi0eta_3piq"]);
+
+		//Phi
+		else if(locReactionName == "skim_phi_2kq")
+			locSaveSkimStreams.insert(dIDXAStreamMap["phi_2kq"]);
+		else if(locReactionName == "skim_phi_3piq")
+			locSaveSkimStreams.insert(dIDXAStreamMap["phi_3piq"]);
+
+		//Strange Baryons
+		else if(locReactionName == "skim_lambda")
+			locSaveSkimStreams.insert(dIDXAStreamMap["lambda"]);
+		else if(locReactionName == "skim_sigma0")
+			locSaveSkimStreams.insert(dIDXAStreamMap["sigma0"]);
+		else if(locReactionName == "skim_sigma+")
+			locSaveSkimStreams.insert(dIDXAStreamMap["sigma+"]);
+		else if(locReactionName == "skim_xi-")
+			locSaveSkimStreams.insert(dIDXAStreamMap["xi-"]);
+		else if(locReactionName == "skim_xi0")
+			locSaveSkimStreams.insert(dIDXAStreamMap["xi0"]);
+	}
+
+	//BUILD TO-PRINT STRING
+	ostringstream locToPrintStream;
+	locToPrintStream << locRunNumber << " " << locEventNumber << " " << locUniqueID;
+	string locToPrintString = locToPrintStream.str();
+
+	//LOCK AND PRINT
+	set<ofstream*>::iterator locSetIterator = locSaveSkimStreams.begin();
 	LockState();
 	{
-		if(locChargedTracks.size() >= 2)
-			dIDXAStream_2track << locRunNumber << " " << locEventNumber << " " << locUniqueID << endl;
-		if(locChargedTracks.size() >= 3)
-			dIDXAStream_3track << locRunNumber << " " << locEventNumber << " " << locUniqueID << endl;
-		if(locChargedTracks.size() >= 4)
-			dIDXAStream_4track << locRunNumber << " " << locEventNumber << " " << locUniqueID << endl;
-		if(locChargedTracks.size() >= 5)
-			dIDXAStream_5track << locRunNumber << " " << locEventNumber << " " << locUniqueID << endl;
-
-		// If a particle combo passed the cuts, save the event info in the output file
-		for(size_t loc_i = 0; loc_i < locAnalysisResultsVector.size(); ++loc_i)
-		{
-			const DAnalysisResults* locAnalysisResults = locAnalysisResultsVector[loc_i];
-			if(locAnalysisResults->Get_Reaction()->Get_ReactionName() != "pi0")
-				continue; // analysis results were for a different reaction
-			if(locAnalysisResults->Get_NumPassedParticleCombos() == 0)
-				continue; // no combos passed
-
-			if(locChargedTracks.size() >= 2)
-				dIDXAStream_2track1pi0 << locRunNumber << " " << locEventNumber << " " << locUniqueID << endl;
-			if(locChargedTracks.size() >= 3)
-				dIDXAStream_3track1pi0 << locRunNumber << " " << locEventNumber << " " << locUniqueID << endl;
-			if(locChargedTracks.size() >= 4)
-				dIDXAStream_4track1pi0 << locRunNumber << " " << locEventNumber << " " << locUniqueID << endl;
-			if(locChargedTracks.size() >= 5)
-				dIDXAStream_5track1pi0 << locRunNumber << " " << locEventNumber << " " << locUniqueID << endl;
-		}
+		for(; locSetIterator != locSaveSkimStreams.end(); ++locSetIterator)
+			(**locSetIterator) << locToPrintString << endl;
 	}
 	UnlockState();
 
@@ -192,17 +323,11 @@ jerror_t DEventProcessor_track_skimmer::erun(void)
 jerror_t DEventProcessor_track_skimmer::fini(void)
 {
 	// Called before program exit after event processing is finished.
-	dIDXAStream_2track.close();
-	dIDXAStream_2track1pi0.close();
 
-	dIDXAStream_3track.close();
-	dIDXAStream_3track1pi0.close();
-
-	dIDXAStream_4track.close();
-	dIDXAStream_4track1pi0.close();
-
-	dIDXAStream_5track.close();
-	dIDXAStream_5track1pi0.close();
+	//Close streams
+	map<string, ofstream*>::iterator locStreamIterator = dIDXAStreamMap.begin();
+	for(; locStreamIterator != dIDXAStreamMap.end(); ++locStreamIterator)
+		locStreamIterator->second.close();
 
 	return NOERROR;
 }

--- a/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.cc
+++ b/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.cc
@@ -129,6 +129,23 @@ jerror_t DEventProcessor_track_skimmer::evnt(jana::JEventLoop* locEventLoop, uin
 	// DOCUMENTATION:
 	// ANALYSIS library: https://halldweb1.jlab.org/wiki/index.php/GlueX_Analysis_Software
 
+	//See if is physics event, or is REST
+	bool locIsRESTEvent = (string(locEventLoop->GetJEvent().GetJEventSource()->className()) == string("DEventSourceREST"));
+	if(!locIsRESTEvent)
+	{
+		if(!locEventLoop->GetJEvent().GetStatusBit(kSTATUS_PHYSICS_EVENT))
+		   return NOERROR;
+
+		vector<const DL1Trigger*> trigger_info;
+		locEventLoop->Get(trigger_info);
+		if(trigger_info.empty())
+			return NOERROR;
+
+		// require event to have production FCAL+BCAL trigger
+		if((trigger_info[0]->trig_mask & 0x01) == 0)
+			return NOERROR;
+	}
+
 	// See whether this is MC data or real data
 	vector<const DMCThrown*> locMCThrowns;
 	locEventLoop->Get(locMCThrowns);

--- a/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.h
+++ b/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.h
@@ -20,6 +20,8 @@
 
 #include "DFactoryGenerator_track_skimmer.h"
 
+#include "DANA/DStatusBits.h"
+
 using namespace jana;
 using namespace std;
 

--- a/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.h
+++ b/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.h
@@ -8,6 +8,9 @@
 #ifndef _DEventProcessor_track_skimmer_
 #define _DEventProcessor_track_skimmer_
 
+#include <map>
+#include <fstream>
+
 #include <JANA/JEventProcessor.h>
 #include <JANA/JApplication.h>
 
@@ -34,17 +37,7 @@ class DEventProcessor_track_skimmer : public jana::JEventProcessor
 
 		int Get_FileNumber(JEventLoop* locEventLoop) const;
 
-		ofstream dIDXAStream_2track;
-		ofstream dIDXAStream_2track1pi0;
-
-		ofstream dIDXAStream_3track;
-		ofstream dIDXAStream_3track1pi0;
-
-		ofstream dIDXAStream_4track;
-		ofstream dIDXAStream_4track1pi0;
-
-		ofstream dIDXAStream_5track;
-		ofstream dIDXAStream_5track1pi0;
+		map<string, ofstream*> dIDXAStreamMap;
 };
 
 #endif // _DEventProcessor_track_skimmer_

--- a/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.h
+++ b/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.h
@@ -21,6 +21,7 @@
 #include "DFactoryGenerator_track_skimmer.h"
 
 #include "DANA/DStatusBits.h"
+#include "TRIGGER/DL1Trigger.h"
 
 using namespace jana;
 using namespace std;

--- a/src/plugins/Utilities/track_skimmer/DReaction_factory_track_skimmer.cc
+++ b/src/plugins/Utilities/track_skimmer/DReaction_factory_track_skimmer.cc
@@ -14,16 +14,353 @@ jerror_t DReaction_factory_track_skimmer::init(void)
 {
 	// Make as many DReaction objects as desired
 	DReactionStep* locReactionStep = NULL;
-	DReaction* locReaction = new DReaction("pi0"); //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
+	DReaction* locReaction = NULL; //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
 
 	// DOCUMENTATION:
 	// ANALYSIS library: https://halldweb1.jlab.org/wiki/index.php/GlueX_Analysis_Software
 	// DReaction factory: https://halldweb1.jlab.org/wiki/index.php/Analysis_DReaction
 
-	/**************************************************** track_skimmer Reaction Steps ****************************************************/
+	/**************************************************** skim_pi0 ****************************************************/
 
-	//Required: DReactionSteps to specify the channel and decay chain you want to study
-		//Particles are of type Particle_t, an enum defined in sim-recon/src/libraries/include/particleType.h
+	locReaction = new DReaction("skim_pi0");
+
+	//pi0 -> g, g
+	DReactionStep* locReactionStep_Pi01 = new DReactionStep();
+	locReactionStep_Pi01->Set_InitialParticleID(Pi0);
+	locReactionStep_Pi01->Add_FinalParticleID(Gamma);
+	locReactionStep_Pi01->Add_FinalParticleID(Gamma);
+	locReaction->Add_ReactionStep(locReactionStep_Pi01);
+	dReactionStepPool.push_back(locReactionStep_Pi01); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_2pi0 ****************************************************/
+
+	locReaction = new DReaction("skim_2pi0");
+
+	//X -> 2pi0
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(Unknown);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+
+	//pi0 -> g, g
+	DReactionStep* locReactionStep_Pi02 = new DReactionStep();
+	locReactionStep_Pi02->Set_InitialParticleID(Pi0);
+	locReactionStep_Pi02->Add_FinalParticleID(Gamma);
+	locReactionStep_Pi02->Add_FinalParticleID(Gamma);
+	locReaction->Add_ReactionStep(locReactionStep_Pi02);
+	dReactionStepPool.push_back(locReactionStep_Pi02); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_3pi0 ****************************************************/
+
+	locReaction = new DReaction("skim_3pi0");
+
+	//X -> 3pi0
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(Unknown);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+	locReaction->Add_ReactionStep(locReactionStep_Pi02); //pi0 -> g, g
+
+	//pi0 -> g, g
+	DReactionStep* locReactionStep_Pi03 = new DReactionStep();
+	locReactionStep_Pi03->Set_InitialParticleID(Pi0);
+	locReactionStep_Pi03->Add_FinalParticleID(Gamma);
+	locReactionStep_Pi03->Add_FinalParticleID(Gamma);
+	locReaction->Add_ReactionStep(locReactionStep_Pi03);
+	dReactionStepPool.push_back(locReactionStep_Pi03); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_ks_2piq ****************************************************/
+
+	locReaction = new DReaction("skim_ks_2piq");
+
+	//ks -> pi+, pi-
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(KShort);
+	locReactionStep->Add_FinalParticleID(PiPlus);
+	locReactionStep->Add_FinalParticleID(PiMinus);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_InvariantMassCut(KShort, 0.3, 0.7);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, KShort, false, 800, 0.3, 0.7, "KShort"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_ks_2pi0 ****************************************************/
+
+	locReaction = new DReaction("skim_ks_2pi0");
+
+	//ks -> 2pi0
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(KShort);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+	locReaction->Add_ReactionStep(locReactionStep_Pi02); //pi0 -> g, g
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(KShort, 0.3, 0.7);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, KShort, false, 800, 0.3, 0.7, "KShort"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_eta_2g ****************************************************/
+
+	locReaction = new DReaction("skim_eta_2g");
+
+	//eta -> g, g
+	DReactionStep* locReactionStep_Eta2g = new DReactionStep();
+	locReactionStep_Eta2g->Set_InitialParticleID(Eta);
+	locReactionStep_Eta2g->Add_FinalParticleID(Gamma);
+	locReactionStep_Eta2g->Add_FinalParticleID(Gamma);
+	locReaction->Add_ReactionStep(locReactionStep_Eta2g);
+	dReactionStepPool.push_back(locReactionStep_Eta2g); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_InvariantMassCut(Eta, 0.3, 0.8);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Eta, false, 1000, 0.3, 0.8, "Eta"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_eta_3pi0 ****************************************************/
+
+	locReaction = new DReaction("skim_eta_3pi0");
+
+	//eta -> 3pi0
+	DReactionStep* locReactionStep_Eta3Pi0 = new DReactionStep();
+	locReactionStep_Eta3Pi0->Set_InitialParticleID(Eta);
+	locReactionStep_Eta3Pi0->Add_FinalParticleID(Pi0);
+	locReactionStep_Eta3Pi0->Add_FinalParticleID(Pi0);
+	locReactionStep_Eta3Pi0->Add_FinalParticleID(Pi0);
+	locReaction->Add_ReactionStep(locReactionStep_Eta3Pi0);
+	dReactionStepPool.push_back(locReactionStep_Eta3Pi0); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+	locReaction->Add_ReactionStep(locReactionStep_Pi02); //pi0 -> g, g
+	locReaction->Add_ReactionStep(locReactionStep_Pi03); //pi0 -> g, g
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(Eta, 0.3, 0.8);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Eta, false, 1000, 0.3, 0.8, "Eta"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_eta_3piq ****************************************************/
+
+	locReaction = new DReaction("skim_eta_3piq");
+
+	//eta -> pi+, pi-, pi0
+	DReactionStep* locReactionStep_Eta3Piq = new DReactionStep();
+	locReactionStep_Eta3Piq->Set_InitialParticleID(Eta);
+	locReactionStep_Eta3Piq->Add_FinalParticleID(PiPlus);
+	locReactionStep_Eta3Piq->Add_FinalParticleID(PiMinus);
+	locReactionStep_Eta3Piq->Add_FinalParticleID(Pi0);
+	locReaction->Add_ReactionStep(locReactionStep_Eta3Piq);
+	dReactionStepPool.push_back(locReactionStep_Eta3Piq); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(Eta, 0.3, 0.8);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Eta, false, 1000, 0.3, 0.8, "Eta"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_omega_3piq ****************************************************/
+
+	locReaction = new DReaction("skim_omega_3piq");
+
+	//omega -> pi+, pi-, pi0
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(omega);
+	locReactionStep->Add_FinalParticleID(PiPlus);
+	locReactionStep->Add_FinalParticleID(PiMinus);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(omega, 0.4, 1.2);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, omega, false, 1600, 0.4, 1.2, "Omega"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_omega_pi0g ****************************************************/
+
+	locReaction = new DReaction("skim_omega_pi0g");
+
+	//omega -> pi0, g
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(omega);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReactionStep->Add_FinalParticleID(Gamma);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(omega, 0.4, 1.2);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, omega, false, 1600, 0.4, 1.2, "Omega"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_etaprm_2piqeta_2g ****************************************************/
+
+	locReaction = new DReaction("skim_etaprm_2piqeta_2g");
+
+	//eta' -> pi+, pi-, eta
+	DReactionStep* locReactionStep_EtaPrime2PiqEta = new DReactionStep();
+	locReactionStep_EtaPrime2PiqEta->Set_InitialParticleID(EtaPrime);
+	locReactionStep_EtaPrime2PiqEta->Add_FinalParticleID(PiPlus);
+	locReactionStep_EtaPrime2PiqEta->Add_FinalParticleID(PiMinus);
+	locReactionStep_EtaPrime2PiqEta->Add_FinalParticleID(Eta);
+	locReaction->Add_ReactionStep(locReactionStep_EtaPrime2PiqEta);
+	dReactionStepPool.push_back(locReactionStep_EtaPrime2PiqEta); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Eta2g); //eta -> g, g
+
+	locReaction->Set_InvariantMassCut(Eta, 0.3, 0.8);
+	locReaction->Set_InvariantMassCut(EtaPrime, 0.6, 1.3);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Eta, false, 1000, 0.3, 0.8, "Eta"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, EtaPrime, false, 1400, 0.6, 1.3, "EtaPrime"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_etaprm_2piqeta_3pi0 ****************************************************/
+
+	locReaction = new DReaction("skim_etaprm_2piqeta_3pi0");
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_EtaPrime2PiqEta); //eta' -> pi+, pi-, eta
+	locReaction->Add_ReactionStep(locReactionStep_Eta3Pi0); //eta -> 3pi0
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+	locReaction->Add_ReactionStep(locReactionStep_Pi02); //pi0 -> g, g
+	locReaction->Add_ReactionStep(locReactionStep_Pi03); //pi0 -> g, g
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(Eta, 0.3, 0.8);
+	locReaction->Set_InvariantMassCut(EtaPrime, 0.6, 1.3);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Eta, false, 1000, 0.3, 0.8, "Eta"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, EtaPrime, false, 1400, 0.6, 1.3, "EtaPrime"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_etaprm_2piqeta_3piq ****************************************************/
+
+	locReaction = new DReaction("skim_etaprm_2piqeta_3piq");
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_EtaPrime2PiqEta); //eta' -> pi+, pi-, eta
+	locReaction->Add_ReactionStep(locReactionStep_Eta3Piq); //eta -> pi+, pi-, pi0
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(Eta, 0.3, 0.8);
+	locReaction->Set_InvariantMassCut(EtaPrime, 0.6, 1.3);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Eta, false, 1000, 0.3, 0.8, "Eta"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, EtaPrime, false, 1400, 0.6, 1.3, "EtaPrime"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_etaprm_2piqg ****************************************************/
+
+	locReaction = new DReaction("skim_etaprm_2piqg");
+
+	//eta' -> pi+, pi-, g
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(EtaPrime);
+	locReactionStep->Add_FinalParticleID(PiPlus);
+	locReactionStep->Add_FinalParticleID(PiMinus);
+	locReactionStep->Add_FinalParticleID(Gamma);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_InvariantMassCut(EtaPrime, 0.6, 1.3);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, EtaPrime, false, 1400, 0.6, 1.3, "EtaPrime"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_etaprm_2pi0eta_2g ****************************************************/
+
+	locReaction = new DReaction("skim_etaprm_2pi0eta_2g");
+
+	//eta' -> 2pi0, eta
+	DReactionStep* locReactionStep_EtaPrime2Pi0Eta = new DReactionStep();
+	locReactionStep_EtaPrime2Pi0Eta->Set_InitialParticleID(EtaPrime);
+	locReactionStep_EtaPrime2Pi0Eta->Add_FinalParticleID(Pi0);
+	locReactionStep_EtaPrime2Pi0Eta->Add_FinalParticleID(Pi0);
+	locReactionStep_EtaPrime2Pi0Eta->Add_FinalParticleID(Eta);
+	locReaction->Add_ReactionStep(locReactionStep_EtaPrime2Pi0Eta);
+	dReactionStepPool.push_back(locReactionStep_EtaPrime2Pi0Eta); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Eta2g); //eta -> g, g
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+	locReaction->Add_ReactionStep(locReactionStep_Pi02); //pi0 -> g, g
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(Eta, 0.3, 0.8);
+	locReaction->Set_InvariantMassCut(EtaPrime, 0.6, 1.3);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Eta, false, 1000, 0.3, 0.8, "Eta"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, EtaPrime, false, 1400, 0.6, 1.3, "EtaPrime"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_etaprm_2pi0eta_3pi0 ****************************************************/
+
+	locReaction = new DReaction("skim_etaprm_2pi0eta_3pi0");
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_EtaPrime2Pi0Eta); //eta' -> 2pi0, eta
+	locReaction->Add_ReactionStep(locReactionStep_Eta3Pi0); //eta -> 3pi0
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+	locReaction->Add_ReactionStep(locReactionStep_Pi02); //pi0 -> g, g
+	locReaction->Add_ReactionStep(locReactionStep_Pi03); //pi0 -> g, g
 
 	//pi0 -> g, g
 	locReactionStep = new DReactionStep();
@@ -33,22 +370,188 @@ jerror_t DReaction_factory_track_skimmer::init(void)
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
 
-	/**************************************************** track_skimmer Control Variables ****************************************************/
+	//pi0 -> g, g
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(Pi0);
+	locReactionStep->Add_FinalParticleID(Gamma);
+	locReactionStep->Add_FinalParticleID(Gamma);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
 
-	// Highly Recommended: When generating particle combinations, reject all beam photons that match to a different RF bunch (delta_t > 1.002 ns)
-	locReaction->Set_MaxPhotonRFDeltaT(0.5*2.004); //beam bunches are every 2.004 ns, (1.002 should be minimum cut value)
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(Eta, 0.3, 0.8);
+	locReaction->Set_InvariantMassCut(EtaPrime, 0.6, 1.3);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Eta, false, 1000, 0.3, 0.8, "Eta"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, EtaPrime, false, 1400, 0.6, 1.3, "EtaPrime"));
 
-	/************************************************** ${ReactionName} Pre-Combo Custom Cuts *************************************************/
+	_data.push_back(locReaction); //Register the DReaction with the factory
 
-	// Highly Recommended: Very loose invariant mass cuts, applied during DParticleComboBlueprint construction
-	// Example: pi0 -> g, g cut
-	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.25);
+	/**************************************************** skim_etaprm_2pi0eta_3piq ****************************************************/
 
-	/**************************************************** track_skimmer Analysis Actions ****************************************************/
+	locReaction = new DReaction("skim_etaprm_2pi0eta_3piq");
 
-	// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
-		//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination 
-		//Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_EtaPrime2Pi0Eta); //eta' -> 2pi0, eta
+	locReaction->Add_ReactionStep(locReactionStep_Eta3Piq); //eta -> pi+, pi-, pi0
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+	locReaction->Add_ReactionStep(locReactionStep_Pi02); //pi0 -> g, g
+	locReaction->Add_ReactionStep(locReactionStep_Pi03); //pi0 -> g, g
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(Eta, 0.3, 0.8);
+	locReaction->Set_InvariantMassCut(EtaPrime, 0.6, 1.3);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Eta, false, 1000, 0.3, 0.8, "Eta"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, EtaPrime, false, 1400, 0.6, 1.3, "EtaPrime"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_phi_2kq ****************************************************/
+
+	locReaction = new DReaction("skim_phi_2kq");
+
+	//phi -> K+, K-
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(phiMeson);
+	locReactionStep->Add_FinalParticleID(KPlus);
+	locReactionStep->Add_FinalParticleID(KMinus);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_InvariantMassCut(phiMeson, 0.8, 1.2);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, phiMeson, false, 800, 0.8, 1.2, "Phi"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_phi_3piq ****************************************************/
+
+	locReaction = new DReaction("skim_phi_3piq");
+
+	//phi -> pi+, pi-, pi0
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(phiMeson);
+	locReactionStep->Add_FinalParticleID(PiPlus);
+	locReactionStep->Add_FinalParticleID(PiMinus);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(phiMeson, 0.8, 1.2);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, phiMeson, false, 800, 0.8, 1.2, "Phi"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_lambda ****************************************************/
+
+	locReaction = new DReaction("skim_lambda");
+
+	//lambda -> p, pi-
+	DReactionStep* locReactionStep_Lambda = new DReactionStep();
+	locReactionStep_Lambda->Set_InitialParticleID(Lambda);
+	locReactionStep_Lambda->Add_FinalParticleID(Proton);
+	locReactionStep_Lambda->Add_FinalParticleID(PiMinus);
+	locReaction->Add_ReactionStep(locReactionStep_Lambda);
+	dReactionStepPool.push_back(locReactionStep_Lambda); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_InvariantMassCut(Lambda, 1.0, 1.2);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Lambda, false, 800, 1.0, 1.2, "Lambda"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_sigma0 ****************************************************/
+
+	locReaction = new DReaction("skim_sigma0");
+
+	//sigma0 -> lambda, g
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(Sigma0);
+	locReactionStep->Add_FinalParticleID(Lambda);
+	locReactionStep->Add_FinalParticleID(Gamma);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Lambda); //lambda -> p, pi-
+
+	locReaction->Set_InvariantMassCut(Lambda, 1.0, 1.2);
+	locReaction->Set_InvariantMassCut(Sigma0, 1.1, 1.3);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Lambda, false, 800, 1.0, 1.2, "Lambda"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Sigma0, false, 800, 1.1, 1.3, "Sigma0"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_sigma+ ****************************************************/
+
+	locReaction = new DReaction("skim_sigma+");
+
+	//sigma+ -> p, pi0
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(SigmaPlus);
+	locReactionStep->Add_FinalParticleID(Proton);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(SigmaPlus, 1.1, 1.3);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, SigmaPlus, false, 800, 1.1, 1.3, "Sigma+"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_xi- ****************************************************/
+
+	locReaction = new DReaction("skim_xi-");
+
+	//xi- -> lambda, pi-
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(XiMinus);
+	locReactionStep->Add_FinalParticleID(Lambda);
+	locReactionStep->Add_FinalParticleID(PiMinus);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Lambda); //lambda -> p, pi-
+
+	locReaction->Set_InvariantMassCut(Lambda, 1.0, 1.2);
+	locReaction->Set_InvariantMassCut(XiMinus, 1.1, 1.5);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Lambda, false, 800, 1.0, 1.2, "Lambda"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, XiMinus, false, 800, 1.1, 1.5, "Xi-"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** skim_xi0 ****************************************************/
+
+	locReaction = new DReaction("skim_xi0");
+
+	//xi0 -> lambda, pi0
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(Xi0);
+	locReactionStep->Add_FinalParticleID(Lambda);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	//Reuse steps: Save time & memory //However, don't reuse within the SAME DReaction!
+	locReaction->Add_ReactionStep(locReactionStep_Lambda); //lambda -> p, pi-
+	locReaction->Add_ReactionStep(locReactionStep_Pi01); //pi0 -> g, g
+
+	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Set_InvariantMassCut(Lambda, 1.0, 1.2);
+	locReaction->Set_InvariantMassCut(Xi0, 1.1, 1.5);
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 510, 0.05, 0.22, "Pi0"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Lambda, false, 800, 1.0, 1.2, "Lambda"));
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Xi0, false, 800, 1.1, 1.5, "Xi0"));
 
 	_data.push_back(locReaction); //Register the DReaction with the factory
 


### PR DESCRIPTION
Overhaul: Break up into #q+, q-, q0, pi0, and by channel.

Don't make ANY combos for ANY reaction if # neutral showers > 20.
This is to prevent blowing out the memory.
This can be modified on command line via -PCOMBO:MAX_NEUTRALS.

Cuts on status bit (kSTATUS_PHYSICS_EVENT), trigger type (0x01). Unless is REST (no cut). 
