### PR TITLE
Fix linking error for gcc-5.3 on Ubuntu 16.04

### DIFF
--- a/src/programs/AmplitudeAnalysis/twopi_plotter/SConscript
+++ b/src/programs/AmplitudeAnalysis/twopi_plotter/SConscript
@@ -14,8 +14,8 @@ if os.getenv('AMPTOOLS', 'nada')!='nada' and os.getenv('AMPPLOTTER', 'nada')!='n
    env.AppendUnique(LIBS = AMPTOOLS_LIBS.split())
 
    sbms.AddHDDM(env)
-   sbms.AddROOT(env)
    sbms.AddAmpTools(env)
    sbms.AddAmpPlotter(env)
+   sbms.AddROOT(env)
 
    sbms.executable(env)


### PR DESCRIPTION
gcc-5.3 on Ubuntu 16.04 passes the "--as-needed" linking flag by default.
For twopi_plotter, the ROOT libs were being linked in before the AmpTools
libs. There was an undefined reference for libGui.so and error adding
symbols for libGpad.so (DSO missing from command line). Apparently, these
ROOT libs were being discarded because none of the previous libs on the
command line needed them. Moving the AmpTools libs to come before the
ROOT libs got rid of this error.

If "-Wl,--no-as-needed" was passed to gcc then the linking completed
without error regardless of the linking order. This flag is added by SBMS
by default for programs that link in CERNLIB, which explains why an error
does not occur when compiling other similar programs which link in ROOT
before AmpTools but additionally add CERNLIB.
