### PR TITLE
Apple Clang: Skip plugins that require thread_local

### DIFF
--- a/src/plugins/monitoring/SConscript
+++ b/src/plugins/monitoring/SConscript
@@ -5,11 +5,9 @@ subdirs = [
 'occupancy_online',
 'BCAL_online',
 'BCAL_LEDonline',
-'BCAL_Hadronic_Eff',
 'CDC_online',
 'DAQ_online',
 'FCAL_online',
-'FCAL_Hadronic_Eff', 
 'FDC_online',
 'FDC_Efficiency',
 'PSC_online',
@@ -17,7 +15,6 @@ subdirs = [
 'pedestal_online',
 'PS_online',
 'PSPair_online',
-'SC_Eff', 
 'ST_online_lowlevel',
 'ST_online_tracking',
 'ST_online_Tresolution',
@@ -27,7 +24,6 @@ subdirs = [
 'TAGH_online',
 'TAGM_online',
 'TOF_online',
-'TOF_Eff',
 'TRIG_online',
 'TPOL_online',
 'CDC_expert',
@@ -38,7 +34,6 @@ subdirs = [
 'CDC_drift',
 'CDC_Cosmics',
 'EPICS_dump',
-'TS_scaler',
 'CDC_Efficiency',
 'L1_online']
 
@@ -46,6 +41,13 @@ subdirs = [
 #'CODA_online',
 #'EVNT_online',
 
+# Apple LLVM/Clang does not support thread_local at this time
+# Skip plugins that require thread_local if Apple LLVM is detected
+require_thread_local = ['BCAL_Hadronic_Eff','FCAL_Hadronic_Eff','SC_Eff','TOF_Eff','TS_scaler']
+if "llvm" not in env["OSNAME"]:
+	for directory in require_thread_local:
+		subdirs.append(directory)
+else: print "Apple Clang does not support thread_local at this time. Skipping\n", require_thread_local
+
 
 SConscript(dirs=subdirs, exports='env osname', duplicate=0)
-


### PR DESCRIPTION
Apple Clang/LLVM does not support thread_local at this time. Mac OS X
builds were failing for plugins that require thread_local because of
this. Skip compilation of plugins that require thread_local if Apple
Clang is detected.
