### PR TITLE
Respect authority of DEBUG option

### DIFF
--- a/src/SBMS/sbms.py
+++ b/src/SBMS/sbms.py
@@ -568,9 +568,10 @@ def AddHDDM(env):
 # MYSQL
 ##################################
 def AddMySQL(env):
-	# TOFIX : heck to see if mysql_config exists
-	env.ParseConfig("mysql_config --cflags")
-	env.ParseConfig("mysql_config --libs")
+	MYSQL_CFLAGS = subprocess.Popen(["mysql_config","--cflags"], stdout=subprocess.PIPE).communicate()[0]
+	MYSQL_LINKFLAGS = subprocess.Popen(["mysql_config","--libs"], stdout=subprocess.PIPE).communicate()[0]
+	AddCompileFlags(env, MYSQL_CFLAGS)
+	AddLinkFlags(env, MYSQL_LINKFLAGS)
 
 ##################################
 # DANA
@@ -616,20 +617,6 @@ def AddCCDB(env):
 		env.AppendUnique(CPPPATH = CCDB_CPPPATH)
 		env.AppendUnique(LIBPATH = CCDB_LIBPATH)
 		env.AppendUnique(LIBS    = CCDB_LIBS)
-
-##################################
-# RCDB
-##################################
-def AddRCDB(env):
-	rcdb_home = os.getenv('RCDB_HOME')
-	if(rcdb_home != None) :
-		env.AppendUnique(CXXFLAGS = ['-DHAVE_RCDB'])
-		RCDB_CPPPATH = "%s/cpp/include" % (rcdb_home)
-		RCDB_LIBPATH = "%s/cpp/lib" % (rcdb_home)
-		RCDB_LIBS = "rcdb"
-		env.AppendUnique(CPPPATH = RCDB_CPPPATH)
-		env.AppendUnique(LIBPATH = RCDB_LIBPATH)
-		env.AppendUnique(LIBS    = RCDB_LIBS)
 
 
 ##################################

--- a/src/libraries/EVENTSTORE/SConscript
+++ b/src/libraries/EVENTSTORE/SConscript
@@ -6,10 +6,6 @@ import sbms
 Import('*')
 env = env.Clone()
 
-# MYSQL
-env.ParseConfig("mysql_config --cflags")
-env.ParseConfig("mysql_config --libs")
-
 # Needed for HDDM
 #env.AppendUnique(CPPPATH=[Dir('.').abspath+"/../../../libraries/HDDM"])   # HACK!
 env.AppendUnique(CPPPATH=["../HDDM"])   # HACK!


### PR DESCRIPTION
mysql_config adds extra debug-symbol flags on some systems.
Modify AddMySQL() so that DEBUG CL-option is respected.

Remove extra AddRCDB() function.
