### PR TITLE
Fdc timing

### DIFF
--- a/src/libraries/FDC/DFDCPseudo_factory.cc
+++ b/src/libraries/FDC/DFDCPseudo_factory.cc
@@ -341,13 +341,15 @@ void DFDCPseudo_factory::makePseudo(vector<const DFDCHit*>& x,
       for (vector<const DFDCHit*>::const_iterator strip=u[i]->members.begin()+1;strip+1!=u[i]->members.end();strip++){  
 	//printf("  %d %f %f\n",(*strip)->element,(*strip)->pulse_height,(*strip)->t);
 	if (FindCentroid(u[i]->members,strip,upeaks)==NOERROR){
+	  //printf("3u:  %d %f %f\n",(*strip)->element,(*strip)->pulse_height,(*strip)->t);
 	  upeaks[upeaks.size()-1].cluster=i;
 	}
       }
     }
     else if (u[i]->members.size()==2){
-      for (vector<const DFDCHit*>::const_iterator strip=u[i]->members.begin()+1;strip+1!=u[i]->members.end();strip++){  
+      for (vector<const DFDCHit*>::const_iterator strip=u[i]->members.begin();strip+1!=u[i]->members.end();strip++){  
 	if (TwoStripCluster(u[i]->members,strip,upeaks)==NOERROR){
+	  //printf("2u:  %d %f %f\n",(*strip)->element,(*strip)->pulse_height,(*strip)->t);
 	  upeaks[upeaks.size()-1].cluster=i;
 	}
       }
@@ -359,20 +361,22 @@ void DFDCPseudo_factory::makePseudo(vector<const DFDCHit*>& x,
     if (DEBUG_HISTS) v_cl_size->Fill(v[i]->members.size());
     if (v[i]->members.size()>2){
       for (vector<const DFDCHit*>::const_iterator strip=v[i]->members.begin()+1;strip+1!=v[i]->members.end();strip++){		
-	//printf("  %d %f %f\n",(*strip)->element,(*strip)->pulse_height,(*strip)->t);
 	if (FindCentroid(v[i]->members,strip,vpeaks)==NOERROR){
+	  //printf("3v:  %d %f %f\n",(*strip)->element,(*strip)->pulse_height,(*strip)->t);
 	  vpeaks[vpeaks.size()-1].cluster=i;
 	}
       }
     }
     else if (v[i]->members.size()==2){
-      for (vector<const DFDCHit*>::const_iterator strip=v[i]->members.begin()+1;strip+1!=v[i]->members.end();strip++){  
+      for (vector<const DFDCHit*>::const_iterator strip=v[i]->members.begin();strip+1!=v[i]->members.end();strip++){  
 	if (TwoStripCluster(v[i]->members,strip,vpeaks)==NOERROR){
+	  //printf("2v:  %d %f %f\n",(*strip)->element,(*strip)->pulse_height,(*strip)->t);
 	  vpeaks[vpeaks.size()-1].cluster=i;
 	}
       }
     }
   }
+  cout << endl;
   if (upeaks.size()*vpeaks.size()>0){
     // Rotation angles for strips
     unsigned int ilay=layer-1;
@@ -808,7 +812,7 @@ jerror_t DFDCPseudo_factory::TwoStripCluster(const vector<const DFDCHit*>& H,
   for (vector<const DFDCHit*>::const_iterator j=peak;j<=peak+1;j++){
     pos = fdccathodes[index][(*j)->element-1]->u;
     
-    // time from large amplitude
+    // time from larger amplitude
     if (double((*j)->pulse_height)>=amp)
       t=double((*j)->t);
     

--- a/src/libraries/FDC/DFDCPseudo_factory.cc
+++ b/src/libraries/FDC/DFDCPseudo_factory.cc
@@ -898,6 +898,7 @@ jerror_t DFDCPseudo_factory::ThreeStripCluster(const vector<const DFDCHit*>& H,
   double wsum=0;
   double t=0;
   double o_amp=0;
+  int i_corr=-2;
   for (vector<const DFDCHit*>::const_iterator j=peak-1;j<=peak+1;j++){
     unsigned int index=2*((*j)->gLayer-1)+(*j)->plane/2;
     
@@ -907,16 +908,23 @@ jerror_t DFDCPseudo_factory::ThreeStripCluster(const vector<const DFDCHit*>& H,
     sum+=amp;
     wsum+=amp*pos;
     
-    // time from largest amplitude
+    // time and correction from largest amplitude
     if (amp > o_amp){
       t=double((*j)->t);
       o_amp = amp;
+      i_corr++;
     }
   }
 
-  // weighted sum
-  temp.pos=wsum/sum;
+  //correct for 'missing' signals on the other side
+  //largest amp on the left: -
+  //largest amp on the right: +
+  //minimum in the centre: 0
+  double pos_corr = 0.1;
   
+  // weighted sum
+  temp.pos=wsum/sum + i_corr*pos_corr;
+
   temp.q_from_pulse_height=sum;
   temp.numstrips=10;
   temp.t=t;

--- a/src/libraries/FDC/DFDCPseudo_factory.cc
+++ b/src/libraries/FDC/DFDCPseudo_factory.cc
@@ -195,6 +195,11 @@ jerror_t DFDCPseudo_factory::brun(JEventLoop *loop, int32_t runnumber)
     if (!dx_vs_dE) dx_vs_dE=new TH2F("dx_vs_dE","dx vs dE",100,0,25.0,
 				     100,-0.2,0.2);
 
+    u_cl_size=(TH1F*)gROOT->FindObject("u_cl_size");
+    if (!u_cl_size) u_cl_size=new TH1F("u_cl_size","u_cl_size",20,.5,20.5);
+    v_cl_size=(TH1F*)gROOT->FindObject("v_cl_size");
+    if (!v_cl_size) v_cl_size=new TH1F("v_cl_size","v_cl_size",20,.5,20.5);
+
 
     for (unsigned int i=0;i<24;i++){
       char hname[80];
@@ -331,6 +336,7 @@ void DFDCPseudo_factory::makePseudo(vector<const DFDCHit*>& x,
   // Loop over all U and V clusters looking for peaks
   for (unsigned int i=0;i<u.size();i++){
     //printf("Cluster %d\n",i);
+    if (DEBUG_HISTS) u_cl_size->Fill(u[i]->members.size());
     if (u[i]->members.size()>2)
       {
       for (vector<const DFDCHit*>::const_iterator strip=u[i]->members.begin()+1;
@@ -345,6 +351,7 @@ void DFDCPseudo_factory::makePseudo(vector<const DFDCHit*>& x,
   //  printf("---------v cluster --------\n");	
   for (unsigned int i=0;i<v.size();i++){
     //printf("Cluster %d\n",i);
+    if (DEBUG_HISTS) v_cl_size->Fill(v[i]->members.size());
     if (v[i]->members.size()>2)
       {
       for (vector<const DFDCHit*>::const_iterator strip=v[i]->members.begin()+1;

--- a/src/libraries/FDC/DFDCPseudo_factory.cc
+++ b/src/libraries/FDC/DFDCPseudo_factory.cc
@@ -486,7 +486,7 @@ void DFDCPseudo_factory::makePseudo(vector<const DFDCHit*>& x,
 
 	      if (DEBUG_HISTS){
 		// number of clusters of each type
-		u_cl_n->Fill(upeaks[j].numstrips);
+		u_cl_n->Fill(upeaks[i].numstrips);
 		v_cl_n->Fill(vpeaks[j].numstrips);
 	      }
 
@@ -894,32 +894,32 @@ jerror_t DFDCPseudo_factory::ThreeStripCluster(const vector<const DFDCHit*>& H,
     return VALUE_OUT_OF_RANGE;
   }
   
-  unsigned int index1=2*((*(peak-1))->gLayer-1)+(*(peak-1))->plane/2;
-  unsigned int index2=2*((*peak)->gLayer-1)+(*peak)->plane/2;
-  unsigned int index3=2*((*(peak+1))->gLayer-1)+(*(peak+1))->plane/2;
-  
-  double pos1=fdccathodes[index1][(*(peak-1))->element-1]->u;
-  double pos2=fdccathodes[index2][(*peak)->element-1]->u;
-  double pos3=fdccathodes[index3][(*(peak+1))->element-1]->u;
-  
-  double amp1=double((*(peak-1))->pulse_height);
-  double amp2=double((*peak)->pulse_height);
-  double amp3=double((*(peak+1))->pulse_height);
-  double sum=amp1+amp2+amp3;
-  
-  double t1=double((*(peak-1))->t);
-  double t2=double((*peak)->t);
-  double t3=double((*(peak+1))->t);
+  double sum=0;
+  double wsum=0;
+  double t=0;
+  double o_amp=0;
+  for (vector<const DFDCHit*>::const_iterator j=peak-1;j<=peak+1;j++){
+    unsigned int index=2*((*j)->gLayer-1)+(*j)->plane/2;
+    
+    double pos=fdccathodes[index][(*j)->element-1]->u;
+    double amp=double((*j)->pulse_height);
+
+    sum+=amp;
+    wsum+=amp*pos;
+    
+    // time from largest amplitude
+    if (amp > o_amp){
+      t=double((*j)->t);
+      o_amp = amp;
+    }
+  }
 
   // weighted sum
-  temp.pos=(pos1*amp1+pos2*amp2+pos3*amp3)/sum;
+  temp.pos=wsum/sum;
+  
   temp.q_from_pulse_height=sum;
   temp.numstrips=10;
-
-  // time from greater amplitude
-  if (amp1 > amp2 && amp1 > amp3) temp.t=t1;
-  else  if (amp2 > amp1 && amp2 > amp3) temp.t=t2;
-  else  if (amp3 > amp1 && amp3 > amp2) temp.t=t3;
+  temp.t=t;
   temp.t_rms=0.;
 
   //CalcMeanTime(peak,temp.t,temp.t_rms);

--- a/src/libraries/FDC/DFDCPseudo_factory.cc
+++ b/src/libraries/FDC/DFDCPseudo_factory.cc
@@ -812,44 +812,36 @@ jerror_t DFDCPseudo_factory::TwoStripCluster(const vector<const DFDCHit*>& H,
                        vector<centroid_t>&centroids){
   centroid_t temp;
   
-  if ((*peak)->pulse_height<MIDDLE_STRIP_THRESHOLD && (*peak+1)->pulse_height<MIDDLE_STRIP_THRESHOLD) {
+  if ((*peak)->pulse_height<MIDDLE_STRIP_THRESHOLD && (*(peak+1))->pulse_height<MIDDLE_STRIP_THRESHOLD) {
     return VALUE_OUT_OF_RANGE;
   }
   
   unsigned int index1=2*((*peak)->gLayer-1)+(*peak)->plane/2;
-  double pos=0;
-  double amp=0;
-  double strip=0;
-  double sum=0;
-  double t=0;
-  for (vector<const DFDCHit*>::const_iterator j=peak;j<=peak+1;j++){
-    pos = fdccathodes[index][(*j)->element-1]->u;
- 
-    // time from larger amplitude
-    if (double((*j)->pulse_height)>=amp)
-      t=double((*j)->t);
-    
-    // weight
-    amp=double((*j)->pulse_height);
+  unsigned int index2=2*((*(peak+1))->gLayer-1)+(*(peak+1))->plane/2;
 
-    //cout << pos << " " << amp << " " << double((*j)->t) << endl;
+  // this should never happen
+  if (index1 != index2) return NOERROR;
 
-    strip+=amp*pos;
-    sum+=amp;
-
-
-
-  }
+  double pos1=fdccathodes[index1][(*peak)->element-1]->u;
+  double pos2=fdccathodes[index2][(*(peak+1))->element-1]->u;
   
-  temp.pos=strip/sum;
+  double amp1=double((*peak)->pulse_height);
+  double amp2=double((*(peak+1))->pulse_height);
+  double sum=amp1+amp2;
+
+  double t1=double((*peak)->t);
+  double t2=double((*(peak+1))->t);
+
+  // weighted sum
+  temp.pos=(pos1*amp1+pos2*amp2)/sum;
   temp.q_from_pulse_height=sum;
-  temp.numstrips=2;  
-  temp.t=t;
+  temp.numstrips=2;
+
+  // time from greater amplitude
+  if (amp1 > amp2) temp.t=t1;
+  else  temp.t=t2;
   temp.t_rms=0.;
 
-  // cout <<  temp.pos << " " << temp.q_from_pulse_height << " " << temp.t << endl;
-  // cout << endl;
-  
   //CalcMeanTime(peak,temp.t,temp.t_rms);
   centroids.push_back(temp);
   

--- a/src/libraries/FDC/DFDCPseudo_factory.cc
+++ b/src/libraries/FDC/DFDCPseudo_factory.cc
@@ -166,17 +166,17 @@ jerror_t DFDCPseudo_factory::brun(JEventLoop *loop, int32_t runnumber)
     if (!qv_vs_qu) qv_vs_qu=new TH2F("qv_vs_qu","Anode charge from each cathode",100,0,20000,100,0,20000);
 
     tv_vs_tu= (TH2F*) gROOT->FindObject("tv_vs_tu");
-    if (!tv_vs_tu) tv_vs_tu=new TH2F("tv_vs_tu","t(v) vs t(u)",100,-50,250,100,-50,250);
+    if (!tv_vs_tu) tv_vs_tu=new TH2F("tv_vs_tu","t(v) vs t(u)",100,-100,250,100,-100,250);
 
-     dtv_vs_dtu= (TH2F*) gROOT->FindObject("dtv_vs_dtu");
-    if (!dtv_vs_dtu) dtv_vs_dtu=new TH2F("dtv_vs_dtu","t(wire)-t(v) vs t(wire)-t(u)",100,-50,25000,100,-50,25000);
+    dtv_vs_dtu= (TH2F*) gROOT->FindObject("dtv_vs_dtu");
+    if (!dtv_vs_dtu) dtv_vs_dtu=new TH2F("dtv_vs_dtu","t(wire)-t(v) vs t(wire)-t(u)",100,-500,500,100,-500,500);
 
     u_wire_dt_vs_wire=(TH2F *) gROOT->FindObject("u_wire_dt_vs_wire");
     if (!u_wire_dt_vs_wire) u_wire_dt_vs_wire=new TH2F("u_wire_dt_vs_wire","wire/u cathode time difference vs wire number",
-			   96,0.5,96.5,100,-50,50);
+						       96,0.5,96.5,100,-500,500);
     v_wire_dt_vs_wire=(TH2F *) gROOT->FindObject("v_wire_dt_vs_wire");
     if (!v_wire_dt_vs_wire) v_wire_dt_vs_wire=new TH2F("v_wire_dt_vs_wire","wire/v cathode time difference vs wire number",
-						       96,0.5,96.5,100,-50,50);
+						       96,0.5,96.5,100,-500,500);
     uv_dt_vs_u=(TH2F *) gROOT->FindObject("uv_dt_vs_u");
     if (!uv_dt_vs_u) uv_dt_vs_u=new TH2F("uv_dt_vs_u","uv time difference vs u",
 					 192,0.5,192.5,100,-50,50); 
@@ -820,7 +820,7 @@ jerror_t DFDCPseudo_factory::TwoStripCluster(const vector<const DFDCHit*>& H,
   unsigned int index2=2*((*(peak+1))->gLayer-1)+(*(peak+1))->plane/2;
 
   // this should never happen
-  if (index1 != index2) return NOERROR;
+  if (index1 != index2) return VALUE_OUT_OF_RANGE;
 
   double pos1=fdccathodes[index1][(*peak)->element-1]->u;
   double pos2=fdccathodes[index2][(*(peak+1))->element-1]->u;

--- a/src/libraries/FDC/DFDCPseudo_factory.h
+++ b/src/libraries/FDC/DFDCPseudo_factory.h
@@ -115,6 +115,14 @@ class DFDCPseudo_factory : public JFactory<DFDCPseudo> {
 					 vector<const DFDCHit *>::const_iterator peak,
 					 vector<centroid_t> &centroids);
 		
+		///
+		/// DFDCPseudo_factory::ThreeStripCluster()
+		/// Calculates the center-of-gravity of Three adjacent strips
+		///
+		jerror_t ThreeStripCluster(const vector<const DFDCHit*>& H,
+					 vector<const DFDCHit *>::const_iterator peak,
+					 vector<centroid_t> &centroids);
+		
  		
 	private:		
 		vector<vector<DFDCWire*> >fdcwires;
@@ -136,7 +144,7 @@ class DFDCPseudo_factory : public JFactory<DFDCPseudo> {
 		TH2F *tv_vs_tu,*u_wire_dt_vs_wire;
 		TH2F *Hxy[24],*ut_vs_u,*vt_vs_v;
 		TH2F *v_vs_u,*dx_vs_dE;
-		TH1F *u_cl_size, *v_cl_size, *u_cl_n, *v_cl_n, *x_dist_2, *x_dist_3, *x_dist_23;
+		TH1F *u_cl_size, *v_cl_size, *u_cl_n, *v_cl_n, *x_dist_2, *x_dist_3, *x_dist_23, *x_dist_33;
 
 //		JStreamLog* _log;
 };

--- a/src/libraries/FDC/DFDCPseudo_factory.h
+++ b/src/libraries/FDC/DFDCPseudo_factory.h
@@ -99,13 +99,22 @@ class DFDCPseudo_factory : public JFactory<DFDCPseudo> {
 		/// containing a peak.
 		///
 		jerror_t FindCentroid(const vector<const DFDCHit*>& H, 
-				 vector<const DFDCHit *>::const_iterator peak,
-				 vector<centroid_t> &centroids);
+				      vector<const DFDCHit *>::const_iterator peak,
+				      vector<centroid_t> &centroids);
 		// Backtracking routine needed by FindCentroid 
 		jerror_t FindNewParmVec(const DMatrix3x1 &N,const DMatrix3x1 &X,
 					const DMatrix3x1 &F,const DMatrix3x3 &J,
 					const DMatrix3x1 &par,
 					DMatrix3x1 &newpar);
+		
+		///
+		/// DFDCPseudo_factory::TwoStripCluster()
+		/// Calculates the center-of-gravity of two adjacent strips
+		///
+		jerror_t TwoStripCluster(const vector<const DFDCHit*>& H,
+					 vector<const DFDCHit *>::const_iterator peak,
+					 vector<centroid_t> &centroids);
+		
  		
 	private:		
 		vector<vector<DFDCWire*> >fdcwires;

--- a/src/libraries/FDC/DFDCPseudo_factory.h
+++ b/src/libraries/FDC/DFDCPseudo_factory.h
@@ -136,7 +136,7 @@ class DFDCPseudo_factory : public JFactory<DFDCPseudo> {
 		TH2F *tv_vs_tu,*u_wire_dt_vs_wire;
 		TH2F *Hxy[24],*ut_vs_u,*vt_vs_v;
 		TH2F *v_vs_u,*dx_vs_dE;
-		TH1F *u_cl_size, *v_cl_size;
+		TH1F *u_cl_size, *v_cl_size, *x_dist_2, *x_dist_3;
 
 //		JStreamLog* _log;
 };

--- a/src/libraries/FDC/DFDCPseudo_factory.h
+++ b/src/libraries/FDC/DFDCPseudo_factory.h
@@ -145,6 +145,7 @@ class DFDCPseudo_factory : public JFactory<DFDCPseudo> {
 		TH2F *Hxy[24],*ut_vs_u,*vt_vs_v;
 		TH2F *v_vs_u,*dx_vs_dE;
 		TH1F *u_cl_size, *v_cl_size, *u_cl_n, *v_cl_n, *x_dist_2, *x_dist_3, *x_dist_23, *x_dist_33;
+		TH1F *d_uv;
 
 //		JStreamLog* _log;
 };

--- a/src/libraries/FDC/DFDCPseudo_factory.h
+++ b/src/libraries/FDC/DFDCPseudo_factory.h
@@ -136,7 +136,7 @@ class DFDCPseudo_factory : public JFactory<DFDCPseudo> {
 		TH2F *tv_vs_tu,*u_wire_dt_vs_wire;
 		TH2F *Hxy[24],*ut_vs_u,*vt_vs_v;
 		TH2F *v_vs_u,*dx_vs_dE;
-		TH1F *u_cl_size, *v_cl_size, *x_dist_2, *x_dist_3;
+		TH1F *u_cl_size, *v_cl_size, *u_cl_n, *v_cl_n, *x_dist_2, *x_dist_3, *x_dist_23;
 
 //		JStreamLog* _log;
 };

--- a/src/libraries/FDC/DFDCPseudo_factory.h
+++ b/src/libraries/FDC/DFDCPseudo_factory.h
@@ -127,6 +127,7 @@ class DFDCPseudo_factory : public JFactory<DFDCPseudo> {
 		TH2F *tv_vs_tu,*u_wire_dt_vs_wire;
 		TH2F *Hxy[24],*ut_vs_u,*vt_vs_v;
 		TH2F *v_vs_u,*dx_vs_dE;
+		TH1F *u_cl_size, *v_cl_size;
 
 //		JStreamLog* _log;
 };

--- a/src/plugins/monitoring/FDC_Efficiency/FDC_Efficiency.C
+++ b/src/plugins/monitoring/FDC_Efficiency/FDC_Efficiency.C
@@ -54,11 +54,11 @@ void FDC_Efficiency(bool save = 0){
   trings_acc->SetLineColor(2);
   trings_acc->Draw("same");
 
-  Float_t minScale = 0.5;
+  Float_t minScale = 0.8;
   Float_t maxScale = 1.0;    
 
   gDirectory->cd("../FDC_View");
-  TCanvas *cEfficiency_Wire = new TCanvas("cEfficiency_Wire", "Wire Efficiency", 1000, 800);
+  TCanvas *cEfficiency_Wire = new TCanvas("cEfficiency_Wire", "Wire Efficiency", 1200, 800);
   cEfficiency_Wire->Divide(6,4);
 
   TGraphAsymmErrors *EffWire[24];
@@ -80,14 +80,17 @@ void FDC_Efficiency(bool save = 0){
       EffWire[icell-1]->SetTitle("");
       EffWire[icell-1]->GetXaxis()->SetTitle("Wire Number");
       EffWire[icell-1]->GetYaxis()->SetTitle("Efficiency");
+      EffWire[icell-1]->GetYaxis()->SetTitleOffset(1.15);
       EffWire[icell-1]->SetMinimum(minScale);
       EffWire[icell-1]->SetMaximum(maxScale);
     }
   }
   if (save) cEfficiency_Wire->SaveAs("cEfficiencyWire.pdf");
 
-  TCanvas *cEfficiency_Pseudo = new TCanvas("cEfficiency_Pseudo", "Pseudo Hit Efficiency", 1000, 800);
+  TCanvas *cEfficiency_Pseudo = new TCanvas("cEfficiency_Pseudo", "Pseudo Hit Efficiency", 1200, 800);
   cEfficiency_Pseudo->Divide(6,4);
+  double eff[24];
+  double tot = 0;
     
   for(unsigned int icell=1; icell<=24; icell++){
     cEfficiency_Pseudo->cd(icell);
@@ -99,6 +102,9 @@ void FDC_Efficiency(bool save = 0){
     TH2 *h4 = (TH2*)(gDirectory->Get(hname4));
       
     if(h3 && h4){
+      eff[icell-1] = (double) h3->GetEntries();
+      eff[icell-1] /= (double) h4->GetEntries();
+      
       h3->Divide(h4);
       //h3->SetMinimum(minScale);
       h3->SetMinimum(0);
@@ -107,8 +113,13 @@ void FDC_Efficiency(bool save = 0){
       h3->GetYaxis()->SetTitle("Y Position (cm)");
       h3->SetStats(0);
       h3->Draw("colz");
+
+      cout << "Pseudo-Efficiency of cell " << icell << " : " << eff[icell-1] << endl;
+      tot += eff[icell-1];
     }
   }
+
+  cout << "Total : " << tot/24. << endl;
 
   dir->cd();
 
@@ -206,6 +217,13 @@ void FDC_Efficiency(bool save = 0){
 
   TCanvas *cResidual_Pseudo = new TCanvas("cResidual_Pseudo", "Pseudo Hit Resolution", 1000, 800);
   cResidual_Pseudo->Divide(6,4);
+
+  double cell[24];
+  double cell_err[24];
+  double meanV[24];
+  double meanV_err[24];
+  double meanU[24];
+  double meanU_err[24];
     
   for(unsigned int icell=1; icell<=24; icell++){
     cResidual_Pseudo->cd(icell);
@@ -217,14 +235,77 @@ void FDC_Efficiency(bool save = 0){
     TH1 *h6 = (TH1*)(gDirectory->Get(hname6));
       
     h5->GetXaxis()->SetTitle("Position Resolution (cm)");
-    h5->Draw("colz");
+    h5->GetXaxis()->SetRangeUser(-1,1);
+    h5->Draw();
+    h5->Fit("gaus","q0");
+    TF1 *fgaus5 = h5->GetFunction("gaus");
+    cell[icell-1] = icell;
+    cell_err[icell-1] = 0;
+    meanV[icell-1] = fgaus5->GetParameter(1);
+    //mean_err[icell-1] = fgaus5->GetParError(1) * fgaus->GetChisquare()/(fgaus->GetNDF()-1);
+    meanV_err[icell-1] = fgaus5->GetParameter(2);
+
     h6->SetLineColor(2);
     h6->Draw("same");
+    h6->Fit("gaus","q0");
+    TF1 *fgaus6 = h6->GetFunction("gaus");
+    meanU[icell-1] = fgaus6->GetParameter(1);
+    //mean_err[icell-1] = fgaus6->GetParError(1) * fgaus->GetChisquare()/(fgaus->GetNDF()-1);
+    meanU_err[icell-1] = fgaus6->GetParameter(2);
     
   }
 
+  TCanvas *cResidual_Pseudo2 = new TCanvas("cResidual_Pseudo2", "Pseudo Hit Resolution 2D", 1000, 800);
+  cResidual_Pseudo2->Divide(6,4);
 
-
+  for(unsigned int icell=1; icell<=24; icell++){
+    cResidual_Pseudo2->cd(icell);
+    char hname7[256];
+    sprintf(hname7, "hPseudoResUvsV_cell[%d]", icell);
+    TH1 *h7 = (TH1*)(gDirectory->Get(hname7));
+      
+    h7->GetXaxis()->SetTitle("Position Resolution along Wire (cm)");
+    h7->GetXaxis()->SetRangeUser(-0.5,0.5);
+    h7->GetYaxis()->SetTitle("Position Resolution perp. to Wire (cm)");
+    h7->GetYaxis()->SetRangeUser(-0.5,0.5);
+    h7->Draw("col");
     
+  }
 
+  TCanvas *cAlignment = new TCanvas("cAlignment", "Alignment", 600, 1000);
+  cAlignment->Divide(1,2);
+  
+  cAlignment->cd(1);
+  TGraphErrors *galignV = new TGraphErrors(24, cell, meanV, cell_err, meanV_err);
+  galignV->SetTitle("Alignment along Wire (Error Bars: Sigma); Cell \# ; V_{Hit} - V_{Track} (cm)");
+  galignV->SetMarkerColor(1);
+  galignV->SetMarkerStyle(2);
+  galignV->Draw("AP");
+
+  TLine *lpack12 = new TLine(6.5, -0.1, 6.5, 0.1);
+  lpack12->SetLineColor(2);
+  lpack12->SetLineStyle(2);
+  lpack12->SetLineWidth(2);
+  lpack12->Draw();
+  TLine *lpack23 = new TLine(12.5, -0.1, 12.5, 0.1);
+  lpack23->SetLineColor(2);
+  lpack23->SetLineStyle(2);
+  lpack23->SetLineWidth(2);
+  lpack23->Draw();
+  TLine *lpack34 = new TLine(18.5, -0.1, 18.5, 0.1);
+  lpack34->SetLineColor(2);
+  lpack34->SetLineStyle(2);
+  lpack34->SetLineWidth(2);
+  lpack34->Draw();
+
+  cAlignment->cd(2);
+  TGraphErrors *galignU = new TGraphErrors(24, cell, meanU, cell_err, meanU_err);
+  galignU->SetTitle("Alignment perp. to Wire (Error Bars: Sigma); Cell \# ; U_{Hit} - U_{Track} (cm)");
+  galignU->SetMarkerColor(1);
+  galignU->SetMarkerStyle(2);
+  galignU->Draw("AP");
+
+  lpack12->Draw();
+  lpack23->Draw();
+  lpack34->Draw();
 }

--- a/src/plugins/monitoring/FDC_Efficiency/FDC_Efficiency.C
+++ b/src/plugins/monitoring/FDC_Efficiency/FDC_Efficiency.C
@@ -262,18 +262,47 @@ void FDC_Efficiency(bool save = 0){
     cResidual_Pseudo2->cd(icell);
     char hname7[256];
     sprintf(hname7, "hPseudoResUvsV_cell[%d]", icell);
-    TH1 *h7 = (TH1*)(gDirectory->Get(hname7));
+    TH2 *h7 = (TH2*)(gDirectory->Get(hname7));
       
-    h7->GetXaxis()->SetTitle("Position Resolution along Wire (cm)");
-    h7->GetXaxis()->SetRangeUser(-0.5,0.5);
-    h7->GetYaxis()->SetTitle("Position Resolution perp. to Wire (cm)");
+    h7->GetYaxis()->SetTitle("Position reconstructed along Wire (cm)");
     h7->GetYaxis()->SetRangeUser(-0.5,0.5);
+    h7->GetXaxis()->SetTitle("Position perp. to Wire (cm)");
+    h7->GetXaxis()->SetRangeUser(-0.5,0.5);
     h7->Draw("col");
+
+    h7->ProfileY();
     
   }
 
-  TCanvas *cAlignment = new TCanvas("cAlignment", "Alignment", 600, 1000);
-  cAlignment->Divide(1,2);
+  double slope[24];
+  double slope_err[24];
+  TCanvas *cResidual_Profile = new TCanvas("cResidual_Profile", "Pseudo Resolution Profile", 1000, 800);
+  cResidual_Profile->Divide(6,4);
+  
+  for(unsigned int icell=1; icell<=24; icell++){
+    cResidual_Profile->cd(icell);
+    char hname8[256];
+    sprintf(hname8, "hPseudoResUvsV_cell[%d]_pfy", icell);
+    TH1 *h8 = (TH1*)(gDirectory->Get(hname8));
+      
+    h8->GetXaxis()->SetTitle("Position reconstructed along Wire (cm)");
+    h8->GetXaxis()->SetRangeUser(-0.15,0.15);
+    h8->GetYaxis()->SetTitle("Position perp. to Wire (cm)");
+    h8->GetYaxis()->SetRangeUser(-0.5,0.5);
+    h8->GetYaxis()->SetTitleFont(42);
+    h8->GetYaxis()->SetTitleSize(0.035);
+    h8->GetYaxis()->SetLabelFont(42);
+    h8->GetYaxis()->SetLabelSize(0.035);
+    h8->Draw();
+
+    TF1 *fp1 = new TF1("fp1","[0]+x*[1]",-0.08,0.08);
+    h8->Fit("fp1","qr");
+    slope[icell-1] = fp1->GetParameter(1);
+    slope_err[icell-1] = fp1->GetParError(1);
+  }
+
+  TCanvas *cAlignment = new TCanvas("cAlignment", "Alignment", 1200, 1000);
+  cAlignment->Divide(2,2);
   
   cAlignment->cd(1);
   TGraphErrors *galignV = new TGraphErrors(24, cell, meanV, cell_err, meanV_err);
@@ -308,4 +337,12 @@ void FDC_Efficiency(bool save = 0){
   lpack12->Draw();
   lpack23->Draw();
   lpack34->Draw();
+
+  cAlignment->cd(3);
+  TGraphErrors *gmagnet = new TGraphErrors(24, cell, slope, cell_err, slope_err);
+  gmagnet->SetTitle("Value for slope of magnetic deflection; Cell \# ; Slope (cm^{-1})");
+  gmagnet->SetMarkerColor(1);
+  gmagnet->SetMarkerStyle(2);
+  gmagnet->Draw("AP");
+
 }

--- a/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
+++ b/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
@@ -23,6 +23,7 @@ static TH1I *hPseudoResX[25];
 static TH1I *hPseudoResY[25];
 static TH1I *hPseudoResU[25];
 static TH1I *hPseudoResV[25];
+static TH2I *hPseudoResUvsV[25];
 static TH2I *hPseudoResVsT;
 static TH2I *hResVsT;
 static TH1I *hMom;
@@ -121,7 +122,7 @@ jerror_t JEventProcessor_FDC_Efficiency::init(void)
 
   gDirectory->cd("/FDC_Efficiency");
   gDirectory->mkdir("Residuals")->cd();
-  hResVsT = new TH2I("hResVsT","Tracking Residual (Biased) Vs Wire Drift Time; Residual (cm); Drift Time (ns)", 100, 0, 0.5, 500, -250, 250);
+  hResVsT = new TH2I("hResVsT","Tracking Residual (Biased) Vs Wire Drift Time; DOCA (cm); Drift Time (ns)", 100, 0, 0.5, 500, -250, 250);
   hPseudoResVsT = new TH2I("hPseudoResVsT","Tracking Residual (Biased) Vs Pseudo Time; Residual (cm); Drift Time (ns)", 100, 0, 0.5, 500, -250, 250);
   hPseudoRes = new TH1I("hPseudoRes","Pseudo Residual in R", 500, 0, 5);
 
@@ -129,6 +130,7 @@ jerror_t JEventProcessor_FDC_Efficiency::init(void)
 
     char hname_X[256];
     char hname_Y[256];
+    char hname_XY[256];
    
     sprintf(hname_X, "hPseudoResX_cell[%d]", icell+1);
     sprintf(hname_Y, "hPseudoResY_cell[%d]", icell+1);
@@ -137,8 +139,10 @@ jerror_t JEventProcessor_FDC_Efficiency::init(void)
 
     sprintf(hname_X, "hPseudoResU_cell[%d]", icell+1);
     sprintf(hname_Y, "hPseudoResV_cell[%d]", icell+1);
+    sprintf(hname_XY, "hPseudoResUvsV_cell[%d]", icell+1);
     hPseudoResU[icell+1] = new TH1I(hname_X,"Pseudo Residual along Wire", 600, -3, 3);
     hPseudoResV[icell+1] = new TH1I(hname_Y,"Pseudo Residual perp. to Wire", 600, -3, 3);
+    hPseudoResUvsV[icell+1] = new TH2I(hname_XY,"Pseudo Residual 2D", 200, -1, 1, 200, -1, 1);
 
   }
 
@@ -428,6 +432,8 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
 	    fdc_wire_measured_cell[cellNum]->SetBinContent(wireNum, 1, v);
 	    japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 	  }
+
+	  break; // break if 1 expected hit was found, 2 are geometrically not possible (speedup!)
 	  
 	} // End expected
       } // End wire loop
@@ -476,6 +482,7 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
 	    hPseudoResY[cellNum]->Fill(residualY);
 	    hPseudoResU[cellNum]->Fill(residualU);
 	    hPseudoResV[cellNum]->Fill(residualV);
+	    hPseudoResUvsV[cellNum]->Fill(residualU, residualV);
 	    japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 	    
 	    if (foundPseudo) continue; 

--- a/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
+++ b/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
@@ -23,7 +23,7 @@ static TH1I *hPseudoResX[25];
 static TH1I *hPseudoResY[25];
 static TH1I *hPseudoResU[25];
 static TH1I *hPseudoResV[25];
-static TH2I *hPseudoResUvsV[25];
+static TH2I *hPseudoResUvsV[25][9];
 static TH2I *hPseudoResVsT;
 static TH2I *hResVsT;
 static TH1I *hMom;
@@ -139,10 +139,12 @@ jerror_t JEventProcessor_FDC_Efficiency::init(void)
 
     sprintf(hname_X, "hPseudoResU_cell[%d]", icell+1);
     sprintf(hname_Y, "hPseudoResV_cell[%d]", icell+1);
-    sprintf(hname_XY, "hPseudoResUvsV_cell[%d]", icell+1);
     hPseudoResU[icell+1] = new TH1I(hname_X,"Pseudo Residual along Wire", 600, -3, 3);
     hPseudoResV[icell+1] = new TH1I(hname_Y,"Pseudo Residual perp. to Wire", 600, -3, 3);
-    hPseudoResUvsV[icell+1] = new TH2I(hname_XY,"Pseudo Residual 2D", 200, -1, 1, 200, -1, 1);
+    for (int r=0; r<9; r++){
+      sprintf(hname_XY, "hPseudoResUvsV_cell[%d]_radius[%d]", icell+1, (r+1)*5);
+      hPseudoResUvsV[icell+1][r] = new TH2I(hname_XY,"Pseudo Residual 2D", 200, -1, 1, 200, -1, 1);
+    }
 
   }
 
@@ -482,7 +484,9 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
 	    hPseudoResY[cellNum]->Fill(residualY);
 	    hPseudoResU[cellNum]->Fill(residualU);
 	    hPseudoResV[cellNum]->Fill(residualV);
-	    hPseudoResUvsV[cellNum]->Fill(residualU, residualV);
+	    int radius = interPosition2D.Mod()/5;
+	    if (radius<9)
+	      hPseudoResUvsV[cellNum][radius]->Fill(residualU, residualV);
 	    japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 	    
 	    if (foundPseudo) continue; 

--- a/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
+++ b/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
@@ -122,8 +122,8 @@ jerror_t JEventProcessor_FDC_Efficiency::init(void)
 
   gDirectory->cd("/FDC_Efficiency");
   gDirectory->mkdir("Residuals")->cd();
-  hResVsT = new TH2I("hResVsT","Tracking Residual (Biased) Vs Wire Drift Time; DOCA (cm); Drift Time (ns)", 100, 0, 0.5, 500, -250, 250);
-  hPseudoResVsT = new TH2I("hPseudoResVsT","Tracking Residual (Biased) Vs Pseudo Time; Residual (cm); Drift Time (ns)", 100, 0, 0.5, 500, -250, 250);
+  hResVsT = new TH2I("hResVsT","Tracking Residual (Biased) Vs Wire Drift Time; DOCA (cm); Drift Time (ns)", 100, 0, 0.5, 600, -100, 500);
+  hPseudoResVsT = new TH2I("hPseudoResVsT","Tracking Residual (Biased) Vs Pseudo Time; Residual (cm); Drift Time (ns)", 100, 0, 0.5, 400, -100, 300);
   hPseudoRes = new TH1I("hPseudoRes","Pseudo Residual in R", 500, 0, 5);
 
   for(int icell=0; icell<24; icell++){
@@ -202,8 +202,7 @@ jerror_t JEventProcessor_FDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
     japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
     // cut on timing of hits
-    // at the moment shifted to -200ns
-    if (-300 > locHit->t || locHit->t > 100) continue;
+    //if (-100 > locHit->t || locHit->t > 300) continue;
     
     locSortedFDCHits[locHit->gLayer][locHit->element].insert(locHit);
 


### PR DESCRIPTION
- adapted timing cut for the combination of wire and cathode hits, works with updated calibrations
- added 3-strip clusters with weird shapes and 2-strip clusters
- FDC_Efficiency extracts slope of magnetic field deflection for each cell and as a function of the radius

Result for run 11553:
Pseudo_Efficiency +15%
TrackCandidates_FDC +10%
