### PR TITLE
Warn user when using pions. Allow target specification at run time.

### DIFF
--- a/src/programs/Simulation/gen_2mu/gen_2mu.cc
+++ b/src/programs/Simulation/gen_2mu/gen_2mu.cc
@@ -182,6 +182,9 @@ void Usage(string message)
 	//cout << " --help       print the long form help message" << endl;
 	cout << " -N events    number of events to generate" << endl;
 	cout << " -o filename  set output filename (def. is gen_2mu.hddm)" << endl;
+	cout << " -T target    set target by name (Pb208, Sn116, C12, H)" << endl;
+	cout << " -A A         set target A (def. " << A << ")" << endl;
+	cout << " -Z Z         set target Z (def. " << Z << ")" << endl;
 	cout << " -p Epeak     coherent peak energy (def="<<Ecoherent_peak<<")" << endl;
 	cout << " -b Ebeam     electron beam energy (def="<<Eelectron_beam<<")" << endl;
 	cout << " -min Emin    minimum photon energy to generate (def="<<Emin<<")" << endl;
@@ -195,6 +198,13 @@ void Usage(string message)
 	cout << " -pions       Make particles pions instead of muons (carfeul!)" << endl;
 	cout << " -debug       create and fill debug histograms in ROOT file" << endl;
 	cout << endl;
+	cout << "Generate mu+mu- pair events. This combines the muon pair production code" << endl;
+	cout << "from GEANT4, the coherent bremstrahlung photon spectrum from HDGeant4, " << endl;
+	cout << "and some angle adjustments to account for beam polarization." <<endl;
+	cout << endl;
+	cout << "One may specify the target type either by name (-T option) or by" << endl;
+	cout << "A and Z explicitly. Valid target names are Pb208, Sn116, C12, and H." << endl;
+	cout << endl; 
 	if(message!=""){
 		cout << message << endl;
 		cout << endl;
@@ -230,6 +240,43 @@ void ParseCommandLineArguments(int narg, char *argv[])
 		}else if(arg=="-o"){
 			if(has_arg){
 				OUTPUT_FILENAME = next;
+				i++;
+			}else{
+				missing_arg = true;
+			}
+		}else if(arg=="-A"){
+			if(has_arg){
+				A = atof(next.c_str());
+				i++;
+			}else{
+				missing_arg = true;
+			}
+		}else if(arg=="-Z"){
+			if(has_arg){
+				Z = atof(next.c_str());
+				i++;
+			}else{
+				missing_arg = true;
+			}
+		}else if(arg=="-T"){
+			if(has_arg){
+				if(next=="Pb208"){
+					A = 208.0;
+					Z = 82.0;
+				}else if(next=="Sn116"){
+					A = 116.0;
+					Z = 50.0;
+				}else if(next=="C12"){
+					A = 12.0;
+					Z = 6.0;
+				}else if(next=="H"){
+					A = 1.0;
+					Z = 1.0;
+				}else{
+					cerr << endl << "Unown target type \""<<next<<"\"!!" << endl;
+					cerr << "(run gen_2mu -h for valid options)" << endl;
+					exit(-1);
+				}
 				i++;
 			}else{
 				missing_arg = true;
@@ -292,6 +339,22 @@ void ParseCommandLineArguments(int narg, char *argv[])
 		Usage("Cannot specify both -c and -i !");
 	}
 	
+	if(PlusType==PiPlus){
+		cout << endl;
+		cout << "################# WARNING! #################"    << endl;
+		cout << "The pi+pi- pair created will not be produced"    << endl;
+		cout << "with the correct physical distribution. Most"    << endl;
+		cout << "notably, no hadronic physics is included here."  << endl;
+		cout << "The exact same code that is used for generating" << endl;
+		cout << "mu+mu- is used except the mass and particle"     << endl;
+		cout << "type are changed to pion. The main use is to"    << endl;
+		cout << "provide events that overlap significantly with"  << endl;
+		cout << "the mu events in phase space to allow testing"   << endl;
+		cout << "classification algorithms."                      << endl;
+		cout << "############################################"    << endl;
+		cout << endl;
+	}
+	
 	cout << endl;
 	cout << "---------------------------------------------" << endl;
 	cout << "             Output file: " << OUTPUT_FILENAME << endl;
@@ -300,6 +363,7 @@ void ParseCommandLineArguments(int narg, char *argv[])
 	cout << "           Coherent peak: " << Ecoherent_peak << " GeV" << endl;
 	cout << "   Minimum photon energy: " << Emin << " GeV" << endl;
 	cout << "           Particle type: " << (PlusType==MuonPlus ? "mu+,mu-":"pi+,pi-") << endl;
+	cout << "                  Target: A=" << A << ", Z=" << Z << endl;
 	cout << "     Collimator diameter: " << (CollimatorDiameter*1000.0) << " mm" << endl;
 	cout << "  z-direction defined by: " << (USE_ELECTRON_BEAM_DIRECTION ? "electron":"photon") << " beam" << endl;
 	cout <<"   Coherent photons only?: " << (ONLY_COHERENT ? "yes":"no") << endl;


### PR DESCRIPTION
Added big warning message if -pions options is used to make sure user is aware the physics will be inaccurate. Added command line options to allow user to specify target type from command line.
