### PR TITLE
Change nsamples_pedestal to 1 for f250 emulation

### DIFF
--- a/src/libraries/DAQ/Df250EmulatorAlgorithm_v1.cc
+++ b/src/libraries/DAQ/Df250EmulatorAlgorithm_v1.cc
@@ -254,7 +254,7 @@ void Df250EmulatorAlgorithm_v1::EmulateFirmware(const Df250WindowRawData* rawDat
         f250PulseIntegral->integral = pulse_integral[p];
         f250PulseIntegral->pedestal = VMIN;
         f250PulseIntegral->nsamples_integral = NSA + NSB;
-        f250PulseIntegral->nsamples_pedestal = 4;
+        f250PulseIntegral->nsamples_pedestal = 1;
         f250PulseIntegral->emulated = true;
         f250PulseIntegral->integral_emulated = pulse_integral[p];
         f250PulseIntegral->pedestal_emulated = VMIN;


### PR DESCRIPTION
This number is supposed to indicate how many samples the pedestal value in the PulseIntegral object represents. nsamples_pedestal should be set to 1 since VMIN is already bit-shifted in the code to represent the average single sample value of the first four samples.
