### PR TITLE
Change default kinfit FOM cut to -1 instead of 0.

### DIFF
--- a/src/programs/Utilities/analysis/MakeReactionPlugin.pl
+++ b/src/programs/Utilities/analysis/MakeReactionPlugin.pl
@@ -285,7 +285,7 @@ jerror_t DReaction_factory_${ReactionFactoryTag}::evnt(JEventLoop* locEventLoop,
 
 	// KINEMATIC FIT
 	// locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	// locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	// locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, -1.0)); // confidence level cut //-1: require kinematic fit converges
 
 	// HISTOGRAM MASSES //false/true: measured/kinfit data
 	//locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, \"Pi0_PostKinFit\"));


### PR DESCRIPTION
Technically, the kinfit can converge with a confidence level == 0.
Cutting at -1 is the only way to truly ONLY require kinfit convergence.
