### PR TITLE
Avoid seg. faults in hdgeant when reading hddm input file that doesn't contain target info.

### DIFF
--- a/src/programs/Simulation/HDGeant/hddmInput.c
+++ b/src/programs/Simulation/HDGeant/hddmInput.c
@@ -172,7 +172,7 @@ int loadInput (int override_run_number, int myInputRunNo)
          beam_momentum[3] = 0;
       }
 
-      if (target)
+      if ( (target!=NULL) && (target!=&hddm_s_nullTarget))
       {
          target_momentum[0] = target->momentum->E;
          target_momentum[1] = target->momentum->px;


### PR DESCRIPTION
Check if target is set to hddm_s_nullTarget and not simply if it is NULL. This was causing crashes with an input file that did not include target information.
