### PR TITLE
Require CERN before compiling 'twopi_plotter'

### DIFF
--- a/src/programs/AmplitudeAnalysis/twopi_plotter/SConscript
+++ b/src/programs/AmplitudeAnalysis/twopi_plotter/SConscript
@@ -6,17 +6,16 @@ import sbms
 Import('*')
 
 # Verify AMPTOOLS environment variable is set
-if os.getenv('AMPTOOLS', 'nada')!='nada' and os.getenv('AMPPLOTTER', 'nada')!='nada':
-   
+if os.getenv('AMPTOOLS', 'nada')!='nada' and os.getenv('AMPPLOTTER', 'nada')!='nada' and os.getenv('CERN', 'nada')!='nada':
+
    env = env.Clone()
-   
+
    AMPTOOLS_LIBS = "AMPTOOLS_AMPS AMPTOOLS_DATAIO AMPTOOLS_MCGEN"
    env.AppendUnique(LIBS = AMPTOOLS_LIBS.split())
-   
+
    sbms.AddHDDM(env)
    sbms.AddROOT(env)
    sbms.AddAmpTools(env)
    sbms.AddAmpPlotter(env)
-   
-   sbms.executable(env)
 
+   sbms.executable(env)


### PR DESCRIPTION
Mac OS X builds with CERN disabled were failing at 'twopi_plotter'
because AMPTOOLS_AMPS and AMPTOOLS_MCGEN require CERN (see 80b617d).
