### PR TITLE
use individual ADC to Energy converstion parameters for each PMT

### DIFF
--- a/src/libraries/TOF/DTOFPaddleHit_factory.h
+++ b/src/libraries/TOF/DTOFPaddleHit_factory.h
@@ -18,7 +18,7 @@
 #include "JANA/JEventLoop.h"
 #include "DTOFPaddleHit.h"
 #include "DTOFGeometry.h"
-
+#include "TMath.h"
 using namespace jana;
 
 /// \htmlonly
@@ -44,6 +44,8 @@ class DTOFPaddleHit_factory:public JFactory<DTOFPaddleHit>{
   double ENERGY_ATTEN_FACTOR;
   double TIME_COINCIDENCE_CUT;
   vector<double>propagation_speed;
+
+  vector < vector <float> > AttenuationLengths;
 
   vector <const DTOFGeometry*> TOFGeom;
 


### PR DESCRIPTION
using a new calibration table TOF/adc2E then also introduce a new
calbiration table with two attenuation legnth parameters for each
individual paddle TOF/attenuation_lengths. These attenuation length
is then used in PaddleHit_factory.cc to translate the adc value to
energy in GeV. Currently all paddle have the same two attenuation
length 75cm and 470cm which represents an average over all paddles.
This can be individualized in the future if necessary.
The ADC to Energy parameters are derived from comparison of MC data
results with Data. As reference an average distance of 144cm from the
PMT was chosen to optimize statistics and not being too close to the
center of the paddle where problems may arrise for paddle close to
the beam hole.
