### PR TITLE
Fdc efficiency

### DIFF
--- a/src/plugins/monitoring/FDC_Efficiency/FDC_Efficiency.C
+++ b/src/plugins/monitoring/FDC_Efficiency/FDC_Efficiency.C
@@ -1,0 +1,189 @@
+
+void FDC_Efficiency(bool save = 0){
+  
+  //gDirectory->cd();
+  //TDirectory *gDirectory = TFile::Open("hd_root.root");
+  TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("FDC_Efficiency");
+  if(!dir) return;
+  dir->cd();
+
+  gDirectory->cd("Track_Quality");
+  TCanvas *cTrackQuality = new TCanvas("cTrackQuality", "Track Quality Histograms", 900, 600);
+  cTrackQuality->Divide(2,2);
+
+  cTrackQuality->cd(1);
+  TH1 *tchi = (TH1*) gDirectory->Get("hChi2OverNDF");
+  TH1 *tchi_acc = (TH1*) gDirectory->Get("hChi2OverNDF_accepted");
+  tchi->Draw();
+  tchi_acc->SetLineColor(2);
+  tchi_acc->Draw("same");
+
+  cTrackQuality->cd(2);
+  TH1 *tmom = (TH1*) gDirectory->Get("hMom");
+  TH1 *tmom_acc = (TH1*) gDirectory->Get("hMom_accepted");
+  tmom->Draw();
+  tmom_acc->SetLineColor(2);
+  tmom_acc->Draw("same");
+
+  cTrackQuality->cd(3);
+  TH1 *tcells = (TH1*) gDirectory->Get("hCellsHit");
+  TH1 *tcells_acc = (TH1*) gDirectory->Get("hCellsHit_accepted");
+  tcells->Draw();
+  tcells_acc->SetLineColor(2);
+  tcells_acc->Draw("same");
+
+  cTrackQuality->cd(4);
+  TH1 *trings = (TH1*) gDirectory->Get("hRingsHit");
+  TH1 *trings_acc = (TH1*) gDirectory->Get("hRingsHit_accepted");
+  trings->Draw();
+  trings_acc->SetLineColor(2);
+  trings_acc->Draw("same");
+
+  Float_t minScale = 0.5;
+  Float_t maxScale = 1.0;    
+
+  gDirectory->cd("../FDC_View");
+  TCanvas *cEfficiency_Wire = new TCanvas("cEfficiency_Wire", "Wire Efficiency", 900, 800);
+  cEfficiency_Wire->Divide(6,4);
+
+  TGraphAsymmErrors *EffWire[24];
+
+  for(unsigned int icell=1; icell<=24; icell++){
+    cEfficiency_Wire->cd(icell);
+    char hname[256];
+    sprintf(hname, "fdc_wire_measured_cell[%d]", icell);
+    TH1 *h = (TH1*)(gDirectory->Get(hname));
+    char hname2[256];
+    sprintf(hname2, "fdc_wire_expected_cell[%d]", icell);
+    TH1 *h2 = (TH1*)(gDirectory->Get(hname2));
+      
+    if(h && h2){
+      EffWire[icell-1] = new  TGraphAsymmErrors(h, h2, "ac");
+      EffWire[icell-1]->Draw("ap");
+      EffWire[icell-1]->SetMinimum(0.0);
+      EffWire[icell-1]->SetMaximum(1.0);
+      EffWire[icell-1]->SetTitle("");
+      EffWire[icell-1]->GetXaxis()->SetTitle("Wire Number");
+      EffWire[icell-1]->GetYaxis()->SetTitle("Efficiency");
+      EffWire[icell-1]->SetMinimum(minScale);
+      EffWire[icell-1]->SetMaximum(maxScale);
+    }
+  }
+  if (save) cEfficiency_Wire->SaveAs("cEfficiencyWire.pdf");
+
+  TCanvas *cEfficiency_Pseudo = new TCanvas("cEfficiency_Pseudo", "Pseudo Hit Efficiency", 900, 800);
+  cEfficiency_Pseudo->Divide(6,4);
+    
+  for(unsigned int icell=1; icell<=24; icell++){
+    cEfficiency_Pseudo->cd(icell);
+    char hname[256];
+    sprintf(hname, "fdc_pseudo_measured_cell[%d]", icell);
+    TH1 *h = (TH1*)(gDirectory->Get(hname));
+    char hname2[256];
+    sprintf(hname2, "fdc_pseudo_expected_cell[%d]", icell);
+    TH1 *h2 = (TH1*)(gDirectory->Get(hname2));
+      
+    if(h && h2){
+      h->Divide(h2);
+      h->SetMinimum(minScale);
+      h->SetMaximum(maxScale);
+      h->GetXaxis()->SetTitle("X Position (cm)");
+      h->GetYaxis()->SetTitle("Y Position (cm)");
+      h->SetStats(0);
+      h->Draw("colz");
+    }
+  }
+
+  dir->cd();
+
+  TCanvas *cEfficiency_vs = new TCanvas("cEfficiency_vs", "Efficiency vs Things", 900, 600);
+  cEfficiency_vs->Divide(3,2);
+
+  cEfficiency_vs->cd(1);
+  TH1I *MeasDOCA = (TH1I*)(gDirectory->Get("Offline/Measured Hits Vs DOCA"));
+  TH1I *ExpDOCA = (TH1I*)(gDirectory->Get("Offline/Expected Hits Vs DOCA"));
+  if(MeasDOCA && ExpDOCA){
+    TGraphAsymmErrors *EffDOCA = new  TGraphAsymmErrors(MeasDOCA, ExpDOCA, "ac");
+    EffDOCA->Draw("ap");
+    EffDOCA->SetMinimum(minScale);
+    EffDOCA->SetMaximum(maxScale);
+    EffDOCA->SetTitle("FDC Per Wire Efficiency Vs. DOCA");
+    EffDOCA->GetXaxis()->SetTitle("Closest distance between track and wire [cm]");
+    EffDOCA->GetYaxis()->SetTitle("Efficiency");
+    TLine *lcut = new TLine(0.5,minScale,0.5,maxScale);
+    lcut->SetLineColor(2);
+    lcut->SetLineStyle(2);
+    lcut->SetLineWidth(2);
+    lcut->Draw();
+  }
+
+  cEfficiency_vs->cd(2);
+  TH1I *MeasTrackingFOM = (TH1I*)(gDirectory->Get("Offline/Measured Hits Vs Tracking FOM"));
+  TH1I *ExpTrackingFOM = (TH1I*)(gDirectory->Get("Offline/Expected Hits Vs Tracking FOM"));
+  if(MeasTrackingFOM && ExpTrackingFOM){
+    TGraphAsymmErrors *EffTrackingFOM = new  TGraphAsymmErrors(MeasTrackingFOM, ExpTrackingFOM, "ac");
+    EffTrackingFOM->Draw("ap");
+    EffTrackingFOM->SetMinimum(minScale);
+    EffTrackingFOM->SetMaximum(maxScale);
+    EffTrackingFOM->SetTitle("FDC Per Wire Efficiency Vs. Tracking FOM");
+    EffTrackingFOM->GetXaxis()->SetTitle("Tracking FOM");
+    EffTrackingFOM->GetYaxis()->SetTitle("Efficiency");
+  }
+
+  cEfficiency_vs->cd(3);
+  TH1I *Meastheta = (TH1I*)(gDirectory->Get("Offline/Measured Hits Vs theta"));
+  TH1I *Exptheta = (TH1I*)(gDirectory->Get("Offline/Expected Hits Vs theta"));
+  if(Meastheta && Exptheta){
+    TGraphAsymmErrors *Efftheta = new  TGraphAsymmErrors(Meastheta, Exptheta, "ac");
+    Efftheta->Draw("ap");
+    Efftheta->SetMinimum(minScale);
+    Efftheta->SetMaximum(maxScale);
+    Efftheta->SetTitle("FDC Per Wire Efficiency Vs. #theta");
+    Efftheta->GetXaxis()->SetTitle("Track #theta [deg.]");
+    Efftheta->GetYaxis()->SetTitle("Efficiency");
+  }
+
+  cEfficiency_vs->cd(4);
+  TH1I *Measphi = (TH1I*)(gDirectory->Get("Offline/Measured Hits Vs phi"));
+  TH1I *Expphi = (TH1I*)(gDirectory->Get("Offline/Expected Hits Vs phi"));
+  if(Measphi && Expphi){
+    TGraphAsymmErrors *Effphi = new  TGraphAsymmErrors(Measphi, Expphi, "ac");
+    Effphi->Draw("ap");
+    Effphi->SetMinimum(minScale);
+    Effphi->SetMaximum(maxScale);
+    Effphi->SetTitle("FDC Per Wire Efficiency Vs. #phi");
+    Effphi->GetXaxis()->SetTitle("Track #phi [deg.]");
+    Effphi->GetYaxis()->SetTitle("Efficiency");
+  }
+
+  cEfficiency_vs->cd(5);
+  TH1I *Measp = (TH1I*)(gDirectory->Get("Offline/Measured Hits Vs p"));
+  TH1I *Expp = (TH1I*)(gDirectory->Get("Offline/Expected Hits Vs p"));
+  if(Measp && Expp){
+    TGraphAsymmErrors *Effp = new  TGraphAsymmErrors(Measp, Expp, "ac");
+    Effp->Draw("ap");
+    Effp->SetMinimum(minScale);
+    Effp->SetMaximum(maxScale);
+    Effp->SetTitle("FDC Per Wire Efficiency Vs. p");
+    Effp->GetXaxis()->SetTitle("Track Momentum [GeV/c]");
+    Effp->GetYaxis()->SetTitle("Efficiency");
+  }
+
+  cEfficiency_vs->cd(6);
+  TH1I *Meascells = (TH1I*)(gDirectory->Get("Offline/Measured Hits Vs Hit Cells"));
+  TH1I *Expcells = (TH1I*)(gDirectory->Get("Offline/Expected Hits Vs Hit Cells"));
+  if(Meascells && Expcells){
+    TGraphAsymmErrors *Effcells = new  TGraphAsymmErrors(Meascells, Expcells, "ac");
+    Effcells->Draw("ap");
+    Effcells->SetMinimum(minScale);
+    Effcells->SetMaximum(maxScale);
+    Effcells->SetTitle("FDC Per Wire Efficiency Vs. Contributing Cells");
+    Effcells->GetXaxis()->SetTitle("FDC Cells");
+    Effcells->GetYaxis()->SetTitle("Efficiency");
+  }
+
+  if (save) cEfficiency_vs->SaveAs("cEfficiency_vs.pdf");
+
+    
+
+}

--- a/src/plugins/monitoring/FDC_Efficiency/FDC_Efficiency.C
+++ b/src/plugins/monitoring/FDC_Efficiency/FDC_Efficiency.C
@@ -8,38 +8,53 @@ void FDC_Efficiency(bool save = 0){
   dir->cd();
 
   gDirectory->cd("Track_Quality");
-  TCanvas *cTrackQuality = new TCanvas("cTrackQuality", "Track Quality Histograms", 900, 600);
-  cTrackQuality->Divide(2,2);
+  TCanvas *cTrackQuality = new TCanvas("cTrackQuality", "Track Quality Histograms", 900, 800);
+  cTrackQuality->Divide(3,2);
 
   cTrackQuality->cd(1);
-  TH1 *tchi = (TH1*) gDirectory->Get("hChi2OverNDF");
-  TH1 *tchi_acc = (TH1*) gDirectory->Get("hChi2OverNDF_accepted");
-  tchi->Draw();
-  tchi_acc->SetLineColor(2);
-  tchi_acc->Draw("same");
-
-  cTrackQuality->cd(2);
   TH1 *tmom = (TH1*) gDirectory->Get("hMom");
   TH1 *tmom_acc = (TH1*) gDirectory->Get("hMom_accepted");
   tmom->Draw();
   tmom_acc->SetLineColor(2);
   tmom_acc->Draw("same");
 
+  cTrackQuality->cd(2);
+  TH1 *ttheta = (TH1*) gDirectory->Get("hTheta");
+  TH1 *ttheta_acc = (TH1*) gDirectory->Get("hTheta_accepted");
+  ttheta->Draw();
+  ttheta_acc->SetLineColor(2);
+  ttheta_acc->Draw("same");
+
   cTrackQuality->cd(3);
+  TH1 *tphi = (TH1*) gDirectory->Get("hPhi");
+  TH1 *tphi_acc = (TH1*) gDirectory->Get("hPhi_accepted");
+  tphi->SetMinimum(0.0);
+  tphi->Draw();
+  tphi_acc->SetLineColor(2);
+  tphi_acc->Draw("same");
+
+  cTrackQuality->cd(4);
+  TH1 *tchi = (TH1*) gDirectory->Get("hChi2OverNDF");
+  TH1 *tchi_acc = (TH1*) gDirectory->Get("hChi2OverNDF_accepted");
+  tchi->Draw();
+  tchi_acc->SetLineColor(2);
+  tchi_acc->Draw("same");
+
+  cTrackQuality->cd(5);
   TH1 *tcells = (TH1*) gDirectory->Get("hCellsHit");
   TH1 *tcells_acc = (TH1*) gDirectory->Get("hCellsHit_accepted");
   tcells->Draw();
   tcells_acc->SetLineColor(2);
   tcells_acc->Draw("same");
 
-  cTrackQuality->cd(4);
+  cTrackQuality->cd(6);
   TH1 *trings = (TH1*) gDirectory->Get("hRingsHit");
   TH1 *trings_acc = (TH1*) gDirectory->Get("hRingsHit_accepted");
   trings->Draw();
   trings_acc->SetLineColor(2);
   trings_acc->Draw("same");
 
-  Float_t minScale = 0.5;
+  Float_t minScale = 0.0;
   Float_t maxScale = 1.0;    
 
   gDirectory->cd("../FDC_View");
@@ -50,15 +65,15 @@ void FDC_Efficiency(bool save = 0){
 
   for(unsigned int icell=1; icell<=24; icell++){
     cEfficiency_Wire->cd(icell);
-    char hname[256];
-    sprintf(hname, "fdc_wire_measured_cell[%d]", icell);
-    TH1 *h = (TH1*)(gDirectory->Get(hname));
+    char hname1[256];
+    sprintf(hname1, "fdc_wire_measured_cell[%d]", icell);
+    TH1 *h1 = (TH1*)(gDirectory->Get(hname1));
     char hname2[256];
     sprintf(hname2, "fdc_wire_expected_cell[%d]", icell);
     TH1 *h2 = (TH1*)(gDirectory->Get(hname2));
       
-    if(h && h2){
-      EffWire[icell-1] = new  TGraphAsymmErrors(h, h2, "ac");
+    if(h1 && h2){
+      EffWire[icell-1] = new  TGraphAsymmErrors(h1, h2, "ac");
       EffWire[icell-1]->Draw("ap");
       EffWire[icell-1]->SetMinimum(0.0);
       EffWire[icell-1]->SetMaximum(1.0);
@@ -76,21 +91,21 @@ void FDC_Efficiency(bool save = 0){
     
   for(unsigned int icell=1; icell<=24; icell++){
     cEfficiency_Pseudo->cd(icell);
-    char hname[256];
-    sprintf(hname, "fdc_pseudo_measured_cell[%d]", icell);
-    TH1 *h = (TH1*)(gDirectory->Get(hname));
-    char hname2[256];
-    sprintf(hname2, "fdc_pseudo_expected_cell[%d]", icell);
-    TH1 *h2 = (TH1*)(gDirectory->Get(hname2));
+    char hname3[256];
+    sprintf(hname3, "fdc_pseudo_measured_cell[%d]", icell);
+    TH2 *h3 = (TH2*)(gDirectory->Get(hname3));
+    char hname4[256];
+    sprintf(hname4, "fdc_pseudo_expected_cell[%d]", icell);
+    TH2 *h4 = (TH2*)(gDirectory->Get(hname4));
       
-    if(h && h2){
-      h->Divide(h2);
-      h->SetMinimum(minScale);
-      h->SetMaximum(maxScale);
-      h->GetXaxis()->SetTitle("X Position (cm)");
-      h->GetYaxis()->SetTitle("Y Position (cm)");
-      h->SetStats(0);
-      h->Draw("colz");
+    if(h3 && h4){
+      h3->Divide(h4);
+      // h3->SetMinimum(minScale);
+      // h3->SetMaximum(maxScale);
+      h3->GetXaxis()->SetTitle("X Position (cm)");
+      h3->GetYaxis()->SetTitle("Y Position (cm)");
+      h3->SetStats(0);
+      h3->Draw("colz");
     }
   }
 

--- a/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
+++ b/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
@@ -1,17 +1,17 @@
 // $Id$
 //
-//    File: JEventProcessor_CDC_Efficiency.cc
-// Created: Tue Sep  9 15:41:38 EDT 2014
-// Creator: hdcdcops (on Linux gluon05.jlab.org 2.6.32-358.18.1.el6.x86_64 x86_64)
+//    File: JEventProcessor_FDC_Efficiency.cc
+// Created: Thu May 26 15:57:38 EDT 2016
+// Creator: aaustreg
 //
 
 #include "JEventProcessor_FDC_Efficiency.h"
 using namespace jana;
 #include "HDGEOMETRY/DMagneticFieldMapNoField.h"
-#include "CDC/DCDCDigiHit.h"
+//#include "CDC/DCDCDigiHit.h"
 #include "FDC/DFDCWireDigiHit.h"
-#include "FDC/DFDCCathodeDigiHit.h"
-#include "DAQ/Df125CDCPulse.h"
+//#include "FDC/DFDCCathodeDigiHit.h"
+//#include "DAQ/Df125CDCPulse.h"
 #include "HistogramTools.h"
 
 static TH1D *fdc_wire_measured_cell[25]; //Filled with total actually detected before division at end
@@ -20,19 +20,23 @@ static TH1D *fdc_wire_expected_cell[25]; // Contains total number of expected hi
 static TH2D *fdc_pseudo_measured_cell[25]; //Filled with total actually detected before division at end
 static TH2D *fdc_pseudo_expected_cell[25]; // Contains total number of expected hits by DOCA
 
-//static TH1I *hCharge;
 static TH1I *hChi2OverNDF;
 static TH1I *hChi2OverNDF_accepted;
 static TH1I *hPseudoRes;
 static TH1I *hPseudoResX;
 static TH1I *hPseudoResY;
-static TH2I *hResVsT;
+//static TH2I *hResVsT;
 static TH1I *hMom;
 static TH1I *hMom_accepted;
+static TH1I *hTheta;
+static TH1I *hTheta_accepted;
+static TH1I *hPhi;
+static TH1I *hPhi_accepted;
 static TH1I *hCellsHit;
 static TH1I *hCellsHit_accepted;
 static TH1I *hRingsHit;
 static TH1I *hRingsHit_accepted;
+static TH2I *hRingsHit_vs_P;
 
 // Routine used to create our JEventProcessor
 #include <JANA/JApplication.h>
@@ -66,12 +70,6 @@ JEventProcessor_FDC_Efficiency::~JEventProcessor_FDC_Efficiency()
 //------------------
 jerror_t JEventProcessor_FDC_Efficiency::init(void)
 {
-  // For the overall 2D plots, thus DOCA cut is used
-  // DOCACUT = 0.35;
-  //   if(gPARMS){
-  //       gPARMS->SetDefaultParameter("CDC_EFFICIENCY:DOCACUT", DOCACUT, "DOCA Cut on Efficiency Measurement");
-  //   }  
-  
   // create root folder for fdc and cd to it, store main dir
   TDirectory *main = gDirectory;
   gDirectory->mkdir("FDC_Efficiency")->cd();
@@ -83,50 +81,38 @@ jerror_t JEventProcessor_FDC_Efficiency::init(void)
     char hname_expected[256];
     sprintf(hname_measured, "fdc_wire_measured_cell[%d]", icell+1);
     sprintf(hname_expected, "fdc_wire_expected_cell[%d]", icell+1);
-    if(gDirectory->Get(hname_measured) == NULL)
-      fdc_wire_measured_cell[icell+1] = new TH1D(hname_measured, "", 96, 0, 95);
-    if(gDirectory->Get(hname_expected) == NULL)
-      fdc_wire_expected_cell[icell+1] = new TH1D(hname_expected, "", 96, 0, 95);
+    fdc_wire_measured_cell[icell+1] = new TH1D(hname_measured, "", 96, 0, 95);
+    fdc_wire_expected_cell[icell+1] = new TH1D(hname_expected, "", 96, 0, 95);
 
     sprintf(hname_measured, "fdc_pseudo_measured_cell[%d]", icell+1);
     sprintf(hname_expected, "fdc_pseudo_expected_cell[%d]", icell+1);
-    if(gDirectory->Get(hname_measured) == NULL)
-      fdc_pseudo_measured_cell[icell+1] = new TH2D(hname_measured, "", 100, -50, 50, 100, -50, 50);
-    if(gDirectory->Get(hname_expected) == NULL)
-      fdc_pseudo_expected_cell[icell+1] = new TH2D(hname_expected, "", 100, -50, 50, 100, -50, 50);
+    fdc_pseudo_measured_cell[icell+1] = new TH2D(hname_measured, "", 100, -50, 50, 100, -50, 50);
+    fdc_pseudo_expected_cell[icell+1] = new TH2D(hname_expected, "", 100, -50, 50, 100, -50, 50);
   }	
 
   gDirectory->cd("/FDC_Efficiency");
   gDirectory->mkdir("Track_Quality")->cd();
-  if(gDirectory->Get("hChi2OverNDF") == NULL)
-    hChi2OverNDF = new TH1I("hChi2OverNDF","hChi2OverNDF", 500, 0.0, 1.0);
-  if(gDirectory->Get("hChi2OverNDF_accepted") == NULL)
-    hChi2OverNDF_accepted = new TH1I("hChi2OverNDF_accepted","hChi2OverNDF_accepted", 500, 0.0, 1.0);
-  if(gDirectory->Get("hMom") == NULL)
-    hMom = new TH1I("hMom","Momentum", 500, 0.0, 10);
-  if(gDirectory->Get("hMom_accepted") == NULL)
-    hMom_accepted = new TH1I("hMom_accepted","Momentum (accepted)", 500, 0.0, 10);
-  // if(gDirectory->Get("hCharge") == NULL)
-  //   hCharge = new TH1I("hCharge", "Charge of Wire Hit", 800, 0, 8.0);
-  if(gDirectory->Get("hCellsHit") == NULL)
-    hCellsHit = new TH1I("hCellsHit", "Cells of FDC Contributing to Track", 25, -0.5, 24.5);
-  if(gDirectory->Get("hCellsHit_accepted") == NULL)
-    hCellsHit_accepted = new TH1I("hCellsHit_accepted", "Cells of FDC Contributing to Track (accepted)", 25, -0.5, 24.5);
-  if(gDirectory->Get("hRingsHit") == NULL)
-    hRingsHit = new TH1I("hRingsHit", "Rings of CDC Contributing to Track", 29, -0.5, 28.5);
-  if(gDirectory->Get("hRingsHit_accepted") == NULL)
-    hRingsHit_accepted = new TH1I("hRingsHit_accepted", "Rings of CDC Contributing to Track (accepted)", 25, -0.5, 24.5);
+  hChi2OverNDF = new TH1I("hChi2OverNDF","hChi2OverNDF", 500, 0.0, 1.0);
+  hChi2OverNDF_accepted = new TH1I("hChi2OverNDF_accepted","hChi2OverNDF_accepted", 500, 0.0, 1.0);
+  hMom = new TH1I("hMom","Momentum", 500, 0.0, 10);
+  hMom_accepted = new TH1I("hMom_accepted","Momentum (accepted)", 500, 0.0, 10);
+  hTheta = new TH1I("hTheta","Theta of Track", 500, 0.0, 50);
+  hTheta_accepted = new TH1I("hTheta_accepted","Theta of Track (accepted)", 500, 0.0, 50);
+  hPhi = new TH1I("hPhi","Phi of Track", 360, -180, 180);
+  hPhi_accepted = new TH1I("hPhi_accepted","Phi of Track (accepted)", 360, -180, 180);
+  hCellsHit = new TH1I("hCellsHit", "Cells of FDC Contributing to Track", 25, -0.5, 24.5);
+  hCellsHit_accepted = new TH1I("hCellsHit_accepted", "Cells of FDC Contributing to Track (accepted)", 25, -0.5, 24.5);
+  hRingsHit = new TH1I("hRingsHit", "Rings of CDC Contributing to Track", 29, -0.5, 28.5);
+  hRingsHit_accepted = new TH1I("hRingsHit_accepted", "Rings of CDC Contributing to Track (accepted)", 25, -0.5, 24.5);
+  
+  hRingsHit_vs_P = new TH2I("hRingsHit_vs_P", "Rings of CDC Contributing to Track vs P (accepted)", 25, -0.5, 24.5, 34, 0.6, 4);
 
   gDirectory->cd("/FDC_Efficiency");
   gDirectory->mkdir("Residuals")->cd();
-  if(gDirectory->Get("hResVsT") == NULL)
-    hResVsT = new TH2I("hResVsT","Tracking Residual (Biased) Vs Wire Drift Time; Drift Time [ns]; Residual [cm]", 700, 0, 70000, 100, 0, 0.5);
-  if(gDirectory->Get("hPseudoRes") == NULL)
-    hPseudoRes = new TH1I("hPseudoRes","Pseudo Residual", 100, 0, 10);
-  if(gDirectory->Get("hPseudoResX") == NULL)
-    hPseudoResX = new TH1I("hPseudoResX","Pseudo Residual in X", 100, -5, 5);
-  if(gDirectory->Get("hPseudoResY") == NULL)
-    hPseudoResY = new TH1I("hPseudoResY","Pseudo Residual in Y", 100, -5, 5);
+  //   hResVsT = new TH2I("hResVsT","Tracking Residual (Biased) Vs Wire Drift Time; Drift Time [ns]; Residual [cm]", 700, 0, 70000, 100, 0, 0.5);
+  hPseudoRes = new TH1I("hPseudoRes","Pseudo Residual", 100, 0, 10);
+  hPseudoResX = new TH1I("hPseudoResX","Pseudo Residual in X", 100, -5, 5);
+  hPseudoResY = new TH1I("hPseudoResY","Pseudo Residual in Y", 100, -5, 5);
   main->cd();
 
   return NOERROR;
@@ -171,8 +157,24 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
   vector< const DFDCPseudo *> locFDCPseudoVector;
   loop->Get(locFDCPseudoVector);
 
+  //Pre-sort WireDigiHits by ring to save time
+  //only need to search within the given cell, wire
+  map<int, map<int, set<const DFDCWireDigiHit*> > > locSortedFDCWireDigiHits; //first int: cell //second int: wire
+  for( unsigned int hitNum = 0; hitNum < locFDCWireDigiHitVector.size(); hitNum++){
+    const DFDCWireDigiHit * locHit = locFDCWireDigiHitVector[hitNum];
+    locSortedFDCWireDigiHits[((locHit->package - 1 ) * 6) + locHit->chamber][locHit->wire].insert(locHit);
+  }
+
+  //Pre-sort PseudoHits by ring to save time
+  //only need to search within the given cell
+  map<int, set<const DFDCPseudo*> > locSortedFDCPseudos; // int: cell
+  for( unsigned int hitNum = 0; hitNum < locFDCPseudoVector.size(); hitNum++){
+    const DFDCPseudo * locPseudo = locFDCPseudoVector[hitNum];
+    locSortedFDCPseudos[locPseudo->wire->layer].insert(locPseudo);
+  }
+  
   const DDetectorMatches *detMatches;
-  vector<DSCHitMatchParams> SCMatches;
+  //vector<DSCHitMatchParams> SCMatches;
   vector<DTOFHitMatchParams> TOFMatches;
   vector<DBCALShowerMatchParams> BCALMatches;
 
@@ -186,10 +188,6 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
   for (unsigned int iTrack = 0; iTrack < chargedTrackVector.size(); iTrack++){
 
     const DChargedTrackHypothesis* bestHypothesis = chargedTrackVector[iTrack]->Get_BestTrackingFOM();
-
-    // Require Single track events
-    //if (trackCandidateVector.size() != 1) return NOERROR;
-    //const DTrackCandidate* thisTrackCandidate = trackCandidateVector[0];
 
     // Cut very loosely on the track quality
     const DTrackTimeBased *thisTimeBasedTrack;
@@ -218,35 +216,50 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
     }
     unsigned int cells = cellsHit.size();
     unsigned int rings = ringsHit.size();
-
+    
     if (cells == 0) continue;
 
+    double theta_deg = thisTimeBasedTrack->momentum().Theta()*TMath::RadToDeg();
+    double phi_deg = thisTimeBasedTrack->momentum().Phi()*TMath::RadToDeg();
+    double tmom = thisTimeBasedTrack->pmag();
+    
     // Fill Histograms for all Tracks    
     japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
     hCellsHit->Fill(cells);
     hRingsHit->Fill(rings);
     hChi2OverNDF->Fill(thisTimeBasedTrack->FOM);
-    hMom->Fill(thisTimeBasedTrack->pmag());
+    hMom->Fill(tmom);
+    hTheta->Fill(theta_deg);
+    hPhi->Fill(phi_deg);
     japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
     // All Cuts on Track Quality:
     
-    if (thisTimeBasedTrack->FOM < 5.73303E-7) return NOERROR; // 5 sigma cut from Paul
+    if (thisTimeBasedTrack->FOM < 1E-20)
+      continue;  // cut from Mike, works better due to the general bad quality of FDC tracks
+    // if (thisTimeBasedTrack->FOM < 5.73303E-7) 
+    //   continue; // 5 sigma cut from Paul
     if(!dIsNoFieldFlag){ // Quality cuts for Field on runs.
-      if(thisTimeBasedTrack->pmag() < .6) {
-      	continue; // Cut on the reconstructed momentum below 600MeV, no curlers
-      }
-      if (thisTimeBasedTrack->pmag() < 2 && rings < 10){
-      	continue; // for Low-Momentum Tracks < 2 GeV, check number of hits in CDC
-      }
-      if(!detMatches->Get_SCMatchParams(thisTimeBasedTrack, SCMatches)) {
-       	continue; // At least one match to the Start Counter
-      }
+      if(tmom < 1)
+      	continue; // Cut on the reconstructed momentum below 800MeV, no curlers
+      if (tmom < 1.2 && rings < 12)
+       	continue; // for Low-Momentum Tracks < 2 GeV, check number of hits in CDC
+      if (tmom < 1.4 && rings < 10)
+       	continue; // for Low-Momentum Tracks < 2 GeV, check number of hits in CDC
+      if (tmom < 1.6 && rings < 8)
+       	continue; // for Low-Momentum Tracks < 2 GeV, check number of hits in CDC
+      if (tmom < 1.8 && rings < 6)
+       	continue; // for Low-Momentum Tracks < 2 GeV, check number of hits in CDC
+      if (tmom < 2 && rings < 4)
+       	continue; // for Low-Momentum Tracks < 2 GeV, check number of hits in CDC
+      // if(!detMatches->Get_SCMatchParams(thisTimeBasedTrack, SCMatches)) {
+      //  	continue; // At least one match to the Start Counter
+      // }
       if(!detMatches->Get_TOFMatchParams(thisTimeBasedTrack, TOFMatches) && !detMatches->Get_BCALMatchParams(thisTimeBasedTrack,BCALMatches)) {
 	continue; // At least one match either to the Time-Of-Flight (forward) OR the BCAL (large angles)
       }
     }
-    else return NOERROR; // Field off not supported for now
+    else return NOERROR; // Field off not supported for now !!
     
     // count how many hits in each package (= 6 cells)
     unsigned int packageHit[4] = {0,0,0,0};
@@ -255,18 +268,21 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
     
     unsigned int minCells = 4; //At least 4 cells hit in any package for relatively "unbiased" efficiencies
     if (packageHit[0] < minCells && packageHit[1] < minCells && packageHit[2] < minCells && packageHit[3] < minCells) continue;
-
+    
     // Fill Histograms for accepted Tracks
     japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
     hCellsHit_accepted->Fill(cells);
-    if (thisTimeBasedTrack->pmag() < 2)
-      hRingsHit_accepted->Fill(rings);
+    //if (tmom < 2)
+    hRingsHit_accepted->Fill(rings);
     hChi2OverNDF_accepted->Fill(thisTimeBasedTrack->FOM);
-    hMom_accepted->Fill(thisTimeBasedTrack->pmag());
+    hMom_accepted->Fill(tmom);
+    hTheta_accepted->Fill(theta_deg);
+    hPhi_accepted->Fill(phi_deg);
+    hRingsHit_vs_P->Fill(rings, tmom);
     japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
-        
+    
     // Start efficiency computation with these tracks
-
+    
     // Loop over cells (24)
     for (unsigned int cellIndex = 0; cellIndex < fdcwires.size(); cellIndex ++){
       unsigned int cellNum = cellIndex +1;
@@ -275,6 +291,7 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
       // Use only tracks that have at least 4 (or other # of) hits in the package this cell is in
       // OR 12 hits in total !!
       if (packageHit[cellIndex / 6] < minCells && cells < 12) continue;
+      
 
       /////////////////// WIRE ANALYSIS /////////////////////////////////
 	
@@ -285,35 +302,35 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
 	double distanceToWire = thisTimeBasedTrack->rt->DistToRT(wire, &wireLength);
 	bool expectHit = false;
 
-	// starting from here, only histograms with distance to wire > 0.5, maybe change later
+	// starting from here, only histograms with distance to wire < 0.5, maybe change later
 	if (distanceToWire < 0.5 )
 	  expectHit = true;
+
+	//SKIP IF NOT CLOSE (from Paul)
+	if(distanceToWire > 50.0)
+	  {
+	    wireIndex += 30;
+	    continue;
+	  }
+	if(distanceToWire > 20.0)
+	  {
+	    wireIndex += 10;
+	    continue;
+	  }
+	if(distanceToWire > 10.0)
+	  {
+	    wireIndex += 5;
+	    continue;
+	  }
+
 	  
 	if (expectHit && fdc_wire_expected_cell[cellNum] != NULL && cellNum < 25){
-	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs DOCA",
-			  distanceToWire,
-			  "Expected Hits",
-			  100, 0 , 0.5);
-	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs Tracking FOM",
-			  thisTimeBasedTrack->FOM,
-			  "Expected Hits",
-			  100, 0 , 1.0);
-	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs theta",
-			  thisTimeBasedTrack->momentum().Theta()*TMath::RadToDeg(),
-			  "Expected Hits",
-			  100, 0, 180);
-	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs phi",
-			  thisTimeBasedTrack->momentum().Phi()*TMath::RadToDeg(),
-			  "Measured Hits",
-			  100, -180, 180);
-	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs p",
-			  thisTimeBasedTrack->pmag(),
-			  "Expected Hits",
-			  100, 0 , 10.0);
-	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs Hit Cells",
-			  cells,
-			  "Expected Hits",
-			  25, -0.5 , 24.5);
+	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs DOCA", distanceToWire, "Expected Hits", 100, 0 , 0.5);
+	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs Tracking FOM", thisTimeBasedTrack->FOM, "Expected Hits", 100, 0 , 1.0);
+	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs theta", theta_deg, "Expected Hits", 100, 0, 180);
+	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs phi", phi_deg, "Measured Hits", 100, -180, 180);
+	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs p", tmom, "Expected Hits", 100, 0 , 10.0);
+	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs Hit Cells", cells, "Expected Hits", 25, -0.5 , 24.5);
 	  
 	  Double_t w, v;
 	  if(fdc_wire_expected_cell[cellNum] != NULL && cellNum < 25){
@@ -326,60 +343,37 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
 	  
 	  
 	  bool foundHit = false;
-	  // loop over the FDC Wire Hits to look for a match
-	  for( unsigned int hitNum = 0; hitNum < locFDCWireDigiHitVector.size(); hitNum++){
-	    const DFDCWireDigiHit * locHit = locFDCWireDigiHitVector[hitNum];
-	    if (((locHit->package - 1 ) * 6) + locHit->chamber == cellNum && locHit->wire == wireNum){
-	      foundHit = true;
-	      Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs DOCA",
-			      distanceToWire,
-			      "Measured Hits",
-			      100, 0 , 0.5);
-	      Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs Tracking FOM",
-			      thisTimeBasedTrack->FOM,
-			      "Measured Hits",
-			      100, 0 , 1.0);
-	      Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs theta",
-			      thisTimeBasedTrack->momentum().Theta()*TMath::RadToDeg(),
-			      "Measured Hits",
-			      100, 0, 180);
-	      Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs phi",
-			      thisTimeBasedTrack->momentum().Phi()*TMath::RadToDeg(),
-			      "Measured Hits",
-			      100, -180, 180);
-	      Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs p",
-			      thisTimeBasedTrack->pmag(),
-			      "Measured Hits",
-			      100, 0 , 10.0);
-	      Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs Hit Cells",
-			      cells,
-			      "Measured Hits",
-			      25, -0.5 , 24.5);
-
-	  
-	      japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
-	      v = fdc_wire_measured_cell[cellNum]->GetBinContent(wireNum, 1) + 1.0;
-	      fdc_wire_measured_cell[cellNum]->SetBinContent(wireNum, 1, v);
-	      
-	      hResVsT->Fill(locHit->time, distanceToWire);
-
-	      japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
-	    }
-	    // break to avoid double conting
-	    if (foundHit) break; 
+	  // look in the presorted FDC WireDigiHits for a match
+	  if(!locSortedFDCWireDigiHits[cellNum][wireNum].empty() || !locSortedFDCWireDigiHits[cellNum][wireNum-1].empty() || !locSortedFDCWireDigiHits[cellNum][wireNum+1].empty()){
+	    // Look not only in one wire, but also in adjacent ones (?)
+	    // This can remove the dependence on the track error
 	    
-	  } // End wire hit loop
-	} // End expected hit loop
+	    foundHit = true;
+	    Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs DOCA", distanceToWire, "Measured Hits", 100, 0 , 0.5);
+	    Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs Tracking FOM", thisTimeBasedTrack->FOM, "Measured Hits", 100, 0 , 1.0);
+	    Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs theta", theta_deg, "Measured Hits", 100, 0, 180);
+	    Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs phi", phi_deg, "Measured Hits", 100, -180, 180);
+	    Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs p", tmom, "Measured Hits", 100, 0 , 10.0);
+	    Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs Hit Cells", cells, "Measured Hits", 25, -0.5 , 24.5);
+	    
+	    japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+	    v = fdc_wire_measured_cell[cellNum]->GetBinContent(wireNum, 1) + 1.0;
+	    fdc_wire_measured_cell[cellNum]->SetBinContent(wireNum, 1, v);
+	    //hResVsT->Fill(locHit->time, distanceToWire);
+	    japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+	  }
+	  
+	} // End expected
       } // End wire loop
       
 	// END WIRE ANALYSIS
-
+      
 
       
 	///////////// START PSEUDO ANALYSIS /////////////////////////////////////////
       
       
-      // different approach, start from tracks intersecting with cathode planes
+      // Different approach: start from tracks intersecting with wire planes
       DVector3 plane_origin(0.0, 0.0, fdcz[cellIndex]);
       DVector3 plane_normal(0.0, 0.0, 1.0);
             
@@ -397,45 +391,48 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
       }
 
       bool foundPseudo = false;
-      // loop over the FDC Pseudo Hits to look for a match
-      for(unsigned int pseudoNum = 0; pseudoNum < locFDCPseudoVector.size(); pseudoNum++){
-	const DFDCPseudo * locPseudo = locFDCPseudoVector[pseudoNum];
+      if(!locSortedFDCPseudos[cellNum].empty()){
 
-	if (locPseudo == NULL) continue;
-	if ((unsigned int) locPseudo->wire->layer != cellNum) continue;
-
-	DVector2 pseudoPosition = locPseudo->xy;
-	DVector2 interPosition2D(interPosition.X(), interPosition.Y());
-	
-	double residual2D = (pseudoPosition - interPosition2D).Mod();
-	double residualX = pseudoPosition.X() - interPosition2D.X();
-	double residualY = pseudoPosition.Y() - interPosition2D.Y();
-
-	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
-	hPseudoRes->Fill(residual2D);
-	hPseudoResX->Fill(residualX);
-	hPseudoResY->Fill(residualY);
-	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
-	
-	if (residual2D < 1){ // = 3 sigma in x and in y
-	  foundPseudo = true;
-	  
-	  if(fdc_pseudo_measured_cell[cellNum] != NULL && cellNum < 25){
-	    // fill histogramms with the predicted, not with the measured position
+	set<const DFDCPseudo*>& locPlanePseudos = locSortedFDCPseudos[cellNum];
+      	// loop over the FDC Pseudo Hits in that cell to look for a match
+	for(set<const DFDCPseudo*>::iterator locIterator = locPlanePseudos.begin();  locIterator !=  locPlanePseudos.end(); ++locIterator)
+	  {
+	    const DFDCPseudo * locPseudo = * locIterator;
+	    if (locPseudo == NULL) continue;
+	    
+	    DVector2 pseudoPosition = locPseudo->xy;
+	    DVector2 interPosition2D(interPosition.X(), interPosition.Y());
+	    
+	    double residual2D = (pseudoPosition - interPosition2D).Mod();
+	    double residualX = pseudoPosition.X() - interPosition2D.X();
+	    double residualY = pseudoPosition.Y() - interPosition2D.Y();
+	    
 	    japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
-	    fdc_pseudo_measured_cell[cellNum]->Fill(interPosition.X(), interPosition.Y());
+	    hPseudoRes->Fill(residual2D);
+	    hPseudoResX->Fill(residualX);
+	    hPseudoResY->Fill(residualY);
 	    japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
-	  }
-	}
-	
-
-	// break to avoid double conting
-	if (foundPseudo) break; 
-	
-      } // End Pseudo Hit loop
+	    
+	    if (foundPseudo) continue; 
+	    // to avoid double conting
+	    	    
+	    if (residual2D < 1.6){ // = 5 sigma in x and in y
+	      foundPseudo = true;
+	      
+	      if(fdc_pseudo_measured_cell[cellNum] != NULL && cellNum < 25){
+		// fill histogramms with the predicted, not with the measured position
+		japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+		fdc_pseudo_measured_cell[cellNum]->Fill(interPosition.X(), interPosition.Y());
+		japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+	      }
+	    }
+	    
+	    
+	  } // End Pseudo Hit loop
+      }
       
       // END PSEUDO ANALYSIS
-	
+      
     } // End cell loop
   } // End track loop
    

--- a/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
+++ b/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
@@ -1,0 +1,463 @@
+// $Id$
+//
+//    File: JEventProcessor_CDC_Efficiency.cc
+// Created: Tue Sep  9 15:41:38 EDT 2014
+// Creator: hdcdcops (on Linux gluon05.jlab.org 2.6.32-358.18.1.el6.x86_64 x86_64)
+//
+
+#include "JEventProcessor_FDC_Efficiency.h"
+using namespace jana;
+#include "HDGEOMETRY/DMagneticFieldMapNoField.h"
+#include "CDC/DCDCDigiHit.h"
+#include "FDC/DFDCWireDigiHit.h"
+#include "FDC/DFDCCathodeDigiHit.h"
+#include "DAQ/Df125CDCPulse.h"
+#include "HistogramTools.h"
+
+static TH1D *fdc_wire_measured_cell[25]; //Filled with total actually detected before division at end
+static TH1D *fdc_wire_expected_cell[25]; // Contains total number of expected hits by DOCA
+
+static TH2D *fdc_pseudo_measured_cell[25]; //Filled with total actually detected before division at end
+static TH2D *fdc_pseudo_expected_cell[25]; // Contains total number of expected hits by DOCA
+
+//static TH1I *hCharge;
+static TH1I *hChi2OverNDF;
+static TH1I *hChi2OverNDF_accepted;
+static TH1I *hPseudoRes;
+static TH1I *hPseudoResX;
+static TH1I *hPseudoResY;
+static TH2I *hResVsT;
+static TH1I *hMom;
+static TH1I *hMom_accepted;
+static TH1I *hCellsHit;
+static TH1I *hCellsHit_accepted;
+static TH1I *hRingsHit;
+static TH1I *hRingsHit_accepted;
+
+// Routine used to create our JEventProcessor
+#include <JANA/JApplication.h>
+#include <JANA/JFactory.h>
+extern "C"{
+void InitPlugin(JApplication *app){
+    InitJANAPlugin(app);
+    app->AddProcessor(new JEventProcessor_FDC_Efficiency());
+}
+} // "C"
+
+
+//------------------
+// JEventProcessor_FDC_Efficiency (Constructor)
+//------------------
+JEventProcessor_FDC_Efficiency::JEventProcessor_FDC_Efficiency()
+{
+    ;
+}
+
+//------------------
+// ~JEventProcessor_FDC_Efficiency (Destructor)
+//------------------
+JEventProcessor_FDC_Efficiency::~JEventProcessor_FDC_Efficiency()
+{
+    ;
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_FDC_Efficiency::init(void)
+{
+  // For the overall 2D plots, thus DOCA cut is used
+  // DOCACUT = 0.35;
+  //   if(gPARMS){
+  //       gPARMS->SetDefaultParameter("CDC_EFFICIENCY:DOCACUT", DOCACUT, "DOCA Cut on Efficiency Measurement");
+  //   }  
+  
+  // create root folder for fdc and cd to it, store main dir
+  TDirectory *main = gDirectory;
+  gDirectory->mkdir("FDC_Efficiency")->cd();
+  gDirectory->mkdir("FDC_View")->cd();
+
+  for(int icell=0; icell<24; icell++){
+      
+    char hname_measured[256];
+    char hname_expected[256];
+    sprintf(hname_measured, "fdc_wire_measured_cell[%d]", icell+1);
+    sprintf(hname_expected, "fdc_wire_expected_cell[%d]", icell+1);
+    if(gDirectory->Get(hname_measured) == NULL)
+      fdc_wire_measured_cell[icell+1] = new TH1D(hname_measured, "", 96, 0, 95);
+    if(gDirectory->Get(hname_expected) == NULL)
+      fdc_wire_expected_cell[icell+1] = new TH1D(hname_expected, "", 96, 0, 95);
+
+    sprintf(hname_measured, "fdc_pseudo_measured_cell[%d]", icell+1);
+    sprintf(hname_expected, "fdc_pseudo_expected_cell[%d]", icell+1);
+    if(gDirectory->Get(hname_measured) == NULL)
+      fdc_pseudo_measured_cell[icell+1] = new TH2D(hname_measured, "", 20, -50, 50, 20, -50, 50);
+    if(gDirectory->Get(hname_expected) == NULL)
+      fdc_pseudo_expected_cell[icell+1] = new TH2D(hname_expected, "", 20, -50, 50, 20, -50, 50);
+  }	
+
+  gDirectory->cd("/FDC_Efficiency");
+  gDirectory->mkdir("Track_Quality")->cd();
+  if(gDirectory->Get("hChi2OverNDF") == NULL)
+    hChi2OverNDF = new TH1I("hChi2OverNDF","hChi2OverNDF", 500, 0.0, 1.0);
+  if(gDirectory->Get("hChi2OverNDF_accepted") == NULL)
+    hChi2OverNDF_accepted = new TH1I("hChi2OverNDF_accepted","hChi2OverNDF_accepted", 500, 0.0, 1.0);
+  if(gDirectory->Get("hMom") == NULL)
+    hMom = new TH1I("hMom","Momentum", 500, 0.0, 10);
+  if(gDirectory->Get("hMom_accepted") == NULL)
+    hMom_accepted = new TH1I("hMom_accepted","Momentum (accepted)", 500, 0.0, 10);
+  // if(gDirectory->Get("hCharge") == NULL)
+  //   hCharge = new TH1I("hCharge", "Charge of Wire Hit", 800, 0, 8.0);
+  if(gDirectory->Get("hCellsHit") == NULL)
+    hCellsHit = new TH1I("hCellsHit", "Cells of FDC Contributing to Track", 25, -0.5, 24.5);
+  if(gDirectory->Get("hCellsHit_accepted") == NULL)
+    hCellsHit_accepted = new TH1I("hCellsHit_accepted", "Cells of FDC Contributing to Track (accepted)", 25, -0.5, 24.5);
+  if(gDirectory->Get("hRingsHit") == NULL)
+    hRingsHit = new TH1I("hRingsHit", "Rings of CDC Contributing to Track", 29, -0.5, 28.5);
+  if(gDirectory->Get("hRingsHit_accepted") == NULL)
+    hRingsHit_accepted = new TH1I("hRingsHit_accepted", "Rings of CDC Contributing to Track (accepted)", 25, -0.5, 24.5);
+
+  gDirectory->cd("/FDC_Efficiency");
+  gDirectory->mkdir("Residuals")->cd();
+  if(gDirectory->Get("hResVsT") == NULL)
+    hResVsT = new TH2I("hResVsT","Tracking Residual (Biased) Vs Wire Drift Time; Drift Time [ns]; Residual [cm]", 700, 0, 70000, 100, 0, 0.5);
+  if(gDirectory->Get("hPseudoRes") == NULL)
+    hPseudoRes = new TH1I("hPseudoRes","Pseudo Residual", 100, 0, 10);
+  if(gDirectory->Get("hPseudoResX") == NULL)
+    hPseudoResX = new TH1I("hPseudoResX","Pseudo Residual in X", 100, -5, 5);
+  if(gDirectory->Get("hPseudoResY") == NULL)
+    hPseudoResY = new TH1I("hPseudoResY","Pseudo Residual in Y", 100, -5, 5);
+  main->cd();
+
+  return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_FDC_Efficiency::brun(JEventLoop *eventLoop, int32_t runnumber)
+{
+  // This is called whenever the run number changes
+  DApplication* dapp=dynamic_cast<DApplication*>(eventLoop->GetJApplication());
+  dIsNoFieldFlag = (dynamic_cast<const DMagneticFieldMapNoField*>(dapp->GetBfield(runnumber)) != NULL);
+  //JCalibration *jcalib = dapp->GetJCalibration(runnumber);
+  dgeom  = dapp->GetDGeometry(runnumber);
+  //bfield = dapp->GetBfield();
+
+  // Get the position of the FDC wires from DGeometry
+  dgeom->GetFDCWires(fdcwires);
+
+  // Get the z position of the FDC planes from DGeometry
+  dgeom->GetFDCZ(fdcz);
+
+  // Get inner radii for FDC packages
+  dgeom->GetFDCRmin(fdcrmin);
+
+  // Get outer radius of FDC 
+  dgeom->GetFDCRmax(fdcrmax);
+		  
+  return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnumber){
+
+  vector< const DFDCHit *> locFDCHitVector;
+  loop->Get(locFDCHitVector);
+  vector< const DFDCWireDigiHit *> locFDCWireDigiHitVector;
+  loop->Get(locFDCWireDigiHitVector);
+  vector< const DFDCPseudo *> locFDCPseudoVector;
+  loop->Get(locFDCPseudoVector);
+
+  const DDetectorMatches *detMatches;
+  vector<DSCHitMatchParams> SCMatches;
+  vector<DTOFHitMatchParams> TOFMatches;
+  vector<DBCALShowerMatchParams> BCALMatches;
+
+  if(!dIsNoFieldFlag){
+    loop->GetSingle(detMatches);
+  }
+
+  vector <const DChargedTrack *> chargedTrackVector;
+  loop->Get(chargedTrackVector);
+
+  for (unsigned int iTrack = 0; iTrack < chargedTrackVector.size(); iTrack++){
+
+    const DChargedTrackHypothesis* bestHypothesis = chargedTrackVector[iTrack]->Get_BestTrackingFOM();
+
+    // Require Single track events
+    //if (trackCandidateVector.size() != 1) return NOERROR;
+    //const DTrackCandidate* thisTrackCandidate = trackCandidateVector[0];
+
+    // Cut very loosely on the track quality
+    const DTrackTimeBased *thisTimeBasedTrack;
+
+    bestHypothesis->GetSingle(thisTimeBasedTrack);
+
+    // First loop over the FDC/CDC hits of the track to find out how many cells/rings were hit
+    
+    // For the first track selection, use already pseudo hits from fdc
+    // Determine how many cells (FDC) and rings (CDC) contribute to track in total, and in which package
+    vector< int > cellsHit;
+    vector< int > ringsHit;
+    vector<DTrackFitter::pull_t> pulls = thisTimeBasedTrack->pulls;
+    for (unsigned int i = 0; i < pulls.size(); i++){
+      const DFDCPseudo * thisTrackFDCHit = pulls[i].fdc_hit;
+      if (thisTrackFDCHit != NULL){      
+	if ( find(cellsHit.begin(), cellsHit.end(), thisTrackFDCHit->wire->layer) == cellsHit.end())
+	  cellsHit.push_back(thisTrackFDCHit->wire->layer);
+      }
+      
+      const DCDCTrackHit * thisTrackCDCHit = pulls[i].cdc_hit;
+      if (thisTrackCDCHit != NULL){
+	if ( find(ringsHit.begin(), ringsHit.end(), thisTrackCDCHit->wire->ring) == ringsHit.end())
+	  ringsHit.push_back(thisTrackCDCHit->wire->ring);
+      }
+    }
+    unsigned int cells = cellsHit.size();
+    unsigned int rings = ringsHit.size();
+
+    if (cells == 0) continue;
+
+    // Fill Histograms for all Tracks    
+    japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+    hCellsHit->Fill(cells);
+    hRingsHit->Fill(rings);
+    hChi2OverNDF->Fill(thisTimeBasedTrack->FOM);
+    hMom->Fill(thisTimeBasedTrack->pmag());
+    japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
+    // All Cuts on Track Quality:
+    
+    if (thisTimeBasedTrack->FOM < 5.73303E-7) return NOERROR; // 5 sigma cut from Paul
+    if(!dIsNoFieldFlag){ // Quality cuts for Field on runs.
+      if(thisTimeBasedTrack->pmag() < .6) {
+      	continue; // Cut on the reconstructed momentum below 600MeV, no curlers
+      }
+      if (thisTimeBasedTrack->pmag() < 2 && rings < 10){
+      	continue; // for Low-Momentum Tracks < 2 GeV, check number of hits in CDC
+      }
+      if(!detMatches->Get_SCMatchParams(thisTimeBasedTrack, SCMatches)) {
+       	continue; // At least one match to the Start Counter
+      }
+      if(!detMatches->Get_TOFMatchParams(thisTimeBasedTrack, TOFMatches) && !detMatches->Get_BCALMatchParams(thisTimeBasedTrack,BCALMatches)) {
+	continue; // At least one match either to the Time-Of-Flight (forward) OR the BCAL (large angles)
+      }
+    }
+    else return NOERROR; // Field off not supported for now
+    
+    // count how many hits in each package (= 6 cells)
+    unsigned int packageHit[4] = {0,0,0,0};
+    for (unsigned int i = 0; i < cells; i++)
+      packageHit[(cellsHit[i] - 1) / 6]++;
+    
+    unsigned int minCells = 5; //At least 4 cells hit in any package for relatively "unbiased" efficiencies
+    if (packageHit[0] < minCells && packageHit[1] < minCells && packageHit[2] < minCells && packageHit[3] < minCells) continue;
+
+    // Fill Histograms for accepted Tracks
+    japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+    hCellsHit_accepted->Fill(cells);
+    //if (thisTimeBasedTrack->pmag() < 2)
+    hRingsHit_accepted->Fill(rings);
+    hChi2OverNDF_accepted->Fill(thisTimeBasedTrack->FOM);
+    hMom_accepted->Fill(thisTimeBasedTrack->pmag());
+    japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+        
+    // Start efficiency computation with these tracks
+
+    // Loop over cells (24)
+    for (unsigned int cellIndex = 0; cellIndex < fdcwires.size(); cellIndex ++){
+      unsigned int cellNum = cellIndex +1;
+      vector< DFDCWire * > wireByNumber = fdcwires[cellIndex];
+
+      // Use only tracks that have at least 4 (or other # of) hits in the package this cell is in
+      // OR 12 hits in total !!
+      if (packageHit[cellIndex / 6] < minCells && cells < 12) continue;
+
+      /////////////////// WIRE ANALYSIS /////////////////////////////////
+	
+      for (unsigned int wireIndex = 0; wireIndex < wireByNumber.size(); wireIndex++){
+	unsigned int wireNum = wireIndex+1;
+	DFDCWire * wire = wireByNumber[wireIndex]; 
+	double wireLength = wire->L;
+	double distanceToWire = thisTimeBasedTrack->rt->DistToRT(wire, &wireLength);
+	bool expectHit = false;
+
+	// starting from here, only histograms with distance to wire > 0.5, maybe change later
+	if (distanceToWire < 0.5 )
+	  expectHit = true;
+	  
+	if (expectHit && fdc_wire_expected_cell[cellNum] != NULL && cellNum < 25){
+	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs DOCA",
+			  distanceToWire,
+			  "Expected Hits",
+			  100, 0 , 0.5);
+	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs Tracking FOM",
+			  thisTimeBasedTrack->FOM,
+			  "Expected Hits",
+			  100, 0 , 1.0);
+	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs theta",
+			  thisTimeBasedTrack->momentum().Theta()*TMath::RadToDeg(),
+			  "Expected Hits",
+			  100, 0, 180);
+	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs phi",
+			  thisTimeBasedTrack->momentum().Phi()*TMath::RadToDeg(),
+			  "Measured Hits",
+			  100, -180, 180);
+	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs p",
+			  thisTimeBasedTrack->pmag(),
+			  "Expected Hits",
+			  100, 0 , 10.0);
+	  Fill1DHistogram("FDC_Efficiency", "Offline", "Expected Hits Vs Hit Cells",
+			  cells,
+			  "Expected Hits",
+			  25, -0.5 , 24.5);
+	  
+	  Double_t w, v;
+	  if(fdc_wire_expected_cell[cellNum] != NULL && cellNum < 25){
+	    // FILL HISTOGRAMS
+	    japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+	    w = fdc_wire_expected_cell[cellNum]->GetBinContent(wireNum, 1) + 1.0;
+	    fdc_wire_expected_cell[cellNum]->SetBinContent(wireNum, 1, w);
+	    japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+	  }
+	  
+	  
+	  bool foundHit = false;
+	  // loop over the FDC Wire Hits to look for a match
+	  for( unsigned int hitNum = 0; hitNum < locFDCWireDigiHitVector.size(); hitNum++){
+	    const DFDCWireDigiHit * locHit = locFDCWireDigiHitVector[hitNum];
+	    if (((locHit->package - 1 ) * 6) + locHit->chamber == cellNum && locHit->wire == wireNum){
+	      foundHit = true;
+	      Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs DOCA",
+			      distanceToWire,
+			      "Measured Hits",
+			      100, 0 , 0.5);
+	      Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs Tracking FOM",
+			      thisTimeBasedTrack->FOM,
+			      "Measured Hits",
+			      100, 0 , 1.0);
+	      Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs theta",
+			      thisTimeBasedTrack->momentum().Theta()*TMath::RadToDeg(),
+			      "Measured Hits",
+			      100, 0, 180);
+	      Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs phi",
+			      thisTimeBasedTrack->momentum().Phi()*TMath::RadToDeg(),
+			      "Measured Hits",
+			      100, -180, 180);
+	      Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs p",
+			      thisTimeBasedTrack->pmag(),
+			      "Measured Hits",
+			      100, 0 , 10.0);
+	      Fill1DHistogram("FDC_Efficiency", "Offline", "Measured Hits Vs Hit Cells",
+			      cells,
+			      "Measured Hits",
+			      25, -0.5 , 24.5);
+
+	  
+	      japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+	      v = fdc_wire_measured_cell[cellNum]->GetBinContent(wireNum, 1) + 1.0;
+	      fdc_wire_measured_cell[cellNum]->SetBinContent(wireNum, 1, v);
+	      
+	      hResVsT->Fill(locHit->time, distanceToWire);
+
+	      japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+	    }
+	    // break to avoid double conting
+	    if (foundHit) break; 
+	    
+	  } // End wire hit loop
+	} // End expected hit loop
+      } // End wire loop
+      
+	// END WIRE ANALYSIS
+
+
+      
+	///////////// START PSEUDO ANALYSIS /////////////////////////////////////////
+      
+      
+      // different approach, start from tracks intersecting with cathode planes
+      DVector3 plane_origin(0.0, 0.0, fdcz[cellIndex]);
+      DVector3 plane_normal(0.0, 0.0, 1.0);
+            
+      DVector3 interPosition;
+      thisTimeBasedTrack->rt->GetIntersectionWithPlane(plane_origin, plane_normal, interPosition);
+
+      int packageIndex = (cellNum - 1) / 6;
+      if (interPosition.Perp() < fdcrmin[packageIndex] || interPosition.Perp() > fdcrmax) continue;
+
+      if(fdc_pseudo_expected_cell[cellNum] != NULL && cellNum < 25){
+	// FILL HISTOGRAMS
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+	fdc_pseudo_expected_cell[cellNum]->Fill(interPosition.X(), interPosition.Y());
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+      }
+
+      bool foundPseudo = false;
+      // loop over the FDC Pseudo Hits to look for a match
+      for(unsigned int pseudoNum = 0; pseudoNum < locFDCPseudoVector.size(); pseudoNum++){
+	const DFDCPseudo * locPseudo = locFDCPseudoVector[pseudoNum];
+
+	if (locPseudo == NULL) continue;
+	if ((unsigned int) locPseudo->wire->layer != cellNum) continue;
+
+	DVector2 pseudoPosition = locPseudo->xy;
+	DVector2 interPosition2D(interPosition.X(), interPosition.Y());
+	
+	double residual2D = (pseudoPosition - interPosition2D).Mod();
+	double residualX = pseudoPosition.X() - interPosition2D.X();
+	double residualY = pseudoPosition.Y() - interPosition2D.Y();
+
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+	hPseudoRes->Fill(residual2D);
+	hPseudoResX->Fill(residualX);
+	hPseudoResY->Fill(residualY);
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+	
+	if (residual2D < 1){ // = 3 sigma in x and in y
+	  foundPseudo = true;
+	  
+	  if(fdc_pseudo_measured_cell[cellNum] != NULL && cellNum < 25){
+	    // fill histogramms with the predicted, not with the measured position
+	    japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+	    fdc_pseudo_measured_cell[cellNum]->Fill(interPosition.X(), interPosition.Y());
+	    japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+	  }
+	}
+	
+
+	// break to avoid double conting
+	if (foundPseudo) break; 
+	
+      } // End Pseudo Hit loop
+      
+      // END PSEUDO ANALYSIS
+	
+    } // End cell loop
+  } // End track loop
+   
+  return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_FDC_Efficiency::erun(void)
+{
+  // This is called whenever the run number changes, before it is
+  // changed to give you a chance to clean up before processing
+  // events from the next run number.
+  return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t JEventProcessor_FDC_Efficiency::fini(void)
+{
+  return NOERROR;
+}
+

--- a/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
+++ b/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
@@ -91,9 +91,9 @@ jerror_t JEventProcessor_FDC_Efficiency::init(void)
     sprintf(hname_measured, "fdc_pseudo_measured_cell[%d]", icell+1);
     sprintf(hname_expected, "fdc_pseudo_expected_cell[%d]", icell+1);
     if(gDirectory->Get(hname_measured) == NULL)
-      fdc_pseudo_measured_cell[icell+1] = new TH2D(hname_measured, "", 20, -50, 50, 20, -50, 50);
+      fdc_pseudo_measured_cell[icell+1] = new TH2D(hname_measured, "", 100, -50, 50, 100, -50, 50);
     if(gDirectory->Get(hname_expected) == NULL)
-      fdc_pseudo_expected_cell[icell+1] = new TH2D(hname_expected, "", 20, -50, 50, 20, -50, 50);
+      fdc_pseudo_expected_cell[icell+1] = new TH2D(hname_expected, "", 100, -50, 50, 100, -50, 50);
   }	
 
   gDirectory->cd("/FDC_Efficiency");
@@ -253,14 +253,14 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
     for (unsigned int i = 0; i < cells; i++)
       packageHit[(cellsHit[i] - 1) / 6]++;
     
-    unsigned int minCells = 5; //At least 4 cells hit in any package for relatively "unbiased" efficiencies
+    unsigned int minCells = 4; //At least 4 cells hit in any package for relatively "unbiased" efficiencies
     if (packageHit[0] < minCells && packageHit[1] < minCells && packageHit[2] < minCells && packageHit[3] < minCells) continue;
 
     // Fill Histograms for accepted Tracks
     japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
     hCellsHit_accepted->Fill(cells);
-    //if (thisTimeBasedTrack->pmag() < 2)
-    hRingsHit_accepted->Fill(rings);
+    if (thisTimeBasedTrack->pmag() < 2)
+      hRingsHit_accepted->Fill(rings);
     hChi2OverNDF_accepted->Fill(thisTimeBasedTrack->FOM);
     hMom_accepted->Fill(thisTimeBasedTrack->pmag());
     japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK

--- a/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.h
+++ b/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.h
@@ -1,0 +1,67 @@
+// $Id$
+//
+//    File: JEventProcessor_FDC_Efficiency.h
+// Created: Tue Sep  9 15:41:38 EDT 2014
+// Creator: hdcdcops (on Linux gluon05.jlab.org 2.6.32-358.18.1.el6.x86_64 x86_64)
+//
+
+#ifndef _JEventProcessor_FDC_Efficiency_
+#define _JEventProcessor_FDC_Efficiency_
+
+//#include <pthread.h>
+#include <map>
+#include <vector>
+#include <deque>
+using namespace std;
+
+#include <TTree.h>
+#include <TFile.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TH3.h>
+#include <TMath.h>
+
+#include <JANA/JFactory.h>
+#include <JANA/JEventProcessor.h>
+#include <JANA/JEventLoop.h>
+#include <JANA/JCalibration.h>
+
+#include <HDGEOMETRY/DGeometry.h>
+#include <TRACKING/DTrackCandidate_factory_StraightLine.h>
+#include <TRACKING/DReferenceTrajectory.h>
+#include <TRACKING/DTrackWireBased.h>
+#include <PID/DChargedTrack.h>
+#include <PID/DDetectorMatches.h>
+#include <FDC/DFDCHit.h>
+#include <FDC/DFDCWireDigiHit.h>
+#include <FDC/DFDCCathodeDigiHit.h>
+
+class JEventProcessor_FDC_Efficiency:public jana::JEventProcessor{
+	public:
+		JEventProcessor_FDC_Efficiency();
+		~JEventProcessor_FDC_Efficiency();
+		const char* className(void){return "JEventProcessor_FDC_Efficiency";}
+
+	private:
+		jerror_t init(void);						///< Called once at program start.
+		jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+        DGeometry * dgeom;
+        bool dIsNoFieldFlag;
+	vector< vector< DFDCWire * > > fdcwires; // FDC Wires Referenced by [layer 1-24][wire 1-96]
+	vector<double> fdcz; // FDC z positions
+	vector<double> fdcrmin; // FDC inner radii
+	double fdcrmax; // FDC outer radius
+
+        vector<vector<double> >max_sag;
+        vector<vector<double> >sag_phi_offset;
+        int ChannelFromRingStraw[28][209];
+        int ROCIDFromRingStraw[28][209];
+        int SlotFromRingStraw[28][209];
+        double DOCACUT;
+};
+
+#endif // _JEventProcessor_FDC_Efficiency_
+

--- a/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.h
+++ b/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.h
@@ -1,8 +1,8 @@
 // $Id$
 //
-//    File: JEventProcessor_FDC_Efficiency.h
-// Created: Tue Sep  9 15:41:38 EDT 2014
-// Creator: hdcdcops (on Linux gluon05.jlab.org 2.6.32-358.18.1.el6.x86_64 x86_64)
+//    File: JEventProcessor_FDC_Efficiency.cc
+// Created: Thu May 26 15:57:38 EDT 2016
+// Creator: aaustreg
 //
 
 #ifndef _JEventProcessor_FDC_Efficiency_
@@ -34,33 +34,26 @@ using namespace std;
 #include <PID/DDetectorMatches.h>
 #include <FDC/DFDCHit.h>
 #include <FDC/DFDCWireDigiHit.h>
-#include <FDC/DFDCCathodeDigiHit.h>
+//#include <FDC/DFDCCathodeDigiHit.h>
 
 class JEventProcessor_FDC_Efficiency:public jana::JEventProcessor{
-	public:
-		JEventProcessor_FDC_Efficiency();
-		~JEventProcessor_FDC_Efficiency();
-		const char* className(void){return "JEventProcessor_FDC_Efficiency";}
-
-	private:
-		jerror_t init(void);						///< Called once at program start.
-		jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
-		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
-		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
-		jerror_t fini(void);						///< Called after last event of last event source has been processed.
-        DGeometry * dgeom;
-        bool dIsNoFieldFlag;
-	vector< vector< DFDCWire * > > fdcwires; // FDC Wires Referenced by [layer 1-24][wire 1-96]
-	vector<double> fdcz; // FDC z positions
-	vector<double> fdcrmin; // FDC inner radii
-	double fdcrmax; // FDC outer radius
-
-        vector<vector<double> >max_sag;
-        vector<vector<double> >sag_phi_offset;
-        int ChannelFromRingStraw[28][209];
-        int ROCIDFromRingStraw[28][209];
-        int SlotFromRingStraw[28][209];
-        double DOCACUT;
+ public:
+  JEventProcessor_FDC_Efficiency();
+  ~JEventProcessor_FDC_Efficiency();
+  const char* className(void){return "JEventProcessor_FDC_Efficiency";}
+  
+ private:
+  jerror_t init(void);						///< Called once at program start.
+  jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+  jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+  jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+  jerror_t fini(void);						///< Called after last event of last event source has been processed.
+  DGeometry * dgeom;
+  bool dIsNoFieldFlag;
+  vector< vector< DFDCWire * > > fdcwires; // FDC Wires Referenced by [layer 1-24][wire 1-96]
+  vector<double> fdcz; // FDC z positions
+  vector<double> fdcrmin; // FDC inner radii
+  double fdcrmax; // FDC outer radius
 };
 
 #endif // _JEventProcessor_FDC_Efficiency_

--- a/src/plugins/monitoring/FDC_Efficiency/SConscript
+++ b/src/plugins/monitoring/FDC_Efficiency/SConscript
@@ -1,0 +1,15 @@
+
+
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddROOTSpyMacros(env)
+sbms.AddJANA(env)
+sbms.AddDANA(env)
+sbms.AddROOT(env)
+sbms.plugin(env)
+
+

--- a/src/plugins/monitoring/SConscript
+++ b/src/plugins/monitoring/SConscript
@@ -10,6 +10,7 @@ subdirs = [
 'DAQ_online',
 'FCAL_online',
 'FDC_online',
+'FDC_Efficiency',
 'PSC_online',
 'RF_online',
 'pedestal_online',


### PR DESCRIPTION
Efficiency for FDC:
- Efficiency for Wires (similar to CDC_Efficiency)
- Efficiency for PseudoHits in 2D
- Some Track Quality Histograms
- ROOT Script to plot the results

Description:
- Tracking requires at least 3 hits in each package to form segment
- For efficiencies, ask for 4 hits in the studied package
- Or 12 in total to catch a completely missing package
- In order to limits the bias
