### PR TITLE
Modified TAGM hit factory for pulse integral cuts

### DIFF
--- a/src/libraries/TAGGER/DTAGMHit_factory.cc
+++ b/src/libraries/TAGGER/DTAGMHit_factory.cc
@@ -31,11 +31,11 @@ jerror_t DTAGMHit_factory::init(void)
 {
     DELTA_T_ADC_TDC_MAX = 10.0; // ns
     USE_ADC = 0;
-    PEAK_CUT = 0;
+    CUT_FACTOR = 1;
     gPARMS->SetDefaultParameter("TAGMHit:DELTA_T_ADC_TDC_MAX", DELTA_T_ADC_TDC_MAX,
                 "Maximum difference in ns between a (calibrated) fADC time and"
                 " F1TDC time for them to be matched in a single hit");
-    gPARMS->SetDefaultParameter("TAGMHit:PEAK_CUT", PEAK_CUT, "TAGM pulse height cut [ADC Counts]");
+    gPARMS->SetDefaultParameter("TAGMHit:CUT_FACTOR", CUT_FACTOR, "TAGM pulse integral cut factor, 0 = no cut");
     gPARMS->SetDefaultParameter("TAGMHit:USE_ADC", USE_ADC, "Use ADC times in TAGM");
 
     // initialize calibration constants
@@ -103,9 +103,9 @@ jerror_t DTAGMHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
     load_ccdb_constants("tdc_timewalk_corrections", "c0", tw_c0) &&
     load_ccdb_constants("tdc_timewalk_corrections", "c1", tw_c1) &&
     load_ccdb_constants("tdc_timewalk_corrections", "c2", tw_c2) &&
-    //load_ccdb_constants("tdc_timewalk_corrections", "threshold", thresh) &&
     load_ccdb_constants("tdc_timewalk_corrections", "threshold", tw_c3) &&
-    load_ccdb_constants("tdc_timewalk_corrections", "reference", ref))
+    load_ccdb_constants("tdc_timewalk_corrections", "reference", ref) &&
+    load_ccdb_constants("integral_cuts", "integral", int_cuts))
     {
         return NOERROR;
     }
@@ -177,7 +177,6 @@ jerror_t DTAGMHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 
         // Skip digihit if pulse peak is lower than cut value
         double P = PPobj->pulse_peak - PPobj->pedestal;
-        if (P < PEAK_CUT) continue;
 
         DTAGMHit *hit = new DTAGMHit;
         int row = digihit->row;
@@ -193,6 +192,7 @@ jerror_t DTAGMHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
         double A = digihit->pulse_integral;
         double T = digihit->pulse_time;
         A -= pedestal;
+        if (A < CUT_FACTOR*int_cuts[row][column]) continue;
         hit->integral = A;
         hit->pulse_peak = P;
         hit->npix_fadc = A * fadc_a_scale * fadc_gains[row][column];

--- a/src/libraries/TAGGER/DTAGMHit_factory.h
+++ b/src/libraries/TAGGER/DTAGMHit_factory.h
@@ -29,7 +29,8 @@ class DTAGMHit_factory: public jana::JFactory<DTAGMHit> {
 
       // config. parameter
       double DELTA_T_ADC_TDC_MAX; 
-      int USE_ADC, PEAK_CUT;
+      //int USE_ADC, PEAK_CUT;
+      int USE_ADC, CUT_FACTOR;
 
       // overall scale factors
       double fadc_a_scale;  // pixels per fADC pulse integral count
@@ -48,6 +49,7 @@ class DTAGMHit_factory: public jana::JFactory<DTAGMHit> {
       double tw_c2[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
       double tw_c3[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
       double ref[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+      double int_cuts[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
 
       bool load_ccdb_constants(std::string table_name,
                                std::string column_name,


### PR DESCRIPTION
Modified TAGM hit factory to use CCDB table 'PHOTON_BEAM/microscope/integral_cuts'. DTAGMHit objects with a pulse integral less than the value in CCDB will be cut. To turn this off use -PTAGMHit:CUT_FACTOR=0
