### PR TITLE
Break REST backwards compatibility, add DTrigger

### DIFF
--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -302,10 +302,18 @@ void DHistogramAction_Reconstruction::Initialize(JEventLoop* locEventLoop)
 	vector<const DMCThrown*> locMCThrowns;
 	locEventLoop->Get(locMCThrowns);
 
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+	double locTargetZCenter = 0.0;
+	locGeometry->GetTargetZ(locTargetZCenter);
+
 	//CREATE THE HISTOGRAMS
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
+		if(dTargetCenter.Z() < -9.8E9)
+			dTargetCenter.SetXYZ(0.0, 0.0, locTargetZCenter);
+
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
 			//If another thread has already created the folder, it just changes to it.
 		CreateAndChangeTo_ActionDirectory();
@@ -337,6 +345,14 @@ void DHistogramAction_Reconstruction::Initialize(JEventLoop* locEventLoop)
 		dHist_SCHitEnergy = GetOrCreate_Histogram<TH1I>(locHistName, ";SC Hit Energy (MeV)", dNumHitEnergyBins, dMinHitEnergy, dMaxHitEnergy);
 		locHistName = "SCHitEnergyVsSector";
 		dHist_SCHitEnergyVsSector = GetOrCreate_Histogram<TH2I>(locHistName, ";SC Hit Sector;SC Hit Energy (MeV)", 30, 0.5, 30.5, dNum2DHitEnergyBins, dMinHitEnergy, dMaxHitEnergy);
+		locHistName = "SCRFDeltaTVsSector";
+		dHist_SCRFDeltaTVsSector = GetOrCreate_Histogram<TH2I>(locHistName, ";SC Hit Sector;SC - RF #Deltat (ns)", 30, 0.5, 30.5, dNum2DDeltaTBins, dMinDeltaT, dMaxDeltaT);
+
+		//TAGH, TAGM
+		locHistName = "TAGMRFDeltaTVsColumn";
+		dHist_TAGMRFDeltaTVsColumn = GetOrCreate_Histogram<TH2I>(locHistName, ";TAGM Column;TAGM - RF #Deltat (ns)", 102, 0.5, 102.5, dNum2DDeltaTBins, dMinDeltaT, dMaxDeltaT);
+		locHistName = "TAGHRFDeltaTVsCounter";
+		dHist_TAGHRFDeltaTVsCounter = GetOrCreate_Histogram<TH2I>(locHistName, ";TAGH Counter;TAGH - RF #Deltat (ns)", 274, 0.5, 274.5, dNum2DDeltaTBins, dMinDeltaT, dMaxDeltaT);
 
 		//TRACKING
 		CreateAndChangeTo_Directory("Tracking", "Tracking");
@@ -473,6 +489,9 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 	vector<const DSCHit*> locSCHits;
 	locEventLoop->Get(locSCHits);
 
+	vector<const DBeamPhoton*> locBeamPhotons;
+	locEventLoop->Get(locBeamPhotons);
+
 	const DDetectorMatches* locDetectorMatches = NULL;
 	locEventLoop->GetSingle(locDetectorMatches);
 
@@ -487,6 +506,9 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 
 	const DParticleID* locParticleID = NULL;
 	locEventLoop->GetSingle(locParticleID);
+
+	const DEventRFBunch* locEventRFBunch = NULL;
+	locEventLoop->GetSingle(locEventRFBunch);
 
 	const DDetectorMatches* locDetectorMatches_WireBased = NULL;
 	vector<const DTrackCandidate*> locTrackCandidates;
@@ -514,10 +536,17 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 
 	//select the best DTrackTimeBased for each track: use best tracking FOM
 		//also, make map from WBT -> TBT (if not rest)
+		//also, select best sc matches for each track
 	map<JObject::oid_t, const DTrackTimeBased*> locBestTrackTimeBasedMap; //lowest tracking FOM for each candidate id
 	map<const DTrackWireBased*, const DTrackTimeBased*> locWireToTimeBasedTrackMap;
+	map<const DTrackTimeBased*, DSCHitMatchParams> locTimeBasedToBestSCMatchMap;
 	for(size_t loc_i = 0; loc_i < locTrackTimeBasedVector.size(); ++loc_i)
 	{
+		//Best SC Match Params
+		DSCHitMatchParams locSCHitMatchParams;
+		if(locParticleID->Get_BestSCMatchParams(locTrackTimeBasedVector[loc_i], locDetectorMatches, locSCHitMatchParams))
+			locTimeBasedToBestSCMatchMap[locTrackTimeBasedVector[loc_i]] = locSCHitMatchParams;
+
 		JObject::oid_t locCandidateID = locTrackTimeBasedVector[loc_i]->candidateid;
 		if(locBestTrackTimeBasedMap.find(locCandidateID) == locBestTrackTimeBasedMap.end())
 			locBestTrackTimeBasedMap[locCandidateID] = locTrackTimeBasedVector[loc_i];
@@ -535,12 +564,14 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
 	Lock_Action(); //ACQUIRE ROOT LOCK!!
 	{
+		//FCAL
 		for(size_t loc_i = 0; loc_i < locFCALShowers.size(); ++loc_i)
 		{
 			dHist_FCALShowerEnergy->Fill(locFCALShowers[loc_i]->getEnergy());
 			dHist_FCALShowerYVsX->Fill(locFCALShowers[loc_i]->getPosition().X(), locFCALShowers[loc_i]->getPosition().Y());
 		}
 
+		//BCAL
 		for(size_t loc_i = 0; loc_i < locBCALShowers.size(); ++loc_i)
 		{
 			dHist_BCALShowerEnergy->Fill(locBCALShowers[loc_i]->E);
@@ -551,12 +582,14 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 			dHist_BCALShowerPhiVsZ->Fill(locBCALPosition.Z(), locBCALPhi);
 		}
 
+		//TOF
 		for(size_t loc_i = 0; loc_i < locTOFPoints.size(); ++loc_i)
 		{
 			dHist_TOFPointEnergy->Fill(locTOFPoints[loc_i]->dE*1.0E3);
 			dHist_TOFPointYVsX->Fill(locTOFPoints[loc_i]->pos.X(), locTOFPoints[loc_i]->pos.Y());
 		}
 
+		//SC
 		for(size_t loc_i = 0; loc_i < locSCHits.size(); ++loc_i)
 		{
 			dHist_SCHitSector->Fill(locSCHits[loc_i]->sector);
@@ -564,6 +597,17 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 			dHist_SCHitEnergyVsSector->Fill(locSCHits[loc_i]->sector, locSCHits[loc_i]->dE*1.0E3);
 		}
 
+		//TAGM, TAGH
+		for(size_t loc_i = 0; loc_i < locBeamPhotons.size(); ++loc_i)
+		{
+			double locDeltaT = locBeamPhotons[loc_i]->time() - locEventRFBunch->dTime;
+			if(locBeamPhotons[loc_i]->t0_detector() == SYS_TAGM)
+				dHist_TAGMRFDeltaTVsColumn->Fill(locBeamPhotons[loc_i]->dCounter, locDeltaT);
+			else
+				dHist_TAGHRFDeltaTVsCounter->Fill(locBeamPhotons[loc_i]->dCounter, locDeltaT);
+		}
+
+		//TRACK CANDIDATES
 		for(size_t loc_i = 0; loc_i < locTrackCandidates.size(); ++loc_i)
 		{
 			int locCharge = (locTrackCandidates[loc_i]->charge() > 0.0) ? 1 : -1;
@@ -582,6 +626,7 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 				dHist_FDCPlaneVsTheta_Candidates->Fill(locTheta, *locIterator);
 		}
 
+		//WIRE-BASED TRACKS
 		map<JObject::oid_t, const DTrackWireBased*>::iterator locWireBasedIterator = locBestTrackWireBasedMap.begin();
 		for(; locWireBasedIterator != locBestTrackWireBasedMap.end(); ++locWireBasedIterator)
 		{
@@ -604,6 +649,7 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 			dHist_TrackingFOM_WireBased->Fill(locTrackWireBased->FOM);
 		}
 
+		//TIME-BASED TRACKS
 		map<JObject::oid_t, const DTrackTimeBased*>::iterator locTimeBasedIterator = locBestTrackTimeBasedMap.begin();
 		for(; locTimeBasedIterator != locBestTrackTimeBasedMap.end(); ++locTimeBasedIterator)
 		{
@@ -621,6 +667,7 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 			dHist_TrackingFOMVsP->Fill(locP, locTrackTimeBased->FOM);
 			dHist_TrackingFOMVsNumHits->Fill(locTrackTimeBased->Ndof + 5, locTrackTimeBased->FOM);
 
+			//CDC
 			set<int> locCDCRings;
 			locParticleID->Get_CDCRings(locTrackTimeBased->dCDCRings, locCDCRings);
 			for(set<int>::iterator locIterator = locCDCRings.begin(); locIterator != locCDCRings.end(); ++locIterator)
@@ -630,6 +677,7 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 					dHist_CDCRingVsTheta_TimeBased_GoodTrackFOM->Fill(locTheta, *locIterator);
 			}
 
+			//FDC
 			set<int> locFDCPlanes;
 			locParticleID->Get_FDCPlanes(locTrackTimeBased->dFDCPlanes, locFDCPlanes);
 			for(set<int>::iterator locIterator = locFDCPlanes.begin(); locIterator != locFDCPlanes.end(); ++locIterator)
@@ -639,12 +687,23 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 					dHist_FDCPlaneVsTheta_TimeBased_GoodTrackFOM->Fill(locTheta, *locIterator);
 			}
 
+			//FOM
 			if(locTrackTimeBased->FOM > dGoodTrackFOM)
 				dHistMap_PVsTheta_TimeBased_GoodTrackFOM[locCharge]->Fill(locTheta, locP);
 			else
 				dHistMap_PVsTheta_TimeBased_LowTrackFOM[locCharge]->Fill(locTheta, locP);
 			if(locTrackTimeBased->FOM > dHighTrackFOM)
 				dHistMap_PVsTheta_TimeBased_HighTrackFOM[locCharge]->Fill(locTheta, locP);
+
+			//SC/RF DELTA-T
+			map<const DTrackTimeBased*, DSCHitMatchParams>::iterator locSCIterator = locTimeBasedToBestSCMatchMap.find(locTrackTimeBased);
+			if(locSCIterator != locTimeBasedToBestSCMatchMap.end())
+			{
+				DSCHitMatchParams& locSCHitMatchParams = locSCIterator->second;
+				double locPropagatedSCTime = locSCHitMatchParams.dHitTime - locSCHitMatchParams.dFlightTime + (dTargetCenter.Z() - locTrackTimeBased->z())/29.9792458;
+				double locDeltaT = locPropagatedSCTime - locEventRFBunch->dTime;
+				dHist_SCRFDeltaTVsSector->Fill(locSCHitMatchParams.dSCHit->sector, locDeltaT);
+			}
 		}
 
 		// If "Good" WBT, see if TBT is good
@@ -677,6 +736,7 @@ bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, c
 				dHistMap_PVsTheta_GoodWireBased_GoodTimeBased[locCharge]->Fill(locTheta, locP);
 		}
 
+		//THROWN
 		for(size_t loc_i = 0; loc_i < locMCThrowns.size(); ++loc_i)
 		{
 			if(fabs(locMCThrowns[loc_i]->charge()) < 0.9)

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.h
@@ -129,36 +129,50 @@ class DHistogramAction_Reconstruction : public DAnalysisAction
 		//user can call any of these three constructors
 		DHistogramAction_Reconstruction(const DReaction* locReaction, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_Reconstruction", false, locActionUniqueString),
-		dNumFCALTOFXYBins(260), dNumShowerEnergyBins(800), dNumPhiBins(720), dNum2DBCALZBins(450), dNum2DPhiBins(360),
-		dNumHitEnergyBins(500), dNum2DHitEnergyBins(250), dNum2DThetaBins(280), dNumFOMBins(500), dNum2DFOMBins(200), dNum2DPBins(250),
+		dNumFCALTOFXYBins(260), dNumShowerEnergyBins(800), dNumPhiBins(720), dNum2DBCALZBins(450), dNum2DPhiBins(360), dNumHitEnergyBins(500),
+		dNum2DHitEnergyBins(250), dNum2DThetaBins(280), dNumFOMBins(500), dNum2DFOMBins(200), dNum2DPBins(250), dNum2DDeltaTBins(800),
 		dMinShowerEnergy(0.0), dMaxShowerEnergy(8.0), dMaxBCALP(1.5), dMinPhi(-180.0), dMaxPhi(180.0), dMinHitEnergy(0.0),
-		dMaxHitEnergy(50.0), dMinTheta(0.0), dMaxTheta(140.0), dMinP(0.0), dMaxP(10.0), dGoodTrackFOM(5.73303E-7), dHighTrackFOM(0.98) {}
+		dMaxHitEnergy(50.0), dMinTheta(0.0), dMaxTheta(140.0), dMinP(0.0), dMaxP(10.0), dMinDeltaT(-20.0), dMaxDeltaT(20.0),
+		dGoodTrackFOM(5.73303E-7), dHighTrackFOM(0.98)
+		{
+			dTargetCenter.SetXYZ(0.0, 0.0, -9.9E9);
+		}
 
 		DHistogramAction_Reconstruction(string locActionUniqueString) :
 		DAnalysisAction(NULL, "Hist_Reconstruction", false, locActionUniqueString),
-		dNumFCALTOFXYBins(260), dNumShowerEnergyBins(800), dNumPhiBins(720), dNum2DBCALZBins(450), dNum2DPhiBins(360),
-		dNumHitEnergyBins(500), dNum2DHitEnergyBins(250), dNum2DThetaBins(280), dNumFOMBins(500), dNum2DFOMBins(200), dNum2DPBins(250),
+		dNumFCALTOFXYBins(260), dNumShowerEnergyBins(800), dNumPhiBins(720), dNum2DBCALZBins(450), dNum2DPhiBins(360), dNumHitEnergyBins(500),
+		dNum2DHitEnergyBins(250), dNum2DThetaBins(280), dNumFOMBins(500), dNum2DFOMBins(200), dNum2DPBins(250), dNum2DDeltaTBins(800),
 		dMinShowerEnergy(0.0), dMaxShowerEnergy(8.0), dMaxBCALP(1.5), dMinPhi(-180.0), dMaxPhi(180.0), dMinHitEnergy(0.0),
-		dMaxHitEnergy(50.0), dMinTheta(0.0), dMaxTheta(140.0), dMinP(0.0), dMaxP(10.0), dGoodTrackFOM(5.73303E-7), dHighTrackFOM(0.98) {}
+		dMaxHitEnergy(50.0), dMinTheta(0.0), dMaxTheta(140.0), dMinP(0.0), dMaxP(10.0), dMinDeltaT(-20.0), dMaxDeltaT(20.0),
+		dGoodTrackFOM(5.73303E-7), dHighTrackFOM(0.98)
+		{
+			dTargetCenter.SetXYZ(0.0, 0.0, -9.9E9);
+		}
 
 		DHistogramAction_Reconstruction(void) :
 		DAnalysisAction(NULL, "Hist_Reconstruction", false, ""),
-		dNumFCALTOFXYBins(260), dNumShowerEnergyBins(800), dNumPhiBins(720), dNum2DBCALZBins(450), dNum2DPhiBins(360),
-		dNumHitEnergyBins(500), dNum2DHitEnergyBins(250), dNum2DThetaBins(280), dNumFOMBins(500), dNum2DFOMBins(200), dNum2DPBins(250),
+		dNumFCALTOFXYBins(260), dNumShowerEnergyBins(800), dNumPhiBins(720), dNum2DBCALZBins(450), dNum2DPhiBins(360), dNumHitEnergyBins(500),
+		dNum2DHitEnergyBins(250), dNum2DThetaBins(280), dNumFOMBins(500), dNum2DFOMBins(200), dNum2DPBins(250), dNum2DDeltaTBins(800),
 		dMinShowerEnergy(0.0), dMaxShowerEnergy(8.0), dMaxBCALP(1.5), dMinPhi(-180.0), dMaxPhi(180.0), dMinHitEnergy(0.0),
-		dMaxHitEnergy(50.0), dMinTheta(0.0), dMaxTheta(140.0), dMinP(0.0), dMaxP(10.0), dGoodTrackFOM(5.73303E-7), dHighTrackFOM(0.98) {}
+		dMaxHitEnergy(50.0), dMinTheta(0.0), dMaxTheta(140.0), dMinP(0.0), dMaxP(10.0), dMinDeltaT(-20.0), dMaxDeltaT(20.0),
+		dGoodTrackFOM(5.73303E-7), dHighTrackFOM(0.98)
+		{
+			dTargetCenter.SetXYZ(0.0, 0.0, -9.9E9);
+		}
 
 		void Initialize(JEventLoop* locEventLoop);
 
 		unsigned int dNumFCALTOFXYBins, dNumShowerEnergyBins, dNumPhiBins, dNum2DBCALZBins, dNum2DPhiBins;
-		unsigned int dNumHitEnergyBins, dNum2DHitEnergyBins, dNum2DThetaBins, dNumFOMBins, dNum2DFOMBins, dNum2DPBins;
+		unsigned int dNumHitEnergyBins, dNum2DHitEnergyBins, dNum2DThetaBins, dNumFOMBins, dNum2DFOMBins, dNum2DPBins, dNum2DDeltaTBins;
 		double dMinShowerEnergy, dMaxShowerEnergy, dMaxBCALP, dMinPhi, dMaxPhi, dMinHitEnergy;
-		double dMaxHitEnergy, dMinTheta, dMaxTheta, dMinP, dMaxP;
+		double dMaxHitEnergy, dMinTheta, dMaxTheta, dMinP, dMaxP, dMinDeltaT, dMaxDeltaT;
 
 		double dGoodTrackFOM, dHighTrackFOM;
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo = NULL);
+
+		DVector3 dTargetCenter;
 
 		TH2I* dHist_FCALShowerYVsX;
 		TH1I* dHist_FCALShowerEnergy;
@@ -173,6 +187,10 @@ class DHistogramAction_Reconstruction : public DAnalysisAction
 		TH1I* dHist_SCHitSector;
 		TH1I* dHist_SCHitEnergy;
 		TH2I* dHist_SCHitEnergyVsSector;
+		TH2I *dHist_SCRFDeltaTVsSector;
+
+		TH2I *dHist_TAGMRFDeltaTVsColumn;
+		TH2I *dHist_TAGHRFDeltaTVsCounter;
 
 		TH1I* dHist_NumDCHitsPerTrack;
 		TH2I* dHist_NumDCHitsPerTrackVsTheta;

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -1270,6 +1270,12 @@ void DHistogramAction_MissingMass::Initialize(JEventLoop* locEventLoop)
 		locHistTitle = string(";Beam Energy (GeV);") + locInitialParticlesROOTName + string("#rightarrow") + locFinalParticlesROOTName + string(" Missing Mass (GeV/c^{2})");
 		dHist_MissingMassVsBeamE = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DBeamEBins, dMinBeamE, dMaxBeamE, dNum2DMassBins, dMinMass, dMaxMass);
 
+		locHistName = "MissingMassVsMissingP";
+		locStream.str("");
+		locStream << locMassPerBin;
+		locHistTitle = string(";Missing P (GeV/c);") + locInitialParticlesROOTName + string("#rightarrow") + locFinalParticlesROOTName + string(" Missing Mass (GeV/c^{2})");
+		dHist_MissingMassVsMissingP = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DMissPBins, dMinMissP, dMaxMissP, dNum2DMassBins, dMinMass, dMaxMass);
+
 		//Return to the base directory
 		ChangeTo_BaseDirectory();
 	}
@@ -1287,7 +1293,7 @@ bool DHistogramAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, cons
 	set<set<size_t> > locIndexCombos = dAnalysisUtilities->Build_IndexCombos(Get_Reaction()->Get_ReactionStep(dMissingMassOffOfStepIndex), dMissingMassOffOfPIDs);
 
 	//loop over them
-	vector<double> locMassesToFill;
+	vector<pair<double, double> > locMassesToFill; //first is missing mass, second is missing p
 	set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
 	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
 	{
@@ -1298,7 +1304,7 @@ bool DHistogramAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, cons
 			continue; //dupe: already histed!
 		dPreviousSourceObjects.insert(locSourceObjects);
 
-		locMassesToFill.push_back(locMissingP4.M());
+		locMassesToFill.push_back(pair<double, double>(locMissingP4.M(), locMissingP4.P()));
 	}
 
 	//FILL HISTOGRAMS
@@ -1308,8 +1314,9 @@ bool DHistogramAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, cons
 	{
 		for(size_t loc_i = 0; loc_i < locMassesToFill.size(); ++loc_i)
 		{
-			dHist_MissingMass->Fill(locMassesToFill[loc_i]);
-			dHist_MissingMassVsBeamE->Fill(locBeamEnergy, locMassesToFill[loc_i]);
+			dHist_MissingMass->Fill(locMassesToFill[loc_i].first);
+			dHist_MissingMassVsBeamE->Fill(locBeamEnergy, locMassesToFill[loc_i].first);
+			dHist_MissingMassVsMissingP->Fill(locMassesToFill[loc_i].second, locMassesToFill[loc_i].first);
 		}
 	}
 	Unlock_Action();
@@ -1344,6 +1351,12 @@ void DHistogramAction_MissingMassSquared::Initialize(JEventLoop* locEventLoop)
 		locHistTitle = string(";Beam Energy (GeV);") + locInitialParticlesROOTName + string("#rightarrow") + locFinalParticlesROOTName + string(" Missing Mass Squared (GeV/c^{2})^{2};");
 		dHist_MissingMassSquaredVsBeamE = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DBeamEBins, dMinBeamE, dMaxBeamE, dNum2DMassBins, dMinMassSq, dMaxMassSq);
 
+		locHistName = "MissingMassSquaredVsMissingP";
+		locStream.str("");
+		locStream << locMassSqPerBin;
+		locHistTitle = string(";Missing P (GeV/c);") + locInitialParticlesROOTName + string("#rightarrow") + locFinalParticlesROOTName + string(" Missing Mass Squared (GeV/c^{2})^{2}");
+		dHist_MissingMassSquaredVsMissingP = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DMissPBins, dMinMissP, dMaxMissP, dNum2DMassBins, dMinMassSq, dMaxMassSq);
+
 		//Return to the base directory
 		ChangeTo_BaseDirectory();
 	}
@@ -1361,7 +1374,7 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoo
 	set<set<size_t> > locIndexCombos = dAnalysisUtilities->Build_IndexCombos(Get_Reaction()->Get_ReactionStep(dMissingMassOffOfStepIndex), dMissingMassOffOfPIDs);
 
 	//loop over them
-	vector<double> locMassesToFill;
+	vector<pair<double, double> > locMassesToFill; //first is missing mass, second is missing p
 	set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
 	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
 	{
@@ -1372,7 +1385,7 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoo
 			continue; //dupe: already histed!
 		dPreviousSourceObjects.insert(locSourceObjects);
 
-		locMassesToFill.push_back(locMissingP4.M2());
+		locMassesToFill.push_back(pair<double, double>(locMissingP4.M2(), locMissingP4.P()));
 	}
 
 	//FILL HISTOGRAMS
@@ -1382,8 +1395,9 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoo
 	{
 		for(size_t loc_i = 0; loc_i < locMassesToFill.size(); ++loc_i)
 		{
-			dHist_MissingMassSquared->Fill(locMassesToFill[loc_i]);
-			dHist_MissingMassSquaredVsBeamE->Fill(locBeamEnergy, locMassesToFill[loc_i]);
+			dHist_MissingMassSquared->Fill(locMassesToFill[loc_i].first);
+			dHist_MissingMassSquaredVsBeamE->Fill(locBeamEnergy, locMassesToFill[loc_i].first);
+			dHist_MissingMassSquaredVsMissingP->Fill(locMassesToFill[loc_i].second, locMassesToFill[loc_i].first);
 		}
 	}
 	Unlock_Action();

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -284,7 +284,8 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		DHistogramAction_MissingMass(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(0),
-		dMissingMassOffOfPIDs(deque<Particle_t>()), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(1200), dMinBeamE(0.0), dMaxBeamE(12.0)
+		dMissingMassOffOfPIDs(deque<Particle_t>()), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -305,7 +306,8 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		DHistogramAction_MissingMass(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex),
-		dMissingMassOffOfPIDs(locMissingMassOffOfPIDs), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(1200), dMinBeamE(0.0), dMaxBeamE(12.0)
+		dMissingMassOffOfPIDs(locMissingMassOffOfPIDs), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -313,7 +315,8 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		DHistogramAction_MissingMass(const DReaction* locReaction, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
-		dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(1200), dMinBeamE(0.0), dMaxBeamE(12.0)
+		dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -329,12 +332,13 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		deque<Particle_t> dMissingMassOffOfPIDs;
 
 	public:
-		unsigned int dNum2DMassBins, dNum2DBeamEBins;
-		double dMinBeamE, dMaxBeamE;
+		unsigned int dNum2DMassBins, dNum2DBeamEBins, dNum2DMissPBins;
+		double dMinBeamE, dMaxBeamE, dMinMissP, dMaxMissP;
 
 	private:
 		TH1I* dHist_MissingMass;
 		TH2I* dHist_MissingMassVsBeamE;
+		TH2I* dHist_MissingMassVsMissingP;
 		const DAnalysisUtilities* dAnalysisUtilities;
 
 		set<set<pair<const JObject*, Particle_t> > > dPreviousSourceObjects;
@@ -346,7 +350,8 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		DHistogramAction_MissingMassSquared(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_MissingMassSquared", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(0),
-		dMissingMassOffOfPIDs(deque<Particle_t>()), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0)
+		dMissingMassOffOfPIDs(deque<Particle_t>()), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -365,17 +370,19 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		//locMissingMassOffOfStepIndex = 0, locMissingMassOffOfPIDs = K+
 		//Then: Will histogram only missing-mass: g, p -> K+_1, (X)    and NOT K+_2!!!
 		DHistogramAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
-		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
+		DAnalysisAction(locReaction, "Hist_MissingMassSquared", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
-		dMissingMassOffOfPIDs(locMissingMassOffOfPIDs), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0)
+		dMissingMassOffOfPIDs(locMissingMassOffOfPIDs), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
 		{
 			dAnalysisUtilities = NULL;
 		}
 
 		DHistogramAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
-		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
+		DAnalysisAction(locReaction, "Hist_MissingMassSquared", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
-		dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0)
+		dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -391,12 +398,13 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		deque<Particle_t> dMissingMassOffOfPIDs;
 
 	public:
-		unsigned int dNum2DMassBins, dNum2DBeamEBins;
-		double dMinBeamE, dMaxBeamE;
+		unsigned int dNum2DMassBins, dNum2DBeamEBins, dNum2DMissPBins;
+		double dMinBeamE, dMaxBeamE, dMinMissP, dMaxMissP;
 
 	private:
 		TH1I* dHist_MissingMassSquared;
 		TH2I* dHist_MissingMassSquaredVsBeamE;
+		TH2I* dHist_MissingMassSquaredVsMissingP;
 		const DAnalysisUtilities* dAnalysisUtilities;
 
 		set<set<pair<const JObject*, Particle_t> > > dPreviousSourceObjects;

--- a/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.cc
+++ b/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.cc
@@ -117,6 +117,12 @@ jerror_t DParticleComboBlueprint_factory::evnt(JEventLoop *locEventLoop, uint64_
 	VT_TRACER("DParticleComboBlueprint_factory::evnt()");
 #endif
 
+	//CHECK TRIGGER TYPE
+	const DTrigger* locTrigger = NULL;
+	locEventLoop->GetSingle(locTrigger);
+	if(!locTrigger->Get_IsPhysicsEvent())
+		return NOERROR;
+
 	Reset_Pools();
 
 	dBlueprintStepMap.clear();

--- a/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.h
+++ b/src/libraries/ANALYSIS/DParticleComboBlueprint_factory.h
@@ -14,6 +14,7 @@
 #include <PID/DNeutralShower.h>
 #include <PID/DVertex.h>
 #include <PID/DDetectorMatches.h>
+#include <TRIGGER/DTrigger.h>
 
 #include <deque>
 #include <map>

--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -1158,11 +1158,27 @@ jerror_t DEventSourceHDDM::Extract_DBeamPhoton(hddm_s::HDDM *record,
    vector<const DMCReaction*> dmcreactions;
    loop->Get(dmcreactions);
 
+   // extract the TAGH geometry
+   vector<const DTAGHGeometry*> taghGeomVect;
+   loop->Get(taghGeomVect);
+   if (taghGeomVect.empty())
+      return OBJECT_NOT_AVAILABLE;
+   const DTAGHGeometry* taghGeom = taghGeomVect[0];
+
+   // extract the TAGM geometry
+   vector<const DTAGMGeometry*> tagmGeomVect;
+   loop->Get(tagmGeomVect);
+   if (tagmGeomVect.empty())
+      return OBJECT_NOT_AVAILABLE;
+   const DTAGMGeometry* tagmGeom = tagmGeomVect[0];
+
    vector<DBeamPhoton*> dbeam_photons;
    for(size_t loc_i = 0; loc_i < dmcreactions.size(); ++loc_i)
    {
       DBeamPhoton *beamphoton = new DBeamPhoton;
       *(DKinematicData*)beamphoton = dmcreactions[loc_i]->beam;
+      if(!tagmGeom->E_to_column(beamphoton->energy(), beamphoton->dCounter))
+    	  taghGeom->E_to_counter(beamphoton->energy(), beamphoton->dCounter);
       dbeam_photons.push_back(beamphoton);
    }
 

--- a/src/libraries/HDDM/DEventSourceHDDM.h
+++ b/src/libraries/HDDM/DEventSourceHDDM.h
@@ -52,6 +52,8 @@ using namespace std;
 #include <TRACKING/DTrackTimeBased.h>
 #include <TAGGER/DTAGMHit.h>
 #include <TAGGER/DTAGHHit.h>
+#include <TAGGER/DTAGMGeometry.h>
+#include <TAGGER/DTAGHGeometry.h>
 // load CERE headers, yqiang Oct 3, 2012
 // modified by yqiang, Oct 10 2012
 // added RichTruthHit object, yqiang, Oct 7, 2013

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -1164,7 +1164,7 @@ uint32_t DEventSourceREST::Convert_SignedIntToUnsigned(int32_t locSignedInt) con
 		//Else, bit 32 is 1, then the uint32_t is -1 * int32_t, + add the last bit
 	if(locSignedInt >= 0)
 		return uint32_t(locSignedInt); //bit 32 is zero
-	else if(locSignedInt == numeric_limits<int32_t>::min())
+	else if(locSignedInt == numeric_limits<int32_t>::min()) // -(2^31)
 		return uint32_t(0x80000000); //bit 32 is 1, all others are 0
 	return uint32_t(-1*locSignedInt) + uint32_t(0x80000000); //bit 32 is 1, all others are negative of signed int (which was negative)
 }

--- a/src/libraries/HDDM/DEventSourceREST.h
+++ b/src/libraries/HDDM/DEventSourceREST.h
@@ -28,7 +28,7 @@
 #include <BCAL/DBCALShower.h>
 #include <START_COUNTER/DSCHit.h>
 #include <TOF/DTOFPoint.h>
-#include <TRIGGER/DMCTrigger.h>
+#include <TRIGGER/DTrigger.h>
 #include <DANA/DApplication.h>
 #include <RF/DRFTime.h>
 #include <TAGGER/DTAGMGeometry.h>
@@ -72,8 +72,8 @@ class DEventSourceREST:public JEventSource
                     JFactory<DBCALShower>* factory);
    jerror_t Extract_DTrackTimeBased(hddm_r::HDDM *record,
                     JFactory<DTrackTimeBased>* factory);
-   jerror_t Extract_DMCTrigger(hddm_r::HDDM *record,
-                    JFactory<DMCTrigger>* factory);
+   jerror_t Extract_DTrigger(hddm_r::HDDM *record,
+                    JFactory<DTrigger>* factory);
    jerror_t Extract_DDetectorMatches(JEventLoop* locEventLoop, hddm_r::HDDM *record,
                     JFactory<DDetectorMatches>* factory);
 #if 0

--- a/src/libraries/HDDM/DEventSourceREST.h
+++ b/src/libraries/HDDM/DEventSourceREST.h
@@ -86,6 +86,8 @@ class DEventSourceREST:public JEventSource
    // Warning: Class JEventSource methods must be re-entrant, so do not
    // store any data here that might change from event to event.
 
+	uint32_t Convert_SignedIntToUnsigned(int32_t locSignedInt) const;
+
 	map<unsigned int, double> dTargetCenterZMap; //unsigned int is run number
 	map<unsigned int, double> dBeamBunchPeriodMap; //unsigned int is run number
 

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -572,7 +572,8 @@ int32_t DEventWriterREST::Convert_UnsignedIntToSigned(uint32_t locUnsignedInt) c
 		return int32_t(locUnsignedInt); //bit 32 is zero: positive or zero
 
 	//bit 32 is 1. see if there is another bit set
-	if((locUnsignedInt & 0x7FFFFFFF) == 0)
+	int32_t locTopBitStripped = int32_t(locUnsignedInt & uint32_t(0x7FFFFFFF)); //strip the top bit
+	if(locTopBitStripped == 0)
 		return numeric_limits<int32_t>::min(); //no other bit is set: minimum int
-	return -1*int32_t(locUnsignedInt & uint32_t(0x7FFFFFFF)); //strip top bit, then return the negative
+	return -1*locTopBitStripped; //return the negative
 }

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -61,9 +61,6 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 	std::vector<const DDetectorMatches*> locDetectorMatches;
 	locEventLoop->Get(locDetectorMatches);
 
-	std::vector<const DMCTrigger*> mctriggers;
-	locEventLoop->Get(mctriggers);
-
 	std::vector<const DTrigger*> locTriggers;
 	locEventLoop->Get(locTriggers);
 
@@ -289,36 +286,14 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 		}
 	}
 
-	// push any DMCTrigger objects to the output record
-	for (size_t i=0; i < mctriggers.size(); i++)
-	{
-		hddm_r::TriggerList trigger = res().addTriggers(1);
-		trigger().setL1a(mctriggers[i]->L1a_fired);
-		trigger().setL1b(mctriggers[i]->L1b_fired);
-		trigger().setL1c(mctriggers[i]->L1c_fired);
-
-        hddm_r::TriggerDataList data = trigger().addTriggerDatas(1);
-	    data().setEbcal(mctriggers[i]->Ebcal);
-		data().setEfcal(mctriggers[i]->Efcal);
-		data().setNschits(mctriggers[i]->Nschits);
-		data().setNtofhits(mctriggers[i]->Ntofhits);
-	}
-/*
 	// push any DTrigger objects to the output record
 	for (size_t i=0; i < locTriggers.size(); ++i)
 	{
 		hddm_r::TriggerList trigger = res().addTriggers(1);
-		trigger().setL1a(mctriggers[i]->L1a_fired);
-		trigger().setL1b(mctriggers[i]->L1b_fired);
-		trigger().setL1c(mctriggers[i]->L1c_fired);
-
-        hddm_r::TriggerDataList data = trigger().addTriggerDatas(1);
-	    data().setEbcal(mctriggers[i]->Ebcal);
-		data().setEfcal(mctriggers[i]->Efcal);
-		data().setNschits(mctriggers[i]->Nschits);
-		data().setNtofhits(mctriggers[i]->Ntofhits);
+		trigger().setL1_trig_bits(locTriggers[i]->Get_L1TriggerBits());
+		trigger().setL1_fp_trig_bits(locTriggers[i]->Get_L1FrontPanelTriggerBits());
 	}
-*/
+
 	// push any DDetectorMatches objects to the output record
 	for(size_t loc_i = 0; loc_i < locDetectorMatches.size(); ++loc_i)
 	{
@@ -329,7 +304,7 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 			locDetectorMatches[loc_i]->Get_BCALMatchParams(tracks[loc_j], locBCALShowerMatchParamsVector);
 			for(size_t loc_k = 0; loc_k < locBCALShowerMatchParamsVector.size(); ++loc_k)
 			{
-				hddm_r::BcalMatchParams_v2List bcalList = matches().addBcalMatchParams_v2s(1);
+				hddm_r::BcalMatchParamsList bcalList = matches().addBcalMatchParamses(1);
 				bcalList().setTrack(loc_j);
 
 				const DBCALShower* locBCALShower = locBCALShowerMatchParamsVector[loc_k].dBCALShower;
@@ -376,7 +351,7 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 			locDetectorMatches[loc_i]->Get_TOFMatchParams(tracks[loc_j], locTOFHitMatchParamsVector);
 			for(size_t loc_k = 0; loc_k < locTOFHitMatchParamsVector.size(); ++loc_k)
 			{
-				hddm_r::TofMatchParams_v2List tofList = matches().addTofMatchParams_v2s(1);
+				hddm_r::TofMatchParamsList tofList = matches().addTofMatchParamses(1);
 				tofList().setTrack(loc_j);
 
 				size_t locTOFindex = 0;
@@ -462,7 +437,7 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 			if(!locDetectorMatches[loc_i]->Get_DistanceToNearestTrack(bcalshowers[loc_j], locDeltaPhi, locDeltaZ))
 				continue;
 
-			hddm_r::BcalDOCAtoTrack_v2List bcalDocaList = matches().addBcalDOCAtoTrack_v2s(1);
+			hddm_r::BcalDOCAtoTrackList bcalDocaList = matches().addBcalDOCAtoTracks(1);
 			bcalDocaList().setShower(loc_j);
 			bcalDocaList().setDeltaphi(locDeltaPhi);
 			bcalDocaList().setDeltaz(locDeltaZ);

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -61,6 +61,12 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 	std::vector<const DDetectorMatches*> locDetectorMatches;
 	locEventLoop->Get(locDetectorMatches);
 
+	std::vector<const DMCTrigger*> mctriggers;
+	locEventLoop->Get(mctriggers);
+
+	std::vector<const DTrigger*> locTriggers;
+	locEventLoop->Get(locTriggers);
+
 	//Check to see if there are any objects to write out.  If so, don't write out an empty event
 	bool locOutputDataPresentFlag = false;
 	if((!reactions.empty()) || (!rftimes.empty()) || (!locBeamPhotons.empty()) || (!tracks.empty()))
@@ -284,22 +290,35 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 	}
 
 	// push any DMCTrigger objects to the output record
-	std::vector<const DMCTrigger*> triggers;
-	locEventLoop->Get(triggers);
-	for (size_t i=0; i < triggers.size(); i++)
+	for (size_t i=0; i < mctriggers.size(); i++)
 	{
 		hddm_r::TriggerList trigger = res().addTriggers(1);
-		trigger().setL1a(triggers[i]->L1a_fired);
-		trigger().setL1b(triggers[i]->L1b_fired);
-		trigger().setL1c(triggers[i]->L1c_fired);
+		trigger().setL1a(mctriggers[i]->L1a_fired);
+		trigger().setL1b(mctriggers[i]->L1b_fired);
+		trigger().setL1c(mctriggers[i]->L1c_fired);
 
         hddm_r::TriggerDataList data = trigger().addTriggerDatas(1);
-	    data().setEbcal(triggers[i]->Ebcal);
-		data().setEfcal(triggers[i]->Efcal);
-		data().setNschits(triggers[i]->Nschits);
-		data().setNtofhits(triggers[i]->Ntofhits);
+	    data().setEbcal(mctriggers[i]->Ebcal);
+		data().setEfcal(mctriggers[i]->Efcal);
+		data().setNschits(mctriggers[i]->Nschits);
+		data().setNtofhits(mctriggers[i]->Ntofhits);
 	}
+/*
+	// push any DTrigger objects to the output record
+	for (size_t i=0; i < locTriggers.size(); ++i)
+	{
+		hddm_r::TriggerList trigger = res().addTriggers(1);
+		trigger().setL1a(mctriggers[i]->L1a_fired);
+		trigger().setL1b(mctriggers[i]->L1b_fired);
+		trigger().setL1c(mctriggers[i]->L1c_fired);
 
+        hddm_r::TriggerDataList data = trigger().addTriggerDatas(1);
+	    data().setEbcal(mctriggers[i]->Ebcal);
+		data().setEfcal(mctriggers[i]->Efcal);
+		data().setNschits(mctriggers[i]->Nschits);
+		data().setNtofhits(mctriggers[i]->Ntofhits);
+	}
+*/
 	// push any DDetectorMatches objects to the output record
 	for(size_t loc_i = 0; loc_i < locDetectorMatches.size(); ++loc_i)
 	{

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -82,8 +82,8 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 	// load the run and event numbers
 	JEvent& event = locEventLoop->GetJEvent();
 	res().setRunNo(event.GetRunNumber());
-	//I think the type for this is a signed-64 bit, whereas the event # is unsigned
-		//However, we should never take 2^63 events in a run anyway ...
+	//The REST type for this is int64_t, whereas the event type is uint64_t
+	//This copy is lazy: the last bit is lost.  However, we should never need the last bit.
 	res().setEventNo(event.GetEventNumber());
 
 	// push any DMCReaction objects to the output record

--- a/src/libraries/HDDM/DEventWriterREST.h
+++ b/src/libraries/HDDM/DEventWriterREST.h
@@ -25,7 +25,6 @@
 #include "TOF/DTOFPoint.h"
 #include "START_COUNTER/DSCHit.h"
 #include "TRACKING/DTrackTimeBased.h"
-#include "TRIGGER/DMCTrigger.h"
 #include "TRIGGER/DTrigger.h"
 #include "RF/DRFTime.h"
 
@@ -56,5 +55,3 @@ class DEventWriterREST : public JObject
 };
 
 #endif //_DEventWriterREST_
-
-

--- a/src/libraries/HDDM/DEventWriterREST.h
+++ b/src/libraries/HDDM/DEventWriterREST.h
@@ -26,6 +26,7 @@
 #include "START_COUNTER/DSCHit.h"
 #include "TRACKING/DTrackTimeBased.h"
 #include "TRIGGER/DMCTrigger.h"
+#include "TRIGGER/DTrigger.h"
 #include "RF/DRFTime.h"
 
 using namespace std;

--- a/src/libraries/HDDM/DEventWriterREST.h
+++ b/src/libraries/HDDM/DEventWriterREST.h
@@ -49,6 +49,8 @@ class DEventWriterREST : public JObject
 		int& Get_NumEventWriterThreads(void) const; //acquire RESTWriter lock before modifying
 		map<string, pair<ofstream*, hddm_r::ostream*> >& Get_RESTOutputFilePointers(void) const;
 
+		int32_t Convert_UnsignedIntToSigned(uint32_t locUnsignedInt) const;
+
 		string dOutputFileBaseName;
 		bool HDDM_USE_COMPRESSION;
 		bool HDDM_USE_INTEGRITY_CHECKS;

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -15,7 +15,7 @@
         </product>
       </vertex>
     </reaction>
-    <!-- taggerHit for backwards compatibility only (replaced by tagmHit and taghHit) -->
+    <!-- taggerHit for backwards compatibility only (replaced by tagmBeamPhoton and taghBeamPhoton) -->
     <taggerHit maxOccurs="unbounded" minOccurs="0" jtag="string"
                 t="float" E="float" tunit="ns" Eunit="GeV"/>
     <tagmBeamPhoton maxOccurs="unbounded" minOccurs="0" jtag="string"
@@ -71,10 +71,14 @@
     </tofPoint>
     <RFtime minOccurs="0" jtag="string"
             tsync="float" tunit="ns"/>
+    <!-- "trigger" corresponds to DMCTrigger. "datatrigger" corresponds to "DTrigger" -->
     <trigger minOccurs="0" jtag="string"
 			 L1a="boolean" L1b="boolean" L1c="boolean">
       <triggerData  Ebcal="float" Efcal="float" Nschits="int" Ntofhits="int" />
     </trigger>
+    <datatrigger minOccurs="0" jtag="string"
+			 l1_trig_bits="int" l1_fp_trig_bits="int">
+    </datatrigger>
 
     <detectorMatches minOccurs="1" maxOccurs="1" jtag="string">
       <!-- 

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1" standalone="no" ?>
-<HDDM xmlns="http://www.gluex.org/hddm" class="r" version="1.0.1">
+<HDDM xmlns="http://www.gluex.org/hddm" class="r" version="1.1.0">
 
-  <reconstructedPhysicsEvent eventNo="int" runNo="int">
+  <reconstructedPhysicsEvent eventNo="long" runNo="int">
     <comment minOccurs="0" maxOccurs="unbounded" text="string"/>
     <reaction maxOccurs="unbounded" minOccurs="0" jtag="string"
                                     type="int" weight="float"
@@ -15,9 +15,6 @@
         </product>
       </vertex>
     </reaction>
-    <!-- taggerHit for backwards compatibility only (replaced by tagmBeamPhoton and taghBeamPhoton) -->
-    <taggerHit maxOccurs="unbounded" minOccurs="0" jtag="string"
-                t="float" E="float" tunit="ns" Eunit="GeV"/>
     <tagmBeamPhoton maxOccurs="unbounded" minOccurs="0" jtag="string"
                 t="float" E="float" tunit="ns" Eunit="GeV"/>
     <taghBeamPhoton maxOccurs="unbounded" minOccurs="0" jtag="string"
@@ -71,14 +68,9 @@
     </tofPoint>
     <RFtime minOccurs="0" jtag="string"
             tsync="float" tunit="ns"/>
-    <!-- "trigger" corresponds to DMCTrigger. "datatrigger" corresponds to "DTrigger" -->
-    <trigger minOccurs="0" jtag="string"
-			 L1a="boolean" L1b="boolean" L1c="boolean">
-      <triggerData  Ebcal="float" Efcal="float" Nschits="int" Ntofhits="int" />
-    </trigger>
-    <datatrigger minOccurs="0" jtag="string"
+    <trigger minOccurs="0" maxOccurs="1" jtag="string"
 			 l1_trig_bits="int" l1_fp_trig_bits="int">
-    </datatrigger>
+    </trigger>
 
     <detectorMatches minOccurs="1" maxOccurs="1" jtag="string">
       <!-- 
@@ -92,12 +84,7 @@
           3) shower = "bcalShower"/"fcalShower" object index in file (starting at 0). 
           4) tflightPCorrelations::system = DetectorSystem_t
       -->
-      <!-- bcalMatchParams for backwards compatibility only (replaced by bcalMatchParams_v2) -->
       <bcalMatchParams maxOccurs="unbounded" minOccurs="0"
-                track="int" shower="int"
-                dx="float" doca="float" pathlength="float" tflight="float" tflightvar="float"
-                tunit="ns" lunit="cm"/>
-      <bcalMatchParams_v2 maxOccurs="unbounded" minOccurs="0"
                 track="int" shower="int"
                 dx="float" deltaphi="float" deltaz="float" pathlength="float" tflight="float" tflightvar="float"
                 tunit="ns" lunit="cm"/>
@@ -105,12 +92,7 @@
                 track="int" shower="int"
                 dx="float" doca="float" pathlength="float" tflight="float" tflightvar="float"
                 tunit="ns" lunit="cm"/>
-      <!-- tofMatchParams for backwards compatibility only (replaced by tofMatchParams_v2) -->
       <tofMatchParams maxOccurs="unbounded" minOccurs="0"
-                track="int" hit="int"
-                dEdx="float" doca="float" pathlength="float" tflight="float" tflightvar="float"
-                tunit="ns" lunit="cm" dEdx_unit="GeV/cm"/>
-      <tofMatchParams_v2 maxOccurs="unbounded" minOccurs="0"
                 track="int" hit="int"
                 dEdx="float" thit="float" thitvar="float" ehit="float"
                 deltax="float" deltay="float" pathlength="float" tflight="float" tflightvar="float"
@@ -120,11 +102,7 @@
                 dEdx="float" thit="float" thitvar="float" ehit="float"
                 pathlength="float" tflight="float" tflightvar="float" deltaphi="float"
                 tunit="ns" lunit="cm" aunit="rad" Eunit="GeV" dEdx_unit="GeV/cm"/>
-      <!-- bcalDOCAtoTrack for backwards compatibility only (replaced by bcalDOCAtoTrack_v2) -->
       <bcalDOCAtoTrack maxOccurs="unbounded" minOccurs="0"
-                shower="int" doca="float"
-                lunit="cm"/>
-      <bcalDOCAtoTrack_v2 maxOccurs="unbounded" minOccurs="0"
                 shower="int" deltaphi="float" deltaz="float"
                 lunit="cm"/>
       <fcalDOCAtoTrack maxOccurs="unbounded" minOccurs="0"
@@ -138,4 +116,3 @@
 
   </reconstructedPhysicsEvent>
 </HDDM>
-

--- a/src/libraries/PID/DBeamPhoton.h
+++ b/src/libraries/PID/DBeamPhoton.h
@@ -10,14 +10,17 @@
 
 #include <PID/DKinematicData.h>
 
-class DBeamPhoton: public DKinematicData{
+class DBeamPhoton: public DKinematicData
+{
 	public:
 		JOBJECT_PUBLIC(DBeamPhoton);
 		
+		unsigned int dCounter; //is TAGM/TAGH if t0_detector is SYS_TAGM/TAGH
+
 		void toStrings(vector<pair<string,string> > &items)const{
 			AddString(items, "E(GeV)", "%3.3f", momentum().Mag());
-			AddString(items, "theta(deg)", "%3.3f", momentum().Theta()*180.0/M_PI);
-			AddString(items, "phi(deg)", "%3.1f", momentum().Phi()*180.0/M_PI);
+			AddString(items, "System", "%s", SystemName(t0_detector()));
+			AddString(items, "Counter", "%d", dCounter);
 			AddString(items, "t(ns)", "%3.1f", time());
 		}
 };

--- a/src/libraries/PID/DBeamPhoton_factory.cc
+++ b/src/libraries/PID/DBeamPhoton_factory.cc
@@ -55,6 +55,7 @@ jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t even
         gamma->setMass(0);
         gamma->setTime(tagm_hits[ih]->t);
         gamma->setT0(tagm_hits[ih]->t, 0.200, SYS_TAGM);
+        gamma->dCounter = tagm_hits[ih]->column;
         gamma->AddAssociatedObject(tagm_hits[ih]);
         _data.push_back(gamma);
     }
@@ -74,6 +75,7 @@ jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t even
         gamma->setMass(0);
         gamma->setTime(tagh_hits[ih]->t);
         gamma->setT0(tagh_hits[ih]->t, 0.350, SYS_TAGH);
+        gamma->dCounter = tagh_hits[ih]->counter_id;
         gamma->AddAssociatedObject(tagh_hits[ih]);
         _data.push_back(gamma);
     }

--- a/src/libraries/PID/DBeamPhoton_factory_TRUTH.cc
+++ b/src/libraries/PID/DBeamPhoton_factory_TRUTH.cc
@@ -54,6 +54,7 @@ jerror_t DBeamPhoton_factory_TRUTH::evnt(jana::JEventLoop *locEventLoop, uint64_
 		gamma->setTime(tagm_hits[ih]->t);
 		gamma->setT0(tagm_hits[ih]->t, 0.200, SYS_TAGM);
 		gamma->setT1(0.0, 0.0, SYS_NULL);
+        gamma->dCounter = tagm_hits[ih]->column;
 		gamma->AddAssociatedObject(tagm_hits[ih]);
 		_data.push_back(gamma);
 	}
@@ -72,6 +73,7 @@ jerror_t DBeamPhoton_factory_TRUTH::evnt(jana::JEventLoop *locEventLoop, uint64_
 		gamma->setTime(tagh_hits[ih]->t);
 		gamma->setT0(tagh_hits[ih]->t, 0.350, SYS_TAGH);
 		gamma->setT1(0.0, 0.0, SYS_NULL);
+        gamma->dCounter = tagh_hits[ih]->counter_id;
 		gamma->AddAssociatedObject(tagh_hits[ih]);
 		_data.push_back(gamma);
 	}

--- a/src/libraries/TAGGER/DTAGHGeometry.cc
+++ b/src/libraries/TAGGER/DTAGHGeometry.cc
@@ -17,22 +17,15 @@ const unsigned int DTAGHGeometry::kCounterCount = 274;
 //---------------------------------
 // DTAGHGeometry    (Constructor)
 //---------------------------------
-DTAGHGeometry::DTAGHGeometry(JEventLoop *loop, std::string tag, int32_t runnumber)
+DTAGHGeometry::DTAGHGeometry(JEventLoop *loop)
 {
    /* read tagger set endpoint energy from calibdb */
-   char dbname1[80];
-   if (tag == "") 
-      sprintf(dbname1, "/PHOTON_BEAM/endpoint_energy:%d", runnumber);
-   else
-      sprintf(dbname1, "/PHOTON_BEAM/endpoint_energy:%d:%s", runnumber,
-                                                             tag.c_str());
    std::map<string,double> result1;
-   loop->GetCalib(dbname1, result1);
+   loop->GetCalib("/PHOTON_BEAM/endpoint_energy", result1);
    if (result1.find("PHOTON_BEAM_ENDPOINT_ENERGY") == result1.end()) {
       std::cerr << "Error in DTAGHGeometry constructor: "
                 << "failed to read photon beam endpoint energy "
-                << "from calibdb at " << dbname1
-                << std::endl;
+                << "from calibdb at /PHOTON_BEAM/endpoint_energy" << std::endl;
       m_endpoint_energy_GeV = 0;
    }
    else {
@@ -40,20 +33,12 @@ DTAGHGeometry::DTAGHGeometry(JEventLoop *loop, std::string tag, int32_t runnumbe
    }
 
    /* read hodoscope counter energy bounds from calibdb */
-   char dbname2[80];
-   if (tag == "")
-      sprintf(dbname2, "/PHOTON_BEAM/hodoscope/scaled_energy_range:%d",
-                                                             runnumber);
-   else
-      sprintf(dbname2, "/PHOTON_BEAM/hodoscope/scaled_energy_range:%d:%s",
-                                                runnumber, tag.c_str());
    std::vector<std::map<string,double> > result2;
-   loop->GetCalib(dbname2, result2);
+   loop->GetCalib("/PHOTON_BEAM/hodoscope/scaled_energy_range", result2);
    if (result2.size() != kCounterCount) {
       jerr << "Error in DTAGHGeometry constructor: "
            << "failed to read photon beam scaled_energy_range table "
-           << "from calibdb at " << dbname2
-           << std::endl;
+           << "from calibdb at /PHOTON_BEAM/hodoscope/scaled_energy_range" << std::endl;
       for (unsigned int i=0; i <= TAGH_MAX_COUNTER; ++i) {
          m_counter_xlow[i] = 0;
          m_counter_xhigh[i] = 0;

--- a/src/libraries/TAGGER/DTAGHGeometry.h
+++ b/src/libraries/TAGGER/DTAGHGeometry.h
@@ -22,7 +22,7 @@ class DTAGHGeometry : public JObject {
    
    JOBJECT_PUBLIC(DTAGHGeometry);
 
-   DTAGHGeometry(JEventLoop *loop, std::string tag, int32_t runnumber);
+   DTAGHGeometry(JEventLoop *loop, int32_t runnumber);
    ~DTAGHGeometry();
 
    static const unsigned int kCounterCount;

--- a/src/libraries/TAGGER/DTAGHGeometry.h
+++ b/src/libraries/TAGGER/DTAGHGeometry.h
@@ -22,7 +22,7 @@ class DTAGHGeometry : public JObject {
    
    JOBJECT_PUBLIC(DTAGHGeometry);
 
-   DTAGHGeometry(JEventLoop *loop, int32_t runnumber);
+   DTAGHGeometry(JEventLoop *loop);
    ~DTAGHGeometry();
 
    static const unsigned int kCounterCount;

--- a/src/libraries/TAGGER/DTAGHGeometry_factory.cc
+++ b/src/libraries/TAGGER/DTAGHGeometry_factory.cc
@@ -20,7 +20,7 @@ jerror_t DTAGHGeometry_factory::brun(JEventLoop *loop, int32_t runnumber)
 	}
 
    flags = PERSISTANT;
-   _data.push_back( new DTAGHGeometry(loop, factory_tag, runnumber) );
+   _data.push_back( new DTAGHGeometry(loop) );
    
    return NOERROR;
 }

--- a/src/libraries/TAGGER/DTAGHGeometry_factory.h
+++ b/src/libraries/TAGGER/DTAGHGeometry_factory.h
@@ -14,15 +14,12 @@
 
 class DTAGHGeometry_factory : public JFactory<DTAGHGeometry> {
  public:
-   DTAGHGeometry_factory(const char *tag="") :
-      JFactory<DTAGHGeometry>(tag), factory_tag(tag) {}
+   DTAGHGeometry_factory(){}
    ~DTAGHGeometry_factory(){}
 
  private:
    jerror_t brun(JEventLoop *loop, int32_t runnumber);   
    jerror_t erun(void);   
-
-   std::string factory_tag;
 };
 
 #endif // _DTAGHGeometry_factory_

--- a/src/libraries/TAGGER/DTAGMGeometry.cc
+++ b/src/libraries/TAGGER/DTAGMGeometry.cc
@@ -21,22 +21,15 @@ const double DTAGMGeometry::kFiberLength = 2.0; // cm
 //---------------------------------
 // DTAGMGeometry    (Constructor)
 //---------------------------------
-DTAGMGeometry::DTAGMGeometry(JEventLoop *loop, std::string tag, int32_t runnumber)
+DTAGMGeometry::DTAGMGeometry(JEventLoop *loop)
 {
    /* read tagger set endpoint energy from calibdb */
-   char dbname1[80];
-   if (tag == "")
-      sprintf(dbname1, "/PHOTON_BEAM/endpoint_energy:%d", runnumber);
-   else
-      sprintf(dbname1, "/PHOTON_BEAM/endpoint_energy:%d:%s", runnumber,
-                                                         tag.c_str());
    std::map<string,double> result1;
-   loop->GetCalib(dbname1, result1);
+   loop->GetCalib("/PHOTON_BEAM/endpoint_energy", result1);
    if (result1.find("PHOTON_BEAM_ENDPOINT_ENERGY") == result1.end()) {
       std::cerr << "Error in DTAGMGeometry constructor: "
                 << "failed to read photon beam endpoint energy "
-                << "from calibdb at " << dbname1
-                << std::endl;
+                << "from calibdb at /PHOTON_BEAM/endpoint_energy" << std::endl;
       m_endpoint_energy_GeV = 0;
    }
    else {
@@ -44,20 +37,12 @@ DTAGMGeometry::DTAGMGeometry(JEventLoop *loop, std::string tag, int32_t runnumbe
    }
 
    /* read microscope channel energy bounds from calibdb */
-   char dbname2[80];
-   if (tag == "") 
-      sprintf(dbname2, "/PHOTON_BEAM/microscope/scaled_energy_range:%d",
-                                                runnumber);
-   else
-      sprintf(dbname2, "/PHOTON_BEAM/microscope/scaled_energy_range:%d:%s",
-                                                runnumber, tag.c_str());
    std::vector<std::map<string,double> > result2;
-   loop->GetCalib(dbname2, result2);
+   loop->GetCalib("/PHOTON_BEAM/microscope/scaled_energy_range", result2);
    if (result2.size() != kColumnCount) {
       std::cerr << "Error in DTAGMGeometry constructor: "
                 << "failed to read photon beam scaled_energy_range table "
-                << "from calibdb at " << dbname2
-                << std::endl;
+                << "from calibdb at /PHOTON_BEAM/microscope/scaled_energy_range" << std::endl;
       for (unsigned int i=0; i <= TAGM_MAX_COLUMN; ++i) {
          m_column_xlow[i] = 0;
          m_column_xhigh[i] = 0;

--- a/src/libraries/TAGGER/DTAGMGeometry.h
+++ b/src/libraries/TAGGER/DTAGMGeometry.h
@@ -24,7 +24,7 @@ class DTAGMGeometry : public JObject {
    
    JOBJECT_PUBLIC(DTAGMGeometry);
 
-   DTAGMGeometry(JEventLoop *loop, int32_t runnumber);
+   DTAGMGeometry(JEventLoop *loop);
    ~DTAGMGeometry();
 
    static const unsigned int kRowCount;

--- a/src/libraries/TAGGER/DTAGMGeometry.h
+++ b/src/libraries/TAGGER/DTAGMGeometry.h
@@ -24,7 +24,7 @@ class DTAGMGeometry : public JObject {
    
    JOBJECT_PUBLIC(DTAGMGeometry);
 
-   DTAGMGeometry(JEventLoop *loop, std::string tag, int32_t runnumber);
+   DTAGMGeometry(JEventLoop *loop, int32_t runnumber);
    ~DTAGMGeometry();
 
    static const unsigned int kRowCount;

--- a/src/libraries/TAGGER/DTAGMGeometry_factory.cc
+++ b/src/libraries/TAGGER/DTAGMGeometry_factory.cc
@@ -22,7 +22,7 @@ jerror_t DTAGMGeometry_factory::brun(JEventLoop *loop, int32_t runnumber)
 	}
 
    flags = PERSISTANT;
-   _data.push_back( new DTAGMGeometry(loop, factory_tag, runnumber) );
+   _data.push_back( new DTAGMGeometry(loop) );
    
    return NOERROR;
 }

--- a/src/libraries/TAGGER/DTAGMGeometry_factory.h
+++ b/src/libraries/TAGGER/DTAGMGeometry_factory.h
@@ -14,15 +14,12 @@
 
 class DTAGMGeometry_factory : public JFactory<DTAGMGeometry> {
  public:
-   DTAGMGeometry_factory(const char *tag="") :
-      JFactory<DTAGMGeometry>(tag), factory_tag(tag) {}
+   DTAGMGeometry_factory(){}
    ~DTAGMGeometry_factory(){}
 
  private:
    jerror_t brun(JEventLoop *loop, int32_t runnumber);   
    jerror_t erun(void);   
-
-   std::string factory_tag;
 };
 
 #endif // _DTAGMGeometry_factory_

--- a/src/libraries/TAGGER/TAGGER_init.cc
+++ b/src/libraries/TAGGER/TAGGER_init.cc
@@ -30,8 +30,6 @@ jerror_t TAGGER_init(JEventLoop *loop)
   loop->AddFactory(new JFactory<DTAGHHit>("TRUTH"));
   loop->AddFactory(new DTAGMGeometry_factory());
   loop->AddFactory(new DTAGHGeometry_factory());
-  loop->AddFactory(new DTAGMGeometry_factory("mc"));
-  loop->AddFactory(new DTAGHGeometry_factory("mc"));
   
   return NOERROR;
 }

--- a/src/libraries/TRIGGER/DTrigger.h
+++ b/src/libraries/TRIGGER/DTrigger.h
@@ -1,0 +1,40 @@
+#ifndef _DTrigger_
+#define _DTrigger_
+
+#include <JANA/JObject.h>
+#include <JANA/JFactory.h>
+
+class DTrigger : public jana::JObject
+{
+	JOBJECT_PUBLIC(DTrigger);
+	public:
+
+		//GETTERS
+		uint32_t Get_L1TriggerBits(void) const{return dL1TriggerBits;}
+		uint32_t Get_L1FrontPanelTriggerBits(void) const{return dL1FrontPanelTriggerBits;}
+		bool Get_IsPhysicsEvent(void) const;
+
+		//SETTERS
+		void Set_L1TriggerBits(uint32_t locL1TriggerBits){dL1TriggerBits = locL1TriggerBits;}
+		void Set_L1FrontPanelTriggerBits(uint32_t locL1FrontPanelTriggerBits){dL1FrontPanelTriggerBits = locL1FrontPanelTriggerBits;}
+
+		// the second argument to AddString is printf style format
+		void toStrings(vector<pair<string,string> >& items) const
+		{
+			AddString(items, "dL1TriggerBits", "%ld", dL1TriggerBits);
+			AddString(items, "dL1FrontPanelTriggerBits", "%ld", dL1FrontPanelTriggerBits);
+		}
+
+	private:
+		//NOTE: If is EPICS/SYNC/etc. event, both L1 values will be 0
+		uint32_t dL1TriggerBits;
+		uint32_t dL1FrontPanelTriggerBits;
+};
+
+inline bool DTrigger::Get_IsPhysicsEvent(void) const
+{
+	//Both L1 = 0: EPICS/SYNC/etc. //L1 = 8: PS
+	return ((dL1FrontPanelTriggerBits == 0) && (dL1TriggerBits != 0) && (dL1TriggerBits != 8));
+}
+
+#endif // _DTrigger_

--- a/src/libraries/TRIGGER/DTrigger.h
+++ b/src/libraries/TRIGGER/DTrigger.h
@@ -6,8 +6,8 @@
 
 class DTrigger : public jana::JObject
 {
-	JOBJECT_PUBLIC(DTrigger);
 	public:
+		JOBJECT_PUBLIC(DTrigger);
 
 		//GETTERS
 		uint32_t Get_L1TriggerBits(void) const{return dL1TriggerBits;}

--- a/src/libraries/TRIGGER/DTrigger_factory.cc
+++ b/src/libraries/TRIGGER/DTrigger_factory.cc
@@ -1,0 +1,45 @@
+#include "DTrigger_factory.h"
+
+//------------------
+// evnt
+//------------------
+jerror_t DTrigger_factory::evnt(JEventLoop* locEventLoop, uint64_t locEventNumber)
+{
+	vector<const DL1Trigger*> locL1Triggers;
+	locEventLoop->Get(locL1Triggers);
+	const DL1Trigger* locL1Trigger = locL1Triggers.empty() ? NULL : locL1Triggers[0];
+
+	vector<const DMCTrigger*> locMCTriggers;
+	locEventLoop->Get(locMCTriggers);
+	const DMCTrigger* locMCTrigger = locMCTriggers.empty() ? NULL : locMCTriggers[0];
+
+	DTrigger *locTrigger = new DTrigger;
+	
+	//SET LEVEL-1 TRIGGER INFO
+	if(locL1Trigger != NULL)
+	{
+		locTrigger->Set_L1TriggerBits(locL1Trigger->trig_mask);
+		locTrigger->Set_L1FrontPanelTriggerBits(locL1Trigger->fp_trig_mask);
+	}
+	else if(locMCTrigger != NULL)
+	{
+		//IS MC DATA: DO NOT TRUST DMCTRIGGER FOR NOW: JUST ALWAYS SET TRIGGER BIT = 1, UNTIL MC TRIGGERING IS WORKED OUT
+		locTrigger->Set_L1TriggerBits(1);
+		locTrigger->Set_L1FrontPanelTriggerBits(0);
+	}
+	else
+	{
+		//NOTHING AVAILABLE: PROBABLY EARLY DATA/MC. OR EPICS/SYNC/etc. EVENTS
+		locTrigger->Set_L1FrontPanelTriggerBits(0);
+		if(locEventLoop->GetJEvent().GetStatusBit(kSTATUS_PHYSICS_EVENT))
+			locTrigger->Set_L1TriggerBits(1); //SET TRIG BIT TO ONE SO IS_PHYSICS WILL BE TRUE
+		else
+			locTrigger->Set_L1TriggerBits(0); //e.g. EPICS event
+	}
+
+	//SET LEVEL-3 TRIGGER INFO HERE
+
+	_data.push_back(locTrigger);
+
+	return NOERROR;
+}

--- a/src/libraries/TRIGGER/DTrigger_factory.cc
+++ b/src/libraries/TRIGGER/DTrigger_factory.cc
@@ -32,7 +32,7 @@ jerror_t DTrigger_factory::evnt(JEventLoop* locEventLoop, uint64_t locEventNumbe
 		//NOTHING AVAILABLE: PROBABLY EARLY DATA/MC. OR EPICS/SYNC/etc. EVENTS
 		locTrigger->Set_L1FrontPanelTriggerBits(0);
 		if(locEventLoop->GetJEvent().GetStatusBit(kSTATUS_PHYSICS_EVENT))
-			locTrigger->Set_L1TriggerBits(1); //SET TRIG BIT TO ONE SO IS_PHYSICS WILL BE TRUE
+			locTrigger->Set_L1TriggerBits(1); //OLD DATA: SET TRIG BIT TO ONE SO IS_PHYSICS WILL BE TRUE
 		else
 			locTrigger->Set_L1TriggerBits(0); //e.g. EPICS event
 	}

--- a/src/libraries/TRIGGER/DTrigger_factory.h
+++ b/src/libraries/TRIGGER/DTrigger_factory.h
@@ -1,0 +1,20 @@
+#ifndef _DTrigger_factory_
+#define _DTrigger_factory_
+
+#include <JANA/JFactory.h>
+#include "DTrigger.h"
+
+using namespace std;
+using namespace jana;
+
+class DTrigger_factory : public jana::JFactory<DL1Trigger>
+{
+	public:
+		DTrigger_factory(){};
+		virtual ~DTrigger_factory(){};
+
+	private:
+		jerror_t evnt(JEventLoop* locEventLoop, uint64_t locEventNumber);
+};
+
+#endif // _DTrigger_factory_

--- a/src/libraries/TRIGGER/DTrigger_factory.h
+++ b/src/libraries/TRIGGER/DTrigger_factory.h
@@ -3,11 +3,15 @@
 
 #include <JANA/JFactory.h>
 #include "DTrigger.h"
+#include "DL1Trigger.h"
+#include "DL3Trigger.h"
+#include "DMCTrigger.h"
+#include "DANA/DStatusBits.h"
 
 using namespace std;
 using namespace jana;
 
-class DTrigger_factory : public jana::JFactory<DL1Trigger>
+class DTrigger_factory : public jana::JFactory<DTrigger>
 {
 	public:
 		DTrigger_factory(){};

--- a/src/libraries/TRIGGER/TRIGGER_init.cc
+++ b/src/libraries/TRIGGER/TRIGGER_init.cc
@@ -11,12 +11,14 @@ using namespace jana;
 #include "DMCTrigger_factory.h"
 #include "DL3Trigger_factory.h"
 #include "DL1Trigger_factory.h"
+#include "DTrigger_factory.h"
 
 jerror_t TRIGGER_init(JEventLoop *loop) {
 
 	loop->AddFactory(new DMCTrigger_factory());
 	loop->AddFactory(new DL3Trigger_factory());
 	loop->AddFactory(new DL1Trigger_factory());
+	loop->AddFactory(new DTrigger_factory());
 
 	return NOERROR;
 }

--- a/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.cc
+++ b/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.cc
@@ -93,45 +93,42 @@ jerror_t DEventProcessor_monitoring_hists::evnt(JEventLoop *locEventLoop, uint64
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
 
-  vector <const DL1Trigger*>  Trig;
-  locEventLoop->Get(Trig);
+	//CHECK TRIGGER TYPE
+	const DTrigger* locTrigger = NULL;
+	locEventLoop->GetSingle(locTrigger);
+	if(!locTrigger->Get_IsPhysicsEvent())
+		return NOERROR;
 
-  if (!Trig.empty()){
-    if (Trig[0]->fp_trig_mask>0){ // Ignore front pannel trigger
-      return NOERROR;
-    }
-  }
-  
-  japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
-  {
-    dHist_IsEvent->Fill(1);
-  }
-  japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
-  
-  vector<const DMCThrown*> locMCThrowns;
-  locEventLoop->Get(locMCThrowns);
-  
-  //Fill reaction-independent histograms.
-  dHistogramAction_NumReconstructedObjects(locEventLoop);
-  dHistogramAction_Reconstruction(locEventLoop);
-  dHistogramAction_EventVertex(locEventLoop);
-  
-  dHistogramAction_DetectorMatching(locEventLoop);
-  dHistogramAction_DetectorMatchParams(locEventLoop);
-  dHistogramAction_Neutrals(locEventLoop);
-  dHistogramAction_DetectorPID(locEventLoop);
-  
-  dHistogramAction_TrackMultiplicity(locEventLoop);
-  dHistogramAction_DetectedParticleKinematics(locEventLoop);
-  //	dHistogramAction_ObjectMemory(locEventLoop);
-  
-  if(!locMCThrowns.empty())
-    {
-      dHistogramAction_ThrownParticleKinematics(locEventLoop);
-      dHistogramAction_ReconnedThrownKinematics(locEventLoop);
-      dHistogramAction_GenReconTrackComparison(locEventLoop);
-    }
-  
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+	{
+		dHist_IsEvent->Fill(1);
+	}
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
+	vector<const DMCThrown*> locMCThrowns;
+	locEventLoop->Get(locMCThrowns);
+
+	//Fill reaction-independent histograms.
+	dHistogramAction_NumReconstructedObjects(locEventLoop);
+	dHistogramAction_Reconstruction(locEventLoop);
+	dHistogramAction_EventVertex(locEventLoop);
+
+	dHistogramAction_DetectorMatching(locEventLoop);
+	dHistogramAction_DetectorMatchParams(locEventLoop);
+	dHistogramAction_Neutrals(locEventLoop);
+	dHistogramAction_DetectorPID(locEventLoop);
+
+	dHistogramAction_TrackMultiplicity(locEventLoop);
+	dHistogramAction_DetectedParticleKinematics(locEventLoop);
+	//	dHistogramAction_ObjectMemory(locEventLoop);
+
+	if(!locMCThrowns.empty())
+	{
+		dHistogramAction_ThrownParticleKinematics(locEventLoop);
+		dHistogramAction_ReconnedThrownKinematics(locEventLoop);
+		dHistogramAction_GenReconTrackComparison(locEventLoop);
+	}
+
   return NOERROR;
 }
 

--- a/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.h
+++ b/src/plugins/Analysis/monitoring_hists/DEventProcessor_monitoring_hists.h
@@ -15,7 +15,7 @@
 
 #include "DANA/DApplication.h"
 #include "ANALYSIS/DHistogramActions.h"
-#include <TRIGGER/DL1Trigger.h>
+#include <TRIGGER/DTrigger.h>
 
 using namespace jana;
 

--- a/src/plugins/Utilities/danarest/JEventProcessor_danarest.cc
+++ b/src/plugins/Utilities/danarest/JEventProcessor_danarest.cc
@@ -37,10 +37,10 @@ jerror_t JEventProcessor_danarest::brun(JEventLoop *locEventLoop, int32_t runnum
 //-------------------------------
 jerror_t JEventProcessor_danarest::evnt(JEventLoop *locEventLoop, uint64_t eventnumber)
 {
-	//Ignore EPICS events
-	vector<const DEPICSvalue*> locEPICSValues;
-	locEventLoop->Get(locEPICSValues);
-	if(!locEPICSValues.empty())
+	//CHECK TRIGGER TYPE
+	const DTrigger* locTrigger = NULL;
+	locEventLoop->GetSingle(locTrigger);
+	if(!locTrigger->Get_IsPhysicsEvent())
 		return NOERROR;
 
 	// Write this event to the rest output stream.

--- a/src/plugins/Utilities/danarest/JEventProcessor_danarest.h
+++ b/src/plugins/Utilities/danarest/JEventProcessor_danarest.h
@@ -14,7 +14,7 @@ using namespace std;
 #include <JANA/JEventLoop.h>
 
 #include <HDDM/DEventWriterREST.h>
-#include "DAQ/DEPICSvalue.h"
+#include <TRIGGER/DTrigger.h>
 
 class JEventProcessor_danarest : public jana::JEventProcessor
 {

--- a/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.cc
+++ b/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.cc
@@ -111,40 +111,11 @@ jerror_t DEventProcessor_track_skimmer::brun(jana::JEventLoop* locEventLoop, int
 //------------------
 jerror_t DEventProcessor_track_skimmer::evnt(jana::JEventLoop* locEventLoop, uint64_t locEventNumber)
 {
-	// This is called for every event. Use of common resources like writing
-	// to a file or filling a histogram should be mutex protected. Using
-	// locEventLoop->Get(...) to get reconstructed objects (and thereby activating the
-	// reconstruction algorithm) should be done outside of any mutex lock
-	// since multiple threads may call this method at the same time.
-	//
-	// Here's an example:
-	//
-	// vector<const MyDataClass*> mydataclasses;
-	// locEventLoop->Get(mydataclasses);
-	//
-	// japp->RootWriteLock();
-	//  ... fill historgrams or trees ...
-	// japp->RootUnLock();
-
-	// DOCUMENTATION:
-	// ANALYSIS library: https://halldweb1.jlab.org/wiki/index.php/GlueX_Analysis_Software
-
-	//See if is physics event, or is REST
-	bool locIsRESTEvent = (string(locEventLoop->GetJEvent().GetJEventSource()->className()) == string("DEventSourceREST"));
-	if(!locIsRESTEvent)
-	{
-		if(!locEventLoop->GetJEvent().GetStatusBit(kSTATUS_PHYSICS_EVENT))
-		   return NOERROR;
-
-		vector<const DL1Trigger*> trigger_info;
-		locEventLoop->Get(trigger_info);
-		if(trigger_info.empty())
-			return NOERROR;
-
-		// require event to have production FCAL+BCAL trigger
-		if((trigger_info[0]->trig_mask & 0x01) == 0)
-			return NOERROR;
-	}
+	//CHECK TRIGGER TYPE
+	const DTrigger* locTrigger = NULL;
+	locEventLoop->GetSingle(locTrigger);
+	if(!locTrigger->Get_IsPhysicsEvent())
+		return NOERROR;
 
 	// See whether this is MC data or real data
 	vector<const DMCThrown*> locMCThrowns;

--- a/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.h
+++ b/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.h
@@ -20,7 +20,6 @@
 
 #include "DFactoryGenerator_track_skimmer.h"
 
-#include "DANA/DStatusBits.h"
 #include <TRIGGER/DTrigger.h>
 
 using namespace jana;

--- a/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.h
+++ b/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.h
@@ -21,7 +21,7 @@
 #include "DFactoryGenerator_track_skimmer.h"
 
 #include "DANA/DStatusBits.h"
-#include "TRIGGER/DL1Trigger.h"
+#include <TRIGGER/DTrigger.h>
 
 using namespace jana;
 using namespace std;


### PR DESCRIPTION
DTrigger:
1) New object. Contains bare minimum of information from DL1Trigger to be saved to REST.  Will be expanded to include L3 trigger info when ready. 
2) Saved to REST
3) Bits checked in the analysis library, monitoring_hists, danarest, and track_skimmer: These aren't run if Get_IsPhysicsEvent() method returns false. 

REST:
1) DTrigger saved to REST
2) Event # type was only 32bit: too small for storing the event #'s during L3-trigger era.  JANA has already switched to 64bit.  This switches REST to 64bit.  
3) This change breaks backwards compatibility: DANA can no longer read REST files created prior to now.  We could have kludged it to maintain compatibility, but chose not to, because:

3a) It would be an ugly kludge: bloating the format, and potentially bloating the file footprint.

3b) If we were to ever break backwards compatibility, NOW is the perfect time, right before the first full reconstruction launch.  After the launch, no one will ever want to read old experimental REST data any more.  After sim1.1, which should be soon, no one will ever want to read old simulated data any more.  If we wait until later, e.g. when L3-trigger turns on, we will still care about older data, and it will be a pain to make both work.  In fact, this is probably the ONLY time we can do this.  Now, in the meantime, users can use software created prior to now (e.g. workshop tags).  

3c) We can use this as an opportunity to clean up bloat in the xml file format itself (not the output).  For example, as modifications were made, _v2 versions of objects had to be declared.  Now, all of the deprecated types have been removed.  

If someone REALLY needs to read older REST data after this change with newer software, we can theoretically support this, but we will not put forth the effort to do so unless there is a very good reason.  
