### PR TITLE
Fix mem explosion

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisUtilities.cc
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.cc
@@ -192,8 +192,8 @@ bool DAnalysisUtilities::Check_IsBDTSignalEvent(JEventLoop* locEventLoop, const 
 		const DParticleCombo* locThrownCombo = dThrownComboFactory->Build_ThrownCombo(locEventLoop, locThrownReaction, locThrownSteps);
 		bool locCheckResult = Check_ThrownsMatchReaction(locThrownCombo, locCurrentReaction, locExclusiveMatchFlag);
 
-		delete locThrownCombo;
-		delete locThrownReaction;
+		dThrownComboFactory->Recycle_Combo(locThrownCombo);
+		dThrownReactionFactory->Recycle_Reaction(locThrownReaction);
 		return locCheckResult;
 	}
 
@@ -226,8 +226,8 @@ bool DAnalysisUtilities::Check_IsBDTSignalEvent(JEventLoop* locEventLoop, const 
 		const DParticleCombo* locThrownCombo = dThrownComboFactory->Build_ThrownCombo(locEventLoop, locThrownReaction, locThrownSteps);
 		bool locCheckResult = Check_ThrownsMatchReaction(locThrownCombo, locCurrentReaction, locExclusiveMatchFlag);
 
-		delete locThrownCombo;
-		delete locThrownReaction;
+		dThrownComboFactory->Recycle_Combo(locThrownCombo);
+		dThrownReactionFactory->Recycle_Reaction(locThrownReaction);
 		return locCheckResult;
 	}
 
@@ -252,12 +252,11 @@ bool DAnalysisUtilities::Check_IsBDTSignalEvent(JEventLoop* locEventLoop, const 
 			const DParticleCombo* locThrownCombo = dThrownComboFactory->Build_ThrownCombo(locEventLoop, locThrownReaction, locCurrentThrownSteps);
 			bool locCheckResult = Check_ThrownsMatchReaction(locThrownCombo, locCurrentReaction, locExclusiveMatchFlag);
 
-			delete locThrownCombo;
-			delete locThrownReaction;
+			dThrownComboFactory->Recycle_Combo(locThrownCombo);
+			dThrownReactionFactory->Recycle_Reaction(locThrownReaction);
 
 			if(locCheckResult)
 				return true; //it worked!
-			locResumeAtIndex[locParticleIndex] = 0;
 			locReplacementThrownSteps.pop_back();
 			--locParticleIndex;
 			continue;

--- a/src/libraries/ANALYSIS/DAnalysisUtilities.cc
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.cc
@@ -188,8 +188,8 @@ bool DAnalysisUtilities::Check_IsBDTSignalEvent(JEventLoop* locEventLoop, const 
 	if(!locIncludeDecayingToReactionFlag)
 	{
 		//don't try decaying thrown particles: compare as-is
-		const DReaction* locThrownReaction = dThrownReactionFactory->Build_ThrownReaction(locEventLoop, locThrownSteps);
-		const DParticleCombo* locThrownCombo = dThrownComboFactory->Build_ThrownCombo(locEventLoop, locThrownReaction, locThrownSteps);
+		DReaction* locThrownReaction = dThrownReactionFactory->Build_ThrownReaction(locEventLoop, locThrownSteps);
+		DParticleCombo* locThrownCombo = dThrownComboFactory->Build_ThrownCombo(locEventLoop, locThrownReaction, locThrownSteps);
 		bool locCheckResult = Check_ThrownsMatchReaction(locThrownCombo, locCurrentReaction, locExclusiveMatchFlag);
 
 		dThrownComboFactory->Recycle_Combo(locThrownCombo);
@@ -222,8 +222,8 @@ bool DAnalysisUtilities::Check_IsBDTSignalEvent(JEventLoop* locEventLoop, const 
 	//if no additional replacements to make: check it
 	if(locPIDVector.empty())
 	{
-		const DReaction* locThrownReaction = dThrownReactionFactory->Build_ThrownReaction(locEventLoop, locThrownSteps);
-		const DParticleCombo* locThrownCombo = dThrownComboFactory->Build_ThrownCombo(locEventLoop, locThrownReaction, locThrownSteps);
+		DReaction* locThrownReaction = dThrownReactionFactory->Build_ThrownReaction(locEventLoop, locThrownSteps);
+		DParticleCombo* locThrownCombo = dThrownComboFactory->Build_ThrownCombo(locEventLoop, locThrownReaction, locThrownSteps);
 		bool locCheckResult = Check_ThrownsMatchReaction(locThrownCombo, locCurrentReaction, locExclusiveMatchFlag);
 
 		dThrownComboFactory->Recycle_Combo(locThrownCombo);
@@ -248,8 +248,8 @@ bool DAnalysisUtilities::Check_IsBDTSignalEvent(JEventLoop* locEventLoop, const 
 		if(locParticleIndex == int(locPIDVector.size()))
 		{
 			//combo defined: try it
-			const DReaction* locThrownReaction = dThrownReactionFactory->Build_ThrownReaction(locEventLoop, locCurrentThrownSteps);
-			const DParticleCombo* locThrownCombo = dThrownComboFactory->Build_ThrownCombo(locEventLoop, locThrownReaction, locCurrentThrownSteps);
+			DReaction* locThrownReaction = dThrownReactionFactory->Build_ThrownReaction(locEventLoop, locCurrentThrownSteps);
+			DParticleCombo* locThrownCombo = dThrownComboFactory->Build_ThrownCombo(locEventLoop, locThrownReaction, locCurrentThrownSteps);
 			bool locCheckResult = Check_ThrownsMatchReaction(locThrownCombo, locCurrentReaction, locExclusiveMatchFlag);
 
 			dThrownComboFactory->Recycle_Combo(locThrownCombo);

--- a/src/libraries/ANALYSIS/DParticleCombo_factory_Thrown.cc
+++ b/src/libraries/ANALYSIS/DParticleCombo_factory_Thrown.cc
@@ -184,6 +184,19 @@ DParticleComboBlueprintStep* DParticleCombo_factory_Thrown::Get_ParticleComboBlu
 	return locParticleComboBlueprintStep;
 }
 
+void DParticleCombo_factory_Thrown::Recycle_Combo(DParticleCombo* locParticleCombo)
+{
+	//deletes combo, but recycles steps
+	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
+	{
+		DParticleComboStep* locParticleComboStep = const_cast<DParticleComboStep*>(locParticleCombo->Get_ParticleComboStep(loc_i));
+		DParticleComboBlueprintStep* locParticleComboBlueprintStep = const_cast<DParticleComboBlueprintStep*>(locParticleComboBlueprintStep->Get_ParticleComboBlueprintStep());
+		dParticleComboStepPool_Available.push_back(locParticleComboStep);
+		dParticleComboBlueprintStepPool_Available.push_back(locParticleComboBlueprintStep);
+	}
+	delete locParticleCombo;
+}
+
 //------------------
 // erun
 //------------------

--- a/src/libraries/ANALYSIS/DParticleCombo_factory_Thrown.cc
+++ b/src/libraries/ANALYSIS/DParticleCombo_factory_Thrown.cc
@@ -190,7 +190,7 @@ void DParticleCombo_factory_Thrown::Recycle_Combo(DParticleCombo* locParticleCom
 	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
 	{
 		DParticleComboStep* locParticleComboStep = const_cast<DParticleComboStep*>(locParticleCombo->Get_ParticleComboStep(loc_i));
-		DParticleComboBlueprintStep* locParticleComboBlueprintStep = const_cast<DParticleComboBlueprintStep*>(locParticleComboBlueprintStep->Get_ParticleComboBlueprintStep());
+		DParticleComboBlueprintStep* locParticleComboBlueprintStep = const_cast<DParticleComboBlueprintStep*>(locParticleComboStep->Get_ParticleComboBlueprintStep());
 		dParticleComboStepPool_Available.push_back(locParticleComboStep);
 		dParticleComboBlueprintStepPool_Available.push_back(locParticleComboBlueprintStep);
 	}

--- a/src/libraries/ANALYSIS/DParticleCombo_factory_Thrown.h
+++ b/src/libraries/ANALYSIS/DParticleCombo_factory_Thrown.h
@@ -29,6 +29,8 @@ class DParticleCombo_factory_Thrown : public jana::JFactory<DParticleCombo>
 
 		DParticleCombo* Build_ThrownCombo(JEventLoop* locEventLoop, const DReaction* locThrownReaction, deque<pair<const DMCThrown*, deque<const DMCThrown*> > >& locThrownSteps);
 
+		void Recycle_Combo(DParticleCombo* locParticleCombo); //deletes combo, but recycles steps
+
 	private:
 		jerror_t init(void);						///< Called once at program start.
 		jerror_t brun(jana::JEventLoop *locEventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.

--- a/src/libraries/ANALYSIS/DReaction_factory_Thrown.cc
+++ b/src/libraries/ANALYSIS/DReaction_factory_Thrown.cc
@@ -110,6 +110,17 @@ DReactionStep* DReaction_factory_Thrown::Get_ReactionStepResource(void)
 	return locReactionStep;
 }
 
+void DReaction_factory_Thrown::Recycle_Reaction(DReaction* locReaction)
+{
+	//deletes reaction, but recycles steps
+	for(size_t loc_i = 0; loc_i < locReaction->Get_NumReactionSteps(); ++loc_i)
+	{
+		DReactionStep* locReactionStep = const_cast<DReactionStep*>(locReaction->Get_ReactionStep(loc_i));
+		dReactionStepPool_Available.push_back(locReactionStep);
+	}
+	delete locReaction;
+}
+
 //------------------
 // erun
 //------------------

--- a/src/libraries/ANALYSIS/DReaction_factory_Thrown.h
+++ b/src/libraries/ANALYSIS/DReaction_factory_Thrown.h
@@ -26,6 +26,8 @@ class DReaction_factory_Thrown:public jana::JFactory<DReaction>
 
 		DReaction* Build_ThrownReaction(JEventLoop* locEventLoop, deque<pair<const DMCThrown*, deque<const DMCThrown*> > >& locThrownSteps);
 
+		void Recycle_Reaction(DReaction* locReaction); //deletes reaction, but recycles steps
+
 	private:
 		jerror_t init(void);						///< Called once at program start.
 		jerror_t brun(jana::JEventLoop *locEventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.


### PR DESCRIPTION
Fix memory explosion that occurs when determining BDT signal combo.

Explosion: not a leak, but on nasty events, it blows up.
Recycle memory (steps) when finished with them.
