### PR TITLE
* external/xstream/src/z.cpp, bz.cpp [rtj]

### DIFF
--- a/src/external/xstream/include/xstream/bz.h
+++ b/src/external/xstream/include/xstream/bz.h
@@ -132,6 +132,9 @@ class ostreambuf: private common, public xstream::ostreambuf {
          */
         ~ostreambuf();
 
+        std::streambuf *get_streambuf() {
+            return _sb;
+        }
         std::streamoff get_block_offset() {
             return block_offset;
         }
@@ -193,6 +196,9 @@ class istreambuf: private common, public std::streambuf {
          */
         ~istreambuf();
 
+        std::streambuf *get_streambuf() {
+            return _sb;
+        }
         std::streamoff get_block_offset() {
             return block_offset;
         }

--- a/src/external/xstream/include/xstream/z.h
+++ b/src/external/xstream/include/xstream/z.h
@@ -159,6 +159,9 @@ class ostreambuf: public common, public xstream::ostreambuf {
          */
         ~ostreambuf();
 
+        std::streambuf *get_streambuf() {
+            return _sb;
+        }
         std::streamoff get_block_offset() {
             return block_offset;
         }
@@ -221,6 +224,9 @@ class istreambuf: public common, public std::streambuf{
          */
         ~istreambuf();
 
+        std::streambuf *get_streambuf() {
+            return _sb;
+        }
         std::streamoff get_block_offset() {
             return block_offset;
         }

--- a/src/external/xstream/src/bz.cpp
+++ b/src/external/xstream/src/bz.cpp
@@ -462,6 +462,10 @@ namespace bz {
         else { // look for prefixed blocksize: leading byte = 0
             block_size = block_pending;
             read = _sb->sgetn(in.buf, 4);
+            if (read < 4) {
+                end = true;
+                return;
+            }
             if (in.buf[0] == 0) { // bz2 blocks have prefixed blocksize
                 int *size = (int*)in.buf;
                 block_pending = ntohl(*size);
@@ -476,8 +480,8 @@ namespace bz {
         block_offset = 0;
 
         if (0 == read) {
-            LOG("\tpremature end of stream");
-            raise_error(BZ_UNEXPECTED_EOF);
+            end = true;
+            return;
         }
 
         // We want to be able to start decompression at an arbitrary position

--- a/src/external/xstream/src/z.cpp
+++ b/src/external/xstream/src/z.cpp
@@ -424,6 +424,10 @@ namespace z {
         }
         else { // look for prefixed blocksize: leading byte = 0
             read = _sb->sgetn(in.buf, 4);
+            if (read < 4) {
+                end = true;
+                return;
+            }
             if (in.buf[0] == 0) { // z blocks have prefixed blocksize
                 int *size = (int*)in.buf;
                 block_pending = ntohl(*size);
@@ -438,9 +442,8 @@ namespace z {
         block_offset = 0;
 
         if (0 == read) {
-            LOG("\tpremature end of stream");
-            //XXX throw exception
-            raise_error(Z_DATA_ERROR);
+            end = true;
+            return;
         }
 
         // We want to be able to start decompression at an arbitrary position


### PR DESCRIPTION
- add some addtional checks for eof condition on input hddm streams
  - external/xstream/include/xstream/z.h, bz.h [rtj]
- add getter methods for access to the underlying stream pointer
