### PR TITLE
fix bug I intruduced that causes hd_root to crash

### DIFF
--- a/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.cc
+++ b/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.cc
@@ -96,12 +96,10 @@ jerror_t DEventProcessor_monitoring_hists::evnt(JEventLoop *locEventLoop, uint64
   vector <const DL1Trigger*>  Trig;
   locEventLoop->Get(Trig);
 
-  if (Trig.size()<1){
-    return NOERROR;
-  }
-
-  if (Trig[0]->fp_trig_mask>0){ // Ignore front pannel trigger
-    return NOERROR;
+  if (!Trig.empty()){
+    if (Trig[0]->fp_trig_mask>0){ // Ignore front pannel trigger
+      return NOERROR;
+    }
   }
   
   japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK

--- a/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.cc
+++ b/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.cc
@@ -93,15 +93,16 @@ jerror_t DEventProcessor_monitoring_hists::evnt(JEventLoop *locEventLoop, uint64
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
 
-  const DL1Trigger*  Trig;
-  locEventLoop->GetSingle(Trig);
+  vector <const DL1Trigger*>  Trig;
+  locEventLoop->Get(Trig);
 
-  if (Trig->fp_trig_mask>0){ // Ignore front pannel trigger
+  if (Trig.size()<1){
     return NOERROR;
   }
- 
-  
-  
+
+  if (Trig[0]->fp_trig_mask>0){ // Ignore front pannel trigger
+    return NOERROR;
+  }
   
   japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
   {


### PR DESCRIPTION
apparently I can not handle ->GetSingle()
resort back to vectors with ->Get()
apparently there are events that do not have DL1Trigger objects.
