### PR TITLE
Spring2016 cdc updates

### DIFF
--- a/src/libraries/TRACKING/DTrackCandidate_factory_CDCCOSMIC.cc
+++ b/src/libraries/TRACKING/DTrackCandidate_factory_CDCCOSMIC.cc
@@ -152,7 +152,6 @@ inline double DTrackCandidate_factory_CDCCOSMIC::CDCDriftVariance(double t){
     //if (t<0.) t=0.;
     //cout << "Entering Variance lookup for time " << t << endl;
 
-    double cutoffTime = 5.0;
     double V = 0.0507;
     if (t>0){
         //cout << "The resolution parameters are {" << CDC_RES_PAR1 <<","<< CDC_RES_PAR2 << "}" << endl;
@@ -167,14 +166,11 @@ inline double DTrackCandidate_factory_CDCCOSMIC::CDCDriftVariance(double t){
         //}
 
         V=sigma*sigma;
-        return V;
     }
     else { // Time is negative, or exactly zero, choose position at wire, with error of t=0 hit
-        double slope = -1.0 * CDC_RES_PAR1 / (( cutoffTime + 1) * (cutoffTime + 1));
-        double sigma = (CDC_RES_PAR1/(cutoffTime+1.)+CDC_RES_PAR2) + slope * (0.0 - cutoffTime);
+        double sigma = CDC_RES_PAR1+CDC_RES_PAR2;
         //cout << "Time is negative...sigma = " << sigma << endl;
         V=sigma*sigma; //Should include T0 variance...
-        return V;
         //V=0.0507; // straw radius^2 / 12
     }
     //cout << "Somehow we got here...returning Variance = " << V << endl;

--- a/src/libraries/TRACKING/DTrackCandidate_factory_CDCCOSMIC.cc
+++ b/src/libraries/TRACKING/DTrackCandidate_factory_CDCCOSMIC.cc
@@ -659,7 +659,7 @@ jerror_t DTrackCandidate_factory_CDCCOSMIC::evnt(JEventLoop *loop, uint64_t even
                 //cout << " The error is as follows, measurment error = " << measurementError << " Tracking Error " << trackError << " Total " << error << endl;
                 double docaphi, docaz;
                 GetDOCAPhiandZ(hits[j]->wire, can->position(), can->momentum(), docaphi, docaz);
-                can->pulls.push_back(DTrackFitter::pull_t(residual, error, 0.0, time , measurement, hits[j], NULL,docaphi,docaz));
+                can->pulls.push_back(DTrackFitter::pull_t(residual, error, 0.0, time , DOCA, hits[j], NULL,docaphi,docaz));
 
             }
             _data.push_back(can);

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -3987,6 +3987,7 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanCentral(double anneal_factor,
 
                     tdrift=my_cdchits[cdc_index]->tdrift-mT0
                         -central_traj[k_minus_1].t*TIME_UNIT_CONVERSION;
+                    if (tdrift < 0.) continue;
                     double B=central_traj[k_minus_1].B;
                     ComputeCDCDrift(dphi,delta,tdrift,B,measurement,V,tcorr);
 		 
@@ -5217,6 +5218,7 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanForwardCDC(double anneal,DMatrix5x1
 
                     tdrift=my_cdchits[cdc_index]->tdrift-mT0
                         -forward_traj[k_minus_1].t*TIME_UNIT_CONVERSION;
+                    if (tdrift < 0.) continue;
                     double B=forward_traj[k_minus_1].B;
                     ComputeCDCDrift(dphi,delta,tdrift,B,dm,V,tcorr);
 		  

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -3987,7 +3987,6 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanCentral(double anneal_factor,
 
                     tdrift=my_cdchits[cdc_index]->tdrift-mT0
                         -central_traj[k_minus_1].t*TIME_UNIT_CONVERSION;
-                    if (tdrift < 0.) continue;
                     double B=central_traj[k_minus_1].B;
                     ComputeCDCDrift(dphi,delta,tdrift,B,measurement,V,tcorr);
 		 
@@ -4055,7 +4054,7 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanCentral(double anneal_factor,
 		      bool skip_ring
 			=(my_cdchits[cdc_index]->hit->wire->ring==RING_TO_SKIP);
 		      //Update covariance matrix  and state vector
-		      if (skip_ring==false){
+		      if (skip_ring==false && tdrift > 0.){
                         Cc=Ctest;
 			Sc+=dm*K;
 		      }
@@ -4071,9 +4070,10 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanCentral(double anneal_factor,
 		      cdc_updates[cdc_index].residual=dm*scale;
 		      cdc_updates[cdc_index].variance=V;
 		      cdc_updates[cdc_index].used_in_fit=true;
+              if (tdrift < 0.) cdc_updates[cdc_index].used_in_fit=false;
 		      
 		      // Update chi2 for this hit
-		      if (skip_ring==false){
+		      if (skip_ring==false && tdrift > 0.){
 			chisq+=scale*dm*dm/V;      
                         my_ndf++;
 		      }
@@ -5218,7 +5218,6 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanForwardCDC(double anneal,DMatrix5x1
 
                     tdrift=my_cdchits[cdc_index]->tdrift-mT0
                         -forward_traj[k_minus_1].t*TIME_UNIT_CONVERSION;
-                    if (tdrift < 0.) continue;
                     double B=forward_traj[k_minus_1].B;
                     ComputeCDCDrift(dphi,delta,tdrift,B,dm,V,tcorr);
 		  
@@ -5270,7 +5269,7 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanForwardCDC(double anneal,DMatrix5x1
 		      bool skip_ring
 			=(my_cdchits[cdc_index]->hit->wire->ring==RING_TO_SKIP);
 		      // update covariance matrix and state vector
-		      if (skip_ring==false){
+		      if (skip_ring==false && tdrift > 0.){
 			C=Ctest;		       
 			S+=res*K;
 		      }
@@ -5285,9 +5284,10 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanForwardCDC(double anneal,DMatrix5x1
 		      cdc_updates[cdc_index].residual=res*scale;
 		      cdc_updates[cdc_index].variance=V;
 		      cdc_updates[cdc_index].used_in_fit=true;
+              if(tdrift < 0.) cdc_updates[cdc_index].used_in_fit=false;
 		      
 		      // Update chi2 for this segment
-		      if (skip_ring==false){
+		      if (skip_ring==false && tdrift > 0.){
 			chisq+=scale*res*res/V;
                         numdof++;	
 		      }

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -143,20 +143,12 @@ void DTrackFitterKalmanSIMD::ComputeCDCDrift(double dphi,double delta,double t,
 					     double &d, double &V, double &tcorr){
     //d=0.39; // initialize at half-cell
     //V=0.0507; // initialize with (cell size)/12.
-    double cutoffTime = 40.0;
     tcorr = t; // Need this value even when t is negative for calibration
     if (t>0){
       //double dtc =(CDC_DRIFT_BSCALE_PAR1 + CDC_DRIFT_BSCALE_PAR2 * B)* t;
         //tcorr=t-dtc;
 	 
 	double sigma=CDC_RES_PAR1/(tcorr+1.)+CDC_RES_PAR2;
-        // This function is very poorly behaved at low drift times
-        // For times less than cutoffTime assume a linear behavior of our function.
-        if( tcorr < cutoffTime ){
-            double slope = -1.0 * CDC_RES_PAR1 / (( cutoffTime + 1) * (cutoffTime + 1));
-            sigma = (CDC_RES_PAR1/(cutoffTime+1.)+CDC_RES_PAR2) + slope * (tcorr - cutoffTime);
-        }
-
 
 	// Variables to store values for time-to-distance functions for delta=0
 	// and delta!=0
@@ -239,9 +231,8 @@ void DTrackFitterKalmanSIMD::ComputeCDCDrift(double dphi,double delta,double t,
     }
     else { // Time is negative, or exactly zero, choose position at wire, with error of t=0 hit
         d=0.;
-        double slope = -1.0 * CDC_RES_PAR1 / (( cutoffTime + 1) * (cutoffTime + 1));
-        double sigma = (CDC_RES_PAR1/(cutoffTime+1.)+CDC_RES_PAR2) + slope * (0.0 - cutoffTime);
-	double dt=cdc_drift_table[1]-cdc_drift_table[0];
+        double sigma = CDC_RES_PAR1+CDC_RES_PAR2;
+	    double dt=cdc_drift_table[1]-cdc_drift_table[0];
         V=sigma*sigma+mVarT0*0.0001/(dt*dt);
         //V=0.0507; // straw radius^2 / 12
     }

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.h
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.h
@@ -73,8 +73,8 @@
 
 // Functions of Moliere fraction F
 #define MOLIERE_RATIO1 5.0   // = 0.5/(1-F)
-#define MOLIERE_RATIO2 11.0e-7 // = (scale factor)*1e-6/(1+F*F)
-#define MOLIERE_RATIO3 11.0e-7 // = (scale factor)*1e-6/(1+F*F)
+#define MOLIERE_RATIO2 5.5e-7 // = (scale factor)*1e-6/(1+F*F)
+#define MOLIERE_RATIO3 5.5e-7 // = (scale factor)*1e-6/(1+F*F)
 //#define DE_PER_STEP_WIRE_BASED 0.0005 // in GeV
 //#define DE_PER_STEP_TIME_BASED 0.0005 // in GeV
 #define DE_PER_STEP 0.0005 // in GeV

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD_ALT1.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD_ALT1.cc
@@ -698,7 +698,7 @@ kalman_error_t DTrackFitterKalmanSIMD_ALT1::KalmanForward(double fdc_anneal_fact
 	      bool skip_ring
 		=(my_cdchits[cdc_index]->hit->wire->ring==RING_TO_SKIP);
 	      // update covariance matrix and state vector
-	      if (my_cdchits[cdc_index]->hit->wire->ring!=RING_TO_SKIP){
+	      if (my_cdchits[cdc_index]->hit->wire->ring!=RING_TO_SKIP && tdrift > 0.){
 		C=Ctest;
 		S+=res*K;
 	      }
@@ -714,9 +714,10 @@ kalman_error_t DTrackFitterKalmanSIMD_ALT1::KalmanForward(double fdc_anneal_fact
 	      cdc_updates[cdc_index].variance=Vc;
 	      cdc_updates[cdc_index].doca=dm;
 	      cdc_updates[cdc_index].used_in_fit=true;
+          if(tdrift < 0.) cdc_updates[cdc_index].used_in_fit=false;
 	    
 	      // Update chi2 and number of degrees of freedom for this hit
-	      if (skip_ring==false){
+	      if (skip_ring==false && tdrift > 0.){
 		chisq+=scale*res*res/Vc;
 		numdof++;
 	      }

--- a/src/plugins/Calibration/CDC_TimeToDistance/JEventProcessor_CDC_TimeToDistance.cc
+++ b/src/plugins/Calibration/CDC_TimeToDistance/JEventProcessor_CDC_TimeToDistance.cc
@@ -117,7 +117,7 @@ jerror_t JEventProcessor_CDC_TimeToDistance::evnt(JEventLoop *loop, uint64_t eve
         // Loop over the pulls to get the appropriate information for our ring
         for (unsigned int i = 0; i < pulls.size(); i++){
             DTrackFitter::pull_t thisPull = pulls[i];
-            double residual = thisPull.resi;
+            //double residual = thisPull.resi;
             //double error = thisPull.err;
             double time = thisPull.tdrift;
             double docaphi = thisPull.docaphi;
@@ -126,7 +126,7 @@ jerror_t JEventProcessor_CDC_TimeToDistance::evnt(JEventLoop *loop, uint64_t eve
             if (docaz < 70.0 || docaz > 110.0) continue; // Only focus on the center of the chamber
             //if (docaz < 140.0) continue; // Only focus on downstream end of chamber
             double predictedDistance = thisPull.d; // This is the DOCA of the track
-            double distance = residual + predictedDistance; // This is the distance from the T-D lookup
+            //double distance = residual + predictedDistance; // This is the distance from the T-D lookup
             const DCDCTrackHit* thisCDCHit = thisPull.cdc_hit;
 
             if (thisCDCHit == NULL) continue;

--- a/src/plugins/Calibration/CDC_TimeToDistance/JEventProcessor_CDC_TimeToDistance.cc
+++ b/src/plugins/Calibration/CDC_TimeToDistance/JEventProcessor_CDC_TimeToDistance.cc
@@ -125,8 +125,8 @@ jerror_t JEventProcessor_CDC_TimeToDistance::evnt(JEventLoop *loop, uint64_t eve
             double docaz = thisPull.z;
             if (docaz < 70.0 || docaz > 110.0) continue; // Only focus on the center of the chamber
             //if (docaz < 140.0) continue; // Only focus on downstream end of chamber
-            double distance = thisPull.d; // This is the distance from the lookup table
-            double predictedDistance = distance - residual; // This is the distance predicted by the fit
+            double predictedDistance = thisPull.d; // This is the DOCA of the track
+            double distance = residual + predictedDistance; // This is the distance from the T-D lookup
             const DCDCTrackHit* thisCDCHit = thisPull.cdc_hit;
 
             if (thisCDCHit == NULL) continue;

--- a/src/plugins/monitoring/CDC_Cosmics/JEventProcessor_CDC_Cosmics.cc
+++ b/src/plugins/monitoring/CDC_Cosmics/JEventProcessor_CDC_Cosmics.cc
@@ -127,8 +127,8 @@ jerror_t JEventProcessor_CDC_Cosmics::evnt(JEventLoop *loop, uint64_t eventnumbe
             double dz = docaz - 92.0;
             //if (docaz < 70.0 || docaz > 110.0) continue; // Only focus on the center of the chamber
             //if (docaz < 140.0) continue; // Only focus on downstream end of chamber
-            double distance = thisPull.d; // This is the distance from the lookup table
-            double predictedDistance = distance - residual; // This is the distance predicted by the fit
+            double predictedDistance = thisPull.d; // This is the DOCA from the track
+            double distance = residual + predictedDistance; // This is the distance from the T-D lookup
             const DCDCTrackHit* thisCDCHit = thisPull.cdc_hit;
 
             if (thisCDCHit == NULL) continue;


### PR DESCRIPTION
- Change MOLIERE_RATIO2 and 3 to match Lynch/Dahl original paper.
- Reject tdrift<0 hits from track.
- Make definition of pull.d consistent between cosmic fitter and Kalman.
