### PR TITLE
AddRCDB: Check if mysql_config exists before using it

### DIFF
--- a/src/SBMS/sbms.py
+++ b/src/SBMS/sbms.py
@@ -621,10 +621,11 @@ def AddRCDB(env):
 		env.AppendUnique(LIBPATH = RCDB_LIBPATH)
 		env.AppendUnique(LIBS    = RCDB_LIBS)
 
-		MYSQL_CFLAGS = subprocess.Popen(["mysql_config", "--cflags"], stdout=subprocess.PIPE).communicate()[0]
-		AddCompileFlags(env, MYSQL_CFLAGS)
-#		MYSQL_LINKFLAGS = subprocess.Popen(["mysql_config", "--libs"], stdout=subprocess.PIPE).communicate()[0]
-#		AddLinkFlags(env, MYSQL_LINKFLAGS)
+		if env.WhereIs("mysql_config") is not None:
+			MYSQL_CFLAGS = subprocess.Popen(["mysql_config", "--cflags"], stdout=subprocess.PIPE).communicate()[0]
+			AddCompileFlags(env, MYSQL_CFLAGS)
+#			MYSQL_LINKFLAGS = subprocess.Popen(["mysql_config", "--libs"], stdout=subprocess.PIPE).communicate()[0]
+#			AddLinkFlags(env, MYSQL_LINKFLAGS)
 
 
 ##################################


### PR DESCRIPTION
AddRCDB() was failing on systems without mysql installed because it
uses mysql_config to add cflags.
This commit allows for compiling against rcdb in sqlite-only mode.
