### PR TITLE
Do not require CERNLIB when building AMPTOOLS_MCGEN

### DIFF
--- a/src/libraries/AMPTOOLS_MCGEN/SConscript
+++ b/src/libraries/AMPTOOLS_MCGEN/SConscript
@@ -6,11 +6,14 @@ import sbms
 Import('*')
 
 # Verify AMPTOOLS environment variable is set
-if os.getenv('AMPTOOLS', 'nada')!='nada' and os.getenv('CERN', 'nada')!='nada':
+if os.getenv('AMPTOOLS') != None:
 
 	env = env.Clone()
-	
-	sbms.AddCERNLIB(env)
+
+	env.PrependUnique(FORTRANFLAGS = ['-ffixed-line-length-0', '-fno-second-underscore', '-fno-automatic'])
+	env.AppendUnique(LINKFLAGS = ['-rdynamic', '-Wl,--no-as-needed'])
+	env.SetOption('warn', 'no-fortran-cxx-mix')  # supress warnings about linking fortran with c++
+
 	sbms.AddAmpTools(env)
 	sbms.AddROOT(env)
 	sbms.library(env)


### PR DESCRIPTION
Replace requirement of CERNLIB with fortran params since this doesn't actually need cernlib.
