### PR TITLE
Reduce memory used by kinematic fitter.

### DIFF
--- a/src/libraries/ANALYSIS/DKinFitResults_factory.cc
+++ b/src/libraries/ANALYSIS/DKinFitResults_factory.cc
@@ -27,7 +27,7 @@ jerror_t DKinFitResults_factory::brun(jana::JEventLoop* locEventLoop, int32_t ru
 
 	//set pool sizes
 	size_t locExpectedNumCombos = 50;
-	dKinFitUtils->Set_MaxPoolSizes(Get_NumReactions(locEventLoop), locExpectedNumCombos);
+	dKinFitUtils->Set_MaxPoolSizes(Get_NumKinFitReactions(locEventLoop), locExpectedNumCombos);
 
 	//pre-allocate matrix memory
 	dKinFitUtils->Preallocate_MatrixMemory();
@@ -35,7 +35,7 @@ jerror_t DKinFitResults_factory::brun(jana::JEventLoop* locEventLoop, int32_t ru
 	return NOERROR;
 }
 
-size_t DKinFitResults_factory::Get_NumReactions(JEventLoop* locEventLoop)
+size_t DKinFitResults_factory::Get_NumKinFitReactions(JEventLoop* locEventLoop)
 {
 	// Get # of DReactions:
 	// Get list of factories and find all the ones producing
@@ -57,7 +57,11 @@ size_t DKinFitResults_factory::Get_NumReactions(JEventLoop* locEventLoop)
 		// overall list.
 		vector<const DReaction*> locReactionsSubset;
 		locFactory->Get(locReactionsSubset);
-		locNumReactions += locReactionsSubset.size();
+		for(size_t loc_j = 0; loc_j < locReactionsSubset.size(); ++loc_j)
+		{
+			if(locReactionsSubset[loc_j]->Get_KinFitType() != d_NoFit)
+				++locNumReactions;
+		}
 	}
 
 	return locNumReactions;

--- a/src/libraries/ANALYSIS/DKinFitResults_factory.h
+++ b/src/libraries/ANALYSIS/DKinFitResults_factory.h
@@ -34,7 +34,7 @@ class DKinFitResults_factory : public jana::JFactory<DKinFitResults>
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
-		size_t Get_NumReactions(JEventLoop* locEventLoop);
+		size_t Get_NumKinFitReactions(JEventLoop* locEventLoop);
 		DKinFitResults* Build_KinFitResults(const DParticleCombo* locParticleCombo, const DKinFitChain* locKinFitChain);
 
 		DKinFitter* dKinFitter;

--- a/src/libraries/KINFITTER/DKinFitUtils.cc
+++ b/src/libraries/KINFITTER/DKinFitUtils.cc
@@ -158,7 +158,7 @@ void DKinFitUtils::Preallocate_MatrixMemory(void)
 		for(size_t loc_i = 0; loc_i < dMaxLargeMatrixDSymPoolSize; ++loc_i)
 		{
 			TMatrixDSym* locMatrix = Get_LargeMatrixDSymResource();	
-			locMatrix->ResizeTo(100, 100);
+			locMatrix->ResizeTo(50, 50);
 		}
 		dLargeMatrixDSymPool_Available = dLargeMatrixDSymPool_All;
 	}


### PR DESCRIPTION
Don't pre-allocate memory for DReactions that are not fit. 
