### PR TITLE
Skip lonely 250PulseIntegral objects 

### DIFF
--- a/src/BMS/osrelease.pl
+++ b/src/BMS/osrelease.pl
@@ -50,6 +50,8 @@ if ($uname eq 'Linux') {
 	    $release = '_RHEL5';
 	} elsif ($release_string =~ /^Red Hat Enterprise Linux Workstation release 6.*/) {
 	    $release = '_RHEL6';
+    } elsif ($release_string =~ /^Red Hat Enterprise Linux Server release 6.*/) {
+        $release = '_RHEL6';
 	} elsif ($release_string =~ /^Red Hat Enterprise Linux Workstation release 7.*/) {
 	    $release = '_RHEL7';
 	} elsif ($release_string =~ /^CentOS release 5.*/) {

--- a/src/libraries/TTAB/DTranslationTable.cc
+++ b/src/libraries/TTAB/DTranslationTable.cc
@@ -345,7 +345,7 @@ void DTranslationTable::ApplyTranslationTable(JEventLoop *loop) const
 	  pi->GetSingle(pp);
 
       // Avoid f250 Error with extra PulseIntegral word
-//      if( pt == NULL || pp == NULL) continue;
+      if( pt == NULL || pp == NULL) continue;
 
       // Create the appropriate hit type based on detector type
       switch (chaninfo.det_sys) {


### PR DESCRIPTION
This re-enables a fix for an earlier issue:

https://github.com/JeffersonLab/sim-recon/issues/240#issuecomment-187796744

This was commented out by David to allow testing of parsing performance without associated objects. This will need to be revisited in the future to allow both use cases, but the line in question is a critical fix.
