### PR TITLE
changed  line 191 from "<" into "<=" this will correctly determine

### DIFF
--- a/src/libraries/TTAB/DTTabUtilities.cc
+++ b/src/libraries/TTAB/DTTabUtilities.cc
@@ -188,7 +188,7 @@ double DTTabUtilities::Convert_DigiTimeToNs_CAEN1290TDC(const DCAEN1290TDCHit* l
 
 	// The number of TI-counter (4 ns) blocks to shift the CAEN time to line-up with the TI time
     int locNum4NsBlocksToShift = dCAENTIPhaseDifference - locSystemClockBinRemainder;
-    if(locNum4NsBlocksToShift < 0)
+    if(locNum4NsBlocksToShift <= 0)
     	locNum4NsBlocksToShift += 6;
 
 	return dTScale_CAEN*double(locCAEN1290TDCHit->time) + 4.0*double(locNum4NsBlocksToShift);


### PR DESCRIPTION
the offset for the 6 fold clock ambiguity

this fix requires also the ccdb to be update so that the parameter TOF_TDC_SHIFT is
zero for runs larger than 11343 of the spring data.
