### PR TITLE
Sparse EVIO readout

### DIFF
--- a/src/libraries/DAQ/HDEVIO.cc
+++ b/src/libraries/DAQ/HDEVIO.cc
@@ -41,6 +41,7 @@ HDEVIO::HDEVIO(string filename):filename(filename)
 	buff_len = 0;
 	buff = new uint32_t[buff_size];
 	next = buff; // needed so initial calculation of left is 0
+	last_event_pos = 0;
 	last_event_len = 0;
 	err_code = HDEVIO_OK;
 
@@ -51,8 +52,9 @@ HDEVIO::HDEVIO(string filename):filename(filename)
 	Nbad_events = 0;
 	
 	event_type_mask = 0xFFFF; // default to accepting all types
-	next_search_block = 0;
 	is_mapped = false;
+	
+	NB_next_pos = 0;
 	
 	ifs.seekg(0, ios_base::end);
 	total_size_bytes = ifs.tellg();
@@ -360,66 +362,246 @@ bool HDEVIO::readSparse(uint32_t *user_buff, uint32_t user_buff_len, bool allow_
 	/// after seeking to the desired location determined from
 	/// a previously generated map.
 	
+	err_code = HDEVIO_OK;
+	ClearErrorMessage();
+
 	// Make sure we've mapped this file
 	if(!is_mapped) MapBlocks();
 	
+	// Loop over all events of all blocks looking for the next
+	// event matching the currently set type mask. 
+	for(; sparse_block_iter!=evio_blocks.end(); sparse_block_iter++, sparse_event_idx = 0){
 
-	// Loop through block map to find next one of interest
-	for( ; next_search_block<evio_blocks.size(); next_search_block++){
-		EVIOBlockRecord &br = evio_blocks[next_search_block];
+		// Filter out blocks of the wrong type
+		EVIOBlockRecord &br = *sparse_block_iter;
 		uint32_t type = (1 << br.block_type);
-		if( type & event_type_mask ){
+
+		for(; sparse_event_idx < br.evio_events.size(); sparse_event_idx++){
+			EVIOEventRecord &er = sparse_block_iter->evio_events[sparse_event_idx];
+
+			uint32_t etype = (1 << er.event_type);
+			if( etype & event_type_mask ) break;
+		}
+		if(sparse_event_idx >= br.evio_events.size()) continue;
 		
-			uint32_t event_len = br.block_len-8; // -8 for EVIO block header
-			last_event_len = event_len;
+		EVIOEventRecord &er = sparse_block_iter->evio_events[sparse_event_idx];
+
+		uint32_t event_len = er.event_len;
+		last_event_len = event_len;
+	
+		// Check if user buffer is big enough to hold block
+		if( event_len > user_buff_len ){
+			ClearErrorMessage();
+			err_mess << "user buffer too small for event (" << user_buff_len << " < " << event_len << ")";
+			err_code = HDEVIO_USER_BUFFER_TOO_SMALL;
+			return false;
+		}
+
+		// At this point we're committed to reading this event so go
+		// ahead and increment pointer to next event so no matter
+		// what happens below, we don't try reading it again.
+		sparse_event_idx++;
+
+		// Set file pointer to start of EVIO event (NOT block header!)
+		last_event_pos = er.pos;
+		ifs.seekg(last_event_pos, ios_base::beg);
 		
-			// Check if user buffer is big enough to hold block
-			if( event_len > user_buff_len ){
-				ClearErrorMessage();
-				err_mess << "user buffer too small for event (" << user_buff_len << " < " << event_len << ")";
-				err_code = HDEVIO_USER_BUFFER_TOO_SMALL;
-				return false;
-			}
-			
-			// Advance pointer past EVIO block header to EVIO bank
-			ifs.seekg(br.pos+(streampos)(8*sizeof(uint32_t)), ios_base::beg);
-			
-			// Read data directly into user buffer
-			ifs.read((char*)user_buff, event_len*sizeof(uint32_t));
-			
-			// Swap entire bank if needed
-			bool isgood = true;
-			if(br.swap_needed && allow_swap){
-				uint32_t Nswapped = swap_bank(user_buff, next, event_len);
-				isgood = (Nswapped == event_len);
-			}
-			
-			// Double check that event length matches EVIO block header
+		// Read data directly into user buffer
+		ifs.read((char*)user_buff, event_len*sizeof(uint32_t));
+
+		// Swap entire bank if needed
+		swap_needed = br.swap_needed; // set flag in HDEVIO
+		bool isgood = true;
+		if(br.swap_needed && allow_swap){
+			uint32_t Nswapped = swap_bank(user_buff, user_buff, event_len);
+			isgood = (Nswapped == event_len);
+		}
+		
+		// Double check that event length matches EVIO block header
+		// but only if we either don't need to swap or need to and
+		// were allowed to (otherwise, the test will almost certainly
+		// fail!)
+		if( (!br.swap_needed) || (br.swap_needed && allow_swap) ){
 			if( (user_buff[0]+1) != event_len ){
 				ClearErrorMessage();
 				err_mess << "WARNING: EVIO bank indicates a different size than block header (" << event_len << " != " << (user_buff[0]+1) << ")";
-				next_search_block++; // setup so subsequent call will read in another block
 				err_code = HDEVIO_EVENT_BIGGER_THAN_BLOCK;
 				Nerrors++;
 				Nbad_blocks++;
 				return false;
 			}
-
-			// Advance search pointer to block header
-			next_search_block++;
-
-			if(isgood) Nevents++;
-
-			return isgood;
 		}
+
+		if(isgood) Nevents++;
+
+		return isgood;
 	}
 
 	// If we got here then we did not find an event of interest
 	// above. Report that there are no more events in the file.
 	SetErrorMessage("No more events");
 	err_code = HDEVIO_EOF;
-	return false; // isgood=false	
+	return false; // isgood=false
+}
+
+//---------------------------------
+// readNoFileBuff
+//---------------------------------
+bool HDEVIO::readNoFileBuff(uint32_t *user_buff, uint32_t user_buff_len, bool allow_swap)
+{
+	/// This is an alternative to the read(...) method above that
+	/// does not use a large primary file buffer. A single EVIO
+	/// header is read in at a time and the events within the block
+	/// mapped just like when using readSparse. The difference is
+	/// that here, only a single block is mapped at a time rather
+	/// than trying to map the entire file before starting. This
+	/// gives a faster start up. This may be quicker for most
+	/// desktop filesystems but may be slower for Lustre file systems
+	/// that are configured for large volume data transfers and show
+	/// perfomance degredation with small reads.
 	
+	err_code = HDEVIO_OK;
+	ClearErrorMessage();
+	
+	// Check if we need to read in a block header using the 
+	// current file position
+	EVIOBlockRecord &br = NB_block_record;
+	if(br.evio_events.empty()){
+
+		// read EVIO block header
+		BLOCKHEADER_t bh;
+		ifs.seekg( NB_next_pos, ios_base::beg);
+		ifs.read((char*)&bh, sizeof(bh));
+		if(!ifs.good()){
+			err_code = HDEVIO_FILE_TRUNCATED;
+			return false;
+		}
+
+		// Check if we need to byte swap and simultaneously
+		// verify header is good by checking magic word
+		bool swap_needed = false;
+		if(bh.magic==0x0001dac0){
+			swap_needed = true;
+		}else{
+			if(bh.magic!=0xc0da0100){
+				err_mess.str() = "Bad magic word";
+				err_code = HDEVIO_BAD_BLOCK_HEADER;
+				return false;
+			}
+		}
+		
+		if(swap_needed)swap_block((uint32_t*)&bh, sizeof(bh)>>2, (uint32_t*)&bh);
+		
+		Nblocks++;
+		streampos pos = ifs.tellg() - (streampos)sizeof(bh);
+
+		if( (uint64_t)(pos+(streampos)bh.length) >  total_size_bytes ){
+			err_mess << "EVIO block extends past end of file!";
+			err_code = HDEVIO_FILE_TRUNCATED;
+			return false;
+		}
+		
+		br.pos = pos;
+		br.block_len = bh.length;
+		br.swap_needed = swap_needed;
+		br.first_event = 0;
+		br.last_event = 0;
+		
+		MapEvents(bh, br);
+		
+		NB_next_pos = pos + (streampos)(bh.length<<2);
+	}
+	
+	// Check if we did not find an event of interest above. 
+	// If not, report that there are no more events in the file.
+	if(br.evio_events.empty() || !ifs.good()){
+		SetErrorMessage("No more events");
+		err_code = HDEVIO_EOF;
+		return false; // isgood=false
+	}
+
+	// Grab next event record
+	EVIOEventRecord &er = br.evio_events.front();
+	
+	uint32_t event_len = er.event_len;
+	last_event_len = event_len;
+
+	// Check if user buffer is big enough to hold block
+	if( event_len > user_buff_len ){
+		ClearErrorMessage();
+		err_mess << "user buffer too small for event (" << user_buff_len << " < " << event_len << ")";
+		err_code = HDEVIO_USER_BUFFER_TOO_SMALL;
+		return false;
+	}
+
+	// Set file pointer to start of EVIO event (NOT block header!)
+	last_event_pos = er.pos;
+	ifs.seekg(last_event_pos, ios_base::beg);
+	
+	// Read data directly into user buffer
+	ifs.read((char*)user_buff, event_len*sizeof(uint32_t));
+	if(!ifs.good()){
+		SetErrorMessage("No more events");
+		err_code = HDEVIO_EOF;
+		return false; // isgood=false
+	}
+
+	// Remove EVIO Event record, effectively advancing to
+	// next event for the next time we're called
+	br.evio_events.erase(NB_block_record.evio_events.begin());
+
+	// Swap entire bank if needed
+	swap_needed = br.swap_needed; // set flag in HDEVIO
+	bool isgood = true;
+	if(br.swap_needed && allow_swap){
+		uint32_t Nswapped = swap_bank(user_buff, user_buff, event_len);
+		isgood = (Nswapped == event_len);
+	}
+	
+	// Double check that event length matches EVIO block header
+	// but only if we either don't need to swap or need to and
+	// were allowed to (otherwise, the test will almost certainly
+	// fail!)
+	if( (!br.swap_needed) || (br.swap_needed && allow_swap) ){
+		if( (user_buff[0]+1) != event_len ){
+			ClearErrorMessage();
+			err_mess << "WARNING: EVIO bank indicates a different size than block header (" << event_len << " != " << (user_buff[0]+1) << ")";
+			err_code = HDEVIO_EVENT_BIGGER_THAN_BLOCK;
+			Nerrors++;
+			Nbad_blocks++;
+			return false;
+		}
+	}
+
+	if(isgood) Nevents++;
+
+	return isgood;
+}
+
+//------------------------
+// rewind
+//------------------------
+void HDEVIO::rewind(void)
+{
+	/// This can be used whe reading from a file to
+	/// reset the file pointer and other position holders
+	/// to the begining of the file. This is done when
+	/// the "LOOP_FOREVER" option is used in the event source
+	/// to continuously re-read a file, essesntially making
+	/// it an infinite stream of events that can be used for
+	/// testing.
+
+	ifs.seekg(0, ios_base::beg);
+	ifs.clear();
+	
+	sparse_block_iter = evio_blocks.begin();
+	sparse_event_idx  = 0;
+	
+	NB_block_record.evio_events.clear();
+	NB_next_pos = 0;
+	
+	ClearErrorMessage();
+	err_code = HDEVIO_OK;
 }
 
 //------------------------
@@ -427,7 +609,10 @@ bool HDEVIO::readSparse(uint32_t *user_buff, uint32_t user_buff_len, bool allow_
 //------------------------
 uint32_t HDEVIO::SetEventMask(uint32_t mask)
 {
-	return 0;
+	uint32_t prev_mask = event_type_mask;
+	event_type_mask = mask;
+
+	return prev_mask;
 }
 
 //------------------------
@@ -435,7 +620,14 @@ uint32_t HDEVIO::SetEventMask(uint32_t mask)
 //------------------------
 uint32_t HDEVIO::SetEventMask(string types_str)
 {
-	return 0;
+	uint32_t prev_mask = event_type_mask;
+
+	event_type_mask = 0;
+	if(types_str.find("BOR"    ) != string::npos) event_type_mask |= (1<<kBT_BOR);
+	if(types_str.find("EPICS"  ) != string::npos) event_type_mask |= (1<<kBT_EPICS);
+	if(types_str.find("PHYSICS") != string::npos) event_type_mask |= (1<<kBT_PHYSICS);
+
+	return prev_mask;
 }
 
 //------------------------
@@ -539,8 +731,10 @@ void HDEVIO::MapBlocks(bool print_ticker)
 		// Update ticker
 		if(print_ticker){
 			if((Nblocks%500) == 0){
-				uint64_t read_MB = ifs.tellg()>>20;
-				cout << Nblocks << " blocks scanned (" << read_MB << " MB)    \r";
+				uint64_t total_MB = total_size_bytes>>20;
+				uint64_t read_MB  = ifs.tellg()>>20;
+				if(Nblocks==0) cout << endl;
+				cout << Nblocks << " blocks scanned (" << read_MB << "/" << total_MB << " MB " << (100*read_MB/total_MB) << "%)     \r";
 				cout.flush();
 			}
 		}
@@ -550,8 +744,13 @@ void HDEVIO::MapBlocks(bool print_ticker)
 	}
 	
 	if(print_ticker) cout << endl;
+	
+	// Setup iterators for sparse reading
+	sparse_block_iter = evio_blocks.begin();
+	sparse_event_idx = 0;
 
 	// Restore file pos and set flag that file has been mapped
+	ifs.clear();
 	ifs.seekg(start_pos, ios_base::beg);
 	is_mapped = true;
 }
@@ -583,7 +782,8 @@ void HDEVIO::MapEvents(BLOCKHEADER_t &bh, EVIOBlockRecord &br)
 		if(i!=0){
 			// Read in first few words of event
 			eh = &myeh;
-			ifs.read((char*)eh, sizeof(EVENTHEADER_t));		
+			ifs.read((char*)eh, sizeof(EVENTHEADER_t));
+			if(!ifs.good()) break;
 			if(br.swap_needed)swap_block((uint32_t*)eh, sizeof(EVENTHEADER_t)>>2, (uint32_t*)eh);
 		}else{
 			ifs.seekg(sizeof(EVENTHEADER_t), ios_base::cur);
@@ -626,12 +826,11 @@ void HDEVIO::MapEvents(BLOCKHEADER_t &bh, EVIOBlockRecord &br)
 		// Move file position to start of next event
 		streampos delta = (streampos)((eh->event_len+1)<<2) - (streampos)sizeof(EVENTHEADER_t);
 		ifs.seekg(delta, ios_base::cur);
-		pos += delta;
+		pos += (streampos)((eh->event_len+1)<<2);
 	}
 
 	ifs.seekg(start_pos, ios_base::beg);
 }
-
 
 //---------------------------------
 // swap_bank
@@ -980,6 +1179,7 @@ void HDEVIO::PrintFileSummary(void)
 		}else{
 			ss << ",";
 		}
+		if( it==events_in_block.end() ) break;
 	}
 	string sevents_in_block = ss.str();
 	

--- a/src/libraries/DAQ/HDEVIO.h
+++ b/src/libraries/DAQ/HDEVIO.h
@@ -162,16 +162,17 @@ class HDEVIO{
 		uint64_t _gcount;
 		
 		
-		uint32_t *buff;         // buffer holding current block (if any)
-		uint32_t *next;         // Pointer to start of next EVIO event within buff
-		uint32_t *buff_end;     // Pointer to word just past end of valid buffer words
-		uint32_t buff_size;     // memory currently allocated for buff in words
-		uint32_t buff_len;      // valid words in buff
-		uint32_t buff_limit;    // maximum allowed allocation for buff_max
-		bool swap_needed;       // true if block header indicates swapping is needed
-		BLOCKHEADER_t *bh;      // =buff, but cast as a BLOCKHEADER_t*
-		uint32_t last_event_len;// used to hold last event length in words if user buffer was
-		                        // too small, this is how big is should be allocated
+		uint32_t *buff;           // buffer holding current block (if any)
+		uint32_t *next;           // Pointer to start of next EVIO event within buff
+		uint32_t *buff_end;       // Pointer to word just past end of valid buffer words
+		uint32_t buff_size;       // memory currently allocated for buff in words
+		uint32_t buff_len;        // valid words in buff
+		uint32_t buff_limit;      // maximum allowed allocation for buff_max
+		bool swap_needed;         // true if block header indicates swapping is needed
+		BLOCKHEADER_t *bh;        // =buff, but cast as a BLOCKHEADER_t*
+		streampos last_event_pos; // used to hold file position at last event read in
+		uint32_t last_event_len;  // used to hold last event length in words if user buffer was
+		                          // too small, this is how big is should be allocated
 		
 		stringstream err_mess;  // last error message
 		uint32_t err_code;    // last error code
@@ -185,6 +186,8 @@ class HDEVIO{
 		bool ReadBlock(void);
 		bool read(uint32_t *user_buff, uint32_t user_buff_len, bool allow_swap=true);
 		bool readSparse(uint32_t *user_buff, uint32_t user_buff_len, bool allow_swap=true);
+		bool readNoFileBuff(uint32_t *user_buff, uint32_t user_buff_len, bool allow_swap=true);
+		void rewind(void);
 
 		uint32_t swap_bank(uint32_t *outbuff, uint32_t *inbuff, uint32_t len);
 		uint32_t swap_tagsegment(uint32_t *outbuff, uint32_t *inbuff, uint32_t len);
@@ -207,9 +210,12 @@ class HDEVIO{
 		bool is_mapped;
 		uint64_t total_size_bytes;
 		vector<EVIOBlockRecord> evio_blocks;
-		uint32_t next_search_block;
 		void MapBlocks(bool print_ticker=true);
 		void MapEvents(BLOCKHEADER_t &bh, EVIOBlockRecord &br);
+		vector<EVIOBlockRecord>::iterator sparse_block_iter;
+		uint32_t sparse_event_idx;
+		EVIOBlockRecord NB_block_record;
+		streampos NB_next_pos;
 
 		void ClearErrorMessage(void){ err_mess.str(""); err_mess.clear();}
 		void SetErrorMessage(string mess){ ClearErrorMessage(); err_mess<<mess;}
@@ -260,11 +266,7 @@ class HDEVIO{
 		inline void swap_block(uint16_t *inbuff, uint16_t len, uint16_t *outbuff)
 		{
 			for(uint32_t i=0; i<len; i++, inbuff++, outbuff++){
-				uint16_t inword = *inbuff;  // copy word to allow using same buffer for input and output
-				uint8_t *inptr  = (uint8_t*)&inword;
-				uint8_t *outptr = (uint8_t*)&outbuff[1];
-				*(--outptr) = *inptr++;
-				*(--outptr) = *inptr++;
+				*outbuff = swap16(*inbuff);
 			}
 		}
 
@@ -274,13 +276,7 @@ class HDEVIO{
 		inline void swap_block(uint32_t *inbuff, uint32_t len, uint32_t *outbuff)
 		{
 			for(uint32_t i=0; i<len; i++, inbuff++, outbuff++){
-				uint32_t inword = *inbuff;  // copy word to allow using same buffer for input and output
-				uint8_t *inptr  = (uint8_t*)&inword;
-				uint8_t *outptr = (uint8_t*)&outbuff[1];
-				*(--outptr) = *inptr++;
-				*(--outptr) = *inptr++;
-				*(--outptr) = *inptr++;
-				*(--outptr) = *inptr++;
+				*outbuff = swap32(*inbuff);
 			}
 		}
 
@@ -290,18 +286,7 @@ class HDEVIO{
 		inline void swap_block(uint64_t *inbuff, uint64_t len, uint64_t *outbuff)
 		{
 			for(uint32_t i=0; i<len; i++, inbuff++, outbuff++){
-				uint64_t inword = *inbuff;  // copy word to allow using same buffer for input and output
-				uint8_t *inptr  = (uint8_t*)&inword;
-				uint8_t *outptr = (uint8_t*)&outbuff[1];
-				*(--outptr) = *inptr++;
-				*(--outptr) = *inptr++;
-				*(--outptr) = *inptr++;
-				*(--outptr) = *inptr++;
-
-				*(--outptr) = *inptr++;
-				*(--outptr) = *inptr++;
-				*(--outptr) = *inptr++;
-				*(--outptr) = *inptr++;
+				*outbuff = swap64(*inbuff);
 			}
 		}
 

--- a/src/libraries/DAQ/JEventSource_EVIO.h
+++ b/src/libraries/DAQ/JEventSource_EVIO.h
@@ -238,6 +238,8 @@ class JEventSource_EVIO: public jana::JEventSource{
 		float TIMEOUT;
 		string MODTYPE_MAP_FILENAME;
 		bool ENABLE_DISENTANGLING;
+		bool EVIO_SPARSE_READ;
+		string EVENT_MASK;
 
         EmulationModeType F125_EMULATION_MODE; ///< F125 emulation mode
         EmulationModeType F250_EMULATION_MODE; ///< F250 emulation mode

--- a/src/programs/Analysis/hd_dump/hd_dump.cc
+++ b/src/programs/Analysis/hd_dump/hd_dump.cc
@@ -18,6 +18,7 @@ void Usage(void);
 
 bool LIST_FACTORIES = false;
 bool SPARSIFY_SUMMARY = true;
+bool ALLOW_SPARSIFIED_EVIO = true;
 
 //-----------
 // main
@@ -50,6 +51,22 @@ int main(int narg, char *argv[])
 	//t.c_cc[VMIN] = 1;
 	tcsetattr(fileno(stdin), TCSANOW, &t);
 
+	// If only DEPICSvalue is specified to print, then automatically
+	// turn on sparsified reading unless user specifically requests
+	// that we don't.
+	if(toprint.size()==1 && ALLOW_SPARSIFIED_EVIO){
+		if( (toprint[0]=="DEPICSvalue") || (toprint[0]=="EPICSvalue")){
+			cout << endl;
+			cout << "-- Only DEPICSvalue objects requested" << endl;
+			cout << "-- * Enabling EVIO file mapping and sparse readout" << endl;
+			cout << "-- * Automatically invoking -f and -s options" << endl;
+			cout << endl;
+			gPARMS->SetParameter("EVIO:SPARSE_READ", true);
+			gPARMS->SetParameter("EVIO:EVENT_MASK", string("EPICS"));
+			PRINT_SUMMARY_HEADER = false;
+			SKIP_BORING_EVENTS = 1;
+		}
+	}
 
 	// Run though all events, calling our event processor's methods
 	app->SetShowTicker(0);
@@ -144,6 +161,9 @@ void ParseCommandLineArguments(int &narg, char *argv[])
 			case 'b':
 				PRINT_STATUS_BITS = true;
 				break;
+			case 'e':
+				ALLOW_SPARSIFIED_EVIO = false;
+				break;
 		}
 	}
 }
@@ -175,6 +195,7 @@ void Usage(void)
 	cout<<"   -f        Skip printing summary header lisiting all factories"<<endl;
 	cout<<"             (This disables auto-activating every single factory)"<<endl;
 	cout<<"   -b        Print event status bits"<<endl;
+	cout<<"   -e        Don't allow automatic EVIO sparse readout for EPICS data"<<endl;
 	cout<<endl;
 
 	dapp.Usage();


### PR DESCRIPTION
Fixed and enabled EVIO file mapping and sparse readout. Also added special case to hd_dump to utilize this when only printing DEPICSvalue objects.
