### PR TITLE
ignore front pannel triggers, this includes the LED triggers

### DIFF
--- a/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.cc
+++ b/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.cc
@@ -92,37 +92,48 @@ jerror_t DEventProcessor_monitoring_hists::evnt(JEventLoop *locEventLoop, uint64
 {
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
-	{
-		dHist_IsEvent->Fill(1);
-	}
-	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
-	vector<const DMCThrown*> locMCThrowns;
-	locEventLoop->Get(locMCThrowns);
+  const DL1Trigger*  Trig;
+  locEventLoop->GetSingle(Trig);
 
-	//Fill reaction-independent histograms.
-	dHistogramAction_NumReconstructedObjects(locEventLoop);
-	dHistogramAction_Reconstruction(locEventLoop);
-	dHistogramAction_EventVertex(locEventLoop);
-
-	dHistogramAction_DetectorMatching(locEventLoop);
-	dHistogramAction_DetectorMatchParams(locEventLoop);
-	dHistogramAction_Neutrals(locEventLoop);
-	dHistogramAction_DetectorPID(locEventLoop);
-
-	dHistogramAction_TrackMultiplicity(locEventLoop);
-	dHistogramAction_DetectedParticleKinematics(locEventLoop);
-//	dHistogramAction_ObjectMemory(locEventLoop);
-
-	if(!locMCThrowns.empty())
-	{
-		dHistogramAction_ThrownParticleKinematics(locEventLoop);
-		dHistogramAction_ReconnedThrownKinematics(locEventLoop);
-		dHistogramAction_GenReconTrackComparison(locEventLoop);
-	}
-
-	return NOERROR;
+  if (Trig->fp_trig_mask>0){ // Ignore front pannel trigger
+    return NOERROR;
+  }
+ 
+  
+  
+  
+  japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+  {
+    dHist_IsEvent->Fill(1);
+  }
+  japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+  
+  vector<const DMCThrown*> locMCThrowns;
+  locEventLoop->Get(locMCThrowns);
+  
+  //Fill reaction-independent histograms.
+  dHistogramAction_NumReconstructedObjects(locEventLoop);
+  dHistogramAction_Reconstruction(locEventLoop);
+  dHistogramAction_EventVertex(locEventLoop);
+  
+  dHistogramAction_DetectorMatching(locEventLoop);
+  dHistogramAction_DetectorMatchParams(locEventLoop);
+  dHistogramAction_Neutrals(locEventLoop);
+  dHistogramAction_DetectorPID(locEventLoop);
+  
+  dHistogramAction_TrackMultiplicity(locEventLoop);
+  dHistogramAction_DetectedParticleKinematics(locEventLoop);
+  //	dHistogramAction_ObjectMemory(locEventLoop);
+  
+  if(!locMCThrowns.empty())
+    {
+      dHistogramAction_ThrownParticleKinematics(locEventLoop);
+      dHistogramAction_ReconnedThrownKinematics(locEventLoop);
+      dHistogramAction_GenReconTrackComparison(locEventLoop);
+    }
+  
+  return NOERROR;
 }
 
 //------------------

--- a/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.h
+++ b/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.h
@@ -15,6 +15,7 @@
 
 #include "DANA/DApplication.h"
 #include "ANALYSIS/DHistogramActions.h"
+#include <TRIGGER/DL1Trigger.h>
 
 using namespace jana;
 


### PR DESCRIPTION
put code into evnt()  to ignore any front panel triggers. This includes the random triggers
and the LED triggers for FCAL and BCAL
