### PR TITLE
Convert DEventWriterROOT static thread_local variables to mutable.

### DIFF
--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -1,12 +1,5 @@
 #include "DEventWriterROOT.h"
 
-//TREE INTERFACES, FILL OBJECTS
-//Ugh.  Why are these thread_local? Because the user gets this object from JANA as const, so the class cannot be modified
-//So, these are not class members: they are static. To make sure that the threads don't need to lock on them, they are thread_local
-
-thread_local DTreeInterface* DEventWriterROOT::dThrownTreeInterface = NULL;
-thread_local DTreeFillData DEventWriterROOT::dThrownTreeFillData;
-
 DEventWriterROOT::DEventWriterROOT(JEventLoop* locEventLoop)
 {
 	dInitNumThrownArraySize = 20;
@@ -14,6 +7,7 @@ DEventWriterROOT::DEventWriterROOT(JEventLoop* locEventLoop)
 	dInitNumTrackArraySize = 50;
 	dInitNumNeutralArraySize = 15;
 	dInitNumComboArraySize = 100;
+	dThrownTreeInterface = NULL;
 
 	//BEWARE: IF THIS IS CHANGED, CHANGE IN THE BLUEPRINT FACTORY AND THE ANALYSIS UTILITIES ALSO!!
 	dTrackSelectionTag = "PreSelect";

--- a/src/libraries/ANALYSIS/DEventWriterROOT.h
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.h
@@ -102,10 +102,10 @@ class DEventWriterROOT : public JObject
 		/****************************************************************************************************************************************/
 
 		//TREE INTERFACES, FILL OBJECTS
-		//Ugh.  Why are these thread_local? Because the user gets this object from JANA as const, so the class cannot be modified
-		//So, these are not class members: they are static. To make sure that the threads don't need to lock on them, they are thread_local
-		static thread_local DTreeInterface* dThrownTreeInterface;
-		static thread_local DTreeFillData dThrownTreeFillData;
+		//The non-thrown objects are created during the constructor, and thus the maps can remain const
+		//The thrown objects are created later by the user (so they can specify file name), when the object is const, so they are declared mutable
+		mutable DTreeInterface* dThrownTreeInterface;
+		mutable DTreeFillData dThrownTreeFillData;
 		map<const DReaction*, DTreeInterface*> dTreeInterfaceMap;
 		map<const DReaction*, DTreeFillData*> dTreeFillDataMap;
 

--- a/src/libraries/ANALYSIS/DParticleCombo_factory.cc
+++ b/src/libraries/ANALYSIS/DParticleCombo_factory.cc
@@ -376,16 +376,10 @@ const DChargedTrackHypothesis* DParticleCombo_factory::Get_ChargedHypothesis(con
 {
 	for(size_t loc_l = 0; loc_l < locChargedTrackHypotheses.size(); ++loc_l)
 	{
-		vector<const DChargedTrackHypothesis*> locChargedTrackHypotheses_Associated;
-		locChargedTrackHypotheses[loc_l]->Get(locChargedTrackHypotheses_Associated);
-		for(size_t loc_m = 0; loc_m < locChargedTrackHypotheses_Associated.size(); ++loc_m)
-		{
-			if(locChargedTrackHypotheses_Associated[loc_m] != locKinematicData_Measured)
-				continue; //wrong track hypothesis
-			if(!locChargedTrackHypotheses[loc_l]->IsAssociated(locParticleCombo))
-				continue; // track created for a different particle combo
+		if(!locChargedTrackHypotheses[loc_l]->IsAssociated(locParticleCombo))
+			continue; // track created for a different particle combo
+		if(locChargedTrackHypotheses[loc_l]->IsAssociated(locKinematicData_Measured))
 			return locChargedTrackHypotheses[loc_l];
-		}
 	}
 	return dynamic_cast<const DChargedTrackHypothesis*>(locKinematicData_Measured); //not used in fit: re-set the measured
 }
@@ -394,16 +388,10 @@ const DNeutralParticleHypothesis* DParticleCombo_factory::Get_NeutralHypothesis(
 {
 	for(size_t loc_l = 0; loc_l < locNeutralParticleHypotheses.size(); ++loc_l)
 	{
-		vector<const DNeutralParticleHypothesis*> locNeutralParticleHypotheses_Associated;
-		locNeutralParticleHypotheses[loc_l]->Get(locNeutralParticleHypotheses_Associated);
-		for(size_t loc_m = 0; loc_m < locNeutralParticleHypotheses_Associated.size(); ++loc_m)
-		{
-			if(locNeutralParticleHypotheses_Associated[loc_m] != locKinematicData_Measured)
-				continue; //wrong track hypothesis
-			if(!locNeutralParticleHypotheses[loc_l]->IsAssociated(locParticleCombo))
-				continue; // track created for a different particle combo
+		if(!locNeutralParticleHypotheses[loc_l]->IsAssociated(locParticleCombo))
+			continue; // track created for a different particle combo
+		if(locNeutralParticleHypotheses[loc_l]->IsAssociated(locKinematicData_Measured))
 			return locNeutralParticleHypotheses[loc_l];
-		}
 	}
 	return dynamic_cast<const DNeutralParticleHypothesis*>(locKinematicData_Measured); //not used in fit: re-set the measured
 }


### PR DESCRIPTION
These are the tree interface objects for the thrown tree.
They cannot be created until after the user gives them a name, which they cannot do until they get the const DEventWriterROOT objects.
So, best to make these mutable. 

Also, significant speed-up when searching for associated objects in DParticleCombo factory. 
