### PR TITLE
Add AddRCDB to SBMS. (This is mostly work from Mark Ito).

### DIFF
--- a/src/SBMS/sbms.py
+++ b/src/SBMS/sbms.py
@@ -511,6 +511,7 @@ def AddDANA(env):
 	AddROOT(env)
 	AddJANA(env)
 	AddCCDB(env)
+	AddRCDB(env)
 	AddHDDS(env)
 	AddXERCES(env)
 	AddEVIO(env)
@@ -545,6 +546,26 @@ def AddCCDB(env):
 		env.AppendUnique(CPPPATH = CCDB_CPPPATH)
 		env.AppendUnique(LIBPATH = CCDB_LIBPATH)
 		env.AppendUnique(LIBS    = CCDB_LIBS)
+
+
+##################################
+# RCDB
+##################################
+def AddRCDB(env):
+	rcdb_home = os.getenv('RCDB_HOME')
+	if(rcdb_home != None) :
+		env.AppendUnique(CXXFLAGS = ['-DHAVE_RCDB'])
+		RCDB_CPPPATH = ["%s/cpp/include" % (rcdb_home), "%s/cpp/include/SQLite" % (rcdb_home)]
+		RCDB_LIBPATH = "%s/cpp/lib" % (rcdb_home)
+		RCDB_LIBS = ["rcdb"]
+		env.AppendUnique(CPPPATH = RCDB_CPPPATH)
+		env.AppendUnique(LIBPATH = RCDB_LIBPATH)
+		env.AppendUnique(LIBS    = RCDB_LIBS)
+
+		MYSQL_CFLAGS = subprocess.Popen(["mysql_config", "--cflags"], stdout=subprocess.PIPE).communicate()[0]
+		AddCompileFlags(env, MYSQL_CFLAGS)
+#		MYSQL_LINKFLAGS = subprocess.Popen(["mysql_config", "--libs"], stdout=subprocess.PIPE).communicate()[0]
+#		AddLinkFlags(env, MYSQL_LINKFLAGS)
 
 
 ##################################


### PR DESCRIPTION
This adds optional RCDB support to sim-recon. One needs only to set RCDB_HOME environment variable. On JLab CUE, this can be set to:

/group/halld/Software/builds/Linux_CentOS6-x86_64-gcc4.9.2/rcdb/rcdb-0.00
