### PR TITLE
added peak time, output scaling & saturation values, param overrides

### DIFF
--- a/src/libraries/DAQ/Df125EmulatorAlgorithm_v2.cc
+++ b/src/libraries/DAQ/Df125EmulatorAlgorithm_v2.cc
@@ -9,11 +9,12 @@
 /* 0xN070 - 0xN084 threshold register defintions */
 #define FA125_FE_THRESHOLD_MASK          0x00000FFF
 /* 0xN0A0 FE ped_sf definitions */
-#define FA125_FE_PED_SF_NP_MASK       0x000000FF
-#define FA125_FE_PED_SF_NP2_MASK      0x0000FF00
+#define FA125_FE_PED_SF_P1_MASK       0x000000FF
+#define FA125_FE_PED_SF_P2_MASK       0x0000FF00
 #define FA125_FE_PED_SF_IBIT_MASK     0x00070000
 #define FA125_FE_PED_SF_ABIT_MASK     0x00380000
 #define FA125_FE_PED_SF_PBIT_MASK     0x01C00000
+#define FA125_FE_PED_SF_PBIT_SIGN     (1<<25)
 /* 0xN0A4 FE timing_thres definitions */
 #define FA125_FE_TIMING_THRES_HI_MASK(x) (0x1FF<<((x%3)*9))
 #define FA125_FE_TIMING_THRES_LO_MASK(x) (0xFF<<(8+((x%2)*16)))
@@ -22,30 +23,91 @@
 #define FA125_FE_IE_PEDESTAL_GAP_MASK     0x000FF000
 
 Df125EmulatorAlgorithm_v2::Df125EmulatorAlgorithm_v2(JEventLoop *loop){
+
+
+  //Normal use - BORConfig params are used if found.  If not, default values are used
+  //FORCE_DEFAULT_CDC=1 - use default values for CDC instead of BORConfig params
+  //FORCE_DEFAULT_FDC=1 - use default values for FDC instead of BORConfig params
+  //Params in command line override both default and BORConfig
+
+
     // Enables forced use of default values
     FORCE_DEFAULT_CDC = 0;
     FORCE_DEFAULT_FDC = 0;
     
     // Default values for the essential parameters
-    CDC_WS_DEF  =  46;      // hit window start - must be >= F125_CDC_NP
-    CDC_WE_DEF  = 150;      // hit window end - must be at least 20 less than number of samples available
+
+    // PG or 'pedestal gap' is the number of samples between the end of the initial pedestal window and start of the hit search
+    // and also the number of samples between the local pedestal window and the hit threshold crossing sample
+
+    // 2**P2 samples are summed to give the integrated local pedestal
+    // The firmware returns the (integrated local pedestal)>>(P2+PBIT)
+    // Firmware 2_00_F + accepts a negative value for PBIT, but the driver ensures that 3 >= PBIT >= -P2
+    // Using PBIT=-P2 obtains pedestal = P2 summed samples 
+    // Using PBIT=0 obtains pedestal = mean of P2 samples
+
+
+    CDC_WS_DEF  =  16;      // hit window start - must be >= F125_CDC_NP
+    CDC_WE_DEF  = 179;      // hit window end - must be at least 20 less than number of samples available, eg WE=179 for 200 samples
     CDC_IE_DEF  = 200;      // end integration at the earlier of WE, or this many samples after threshold crossing of TH  
-    CDC_NP_DEF  =  16;      // # samples used for pedestal used to find hit. 2**integer
-    CDC_NP2_DEF =  16;      // # samples used for pedestal calculated just before hit. 2**integer
-    CDC_PG_DEF  =   4;      // # samples between hit threshold crossing and local pedestal sample
+    CDC_P1_DEF  =   4;      // 2**P1 = # samples used for initial pedestal, used to find hit
+    CDC_P2_DEF  =   4;      // 2**P2 = # samples used for pedestal calculated just before hit, and returned 
+    CDC_PG_DEF  =   4;      // # samples between hit threshold crossing and local pedestal sample 'pedestal gap'
     CDC_H_DEF   = 125;      // 5 sigma hit threshold
     CDC_TH_DEF  = 100;      // 4 sigma high timing threshold
     CDC_TL_DEF  =  25;      // 1 sigma low timing threshold
 
-    FDC_WS_DEF  =  30;      // hit window start - must be >= F125_FDC_NP
-    FDC_WE_DEF  =  52;      // hit window end - must be at least 20 less than number of samples available
-    FDC_IE_DEF  =  10;      // end integration at the earlier of WE, or this many samples after threshold crossing of TH  
-    FDC_NP_DEF  =  16;      // # samples used for pedestal used to find hit. 2**integer
-    FDC_NP2_DEF =  16;      // # samples used for pedestal calculated just before hit. 2**integer
+    CDC_IBIT_DEF =  4;      // Scaling factor for integral
+    CDC_ABIT_DEF =  3;      // Scaling factor for amplitude
+    CDC_PBIT_DEF =  0;      // Scaling factor for pedestal
+
+    FDC_WS_DEF  =  16;      // hit window start - must be >= F125_FDC_NP
+    FDC_WE_DEF  =  59;      // hit window end - must be at least 20 less than number of samples available, eg WE=59 for 80 samples
+    FDC_IE_DEF  =  16;      // end integration at the earlier of WE, or this many samples after threshold crossing of TH  
+    FDC_P1_DEF  =   4;      // 2**P1 = # samples used for pedestal used to find hit
+    FDC_P2_DEF  =   4;      // 2**P2 = # samples used for pedestal calculated just before hit, and returned
     FDC_PG_DEF  =   4;      // # samples between hit threshold crossing and local pedestal sample
-    FDC_H_DEF   = 125;      // 5 sigma hit threshold
-    FDC_TH_DEF  = 100;      // 4 sigma high timing threshold
-    FDC_TL_DEF  =  25;      // 1 sigma low timing threshold
+    FDC_H_DEF   =  50;      // 5 sigma hit threshold
+    FDC_TH_DEF  =  40;      // 4 sigma high timing threshold
+    FDC_TL_DEF  =  10;      // 1 sigma low timing threshold
+
+    FDC_IBIT_DEF =  4;      // Scaling factor for integral
+    FDC_ABIT_DEF =  0;      // Scaling factor for amplitude
+    FDC_PBIT_DEF =  0;      // Scaling factor for pedestal
+
+    
+    // Override values set in command line - set in command line, override default and BORConfig if found
+
+    CDC_WS = NULL;          // hit window start - must be >= F125_CDC_NP
+    CDC_WE = NULL;          // hit window end - must be at least 20 less than number of samples available, eg WE=179 for 200 samples
+    CDC_IE = NULL;          // end integration at the earlier of WE, or this many samples after threshold crossing of TH  
+    CDC_P1 = NULL;          // 2**P1 = # samples used for initial pedestal, used to find hit
+    CDC_P2 = NULL;          // 2**P2 = # samples used for pedestal calculated just before hit, and returned 
+    CDC_PG = NULL;          // # samples between hit threshold crossing and local pedestal sample 'pedestal gap'
+    CDC_H  = NULL;          // 5 sigma hit threshold
+    CDC_TH = NULL;          // 4 sigma high timing threshold
+    CDC_TL = NULL;          // 1 sigma low timing threshold
+
+    CDC_IBIT = NULL;        // Scaling factor for integral
+    CDC_ABIT = NULL;        // Scaling factor for amplitude 
+    CDC_PBIT = NULL;        // Scaling factor for pedestal
+
+
+    FDC_WS = NULL;          // hit window start - must be >= F125_FDC_NP
+    FDC_WE = NULL;          // hit window end - must be at least 20 less than number of samples available, eg WE=179 for 200 samples
+    FDC_IE = NULL;          // end integration at the earlier of WE, or this many samples after threshold crossing of TH  
+    FDC_P1 = NULL;          // 2**P1 = # samples used for initial pedestal, used to find hit
+    FDC_P2 = NULL;          // 2**P2 = # samples used for pedestal calculated just before hit, and returned 
+    FDC_PG = NULL;          // # samples between hit threshold crossing and local pedestal sample 'pedestal gap'
+    FDC_H  = NULL;          // 5 sigma hit threshold
+    FDC_TH = NULL;          // 4 sigma high timing threshold
+    FDC_TL = NULL;          // 1 sigma low timing threshold
+
+    FDC_IBIT = NULL;        // Scaling factor for integral
+    FDC_ABIT = NULL;        // Scaling factor for amplitude 
+    FDC_PBIT = NULL;        // Scaling factor for pedestal
+
+
     
     // Set verbosity
     VERBOSE = 0;
@@ -53,24 +115,30 @@ Df125EmulatorAlgorithm_v2::Df125EmulatorAlgorithm_v2(JEventLoop *loop){
     if(gPARMS){
         gPARMS->SetDefaultParameter("EMULATION125:FORCE_DEFAULT_CDC", FORCE_DEFAULT_CDC,"Set to >0 to force use of CDC default values");
         gPARMS->SetDefaultParameter("EMULATION125:FORCE_DEFAULT_FDC", FORCE_DEFAULT_FDC,"Set to >0 to force use of FDC default values");
-        gPARMS->SetDefaultParameter("EMULATION125:CDC_WS",  CDC_WS_DEF,  "Set CDC_WS for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:CDC_WE",  CDC_WE_DEF,  "Set CDC_WE for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:CDC_IE",  CDC_IE_DEF,  "Set CDC_IE for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:CDC_NP",  CDC_NP_DEF,  "Set CDC_NP for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:CDC_NP2", CDC_NP2_DEF, "Set CDC_NP2 for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:CDC_PG",  CDC_PG_DEF,  "Set CDC_PG for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:CDC_H",   CDC_H_DEF,   "Set CDC_H (hit threshold) for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:CDC_TH",  CDC_TH_DEF,  "Set CDC_TH for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:CDC_TL",  CDC_TL_DEF,  "Set CDC_TL for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:FDC_WS",  FDC_WS_DEF,  "Set FDC_WS for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:FDC_WE",  FDC_WE_DEF,  "Set FDC_WE for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:FDC_IE",  FDC_IE_DEF,  "Set FDC_IE for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:FDC_NP",  FDC_NP_DEF,  "Set FDC_NP for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:FDC_NP2", FDC_NP2_DEF, "Set FDC_NP2 for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:FDC_PG",  FDC_PG_DEF,  "Set FDC_PG for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:FDC_H",   FDC_H_DEF,   "Set FDC_H (hit threshold) for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:FDC_TH",  FDC_TH_DEF,  "Set FDC_TH for firmware emulation, will be overwritten by BORConfig if present");
-        gPARMS->SetDefaultParameter("EMULATION125:FDC_TL",  FDC_TL_DEF,  "Set FDC_TL for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:CDC_WS",  CDC_WS,  "Set CDC_WS for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:CDC_WE",  CDC_WE,  "Set CDC_WE for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:CDC_IE",  CDC_IE,  "Set CDC_IE for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:CDC_P1",  CDC_P1,  "Set CDC_P1 for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:CDC_P2",  CDC_P2, "Set CDC_P2 for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:CDC_PG",  CDC_PG,  "Set CDC_PG for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:CDC_H",   CDC_H,   "Set CDC_H (hit threshold) for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:CDC_TH",  CDC_TH,  "Set CDC_TH for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:CDC_TL",  CDC_TL,  "Set CDC_TL for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:CDC_IBIT",CDC_IBIT,"Set CDC_IBIT for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:CDC_ABIT",CDC_ABIT,"Set CDC_ABIT for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:CDC_PBIT",CDC_PBIT,"Set CDC_PBIT for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:FDC_WS",  FDC_WS,  "Set FDC_WS for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:FDC_WE",  FDC_WE,  "Set FDC_WE for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:FDC_IE",  FDC_IE,  "Set FDC_IE for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:FDC_P1",  FDC_P1,  "Set FDC_P1 for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:FDC_P2",  FDC_P2,  "Set FDC_P2 for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:FDC_PG",  FDC_PG,  "Set FDC_PG for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:FDC_H",   FDC_H,   "Set FDC_H (hit threshold) for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:FDC_TH",  FDC_TH,  "Set FDC_TH for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:FDC_TL",  FDC_TL,  "Set FDC_TL for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:FDC_IBIT",FDC_IBIT,"Set FDC_IBIT for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:FDC_ABIT",FDC_ABIT,"Set FDC_ABIT for firmware emulation, will be overwritten by BORConfig if present");
+        gPARMS->SetDefaultParameter("EMULATION125:FDC_PBIT",FDC_PBIT,"Set FDC_PBIT for firmware emulation, will be overwritten by BORConfig if present");
         gPARMS->SetDefaultParameter("EMULATION125:VERBOSE", VERBOSE,"Set verbosity for f125 emulation");
     }
 }
@@ -98,10 +166,23 @@ void Df125EmulatorAlgorithm_v2::EmulateFirmware(const Df125WindowRawData *rawDat
 
     // The following are the essential values needed for the emulation 
     // (will use ROOT types since that is what the existing f125_algos code uses)
-    Int_t WS=0,WE=0,IE=0,NP=0,NP2=0,PG=0,H=0,TH=0,TL=0;
+    Int_t WS=0,WE=0,IE=0,P1=0,P2=0,PG=0,H=0,TH=0,TL=0;
     Int_t IBIT=0, ABIT=0, PBIT=0;
 
     Int_t NE = 20; // This is a hardcoded constant in the firmware WE = NW - NE - 1  
+
+    // Field max (saturation) values
+
+    Int_t CDC_IMAX = 16383; //field max for integral
+    Int_t CDC_AMAX = 511; //field max for max amp
+    Int_t CDC_PMAX = 255; //field max for pedestal
+    Int_t CDC_OMAX = 7; // field max for overflows
+
+    Int_t FDC_IMAX = 4095; //field max for integral
+    Int_t FDC_AMAX = 4095; //field max for max amp
+    Int_t FDC_PMAX = 2047; //field max for pedestal
+    Int_t FDC_OMAX = 7; // field max for overflows
+
 
     // Now try to get the configuration form the BOR record, if this does not exist,
     // or is forced, use the default values.
@@ -111,21 +192,20 @@ void Df125EmulatorAlgorithm_v2::EmulateFirmware(const Df125WindowRawData *rawDat
     if(BORConfig != NULL){
         if (VERBOSE > 0) jout << "--Found BORConfig" << endl; 
         Int_t NW = BORConfig->fe[0].nw;
-        Int_t P1 = BORConfig->fe[0].ped_sf & FA125_FE_PED_SF_NP_MASK;
-        Int_t P2 = (BORConfig->fe[0].ped_sf & FA125_FE_PED_SF_NP2_MASK) >> 8;
+        P1 = BORConfig->fe[0].ped_sf & FA125_FE_PED_SF_P1_MASK;
+        P2 = (BORConfig->fe[0].ped_sf & FA125_FE_PED_SF_P2_MASK) >> 8;
         if (NW != Int_t(rawData->samples.size())) jout << "WARNING Df125EmulatorAlgorithm_v2::EmulateFirmware NW != rawData->samples.size()" << endl;
         WE  = NW - NE - 1;
         IE  = BORConfig->fe[0].ie & FA125_FE_IE_INTEGRATION_END_MASK;
-        NP  = 1 << P1;
-        NP2 = 1 << P2;
         PG  = (BORConfig->fe[0].ie & FA125_FE_IE_PEDESTAL_GAP_MASK) >> 12;
-        WS  = NP;
+        WS  = 1<<P1;
         H   = BORConfig->fe[channel/6].threshold[channel%6] & FA125_FE_THRESHOLD_MASK;
         TH  = (BORConfig->fe[channel/6].timing_thres_hi[(channel/3)%2] & FA125_FE_TIMING_THRES_HI_MASK(channel)) >> ((channel%3) * 9);
         TL  = (BORConfig->fe[channel/6].timing_thres_lo[(channel/2)%3] & FA125_FE_TIMING_THRES_LO_MASK(channel)) >> ((channel%2) * 16 + 8);
         IBIT = (BORConfig->fe[0].ped_sf & FA125_FE_PED_SF_IBIT_MASK)>>16;
         ABIT = (BORConfig->fe[0].ped_sf & FA125_FE_PED_SF_ABIT_MASK)>>19;
         PBIT = (BORConfig->fe[0].ped_sf & FA125_FE_PED_SF_PBIT_MASK)>>22;
+        if (BORConfig->fe[0].ped_sf & FA125_FE_PED_SF_PBIT_MASK) PBIT = -1*PBIT;
     }
 
     // Set defaults if BORConfig missing or if forced
@@ -134,56 +214,113 @@ void Df125EmulatorAlgorithm_v2::EmulateFirmware(const Df125WindowRawData *rawDat
         WS  = CDC_WS_DEF;
         WE  = CDC_WE_DEF;
         IE  = CDC_IE_DEF;
-        NP  = CDC_NP_DEF;
-        NP2 = CDC_NP2_DEF;
+        P1  = CDC_P1_DEF;
+        P2  = CDC_P2_DEF;
         PG  = CDC_PG_DEF;
         H   = CDC_H_DEF;
         TH  = CDC_TH_DEF;
         TL  = CDC_TL_DEF;
+        IBIT= CDC_IBIT_DEF;
+        ABIT= CDC_ABIT_DEF;
+        PBIT= CDC_PBIT_DEF;
     }
+
+
+
+    //Set override params if given in command line
+    if ( isCDC ) {
+      if (VERBOSE > 0) jout << "WARNING Df125EmulatorAlgorithm_v2::EmulateFirmware Using CDC override values" << endl;
+      if (CDC_WS) WS  = CDC_WS;
+      if (CDC_WE) WE  = CDC_WE;
+      if (CDC_IE) IE  = CDC_IE;
+      if (CDC_P1) P1  = CDC_P1;
+      if (CDC_P2) P2  = CDC_P2;
+      if (CDC_PG) PG  = CDC_PG;
+      if (CDC_H)  H   = CDC_H;
+      if (CDC_TH) TH  = CDC_TH;
+      if (CDC_TL) TL  = CDC_TL;
+      if (CDC_IBIT) IBIT = CDC_IBIT;
+      if (CDC_ABIT) ABIT = CDC_ABIT;
+      if (CDC_PBIT) PBIT = CDC_PBIT;
+    }
+
+
     if( isFDC && ((BORConfig == NULL) || FORCE_DEFAULT_FDC) ){
         if (VERBOSE > 0) jout << "WARNING Df125EmulatorAlgorithm_v2::EmulateFirmware Using FDC Default values" << endl;
         WS  = FDC_WS_DEF;
         WE  = FDC_WE_DEF;
         IE  = FDC_IE_DEF;
-        NP  = FDC_NP_DEF;
-        NP2 = FDC_NP2_DEF;
+        P1  = FDC_P1_DEF;
+        P2  = FDC_P2_DEF;
         PG  = FDC_PG_DEF;
         H   = FDC_H_DEF;
         TH  = FDC_TH_DEF;
         TL  = FDC_TL_DEF;
+        IBIT= FDC_IBIT_DEF;
+        ABIT= FDC_ABIT_DEF;
+        PBIT= FDC_PBIT_DEF;
     }
+
+
+    //Set override params if given in command line
+    if ( isFDC ) {
+      if (VERBOSE > 0) jout << "WARNING Df125EmulatorAlgorithm_v2::EmulateFirmware Using FDC override values" << endl;
+      if (FDC_WS) WS  = FDC_WS;
+      if (FDC_WE) WE  = FDC_WE;
+      if (FDC_IE) IE  = FDC_IE;
+      if (FDC_P1) P1  = FDC_P1;
+      if (FDC_P2) P2  = FDC_P2;
+      if (FDC_PG) PG  = FDC_PG;
+      if (FDC_H)  H   = FDC_H;
+      if (FDC_TH) TH  = FDC_TH;
+      if (FDC_TL) TL  = FDC_TL;
+      if (FDC_IBIT) IBIT = FDC_IBIT;
+      if (FDC_ABIT) ABIT = FDC_ABIT;
+      if (FDC_PBIT) PBIT = FDC_PBIT;
+    }
+
+
 
     if (VERBOSE > 0) {
         jout << "============ Parameters used for emulation ================" << endl;
-        jout << "WS: " << WS << " WE: " << WE << " IE: " << IE << " NP: " << NP << " NP2: " << NP2 << endl;
+        jout << "WS: " << WS << " WE: " << WE << " IE: " << IE << " P1: " << P1 << " P2: " << P2 << endl;
         jout << "PG: " << PG << " H: " << H << " TH: " << TH << " TL: " << TL << endl;
         jout << "IBIT: " << IBIT << " ABIT: " << ABIT << " PBIT: " << PBIT << endl;
     }
 
     // The calculated quantities are passed by reference
-    Int_t time=0, q_code=0, pedestal=0, overflows=0, maxamp=0;
+    Int_t time=0, q_code=0, pedestal=0, overflows=0, maxamp=0, pktime=0;
     Long_t integral=0;
 
+   
+
     // Perform the emulation
-    fa125_algos(time, q_code, pedestal, integral, overflows, maxamp, &rawData->samples[0], WS, WE, IE, NP, NP2, PG, H, TH, TL);
+    fa125_algos(time, q_code, pedestal, integral, overflows, maxamp, pktime, &rawData->samples[0], WS, WE, IE, P1, P2, PG, H, TH, TL);
+
+    // Scale down
+    
+    integral = integral >> IBIT;
+    maxamp = maxamp >> ABIT;
+    pedestal = pedestal >> (P2 + PBIT);
+
 
     // Put the emulated values in the objects
     if (isCDC){
         cdcPulse->le_time_emulated = time;
         cdcPulse->time_quality_bit_emulated = q_code;
-        cdcPulse->overflow_count_emulated = overflows;
-        cdcPulse->pedestal_emulated = pedestal >> PBIT;
-        cdcPulse->integral_emulated = integral >> IBIT;
-        cdcPulse->first_max_amp_emulated = maxamp >> ABIT;
+        cdcPulse->overflow_count_emulated = ( overflows > CDC_OMAX) ? CDC_OMAX : overflows;
+        cdcPulse->pedestal_emulated = ( pedestal > CDC_PMAX ) ? CDC_PMAX : pedestal;
+        cdcPulse->integral_emulated = ( integral > CDC_IMAX ) ? CDC_IMAX : integral;
+        cdcPulse->first_max_amp_emulated = ( maxamp > CDC_AMAX ) ? CDC_AMAX : maxamp;
     }
     else{
         fdcPulse->le_time_emulated = time;
         fdcPulse->time_quality_bit_emulated = q_code;
-        fdcPulse->overflow_count_emulated = overflows;
-        fdcPulse->pedestal_emulated = pedestal >> PBIT;
-        fdcPulse->integral_emulated = integral >> IBIT;
-        fdcPulse->peak_amp_emulated = maxamp >> ABIT;
+        fdcPulse->overflow_count_emulated =  ( overflows > FDC_OMAX) ? FDC_OMAX : overflows;
+        fdcPulse->pedestal_emulated = ( pedestal > FDC_PMAX ) ? FDC_PMAX : pedestal;
+        fdcPulse->integral_emulated = ( integral > FDC_IMAX ) ? FDC_IMAX : integral;
+        fdcPulse->peak_amp_emulated = ( maxamp > FDC_AMAX ) ? FDC_AMAX : maxamp;
+        fdcPulse->peak_time_emulated = pktime;
     }
 
     // Copy the emulated values to the main values if needed
@@ -202,6 +339,7 @@ void Df125EmulatorAlgorithm_v2::EmulateFirmware(const Df125WindowRawData *rawDat
         fdcPulse->pedestal = fdcPulse->pedestal_emulated;
         fdcPulse->integral = fdcPulse->integral_emulated;
         fdcPulse->peak_amp = fdcPulse->peak_amp_emulated;
+        fdcPulse->peak_time = fdcPulse->peak_time_emulated;
     }
 
     if (VERBOSE > 0) jout << "=== Exiting f125 Firmware Emulation === " << endl;
@@ -209,7 +347,7 @@ void Df125EmulatorAlgorithm_v2::EmulateFirmware(const Df125WindowRawData *rawDat
     return;
 }
 
-void Df125EmulatorAlgorithm_v2::fa125_algos(Int_t &time, Int_t &q_code, Int_t &pedestal, Long_t &integral, Int_t &overflows, Int_t &maxamp, const uint16_t adc[], Int_t WINDOW_START, Int_t WINDOW_END, Int_t INT_END, Int_t NPED, Int_t NPED2, Int_t PG, Int_t HIT_THRES, Int_t HIGH_THRESHOLD, Int_t LOW_THRESHOLD) {
+void Df125EmulatorAlgorithm_v2::fa125_algos(Int_t &time, Int_t &q_code, Int_t &pedestal, Long_t &integral, Int_t &overflows, Int_t &maxamp, Int_t &pktime, const uint16_t adc[], Int_t WINDOW_START, Int_t WINDOW_END, Int_t INT_END, Int_t P1, Int_t P2, Int_t PG, Int_t HIT_THRES, Int_t HIGH_THRESHOLD, Int_t LOW_THRESHOLD) {
 
     const Int_t NU = 20;  //number of samples sent to time algo
     const Int_t PED = 5;  //sample to be used as pedestal for timing is in place 5
@@ -223,45 +361,49 @@ void Df125EmulatorAlgorithm_v2::fa125_algos(Int_t &time, Int_t &q_code, Int_t &p
 
     Int_t i=0;
 
-    time=0;       // hit time in 0.1xsamples since start of buffer passed to cdc_time
+    time=0;       // hit time in 0.1xsamples since start of buffer passed to fa125_time
     q_code=-1;    // quality code, 0=good, 1=returned rough estimate
     pedestal=0;   // pedestal just before hit
     integral=0;   // signal integral, total
     overflows=0;  // count of samples with overflow bit set (need raw data, not possible from my root files)
     maxamp=0;     // signal amplitude at first max after hit
+    pktime=0;     // sample number containing maxamp
 
     // look for hit using mean pedestal of NPED samples before trigger
-    cdc_hit(hitfound, hitsample, pedestal, adc, WINDOW_START, WINDOW_END, HIT_THRES, NPED, NPED2, PG);
+    fa125_hit(hitfound, hitsample, pedestal, adc, WINDOW_START, WINDOW_END, HIT_THRES, P1, P2, PG);
 
     if (hitfound==1) {
         for (i=0; i<NU; i++) {
             adc_subset[i] = adc[hitsample+i-XTHR_SAMPLE];
         }
 
-        cdc_time(time, q_code, adc_subset, NU, PG, HIGH_THRESHOLD, LOW_THRESHOLD);
+        fa125_time(time, q_code, adc_subset, NU, PG, HIGH_THRESHOLD, LOW_THRESHOLD);
 
         timesample = hitsample-XTHR_SAMPLE + (Int_t)(0.1*time);  //sample number containing leading edge sample
 
-        cdc_integral(integral, overflows, timesample, adc, WINDOW_END, INT_END);
+        fa125_integral(integral, overflows, timesample, adc, WINDOW_END, INT_END);
 
-        cdc_max(maxamp, hitsample, adc, WINDOW_END);
+        fa125_max(maxamp, pktime, timesample, adc, WINDOW_END);
 
         time = 10*(hitsample-XTHR_SAMPLE) + time;   // integer number * 0.1 samples
     }
 }
 
-void Df125EmulatorAlgorithm_v2::cdc_hit(Int_t &hitfound, Int_t &hitsample, Int_t &pedestal, const uint16_t adc[], Int_t WINDOW_START, Int_t WINDOW_END, Int_t HIT_THRES, Int_t NPED, Int_t NPED2, Int_t PG) {
+void Df125EmulatorAlgorithm_v2::fa125_hit(Int_t &hitfound, Int_t &hitsample, Int_t &pedestal, const uint16_t adc[], Int_t WINDOW_START, Int_t WINDOW_END, Int_t HIT_THRES, Int_t P1, Int_t P2, Int_t PG) {
 
     pedestal=0;  //pedestal
     Int_t threshold=0;
     Int_t i=0;
+
+    Int_t NPED = 1<<P1;
+    Int_t NPED2 = 1<<P2;
 
     // calc pedestal as mean of NPED samples before trigger
     for (i=0; i<NPED; i++) {
         pedestal += adc[WINDOW_START-NPED+i];
     }
 
-    pedestal = ( NPED==0 ? 0:(pedestal/NPED) );   // Integer div is ok as fpga will do 2 rightshifts
+    pedestal = pedestal>>P1; 
     threshold = pedestal + HIT_THRES;
 
     // look for threshold crossing
@@ -279,16 +421,15 @@ void Df125EmulatorAlgorithm_v2::cdc_hit(Int_t &hitfound, Int_t &hitsample, Int_t
     }
 
     if (hitfound == 1) {
-        //calculate new pedestal ending just before the hit
+        //calculate INTEGRATED pedestal ending just before the hit (this is rightshifted by P2+PBIT later on)
         pedestal = 0;
         for (i=0; i<NPED2; i++) {
             pedestal += adc[hitsample-PG-i];
         }
-        pedestal = ( NPED2==0 ? 0:(pedestal/NPED2) );
     }
 }
 
-void Df125EmulatorAlgorithm_v2::cdc_integral(Long_t& integral, Int_t& overflows, Int_t timesample, const uint16_t adc[], Int_t WINDOW_END, Int_t INT_END) {
+void Df125EmulatorAlgorithm_v2::fa125_integral(Long_t& integral, Int_t& overflows, Int_t timesample, const uint16_t adc[], Int_t WINDOW_END, Int_t INT_END) {
 
     Int_t i=0;
 
@@ -312,7 +453,7 @@ void Df125EmulatorAlgorithm_v2::cdc_integral(Long_t& integral, Int_t& overflows,
 
 }
 
-void Df125EmulatorAlgorithm_v2::cdc_max(Int_t& maxamp, Int_t hitsample, const uint16_t adc[], Int_t WINDOW_END) {
+void Df125EmulatorAlgorithm_v2::fa125_max(Int_t& maxamp, Int_t &maxsample, Int_t hitsample, const uint16_t adc[], Int_t WINDOW_END) {
 
     int i;
     int ndec = 0;  //number of decreasing samples
@@ -322,11 +463,13 @@ void Df125EmulatorAlgorithm_v2::cdc_max(Int_t& maxamp, Int_t hitsample, const ui
     while ((adc[hitsample] <= adc[hitsample-1]) && (hitsample <= WINDOW_END)) hitsample++;
 
     maxamp = adc[hitsample];
+    maxsample = hitsample;
 
     for (i=hitsample; i<=WINDOW_END; i++) {
 
         if (adc[i] > adc[i-1]) {
             maxamp = adc[i];
+            maxsample = i;
             ndec = 0;
         }
 
@@ -334,11 +477,14 @@ void Df125EmulatorAlgorithm_v2::cdc_max(Int_t& maxamp, Int_t hitsample, const ui
         if (ndec==2) break;
     }
 
-    if (hitsample >= WINDOW_END) maxamp = adc[WINDOW_END];
+    if (hitsample >= WINDOW_END) {
+      maxamp = adc[WINDOW_END];
+      maxsample = WINDOW_END;
+    }
 
 }
 
-void Df125EmulatorAlgorithm_v2::cdc_time(Int_t &le_time, Int_t &q_code, Int_t adc[], Int_t NU, Int_t PG, Int_t THRES_HIGH, Int_t THRES_LOW) {
+void Df125EmulatorAlgorithm_v2::fa125_time(Int_t &le_time, Int_t &q_code, Int_t adc[], Int_t NU, Int_t PG, Int_t THRES_HIGH, Int_t THRES_LOW) {
 
     // adc[NU]     array of samples
     // NU=20       size of array

--- a/src/libraries/DAQ/Df125EmulatorAlgorithm_v2.h
+++ b/src/libraries/DAQ/Df125EmulatorAlgorithm_v2.h
@@ -17,44 +17,86 @@ class Df125EmulatorAlgorithm_v2:public Df125EmulatorAlgorithm{
         //Only the emulation routines need to be overwritten
         void EmulateFirmware(const Df125WindowRawData*, Df125CDCPulse*, Df125FDCPulse*);
 
-    protected:
-
-        Df125EmulatorAlgorithm_v2(){};
         // Many helper functions from the old fa125algos files
-        void cdc_hit(Int_t&, Int_t&, Int_t&, const uint16_t[], Int_t, Int_t, Int_t, Int_t, Int_t, Int_t);   // look for a hit
-        void cdc_time(Int_t&, Int_t&, Int_t[], Int_t, Int_t, Int_t, Int_t); // find hit time
-        void cdc_integral(Long_t&, Int_t&, Int_t, const uint16_t[], Int_t, Int_t); // find integral
-        void cdc_max(Int_t&, Int_t, const uint16_t[], Int_t); // find first max amplitude after hit
+        void fa125_hit(Int_t&, Int_t&, Int_t&, const uint16_t[], Int_t, Int_t, Int_t, Int_t, Int_t, Int_t);   // look for a hit
+        void fa125_time(Int_t&, Int_t&, Int_t[], Int_t, Int_t, Int_t, Int_t); // find hit time
+        void fa125_integral(Long_t&, Int_t&, Int_t, const uint16_t[], Int_t, Int_t); // find integral
+        void fa125_max(Int_t&, Int_t&, Int_t, const uint16_t[], Int_t); // find first max amplitude after hit
+        void fa125_algos(Int_t&, Int_t&, Int_t&, Long_t&, Int_t&, Int_t&, Int_t&, const uint16_t[], Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t);
+
+
+    protected:
+        Df125EmulatorAlgorithm_v2(){};
+
         void upsamplei(Int_t[], Int_t, Int_t[], Int_t);   // upsample
-        void fa125_algos(Int_t&, Int_t&, Int_t&, Long_t&, Int_t&, Int_t&, const uint16_t[], Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t);
+
+   private:
 
         // Enables forced use of default values
         int FORCE_DEFAULT_CDC;
         int FORCE_DEFAULT_FDC;
 
-        // Default values for the essential parameters
+        // Default values, used if FORCE_DEFAULT_xDC=1 or if BORConfig is not found
         Int_t CDC_WS_DEF ;      // hit window start - must be >= F125_CDC_NP
         Int_t CDC_WE_DEF ;      // hit window end - must be at least 20 less than number of samples available
         Int_t CDC_IE_DEF ;      // end integration at the earlier of WE, or this many samples after threshold crossing of TH
-        Int_t CDC_NP_DEF ;      // # samples used for pedestal used to find hit. 2**integer
-        Int_t CDC_NP2_DEF;      // # samples used for pedestal calculated just before hit. 2**integer
+        Int_t CDC_P1_DEF ;      // 2**P1 = # samples used for initial pedestal, used to find hit
+        Int_t CDC_P2_DEF ;      // 2**P2 = # samples used for pedestal calculated just before hit
         Int_t CDC_PG_DEF ;      // # samples between hit threshold crossing and local pedestal sample
         Int_t CDC_H_DEF  ;      // 5 sigma hit threshold
         Int_t CDC_TH_DEF ;      // 4 sigma high timing threshold
         Int_t CDC_TL_DEF ;      // 1 sigma low timing threshold
+        Int_t CDC_IBIT_DEF ;    // scaling factor for integral
+        Int_t CDC_ABIT_DEF ;    // scaling factor for amplitude
+        Int_t CDC_PBIT_DEF ;    // scaling factor for pedestal
+
 
         Int_t FDC_WS_DEF ;      // hit window start - must be >= F125_FDC_NP
         Int_t FDC_WE_DEF ;      // hit window end - must be at least 20 less than number of samples available
         Int_t FDC_IE_DEF ;      // end integration at the earlier of WE, or this many samples after threshold crossing of TH
-        Int_t FDC_NP_DEF ;      // # samples used for pedestal used to find hit. 2**integer
-        Int_t FDC_NP2_DEF;      // # samples used for pedestal calculated just before hit. 2**integer
+        Int_t FDC_P1_DEF ;      // 2**P1 = # samples used for initial pedestal, used to find hit
+        Int_t FDC_P2_DEF ;      // 2**P2 = # samples used for pedestal calculated just before hit
         Int_t FDC_PG_DEF ;      // # samples between hit threshold crossing and local pedestal sample
         Int_t FDC_H_DEF  ;      // 5 sigma hit threshold
         Int_t FDC_TH_DEF ;      // 4 sigma high timing threshold
         Int_t FDC_TL_DEF ;      // 1 sigma low timing threshold
+        Int_t FDC_IBIT_DEF ;    // scaling factor for integral
+        Int_t FDC_ABIT_DEF ;    // scaling factor for amplitude
+        Int_t FDC_PBIT_DEF ;    // scaling factor for pedestal
+
+
+        //Override values, used if given in command line
+        Int_t CDC_WS ;      // hit window start - must be >= F125_CDC_NP
+        Int_t CDC_WE ;      // hit window end - must be at least 20 less than number of samples available
+        Int_t CDC_IE ;      // end integration at the earlier of WE, or this many samples after threshold crossing of TH
+        Int_t CDC_P1 ;      // 2**P1 = # samples used for initial pedestal, used to find hit
+        Int_t CDC_P2 ;      // 2**P2 = # samples used for pedestal calculated just before hit
+        Int_t CDC_PG ;      // # samples between hit threshold crossing and local pedestal sample
+        Int_t CDC_H  ;      // 5 sigma hit threshold
+        Int_t CDC_TH ;      // 4 sigma high timing threshold
+        Int_t CDC_TL ;      // 1 sigma low timing threshold
+        Int_t CDC_IBIT ;    // scaling factor for integral
+        Int_t CDC_ABIT ;    // scaling factor for amplitude
+        Int_t CDC_PBIT ;    // scaling factor for pedestal
+
+        Int_t FDC_WS ;      // hit window start - must be >= F125_FDC_NP
+        Int_t FDC_WE ;      // hit window end - must be at least 20 less than number of samples available
+        Int_t FDC_IE ;      // end integration at the earlier of WE, or this many samples after threshold crossing of TH
+        Int_t FDC_P1 ;      // 2**P1 = # samples used for initial pedestal, used to find hit
+        Int_t FDC_P2 ;      // 2**P2 = # samples used for pedestal calculated just before hit
+        Int_t FDC_PG ;      // # samples between hit threshold crossing and local pedestal sample
+        Int_t FDC_H  ;      // 5 sigma hit threshold
+        Int_t FDC_TH ;      // 4 sigma high timing threshold
+        Int_t FDC_TL ;      // 1 sigma low timing threshold
+        Int_t FDC_IBIT ;    // scaling factor for integral
+        Int_t FDC_ABIT ;    // scaling factor for amplitude
+        Int_t FDC_PBIT ;    // scaling factor for pedestal
 
         // Set verbosity
         int VERBOSE;
 };
 
 #endif // _Df125EmulatorAlgorithm_v2_
+
+
+


### PR DESCRIPTION
Normal behaviour is to use the fa125 parameters in the BORConfig.  If these are not found, or if FORCE_DEFAULT_CDC=1, the default parameters are used.  There are command line args to change individual default parameters.

Added more cmd line args to specify override parameters, to be used instead of either of the above.  This allows single (or more) parameter values to be altered from the BORconfig values.

Also added output scaling (by IBIT, ABIT, PBIT) & saturation, and peak time sample.
