### PR TITLE
Updates to ROOT scripts for ROOT6

### DIFF
--- a/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_SC.C
+++ b/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_SC.C
@@ -160,11 +160,11 @@
 		locAcceptanceHist->GetYaxis()->SetLabelSize(0.05);
 		locAcceptanceHist->Draw("COLZ");
 	}
-
-	TH1I* locHist_SCPaddle_BarrelRegion_HasHit = (TH1I*)gDirectory->Get("SCPaddle_BarrelRegion_HasHit");
-	TH1I* locHist_SCPaddle_BarrelRegion_NoHit = (TH1I*)gDirectory->Get("SCPaddle_BarrelRegion_NoHit");
-	TH1I* locHist_SCPaddle_NoseRegion_HasHit = (TH1I*)gDirectory->Get("SCPaddle_NoseRegion_HasHit");
-	TH1I* locHist_SCPaddle_NoseRegion_NoHit = (TH1I*)gDirectory->Get("SCPaddle_NoseRegion_NoHit");
+    
+	locHist_SCPaddle_BarrelRegion_HasHit = (TH1I*)gDirectory->Get("SCPaddle_BarrelRegion_HasHit");
+	locHist_SCPaddle_BarrelRegion_NoHit = (TH1I*)gDirectory->Get("SCPaddle_BarrelRegion_NoHit");
+	locHist_SCPaddle_NoseRegion_HasHit = (TH1I*)gDirectory->Get("SCPaddle_NoseRegion_HasHit");
+	locHist_SCPaddle_NoseRegion_NoHit = (TH1I*)gDirectory->Get("SCPaddle_NoseRegion_NoHit");
 	locCanvas->cd(5);
 	gPad->SetTicks();
 	gPad->SetGrid();
@@ -184,9 +184,9 @@
 			{
 				double locAcceptance = locNumFound_Barrel/locTotal_Barrel;
 				locBarrelEffVector.push_back(locAcceptance);
-				double locNumFoundError = sqrt(locNumFound*(1.0 - locAcceptance));
+				double locNumFoundError = sqrt(locNumFound_Barrel*(1.0 - locAcceptance));
 
-				double locAcceptanceError = locNumFoundError/locTotal;
+				double locAcceptanceError = locNumFoundError/locTotal_Barrel;
 				locBarrelEffUncertaintyVector.push_back(locAcceptanceError);
 
 				locBarrelXAxisVector.push_back(loc_i + 1);
@@ -200,9 +200,9 @@
 			{
 				double locAcceptance = locNumFound_Nose/locTotal_Nose;
 				locNoseEffVector.push_back(locAcceptance);
-				double locNumFoundError = sqrt(locNumFound*(1.0 - locAcceptance));
+				double locNumFoundError = sqrt(locNumFound_Nose*(1.0 - locAcceptance));
 
-				double locAcceptanceError = locNumFoundError/locTotal;
+				double locAcceptanceError = locNumFoundError/locTotal_Nose;
 				locNoseEffUncertaintyVector.push_back(locAcceptanceError);
 
 				locNoseXAxisVector.push_back(loc_i + 1);

--- a/src/plugins/Analysis/p2pi_hists/HistMacro_p2pi_pmiss.C
+++ b/src/plugins/Analysis/p2pi_hists/HistMacro_p2pi_pmiss.C
@@ -11,14 +11,14 @@
 	  return;
 
 	//Go to NoCut directory
-	TDirectory *locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p2pi_hists_NoCut_Measured");
+	locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p2pi_hists_NoCut_Measured");
 	if(!locDirectory)
 		return;
 	locDirectory->cd();
 	TH2I* locHist_NoCut_MM_M2pi = (TH2I*)gDirectory->Get("MM_M2pi");
 
 	//Go to KinFitConverge directory
-	TDirectory *locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p2pi_hists_KinFitConverge_Measured");
+	locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p2pi_hists_KinFitConverge_Measured");
 	if(!locDirectory)
 		return;
 	locDirectory->cd();

--- a/src/plugins/Analysis/p3pi_hists/HistMacro_p3pi_pmiss_2FCAL.C
+++ b/src/plugins/Analysis/p3pi_hists/HistMacro_p3pi_pmiss_2FCAL.C
@@ -11,21 +11,21 @@
 	  return;
 
 	//Go to Pi0 mass directory
-	TDirectory *locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Hist_InvariantMass_NoKinFit_Measured");
+	locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Hist_InvariantMass_NoKinFit_Measured");
 	if(!locDirectory)
 		return;
 	locDirectory->cd();
 	TH1I* locHist_NoKinFit_MPi0 = (TH1I*)gDirectory->Get("InvariantMass");
 
 	//Go to NoKinFit directory
-	TDirectory *locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p3pi_hists_NoKinFit_Measured");
+	locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p3pi_hists_NoKinFit_Measured");
 	if(!locDirectory)
 		return;
 	locDirectory->cd();
 	TH2I* locHist_NoKinFit_MM_M3pi = (TH2I*)gDirectory->Get("MM_M3pi");
 
 	//Go to KinFitCut10 directory
-	TDirectory *locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p3pi_hists_KinFitCut10_Measured");
+	locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p3pi_hists_KinFitCut10_Measured");
 	if(!locDirectory)
 		return;
 	locDirectory->cd();

--- a/src/plugins/Analysis/p3pi_hists/HistMacro_p3pi_pmiss_FCAL-BCAL.C
+++ b/src/plugins/Analysis/p3pi_hists/HistMacro_p3pi_pmiss_FCAL-BCAL.C
@@ -4,7 +4,6 @@
 
 {
 	TDirectory *locTopDirectory = gDirectory;
-	TDirectory *locTopDirectory = gDirectory;
 	TDirectory *locReactionDirectory;
 	if((TDirectory*)locTopDirectory->FindObjectAny("p3pi_pmiss_FCAL-BCAL") != 0)
 	  locReactionDirectory = (TDirectory*)locTopDirectory->FindObjectAny("p3pi_pmiss_FCAL-BCAL");
@@ -19,14 +18,14 @@
 	TH1I* locHist_NoKinFit_MPi0 = (TH1I*)gDirectory->Get("InvariantMass");
 
 	//Go to NoKinFit directory
-	TDirectory *locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p3pi_hists_NoKinFit_Measured");
+	locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p3pi_hists_NoKinFit_Measured");
 	if(!locDirectory)
 		return;
 	locDirectory->cd();
 	TH2I* locHist_NoKinFit_MM_M3pi = (TH2I*)gDirectory->Get("MM_M3pi");
 
 	//Go to KinFitCut10 directory
-	TDirectory *locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p3pi_hists_KinFitCut10_Measured");
+	locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p3pi_hists_KinFitCut10_Measured");
 	if(!locDirectory)
 		return;
 	locDirectory->cd();

--- a/src/plugins/Analysis/p3pi_hists/HistMacro_p3pi_preco_2FCAL.C
+++ b/src/plugins/Analysis/p3pi_hists/HistMacro_p3pi_preco_2FCAL.C
@@ -18,7 +18,7 @@
 	TH1I* locHist_NoKinFit_MPi0 = (TH1I*)gDirectory->Get("InvariantMass");
 
 	//Go to NoKinFit directory
-	TDirectory *locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p3pi_hists_CutPi0_Measured");
+	locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p3pi_hists_CutPi0_Measured");
 	if(!locDirectory)
 		return;
 	locDirectory->cd();

--- a/src/plugins/Analysis/p3pi_hists/HistMacro_p3pi_preco_FCAL-BCAL.C
+++ b/src/plugins/Analysis/p3pi_hists/HistMacro_p3pi_preco_FCAL-BCAL.C
@@ -18,7 +18,7 @@
 	TH1I* locHist_NoKinFit_MPi0 = (TH1I*)gDirectory->Get("InvariantMass");
 
 	//Go to NoKinFit directory
-	TDirectory *locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p3pi_hists_CutPi0_Measured");
+	locDirectory = (TDirectory*)locReactionDirectory->FindObjectAny("Custom_p3pi_hists_CutPi0_Measured");
 	if(!locDirectory)
 		return;
 	locDirectory->cd();

--- a/src/plugins/Calibration/BCAL_TDC_Timing/FitScripts/ExtractTimeOffsetsAndCEff.C
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/FitScripts/ExtractTimeOffsetsAndCEff.C
@@ -1,6 +1,6 @@
 // Script to extract time-walk constants for the BCAL
 
-namespace ExtractTimeOffsetsAndCEff {
+namespace ExtractTimeOffsetsAndCEffNS {
   //Leave this global so the accesors don't need the pointer as an argument
   TFile *thisFile;
 
@@ -20,7 +20,7 @@ namespace ExtractTimeOffsetsAndCEff {
   TH2I * Get2DHistogram(const char * plugin, const char * directoryName, const char * name){
     TH2I * histogram;
     TString fullName = TString(plugin) + "/" + TString(directoryName) + "/" + TString(name);
-    histogram = thisFile->GetObject(fullName, histogram);
+    thisFile->GetObject(fullName, histogram);
     if (histogram == 0){
         cout << "Unable to find histogram " << fullName.Data() << endl;
         return NULL;
@@ -33,14 +33,14 @@ namespace ExtractTimeOffsetsAndCEff {
 void ExtractTimeOffsetsAndCEff(int run = 2931, TString filename = "hd_root.root"){
 
     // Open our input and output file
-    ExtractTimeOffsetsAndCEff::thisFile = TFile::Open(filename);
+    ExtractTimeOffsetsAndCEffNS::thisFile = TFile::Open(filename);
     TFile *outputFile = TFile::Open("BCALTimeOffsetAndCEff_Results.root", "RECREATE");
     outputFile->mkdir("Fits");
     outputFile->mkdir("ResultOverview");
 
     // Check to make sure it is open
-    if (ExtractTimeOffsetsAndCEff::thisFile == 0) {
-        cout << "Unable to open file " << fileName.Data() << "...Exiting" << endl;
+    if (ExtractTimeOffsetsAndCEffNS::thisFile == 0) {
+        cout << "Unable to open file " << filename.Data() << "...Exiting" << endl;
         return;
     }
 
@@ -82,7 +82,7 @@ void ExtractTimeOffsetsAndCEff(int run = 2931, TString filename = "hd_root.root"
     if(locInputFile == NULL)
         return 0;
     //get the first (comment) line
-    char buff[1024];
+    //char buff[1024];
     if(fgets(buff, sizeof(buff), locInputFile) == NULL)
         return 0;
     //get the remaining lines
@@ -120,7 +120,7 @@ void ExtractTimeOffsetsAndCEff(int run = 2931, TString filename = "hd_root.root"
     TH1D * selectedBCALOffset = new TH1D("selectedBCALOffset", "Selected Global BCAL Offset; CCDB Index; Offset [ns]", 768, 0.5, 768 + 0.5);
     TH1I * BCALOffsetDistribution = new TH1I("BCALOffsetDistribution", "Global BCAL Offset; Global Offset [ns]; Entries", 100, -10, 10);
 
-    thisHist = ExtractTimeOffsetsAndCEff::Get2DHistogram("BCAL_Global_Offsets", "Target Time", "Target Time Minus RF Time Vs. Cell Number");
+    auto thisHist = ExtractTimeOffsetsAndCEffNS::Get2DHistogram("BCAL_Global_Offsets", "Target Time", "Target Time Minus RF Time Vs. Cell Number");
     if(thisHist != NULL){
         int nBinsX = thisHist->GetNbinsX();
         int nBinsY = thisHist->GetNbinsY();
@@ -166,7 +166,7 @@ void ExtractTimeOffsetsAndCEff(int run = 2931, TString filename = "hd_root.root"
 
                 // These histograms are created on the fly in the plugin, so there is a chance that they do not exist, in which case the pointer will be NULL
 
-                TH2I *h_offsets   = ExtractTimeOffsetsAndCEff::Get2DHistogram ("BCAL_TDC_Offsets", "Z Position", name);
+                TH2I *h_offsets   = ExtractTimeOffsetsAndCEffNS::Get2DHistogram ("BCAL_TDC_Offsets", "Z Position", name);
 
                 // Use FitSlicesY routine to extract the mean of each x bin
                 TObjArray ySlices;
@@ -204,7 +204,7 @@ void ExtractTimeOffsetsAndCEff(int run = 2931, TString filename = "hd_root.root"
     channel_global_offset_File.close();
     tdiff_u_d_File.close();
     outputFile->Write();
-    ExtractTimeOffsetsAndCEff::thisFile->Close();
+    ExtractTimeOffsetsAndCEffNS::thisFile->Close();
     return;
 }
 

--- a/src/plugins/Calibration/BCAL_TDC_Timing/FitScripts/ExtractTimeWalk.C
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/FitScripts/ExtractTimeWalk.C
@@ -2,7 +2,7 @@
 
 //Leave this global so the accesors don't need the pointer as an argument
 
-namespace ExtractTimeWalk {
+namespace ExtractTimeWalkNS {
   TFile *thisFile;
 
 // Accessor functions to grab histograms from our file
@@ -21,7 +21,7 @@ namespace ExtractTimeWalk {
   TH2I * Get2DHistogram(const char * plugin, const char * directoryName, const char * name){
     TH2I * histogram;
     TString fullName = TString(plugin) + "/" + TString(directoryName) + "/" + TString(name);
-    histogram = thisFile->GetObject(fullName, histogram);
+    thisFile->GetObject(fullName, histogram);
     if (histogram == 0){
         cout << "Unable to find histogram " << fullName.Data() << endl;
         return NULL;
@@ -34,14 +34,14 @@ namespace ExtractTimeWalk {
 void ExtractTimeWalk(TString filename = "hd_root.root"){
 
     // Open our input and output file
-    ExtractTimeWalk::thisFile = TFile::Open(filename);
+    ExtractTimeWalkNS::thisFile = TFile::Open(filename);
     TFile *outputFile = TFile::Open("BCALTimewalk_Results.root", "RECREATE");
     outputFile->mkdir("Upstream");
     outputFile->mkdir("Downstream");
 
     // Check to make sure it is open
-    if (ExtractTimeWalk::thisFile == 0) {
-        cout << "Unable to open file " << fileName.Data() << "...Exiting" << endl;
+    if (ExtractTimeWalkNS::thisFile == 0) {
+        cout << "Unable to open file " << filename.Data() << "...Exiting" << endl;
         return;
     }
 
@@ -57,7 +57,7 @@ void ExtractTimeWalk(TString filename = "hd_root.root"){
     // The threshold in ADC counts is ~14 so this is in the denominator
     double a_thresh = 14.0;
     char formula[100];
-    sprintf(formula,  "[0]+[1]/TMath::Power(x/%d,[2])", a_thresh);
+    sprintf(formula,  "[0]+[1]/TMath::Power(x/%f,[2])", a_thresh);
     TF1 *f1 = new TF1("f1", formula , 15, 400);
     f1->SetParLimits(2, 0.25, 1.5);
 
@@ -82,10 +82,10 @@ void ExtractTimeWalk(TString filename = "hd_root.root"){
                 // For each M/L/S we have Upstream and downstream, lets grab them
                 // These histograms are created on the fly in the plugin, so there is a chance that they do not exist, in which case the pointer will be NULL
 
-                TH2I *h_UpstreamTW_E   = ExtractTimeWalk::Get2DHistogram ("BCAL_TDC_Timing", "BCAL_Upstream_Timewalk_NoCorrection_E", name);
-                TH2I *h_UpstreamTW_PP  = ExtractTimeWalk::Get2DHistogram ("BCAL_TDC_Timing", "BCAL_Upstream_Timewalk_NoCorrection_PP", name);
-                TH2I *h_DownstreamTW_E = ExtractTimeWalk::Get2DHistogram ("BCAL_TDC_Timing", "BCAL_Downstream_Timewalk_NoCorrection_E", name);
-                TH2I *h_DownstreamTW_PP = ExtractTimeWalk::Get2DHistogram ("BCAL_TDC_Timing", "BCAL_Downstream_Timewalk_NoCorrection_PP", name); 
+                TH2I *h_UpstreamTW_E   = ExtractTimeWalkNS::Get2DHistogram ("BCAL_TDC_Timing", "BCAL_Upstream_Timewalk_NoCorrection_E", name);
+                TH2I *h_UpstreamTW_PP  = ExtractTimeWalkNS::Get2DHistogram ("BCAL_TDC_Timing", "BCAL_Upstream_Timewalk_NoCorrection_PP", name);
+                TH2I *h_DownstreamTW_E = ExtractTimeWalkNS::Get2DHistogram ("BCAL_TDC_Timing", "BCAL_Downstream_Timewalk_NoCorrection_E", name);
+                TH2I *h_DownstreamTW_PP = ExtractTimeWalkNS::Get2DHistogram ("BCAL_TDC_Timing", "BCAL_Downstream_Timewalk_NoCorrection_PP", name); 
 
                 // Use FitSlicesY routine to extract the mean of each x bin
                 TObjArray ySlicesUpstream;
@@ -145,7 +145,7 @@ void ExtractTimeWalk(TString filename = "hd_root.root"){
     }
     textFile.close();
     outputFile->Write();
-    ExtractTimeWalk::thisFile->Close();
+    ExtractTimeWalkNS::thisFile->Close();
     return;
 }
 

--- a/src/plugins/Calibration/BCAL_attenlength_gainratio/scripts/plot_module_histos.C
+++ b/src/plugins/Calibration/BCAL_attenlength_gainratio/scripts/plot_module_histos.C
@@ -1,14 +1,19 @@
 
 
-plot_module_histos(int module=1, char filename[255]="/home/dalton/work/BCAL/rootfiles/analysis_highlevel/bcal_atten_gain_003182.root")
+void plot_module_histos(int module, char filename[255])
 {
 	gStyle->SetPadRightMargin(0.15);
 	gStyle->SetPadLeftMargin(0.15);
 	gStyle->SetPadBottomMargin(0.15);
 
 	TFile *_file0 = TFile::Open(filename);
-	bcalgainratio->cd();
-	channels->cd();
+
+	//	TDirectory *main = gDirectory;  // save current directory
+    //Goto Path
+    TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("bcalgainratio");
+    if(!locDirectory)
+        return;
+    locDirectory->cd("channels");
 
 	char name[255];
 	int pad=0;

--- a/src/plugins/Calibration/BCAL_attenlength_gainratio/scripts/plot_results.C
+++ b/src/plugins/Calibration/BCAL_attenlength_gainratio/scripts/plot_results.C
@@ -1,6 +1,5 @@
 
-
-plot_results(char filename[255]="/home/dalton/work/BCAL/rootfiles/analysis_highlevel/bcal_atten_gain_003182.root", int module=1)
+void plot_results(char filename[255], int module=1)
 {
 
 	gStyle->SetPadRightMargin(0.15);
@@ -10,8 +9,27 @@ plot_results(char filename[255]="/home/dalton/work/BCAL/rootfiles/analysis_highl
 	TFile *_file0 = TFile::Open(filename);
 
 	//	TDirectory *main = gDirectory;  // save current directory
-	bcalgainratio->cd();
+    //Goto Path
+    TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("bcalgainratio");
+    if(!locDirectory)
+        return;
+    locDirectory->cd();
 
+    // load directories
+    TH1I *hist_attenlength  = (TH1I *)gDirectory->Get("hist_attenlength");
+    TH1I *hist_gainratio  = (TH1I *)gDirectory->Get("hist_gainratio");
+    TH1I *hist_attenlength_err  = (TH1I *)gDirectory->Get("hist_attenlength_err");
+    TH1I *hist_gainratio_err  = (TH1I *)gDirectory->Get("hist_gainratio_err");
+    TH1I *hist_attenlength_relerr  = (TH1I *)gDirectory->Get("hist_attenlength_relerr");
+    TH1I *hist_gainratio_relerr  = (TH1I *)gDirectory->Get("hist_gainratio_relerr");
+
+    TH2I *hist2D_attenlength  = (TH2I *)gDirectory->Get("hist2D_attenlength");
+    TH2I *hist2D_gainratio  = (TH2I *)gDirectory->Get("hist2D_gainratio");
+    TH2I *EvsZ_layer1  = (TH2I *)gDirectory->Get("EvsZ_layer1");
+    TH2I *EvsZ_layer2  = (TH2I *)gDirectory->Get("EvsZ_layer2");
+    TH2I *EvsZ_layer3  = (TH2I *)gDirectory->Get("EvsZ_layer3");
+    TH2I *EvsZ_layer4  = (TH2I *)gDirectory->Get("EvsZ_layer4");
+    
 
 	TCanvas *results = new TCanvas("results","Results of fit",800,800);
 	results->Divide(2,2,0.001,0.001);

--- a/src/plugins/Calibration/BCAL_point_time/macros/plot_BCAL_point_time.C
+++ b/src/plugins/Calibration/BCAL_point_time/macros/plot_BCAL_point_time.C
@@ -1,16 +1,17 @@
 
 // Plot the various histograms produced by the BCAL_point_time plugin
+#include <stdio.h>
 
 
-void plot_BCAL_point_time(char filename[255] = "photons_mom_0.50_angle_011_127_tlog_smeared.root", char prefix[255] = "05GeVgamma")
+void plot_BCAL_point_time(string filename, string prefix = "05GeVgamma")
 {
-	//	char filename[255];
+	char plot_filename[255];
 
 	gStyle->SetOptStat(0);
 
 	TDirectory *main = gDirectory;
 
-	TFile *_file0 = TFile::Open(filename);
+	TFile *_file0 = new TFile(filename.c_str());
 	TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("bcalpointtime");
 	if(dir) dir->cd();
 
@@ -27,16 +28,16 @@ void plot_BCAL_point_time(char filename[255] = "photons_mom_0.50_angle_011_127_t
 	point_NormVsZ_layer3->Draw("same");
 	point_NormVsZ_layer4->Draw("same");
 	//thrown_NVsZ->Draw("same");
-	leg = new TLegend(0.85,0.8,0.99,0.99);
+	TLegend *leg = new TLegend(0.85,0.8,0.99,0.99);
 	leg->AddEntry(point_NormVsZ_layer1,"Layer 1");
 	leg->AddEntry(point_NormVsZ_layer2,"Layer 2");
 	leg->AddEntry(point_NormVsZ_layer3,"Layer 3");
 	leg->AddEntry(point_NormVsZ_layer4,"Layer 4");
 	leg->Draw();
-	sprintf(filename,"plots/point_NormVsZ_%s.png",prefix);
-	canvas_point_NormVsZ->Print(filename);
-	sprintf(filename,"plots/point_NormVsZ_%s.pdf",prefix);
-	canvas_point_NormVsZ->Print(filename);
+	sprintf(plot_filename,"plots/point_NormVsZ_%s.png",prefix.c_str());
+	canvas_point_NormVsZ->Print(plot_filename);
+	sprintf(plot_filename,"plots/point_NormVsZ_%s.pdf",prefix.c_str());
+	canvas_point_NormVsZ->Print(plot_filename);
 
 	TCanvas *canvas_point_NormVsTheta = new TCanvas("canvas_point_NormVsTheta","canvas_point_NormVsTheta");
 	gPad->SetGridx();
@@ -57,10 +58,10 @@ void plot_BCAL_point_time(char filename[255] = "photons_mom_0.50_angle_011_127_t
 	leg->AddEntry(point_NormVsTheta_layer3,"Layer 3");
 	leg->AddEntry(point_NormVsTheta_layer4,"Layer 4");
 	leg->Draw();
-	sprintf(filename,"plots/point_NormVsTheta_%s.png",prefix);
-	canvas_point_NormVsTheta->Print(filename);
-	sprintf(filename,"plots/point_NormVsTheta_%s.pdf",prefix);
-	canvas_point_NormVsTheta->Print(filename);
+	sprintf(plot_filename,"plots/point_NormVsTheta_%s.png",prefix.c_str());
+	canvas_point_NormVsTheta->Print(plot_filename);
+	sprintf(plot_filename,"plots/point_NormVsTheta_%s.pdf",prefix.c_str());
+	canvas_point_NormVsTheta->Print(plot_filename);
 
 	TCanvas *canvas_point_TimeVsZ = new TCanvas("canvas_point_TimeVsZ","canvas_point_TimeVsZ");
 	gPad->SetGridx();
@@ -79,10 +80,10 @@ void plot_BCAL_point_time(char filename[255] = "photons_mom_0.50_angle_011_127_t
 	leg->AddEntry(point_TimeVsZ_layer3_prof,"Layer 3");
 	leg->AddEntry(point_TimeVsZ_layer4_prof,"Layer 4");
 	leg->Draw();
-	sprintf(filename,"plots/point_TimeVsZ_prof_%s.png",prefix);
-	canvas_point_TimeVsZ->Print(filename);
-	sprintf(filename,"plots/point_TimeVsZ_prof_%s.pdf",prefix);
-	canvas_point_TimeVsZ->Print(filename);
+	sprintf(plot_filename,"plots/point_TimeVsZ_prof_%s.png",prefix.c_str());
+	canvas_point_TimeVsZ->Print(plot_filename);
+	sprintf(plot_filename,"plots/point_TimeVsZ_prof_%s.pdf",prefix.c_str());
+	canvas_point_TimeVsZ->Print(plot_filename);
 
 	TCanvas *canvas_hit_TimeVsZ = new TCanvas("canvas_hit_TimeVsZ","canvas_hit_TimeVsZ");
 	gPad->SetGridx();
@@ -104,10 +105,10 @@ void plot_BCAL_point_time(char filename[255] = "photons_mom_0.50_angle_011_127_t
 	hitds_TimeVsZ_layer3_prof->Draw("same");
 	hitds_TimeVsZ_layer4_prof->Draw("same");
 	leg->Draw();
-	sprintf(filename,"plots/hit_TimeVsZ_prof_%s.png",prefix);
-	canvas_hit_TimeVsZ->Print(filename);
-	sprintf(filename,"plots/hit_TimeVsZ_prof_%s.pdf",prefix);
-	canvas_hit_TimeVsZ->Print(filename);
+	sprintf(plot_filename,"plots/hit_TimeVsZ_prof_%s.png",prefix.c_str());
+	canvas_hit_TimeVsZ->Print(plot_filename);
+	sprintf(plot_filename,"plots/hit_TimeVsZ_prof_%s.pdf",prefix.c_str());
+	canvas_hit_TimeVsZ->Print(plot_filename);
 
 	TCanvas *canvas_hit_TimediffVsZ = new TCanvas("canvas_TimediffVsZ","canvas_TimediffVsZ");
 	gPad->SetGridx();
@@ -121,10 +122,10 @@ void plot_BCAL_point_time(char filename[255] = "photons_mom_0.50_angle_011_127_t
 	hit_TimediffVsZ_layer3_prof->Draw("same");
 	hit_TimediffVsZ_layer4_prof->Draw("same");
 	leg->Draw();
-	sprintf(filename,"plots/hit_TimediffVsZ_prof_%s.png",prefix);
-	canvas_hit_TimediffVsZ->Print(filename);
-	sprintf(filename,"plots/hit_TimediffVsZ_prof_%s.pdf",prefix);
-	canvas_hit_TimediffVsZ->Print(filename);
+	sprintf(plot_filename,"plots/hit_TimediffVsZ_prof_%s.png",prefix.c_str());
+	canvas_hit_TimediffVsZ->Print(plot_filename);
+	sprintf(plot_filename,"plots/hit_TimediffVsZ_prof_%s.pdf",prefix.c_str());
+	canvas_hit_TimediffVsZ->Print(plot_filename);
 
 	TCanvas *canvas_hit_TimesumVsZ = new TCanvas("canvas_hit_TimesumVsZ","canvas_hit_TimesumVsZ");
 	gPad->SetGridx();
@@ -139,10 +140,10 @@ void plot_BCAL_point_time(char filename[255] = "photons_mom_0.50_angle_011_127_t
 	hit_TimesumVsZ_layer2_prof->Draw("same");
 	hit_TimesumVsZ_layer3_prof->Draw("same");
 	leg->Draw();
-	sprintf(filename,"plots/hit_TimesumVsZ_prof_%s.png",prefix);
-	canvas_hit_TimesumVsZ->Print(filename);
-	sprintf(filename,"plots/hit_TimesumVsZ_prof_%s.pdf",prefix);
-	canvas_hit_TimesumVsZ->Print(filename);
+	sprintf(plot_filename,"plots/hit_TimesumVsZ_prof_%s.png",prefix.c_str());
+	canvas_hit_TimesumVsZ->Print(plot_filename);
+	sprintf(plot_filename,"plots/hit_TimesumVsZ_prof_%s.pdf",prefix.c_str());
+	canvas_hit_TimesumVsZ->Print(plot_filename);
 
 
 	TCanvas *canvashit_TimeVsZ_scat = new TCanvas("canvashit_TimeVsZ_scat","canvashit_TimeVsZ_scat",800,1000);
@@ -171,10 +172,10 @@ void plot_BCAL_point_time(char filename[255] = "photons_mom_0.50_angle_011_127_t
 	hitds_TimeVsZ_layer3->Draw("colz");
 	canvashit_TimeVsZ_scat->cd(8);
 	hitds_TimeVsZ_layer4->Draw("colz");
-	sprintf(filename,"plots/hit_TimeVsZ_%s.png",prefix);
-	canvashit_TimeVsZ_scat->Print(filename);
-	sprintf(filename,"plots/hit_TimeVsZ_%s.pdf",prefix);
-	canvashit_TimeVsZ_scat->Print(filename);
+	sprintf(plot_filename,"plots/hit_TimeVsZ_%s.png",prefix.c_str());
+	canvashit_TimeVsZ_scat->Print(plot_filename);
+	sprintf(plot_filename,"plots/hit_TimeVsZ_%s.pdf",prefix.c_str());
+	canvashit_TimeVsZ_scat->Print(plot_filename);
 
 
 	TCanvas *canvas_hit_TimediffVsZ_scat = new TCanvas("canvas_hit_TimediffVsZ_scat","canvas_hit_TimediffVsZ_scat",800,600);
@@ -191,10 +192,10 @@ void plot_BCAL_point_time(char filename[255] = "photons_mom_0.50_angle_011_127_t
 	hit_TimediffVsZ_layer3->Draw("colz");
 	canvas_hit_TimediffVsZ_scat->cd(4);
 	hit_TimediffVsZ_layer4->Draw("colz");
-	sprintf(filename,"plots/hit_TimediffVsZ_%s.png",prefix);
-	canvas_hit_TimediffVsZ_scat->Print(filename);
-	sprintf(filename,"plots/hit_TimediffVsZ_%s.pdf",prefix);
-	canvas_hit_TimediffVsZ_scat->Print(filename);
+	sprintf(plot_filename,"plots/hit_TimediffVsZ_%s.png",prefix.c_str());
+	canvas_hit_TimediffVsZ_scat->Print(plot_filename);
+	sprintf(plot_filename,"plots/hit_TimediffVsZ_%s.pdf",prefix.c_str());
+	canvas_hit_TimediffVsZ_scat->Print(plot_filename);
 
 	TCanvas *canvas_hit_TimesumVsZ_scat = new TCanvas("canvas_hit_TimesumVsZ_scat","canvas_hit_TimesumVsZ_scat",800,600);
 	TH1I *hit_TimesumVsZ_layer1 = (TH1I*)gDirectory->FindObjectAny("hit_TimesumVsZ_layer1");
@@ -210,10 +211,10 @@ void plot_BCAL_point_time(char filename[255] = "photons_mom_0.50_angle_011_127_t
 	hit_TimesumVsZ_layer3->Draw("colz");
 	canvas_hit_TimesumVsZ_scat->cd(4);
 	hit_TimesumVsZ_layer4->Draw("colz");
-	sprintf(filename,"plots/hit_TimesumVsZ_%s.png",prefix);
-	canvas_hit_TimesumVsZ_scat->Print(filename);
-	sprintf(filename,"plots/hit_TimesumVsZ_%s.pdf",prefix);
-	canvas_hit_TimesumVsZ_scat->Print(filename);
+	sprintf(plot_filename,"plots/hit_TimesumVsZ_%s.png",prefix.c_str());
+	canvas_hit_TimesumVsZ_scat->Print(plot_filename);
+	sprintf(plot_filename,"plots/hit_TimesumVsZ_%s.pdf",prefix.c_str());
+	canvas_hit_TimesumVsZ_scat->Print(plot_filename);
 
 
 	// back to main dir

--- a/src/plugins/Calibration/CDC_TimeToDistance/FitScripts/FitTimeToDistance.C
+++ b/src/plugins/Calibration/CDC_TimeToDistance/FitScripts/FitTimeToDistance.C
@@ -247,15 +247,13 @@ void FitTimeToDistance(TString inputROOTFile = "hd_root.root", int run = 3650)
     gSystem->ClosePipe(locInputFile);
 
     sprintf(command, "ccdb dump /CDC/cdc_drift_table:%i:NoBField", run);
-    FILE* locInputFile = gSystem->OpenPipe(command, "r");
+    locInputFile = gSystem->OpenPipe(command, "r");
     if(locInputFile == NULL)
         return 0;
     //get the first (comment) line
-    char buff[1024];
     if(fgets(buff, sizeof(buff), locInputFile) == NULL)
         return 0;
     //get the remaining lines
-    double value;
     while(fgets(buff, sizeof(buff), locInputFile) != NULL){
         istringstream locConstantsStream(buff);
         while (locConstantsStream >> value){

--- a/src/plugins/Calibration/HLDetectorTiming/FitScripts/ExtractTDCADCTiming.C
+++ b/src/plugins/Calibration/HLDetectorTiming/FitScripts/ExtractTDCADCTiming.C
@@ -1,3 +1,4 @@
+namespace ExtractTDCADCTimingNS {
 TFile * thisFile;
 
 TH1I * Get1DHistogram(const char * plugin, const char * directoryName, const char * name, bool print = true){
@@ -14,13 +15,14 @@ TH1I * Get1DHistogram(const char * plugin, const char * directoryName, const cha
 TH2I * Get2DHistogram(const char * plugin, const char * directoryName, const char * name){
     TH2I * histogram;
     TString fullName = TString(plugin) + "/" + TString(directoryName) + "/" + TString(name);
-    histogram = thisFile->GetObject(fullName, histogram);
+    thisFile->GetObject(fullName, histogram);
     if (histogram == 0){
         cout << "Unable to find histogram " << fullName.Data() << endl;
         return NULL;
     }
     return histogram;
 }
+};
 
 void GetCCDBConstants(TString path, Int_t run, TString variation, vector<double>& container, Int_t column = 1){
     char command[256];
@@ -113,8 +115,8 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
     // set "prefix" in case you want to think about thowing the text files into another directory
     cout << "Performing TDC/ADC timing fits for File: " << fileName.Data() << " Run: " << runNumber << " Variation: " << variation.Data() << endl;
 
-    thisFile = TFile::Open( fileName , "UPDATE");
-    if (thisFile == 0) {
+    ExtractTDCADCTimingNS::thisFile = TFile::Open( fileName , "UPDATE");
+    if (ExtractTDCADCTimingNS::thisFile == 0) {
         cout << "Unable to open file " << fileName.Data() << "...Exiting" << endl;
         return;
     }
@@ -173,7 +175,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
     //Move the base times just for the tracking
 
     float CDC_ADC_Offset = 0.0;
-    TH1I * this1DHist = Get1DHistogram("HLDetectorTiming", "CDC", "CDCHit time");
+    TH1I * this1DHist = ExtractTDCADCTimingNS::Get1DHistogram("HLDetectorTiming", "CDC", "CDCHit time");
     if(this1DHist != NULL){
         Int_t firstBin = this1DHist->FindLastBinAbove( 1 , 1); // Find first bin with content above 1 in the histogram
         for (int i = 0; i <= 25; i++){
@@ -197,7 +199,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
     outFile.close();
 
     float FDC_ADC_Offset = 0.0, FDC_TDC_Offset = 0.0;
-    this1DHist = Get1DHistogram("HLDetectorTiming", "FDC", "FDCHit Cathode time");
+    this1DHist = ExtractTDCADCTimingNS::Get1DHistogram("HLDetectorTiming", "FDC", "FDCHit Cathode time");
     if(this1DHist != NULL){
         Int_t firstBin = this1DHist->FindLastBinAbove( 1 , 1); // Find first bin with content above 1 in the histogram
         for (int i = 0; i <= 25; i++){
@@ -214,7 +216,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
         FDC_ADC_Offset = mean;
         delete f;
     }
-    this1DHist = Get1DHistogram("HLDetectorTiming", "FDC", "FDCHit Wire time");
+    this1DHist = ExtractTDCADCTimingNS::Get1DHistogram("HLDetectorTiming", "FDC", "FDCHit Wire time");
     if(this1DHist != NULL){
         Int_t firstBin = this1DHist->FindLastBinAbove( 1 , 1); // Find first bin with content above 1 in the histogram
         for (int i = 0; i <= 25; i++){
@@ -247,7 +249,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
 
     float sc_tdc_base_time = 0.0;
 
-    this1DHist = Get1DHistogram("HLDetectorTiming", "SC", "SCHit TDC time");
+    this1DHist = ExtractTDCADCTimingNS::Get1DHistogram("HLDetectorTiming", "SC", "SCHit TDC time");
     if(this1DHist != NULL){
         //Gaussian
         Double_t maximum = this1DHist->GetBinCenter(this1DHist->GetMaximumBin());
@@ -256,7 +258,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
         sc_tdc_base_time = mean;
     }
 
-    TH2I *thisHist = Get2DHistogram("HLDetectorTiming", "SC", "SCHit TDC_ADC Difference");
+    TH2I *thisHist = ExtractTDCADCTimingNS::Get2DHistogram("HLDetectorTiming", "SC", "SCHit TDC_ADC Difference");
     TH1D * selected_SC_TDCADCOffset = NULL;
     TH1I * SCOffsetDistribution = NULL;
     if(thisHist != NULL){
@@ -315,7 +317,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
     outFile << sc_base_time_adc - (sc_tdc_base_time + meanDiff) << " " << sc_base_time_tdc - sc_tdc_base_time << endl;
     outFile.close();
 
-    thisHist = Get2DHistogram("HLDetectorTiming", "TOF", "TOFHit TDC_ADC Difference");
+    thisHist = ExtractTDCADCTimingNS::Get2DHistogram("HLDetectorTiming", "TOF", "TOFHit TDC_ADC Difference");
     if(thisHist != NULL){
         int nBinsX = thisHist->GetNbinsX();
         int nBinsY = thisHist->GetNbinsY();
@@ -369,7 +371,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
 
     }
 
-    thisHist = Get2DHistogram("HLDetectorTiming", "TAGM", "TAGMHit TDC_ADC Difference");
+    thisHist = ExtractTDCADCTimingNS::Get2DHistogram("HLDetectorTiming", "TAGM", "TAGMHit TDC_ADC Difference");
     if(thisHist != NULL){
         float tdcRFOffset[122] = {}; // 122 possible offsets
         char name[100];
@@ -380,7 +382,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
         for (unsigned int column = 1; column <= 102; column++){
             for (unsigned int row = 0; row <= 5; row++){
                 sprintf(name, "Column %.3i Row %.1i", column, row);
-                TH1I *rf_hist = Get1DHistogram("HLDetectorTiming", "TAGM_TDC_RF_Compare", name, false);
+                TH1I *rf_hist = ExtractTDCADCTimingNS::Get1DHistogram("HLDetectorTiming", "TAGM_TDC_RF_Compare", name, false);
                 if (rf_hist != NULL){
                     // do the fit and store the result
                     // Some fancy footwork to fit this periodic function
@@ -478,7 +480,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
         outFile.close();
     }
 
-    thisHist = Get2DHistogram("HLDetectorTiming", "TAGH", "TAGHHit TDC_ADC Difference");
+    thisHist = ExtractTDCADCTimingNS::Get2DHistogram("HLDetectorTiming", "TAGH", "TAGHHit TDC_ADC Difference");
     if(thisHist != NULL){
         // First take a look at the RF offsets
         float tdcRFOffsetTAGH[274] = {}; // 274 possible offsets
@@ -490,7 +492,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
         for (unsigned int counter_id = 1; counter_id <= 274; counter_id++){
             sprintf(name, "Counter ID %.3i", counter_id);
             cout << "Fitting TAGH " << name << endl;
-            TH1I *rf_hist = Get1DHistogram("HLDetectorTiming", "TAGH_TDC_RF_Compare", name, false);
+            TH1I *rf_hist = ExtractTDCADCTimingNS::Get1DHistogram("HLDetectorTiming", "TAGH_TDC_RF_Compare", name, false);
             if (rf_hist != NULL){
                 // do the fit and store the result
                 // Some fancy footwork to fit this periodic function
@@ -577,7 +579,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
     TH1D * selectedBCALOffset = new TH1D("selectedBCALOffset", "Selected BCAL TDC Offset; Column; Offset [ns]", 1152, 0.5, 1152 + 0.5);
     TH1I * BCALOffsetDistribution = new TH1I("BCALOffsetDistribution", "BCAL TDC Offset; TDC Offset [ns]; Entries", 500, -500, 500); 
 
-    thisHist = Get2DHistogram("HLDetectorTiming", "BCAL", "BCALHit Upstream Per Channel TDC-ADC Hit Time");
+    thisHist = ExtractTDCADCTimingNS::Get2DHistogram("HLDetectorTiming", "BCAL", "BCALHit Upstream Per Channel TDC-ADC Hit Time");
     if(thisHist != NULL){
         int nBinsX = thisHist->GetNbinsX();
         int nBinsY = thisHist->GetNbinsY();
@@ -609,7 +611,7 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
         }
     }
 
-    thisHist = Get2DHistogram("HLDetectorTiming", "BCAL", "BCALHit Downstream Per Channel TDC-ADC Hit Time");
+    thisHist = ExtractTDCADCTimingNS::Get2DHistogram("HLDetectorTiming", "BCAL", "BCALHit Downstream Per Channel TDC-ADC Hit Time");
     if(thisHist != NULL){
         int nBinsX = thisHist->GetNbinsX();
         int nBinsY = thisHist->GetNbinsY();
@@ -658,6 +660,6 @@ void ExtractTDCADCTiming(TString fileName = "hd_root.root", int runNumber = 1039
         outFile.close();
     }
 
-    thisFile->Write();
+    ExtractTDCADCTimingNS::thisFile->Write();
     return;
     }

--- a/src/plugins/Calibration/HLDetectorTiming/FitScripts/ExtractTrackBasedTiming.C
+++ b/src/plugins/Calibration/HLDetectorTiming/FitScripts/ExtractTrackBasedTiming.C
@@ -1,6 +1,7 @@
+namespace ExtractTrackBasedTimingNS {
 TFile * thisFile;
 
-TH1I * Get1DHistogram(const char * plugin, const char * directoryName, const char * name){
+TH1I * ExtractTrackBasedTimingNS::Get1DHistogram(const char * plugin, const char * directoryName, const char * name){
     TH1I * histogram;
     TString fullName = TString(plugin) + "/" + TString(directoryName) + "/" + TString(name);
     thisFile->GetObject(fullName, histogram);
@@ -14,13 +15,14 @@ TH1I * Get1DHistogram(const char * plugin, const char * directoryName, const cha
 TH2I * Get2DHistogram(const char * plugin, const char * directoryName, const char * name){
     TH2I * histogram;
     TString fullName = TString(plugin) + "/" + TString(directoryName) + "/" + TString(name);
-    histogram = thisFile->GetObject(fullName, histogram);
+    thisFile->GetObject(fullName, histogram);
     if (histogram == 0){
         cout << "Unable to find histogram " << fullName.Data() << endl;
         return NULL;
     }
     return histogram;
 }
+};
 
 void GetCCDBConstants(TString path, Int_t run, TString variation, vector<double>& container, Int_t column = 1){
     char command[256];
@@ -101,8 +103,8 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
     // set "prefix" in case you want to ship the txt files elsewhere...
     cout << "Performing TDC/ADC timing fits for File: " << fileName.Data() << " Run: " << runNumber << " Variation: " << variation.Data() << endl;
 
-    thisFile = TFile::Open( fileName , "UPDATE");
-    if (thisFile == 0) {
+    ExtractTrackBasedTimingNS::thisFile = TFile::Open( fileName , "UPDATE");
+    if (ExtractTrackBasedTimingNS::thisFile == 0) {
         cout << "Unable to open file " << fileName.Data() << "...Exiting" << endl;
         return;
     }
@@ -165,15 +167,15 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
     //First just a simple check to see if we have the appropriate data
     bool useRF = false;
     double RF_Period = 4.0080161;
-    TH1I *testHist = Get1DHistogram("HLDetectorTiming", "TAGH_TDC_RF_Compare","Counter ID 001");
+    TH1I *testHist = ExtractTrackBasedTimingNS::Get1DHistogram("HLDetectorTiming", "TAGH_TDC_RF_Compare","Counter ID 001");
     if (testHist != NULL){ // Not great since we rely on channel 1 working, but can be craftier later.
         cout << "Using RF Times for Calibration" << endl;
         useRF = true;
     }
     ofstream outFile;
     TH2I *thisHist; 
-    thisHist = Get2DHistogram("HLDetectorTiming", "TRACKING", "TAGM - SC Target Time");
-    if (useRF) thisHist = Get2DHistogram("HLDetectorTiming", "TRACKING", "TAGM - RFBunch Time");
+    thisHist = ExtractTrackBasedTimingNS::Get2DHistogram("HLDetectorTiming", "TRACKING", "TAGM - SC Target Time");
+    if (useRF) thisHist = ExtractTrackBasedTimingNS::Get2DHistogram("HLDetectorTiming", "TRACKING", "TAGM - RFBunch Time");
     if (thisHist != NULL){
         //Statistics on these histograms are really quite low we will have to rebin and do some interpolation
         outFile.open(prefix + "tagm_tdc_timing_offsets.txt", ios::out | ios::trunc);
@@ -293,8 +295,8 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
 
     }
 
-    thisHist = Get2DHistogram("HLDetectorTiming", "TRACKING", "TAGH - SC Target Time");
-    if (useRF) thisHist = Get2DHistogram("HLDetectorTiming", "TRACKING", "TAGH - RFBunch Time");
+    thisHist = ExtractTrackBasedTimingNS::Get2DHistogram("HLDetectorTiming", "TRACKING", "TAGH - SC Target Time");
+    if (useRF) thisHist = ExtractTrackBasedTimingNS::Get2DHistogram("HLDetectorTiming", "TRACKING", "TAGH - RFBunch Time");
     if(thisHist != NULL){
         outFile.open(prefix + "tagh_tdc_timing_offsets.txt", ios::out | ios::trunc);
         outFile.close(); // clear file
@@ -352,7 +354,7 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
             cout << "Type\tChannel\tvalueToUse\toldValue\tmeanOffset\tTotal" << endl;
         }
         for (int i = 1 ; i <= nBinsX; i++){
-            valueToUse = selectedTAGHOffset->GetBinContent(i);
+            double valueToUse = selectedTAGHOffset->GetBinContent(i);
             if (useRF) valueToUse *= RF_Period;
             //if (valueToUse == 0) valueToUse = meanOffset;
             outFile.open(prefix + "tagh_tdc_timing_offsets.txt", ios::out | ios::app);
@@ -383,7 +385,7 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
         TH1F * selectedSCSectorOffsetDistribution = new TH1F("selectedSCSectorOffsetDistribution", "Selected TDC-RF offset;Time;Entries", 100, -3.0, 3.0);
         TF1* f = new TF1("f","pol0(0)+gaus(1)", -3.0, 3.0);
         for (int sector = 1; sector <= 30; sector++){
-            TH1I *scRFHist = Get1DHistogram("HLDetectorTiming", "SC_Target_RF_Compare", Form("Sector %.2i", sector));
+            TH1I *scRFHist = ExtractTrackBasedTimingNS::Get1DHistogram("HLDetectorTiming", "SC_Target_RF_Compare", Form("Sector %.2i", sector));
             if (scRFHist == NULL) continue;
             //Do the fit
             TFitResultPtr fr = scRFHist->Fit("pol0", "SQ", "", -2, 2);
@@ -437,7 +439,7 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
         outFile.close();
     }
 
-    TH1I *this1DHist = Get1DHistogram("HLDetectorTiming", "TRACKING", "TOF - RF Time");
+    TH1I *this1DHist = ExtractTrackBasedTimingNS::Get1DHistogram("HLDetectorTiming", "TRACKING", "TOF - RF Time");
     if(this1DHist != NULL){
         //Gaussian
         Double_t maximum = this1DHist->GetBinCenter(this1DHist->GetMaximumBin());
@@ -452,7 +454,7 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
         outFile.close();
     }
 
-    this1DHist = Get1DHistogram("HLDetectorTiming", "TRACKING", "BCAL - RF Time");
+    this1DHist = ExtractTrackBasedTimingNS::Get1DHistogram("HLDetectorTiming", "TRACKING", "BCAL - RF Time");
     if(this1DHist != NULL){
         //Gaussian
         Double_t maximum = this1DHist->GetBinCenter(this1DHist->GetMaximumBin());
@@ -467,7 +469,7 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
         outFile.close();
     }
 
-    this1DHist = Get1DHistogram("HLDetectorTiming", "TRACKING", "FCAL - RF Time");
+    this1DHist = ExtractTrackBasedTimingNS::Get1DHistogram("HLDetectorTiming", "TRACKING", "FCAL - RF Time");
     if(this1DHist != NULL){
         //Gaussian
         Double_t maximum = this1DHist->GetBinCenter(this1DHist->GetMaximumBin());
@@ -481,7 +483,7 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
         outFile.close();
     }
 
-    this1DHist = Get1DHistogram("HLDetectorTiming", "TRACKING", "Earliest CDC Time Minus Matched SC Time");
+    this1DHist = ExtractTrackBasedTimingNS::Get1DHistogram("HLDetectorTiming", "TRACKING", "Earliest CDC Time Minus Matched SC Time");
     if(this1DHist != NULL){
         //Gaussian
         Double_t maximum = this1DHist->GetBinCenter(this1DHist->GetMaximumBin());
@@ -494,6 +496,6 @@ void ExtractTrackBasedTiming(TString fileName = "hd_root.root", int runNumber = 
         outFile << cdc_t_base - mean - meanSCOffset << endl;
         outFile.close();
     }
-    thisFile->Write();
+    ExtractTrackBasedTimingNS::thisFile->Write();
     return;
     }

--- a/src/plugins/Calibration/PS_E_calib/PSEcorr.C
+++ b/src/plugins/Calibration/PS_E_calib/PSEcorr.C
@@ -24,17 +24,17 @@
 #if TAGM
 const int MAX_COLUMNS			= 100;	// Number of TAGM channels
 int bad_channels_tm			= 0;	// Number of channels excluded in fit
-double fitResults_tm[MAX_COLUMNS][3]	= {},{};// fit parameters, 3 pol2 params
-double max_E_tm[MAX_COLUMNS]		= {};	// maximum of fit
-double fit_tm[3]			= {};	// average fit parameters
+double fitResults_tm[MAX_COLUMNS][3]	= {0}; // fit parameters, 3 pol2 params
+double max_E_tm[MAX_COLUMNS]		= {0};	// maximum of fit
+double fit_tm[3]			= {0};	// average fit parameters
 #endif
 
 #if TAGH
 const int MAX_COUNTERS			= 274;	// Number of TAGH channels
 int bad_channels_th			= 0;	// Number of channels excluded in fit
-double fitResults_th[MAX_COUNTERS][3]	= {},{};// fit parameters, 3 pol2 params
-double max_E_th[MAX_COUNTERS]		= {};	// maximum of fit
-double fit_th[3]			= {};	// average fit parameters
+double fitResults_th[MAX_COUNTERS][3]	= {0};// fit parameters, 3 pol2 params
+double max_E_th[MAX_COUNTERS]		= {0};	// maximum of fit
+double fit_th[3]			= {0};	// average fit parameters
 #endif
 
 double Ebw_PS = 0.013;				// PS energy bin width

--- a/src/plugins/Calibration/ST_Propagation_Time/macros/st_prop_time_v1.C
+++ b/src/plugins/Calibration/ST_Propagation_Time/macros/st_prop_time_v1.C
@@ -90,6 +90,7 @@ void st_prop_time_v1(char*input_filename)
       h2_ss->GetXaxis()->SetRangeUser(0.,40.0);
       h2_ss->Draw("colz");
       h2_ss->Fit("pol1");		
+      TF1 *pol1 = h2_ss->GetFunction("pol1");
       t_z_ss_fit_slope[j][1] = pol1->GetParameter(1);
       t_z_ss_fit_slope_err[j][1] = pol1->GetParError(1);
       t_z_ss_fit_intercept[j][0] = pol1->GetParameter(0);
@@ -111,6 +112,7 @@ void st_prop_time_v1(char*input_filename)
      
 
       h2_bs->Fit("pol1");
+      pol1 = h2_bs->GetFunction("pol1");
       t_z_bs_fit_slope[j][1] = pol1->GetParameter(1);
       t_z_bs_fit_slope_err[j][1] = pol1->GetParError(1);
       t_z_bs_fit_intercept[j][0] = pol1->GetParameter(0);
@@ -131,6 +133,7 @@ void st_prop_time_v1(char*input_filename)
       h2_ns->GetXaxis()->SetTitle("Path Length (cm)");
       h2_ns->GetXaxis()->SetRangeUser(43.,60.0);
       h2_ns->Fit("pol1");
+      pol1 = h2_ns->GetFunction("pol1");
       t_z_ns_fit_slope[j][1] = pol1->GetParameter(1);
       t_z_ns_fit_slope_err[j][1] = pol1->GetParError(1);
       t_z_ns_fit_intercept[j][0] = pol1->GetParameter(0);

--- a/src/plugins/Calibration/ST_Tresolution/macros/st_time_resolution.C
+++ b/src/plugins/Calibration/ST_Tresolution/macros/st_time_resolution.C
@@ -139,6 +139,7 @@ void st_time_resolution(char*input_filename)
       	    } 
       	}
       pytotal->Fit("gaus");
+      TF1 *gaus = pytotal->GetFunction("gaus");
       gPad->Update();
        PT_can[j]->Print(Form("ST_Sector_%i.png",j+1));
       t_total_fit[j][2] = gaus->GetParameter(2)*1000;
@@ -156,7 +157,7 @@ void st_time_resolution(char*input_filename)
   ntuple->Write();
   in.close();
   //Create the canvas
-  Time_can = new TCanvas( "Time_can", "Time_can", 800, 600);
+  TCanvas *Time_can = new TCanvas( "Time_can", "Time_can", 800, 600);
   Time_can->SetFillColor(41);
   gStyle->SetOptFit(011);
   ntuple->Draw("sector:tall:taller:ser");

--- a/src/plugins/monitoring/BCAL_Eff/offline/bcal_hist_eff_summary.C
+++ b/src/plugins/monitoring/BCAL_Eff/offline/bcal_hist_eff_summary.C
@@ -1,10 +1,11 @@
+#include <TRandom.h>
+#include <iostream>
+#include <fstream>
+
 void bcal_hist_eff_summary(void)
 {
 // read in histograms plotting BCAL efficiencies and print history to file.
 //
-
-#include <TRandom.h>
-#include <fstream.h>
 
 gROOT->Reset();
 //TTree *Bfield = (TTree *) gROOT->FindObject("Bfield");
@@ -93,7 +94,7 @@ gStyle->SetPadBottomMargin(0.15);
      printf ("Histogram input filename=%s does not open\n",string);
      continue;
    }
-   else if {
+   else {
      printf ("Histogram input filename=%s OK\n",string);
    }
 
@@ -103,11 +104,11 @@ gStyle->SetPadBottomMargin(0.15);
 
    TH1F *h1eff_eff= NULL;
    h1eff_eff = (TH1F*)gDirectory->FindObjectAny("h1eff_eff");
-   TH1F *h1eff_cellideff = (TH1F*))gDirectory->FindObjectAny("h1eff_cellideff");
-   TH1F *h1eff2_eff2 = (TH1F*))gDirectory->FindObjectAny("h1eff2_eff2");
-   TH1F *h1eff2_cellideff2 = (TH1F*))gDirectory->FindObjectAny("h1eff2_cellideff2");
+   TH1F *h1eff_cellideff = (TH1F*)gDirectory->FindObjectAny("h1eff_cellideff");
+   TH1F *h1eff2_eff2 = (TH1F*)gDirectory->FindObjectAny("h1eff2_eff2");
+   TH1F *h1eff2_cellideff2 = (TH1F*)gDirectory->FindObjectAny("h1eff2_cellideff2");
 
-   if (!h1eff_eff == NULL !! h1eff_eff->GetEntries() <=0) continue;
+   if ( (h1eff_eff == NULL) ||  (h1eff_eff->GetEntries() <=0)) continue;
 
    // retrieving information from the histogram
 
@@ -148,11 +149,11 @@ gStyle->SetPadBottomMargin(0.15);
 
    // retrieving information from the histogram
 
-   Int_t ndim = h1eff2_eff2->GetNbinsX();
-   Double_t xlo = h1eff2_eff2->GetBinLowEdge(1);
-   Double_t width = h1eff2_eff2->GetBinWidth(1);
-   Double_t xhi = xlo + width*ndim;
-   printf ("\nbcal_hist_eff2_summary: ndx=%d, ndim=%d, xlo=%f, width=%f, xhi=%d\n\n",ndx,ndim,xlo,width,xhi);
+   ndim = h1eff2_eff2->GetNbinsX();
+   xlo = h1eff2_eff2->GetBinLowEdge(1);
+   width = h1eff2_eff2->GetBinWidth(1);
+   xhi = xlo + width*ndim;
+   printf ("\nbcal_hist_eff2_summary: ndx=%d, ndim=%d, xlo=%f, width=%f, xhi=%f\n\n",ndx,ndim,xlo,width,xhi);
 
       for(j=0;j<ndim;j++) {
       Double_t xbin = xlo + j*width;
@@ -230,7 +231,7 @@ gStyle->SetPadBottomMargin(0.15);
 
    sprintf(string,"hd_rawdata_002179");
    printf ("Histogram input filename=%s\n",string);
-   t1 = new TLatex(0.15,0.92,string);
+   TLatex *t1 = new TLatex(0.15,0.92,string);
    t1->SetNDC();
    t1->SetTextSize(0.03);
    t1->Draw();
@@ -247,7 +248,7 @@ gStyle->SetPadBottomMargin(0.15);
    c2->SetBorderMode(0);
    c2->SetFillColor(0);
 
-  TLegend *leg = new TLegend(0.6,0.80,0.85,0.95);
+   leg = new TLegend(0.6,0.80,0.85,0.95);
   leg->AddEntry(hsummary2_layer1,"Layer 1","p");
   leg->AddEntry(hsummary2_layer2,"Layer 2","p");
   leg->AddEntry(hsummary2_layer3,"Layer 3","p");

--- a/src/plugins/monitoring/BCAL_inv_mass/bcal_inv_mass.C
+++ b/src/plugins/monitoring/BCAL_inv_mass/bcal_inv_mass.C
@@ -26,18 +26,21 @@
   float par_500[15];
   float par_700[15];
   float par_900[15];
-  if(gPad == NULL){
 
-    TCanvas *c1 = new TCanvas( "c1", "BCAL_inv_mass_plot", 800, 800 );
+  TCanvas *c1 = NULL;
+  if(gPad == NULL){
+    c1 = new TCanvas( "c1", "BCAL_inv_mass_plot", 800, 800 );
     c1->cd(0);
     c1->Draw();
     c1->Update();
-
-    TCanvas *c2 = new TCanvas( "c2", "BCAL_inv_mass_dependencies", 800, 800 );
-    c2->cd(0);
-    c2->Draw();
-    c2->Update();
+  } else {
+      c1 = gPad->GetCanvas();
   }
+
+  TCanvas *c2 = new TCanvas( "c2", "BCAL_inv_mass_dependencies", 800, 800 );
+  c2->cd(0);
+  c2->Draw();
+  c2->Update();
 
   if( !gPad ) return;
   c1->Divide(2,2);

--- a/src/plugins/monitoring/CDC_Cosmics/FitScripts/ExtractCDCDeformation.C
+++ b/src/plugins/monitoring/CDC_Cosmics/FitScripts/ExtractCDCDeformation.C
@@ -19,7 +19,7 @@ TH1I * Get1DHistogram(const char * plugin, const char * directoryName, const cha
 TH2I * Get2DHistogram(const char * plugin, const char * directoryName, const char * name){
     TH2I * histogram;
     TString fullName = TString(plugin) + "/" + TString(directoryName) + "/" + TString(name);
-    histogram = thisFile->GetObject(fullName, histogram);
+    thisFile->GetObject(fullName, histogram);
     if (histogram == 0){
         cout << "Unable to find histogram " << fullName.Data() << endl;
         return NULL;
@@ -52,7 +52,7 @@ void ExtractCDCDeformation(TString filename = "hd_root.root"){
 
     // Check to make sure it is open
     if (thisFile == 0) {
-        cout << "Unable to open file " << fileName.Data() << "...Exiting" << endl;
+        cout << "Unable to open file " << filename.Data() << "...Exiting" << endl;
         return;
     }
 

--- a/src/plugins/monitoring/CDC_Efficiency/CDC_Efficiency.C
+++ b/src/plugins/monitoring/CDC_Efficiency/CDC_Efficiency.C
@@ -45,7 +45,7 @@
     TH2D *axesDOCA0 = (TH2D *)gDirectory->Get("axesDOCA0");
     if(!axesDOCA0) axesDOCA0 = new TH2D("axesDOCA0", "CDC Efficiency for DOCA #in [0.0, 0.1 cm]", 100, -65.0, 65.0, 100, -65.0, 65.0);
 
-    Float_t minScale = 0.5; Float_t maxScale = 1.0;
+    minScale = 0.5;   maxScale = 1.0;
     axesDOCA0->SetStats(0);
     axesDOCA0->Fill(100,100); // without this, the color ramp is not drawn
     axesDOCA0->GetZaxis()->SetRangeUser(minScale, maxScale);
@@ -77,7 +77,7 @@
     TH2D *axesDOCA1 = (TH2D *)gDirectory->Get("axesDOCA1");
     if(!axesDOCA1) axesDOCA1 = new TH2D("axesDOCA1", "CDC Efficiency for DOCA #in [0.1, 0.2 cm]", 100, -65.0, 65.0, 100, -65.0, 65.0);
 
-    Float_t minScale = 0.5; Float_t maxScale = 1.0;
+    minScale = 0.5;  maxScale = 1.0;
     axesDOCA1->SetStats(0);
     axesDOCA1->Fill(100,100); // without this, the color ramp is not drawn
     axesDOCA1->GetZaxis()->SetRangeUser(minScale, maxScale);
@@ -109,7 +109,7 @@
     TH2D *axesDOCA2 = (TH2D *)gDirectory->Get("axesDOCA2");
     if(!axesDOCA2) axesDOCA2 = new TH2D("axesDOCA2", "CDC Efficiency for DOCA #in [0.2, 0.3 cm]", 100, -65.0, 65.0, 100, -65.0, 65.0);
 
-    Float_t minScale = 0.5; Float_t maxScale = 1.0;
+    minScale = 0.5;  maxScale = 1.0;
     axesDOCA2->SetStats(0);
     axesDOCA2->Fill(100,100); // without this, the color ramp is not drawn
     axesDOCA2->GetZaxis()->SetRangeUser(minScale, maxScale);
@@ -141,7 +141,7 @@
     TH2D *axesDOCA3 = (TH2D *)gDirectory->Get("axesDOCA3");
     if(!axesDOCA3) axesDOCA3 = new TH2D("axesDOCA3", "CDC Efficiency for DOCA #in [0.3, 0.4 cm]", 100, -65.0, 65.0, 100, -65.0, 65.0);
 
-    Float_t minScale = 0.5; Float_t maxScale = 1.0;
+    minScale = 0.5;  maxScale = 1.0;
     axesDOCA3->SetStats(0);
     axesDOCA3->Fill(100,100); // without this, the color ramp is not drawn
     axesDOCA3->GetZaxis()->SetRangeUser(minScale, maxScale);
@@ -173,7 +173,7 @@
     TH2D *axesDOCA4 = (TH2D *)gDirectory->Get("axesDOCA4");
     if(!axesDOCA4) axesDOCA4 = new TH2D("axesDOCA4", "CDC Efficiency for DOCA #in [0.4, 0.5 cm]", 100, -65.0, 65.0, 100, -65.0, 65.0);
 
-    Float_t minScale = 0.5; Float_t maxScale = 1.0;
+    minScale = 0.5;  maxScale = 1.0;
     axesDOCA4->SetStats(0);
     axesDOCA4->Fill(100,100); // without this, the color ramp is not drawn
     axesDOCA4->GetZaxis()->SetRangeUser(minScale, maxScale);
@@ -205,7 +205,7 @@
     TH2D *axesDOCA5 = (TH2D *)gDirectory->Get("axesDOCA5");
     if(!axesDOCA5) axesDOCA5 = new TH2D("axesDOCA5", "CDC Efficiency for DOCA #in [0.5, 0.6 cm]", 100, -65.0, 65.0, 100, -65.0, 65.0);
 
-    Float_t minScale = 0.5; Float_t maxScale = 1.0;
+    minScale = 0.5;  maxScale = 1.0;
     axesDOCA5->SetStats(0);
     axesDOCA5->Fill(100,100); // without this, the color ramp is not drawn
     axesDOCA5->GetZaxis()->SetRangeUser(minScale, maxScale);
@@ -237,7 +237,7 @@
     TH2D *axesDOCA6 = (TH2D *)gDirectory->Get("axesDOCA6");
     if(!axesDOCA6) axesDOCA6 = new TH2D("axesDOCA6", "CDC Efficiency for DOCA #in [0.6, 0.7 cm]", 100, -65.0, 65.0, 100, -65.0, 65.0);
 
-    Float_t minScale = 0.5; Float_t maxScale = 1.0;
+    minScale = 0.5;  maxScale = 1.0;
     axesDOCA6->SetStats(0);
     axesDOCA6->Fill(100,100); // without this, the color ramp is not drawn
     axesDOCA6->GetZaxis()->SetRangeUser(minScale, maxScale);
@@ -268,8 +268,8 @@
     // Draw axes
     TH2D *axesDOCA7 = (TH2D *)gDirectory->Get("axesDOCA7");
     if(!axesDOCA7) axesDOCA7 = new TH2D("axesDOCA7", "CDC Efficiency for DOCA #in [0.7, 0.78 cm]", 100, -65.0, 65.0, 100, -65.0, 65.0);
-
-    Float_t minScale = 0.5; Float_t maxScale = 1.0;
+    
+    minScale = 0.5;  maxScale = 1.0;
     axesDOCA7->SetStats(0);
     axesDOCA7->Fill(100,100); // without this, the color ramp is not drawn
     axesDOCA7->GetZaxis()->SetRangeUser(minScale, maxScale);

--- a/src/plugins/monitoring/FDC_Efficiency/FDC_Efficiency.C
+++ b/src/plugins/monitoring/FDC_Efficiency/FDC_Efficiency.C
@@ -314,7 +314,7 @@ void FDC_Efficiency(bool save = 0){
   
   cAlignment->cd(1);
   TGraphErrors *galignV = new TGraphErrors(24, cell[0], meanV, cell_err[0], meanV_err);
-  galignV->SetTitle("Alignment along Wire (Error Bars: Sigma); Cell \# ; V_{Hit} - V_{Track} (cm)");
+  galignV->SetTitle("Alignment along Wire (Error Bars: Sigma); Cell # ; V_{Hit} - V_{Track} (cm)");
   galignV->SetMarkerColor(1);
   galignV->SetMarkerStyle(2);
   galignV->Draw("AP");
@@ -337,7 +337,7 @@ void FDC_Efficiency(bool save = 0){
 
   cAlignment->cd(2);
   TGraphErrors *galignU = new TGraphErrors(24, cell[0], meanU, cell_err[0], meanU_err);
-  galignU->SetTitle("Alignment perp. to Wire (Error Bars: Sigma); Cell \# ; U_{Hit} - U_{Track} (cm)");
+  galignU->SetTitle("Alignment perp. to Wire (Error Bars: Sigma); Cell # ; U_{Hit} - U_{Track} (cm)");
   galignU->SetMarkerColor(1);
   galignU->SetMarkerStyle(2);
   galignU->Draw("AP");
@@ -350,7 +350,7 @@ void FDC_Efficiency(bool save = 0){
   TGraphErrors *gmagnet[9];
   for (unsigned int r=0; r<9; r++){
     gmagnet[r] = new TGraphErrors(24, cell[r], slope[r], cell_err[r], slope_err[r]);
-    gmagnet[r]->SetTitle("Value for slope of magnetic deflection; Cell \# ; Slope (cm^{-1})");
+    gmagnet[r]->SetTitle("Value for slope of magnetic deflection; Cell # ; Slope (cm^{-1})");
     gmagnet[r]->SetMarkerColor(r+1);
     gmagnet[r]->SetMarkerStyle(2);
     if (r==0)

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_BeamBunchPeriod.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_BeamBunchPeriod.C
@@ -33,4 +33,6 @@ int RFMacro_BeamBunchPeriod(void)
 		locHist->GetYaxis()->SetLabelSize(0.05);
 		locHist->Draw();
 	}
+
+    return 1;
 }

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_CoarseTimeOffsets.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_CoarseTimeOffsets.C
@@ -173,4 +173,6 @@ int RFMacro_CoarseTimeOffsets(int locRunNumber, string locVariation = "default")
 		locHist_RFDeltaT_PSC_TAGH->GetYaxis()->SetLabelSize(0.05);
 		locHist_RFDeltaT_PSC_TAGH->Draw();
 	}
+
+    return 1;
 }

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_FineTimeOffsets.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_FineTimeOffsets.C
@@ -249,4 +249,6 @@ int RFMacro_FineTimeOffsets(int locRunNumber, string locVariation = "default")
 	locOutputFileStream2.open("rf_time_offset_vars.txt");
 	locOutputFileStream2 << "0.0 " << std::setprecision(8) << locTimeOffsetVariance_TAGH << " " << locTimeOffsetVariance_PSC << " " << locTimeOffsetVariance_FDC << endl;
 	locOutputFileStream2.close();
+
+    return 1;
 }

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_InternalDeltaTs.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_InternalDeltaTs.C
@@ -139,4 +139,6 @@ void Draw_Array(string locSystem, TObjArray* locTotalArray)
 	locCanvasName = string("DeltaTKurtosis_") + locSystem + string("RFCanvas");
 	new TCanvas(locCanvasName.c_str(), locCanvasName.c_str(), 1600, 900);
 	locKurtosisHist->Draw("COLZ");
+
+    return 1;
 }

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_ROCTITimes.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_ROCTITimes.C
@@ -49,4 +49,6 @@ int RFMacro_ROCTITimes(void)
 		TCanvas* locCanvas = new TCanvas(locCanvasName.c_str(), locCanvasName.c_str(), 1200, 800);
 		locHist->Draw();
 	}
+
+    return 1;
 }

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_SelfResolution.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_SelfResolution.C
@@ -100,4 +100,6 @@ int RFMacro_SelfResolution(void)
 		locHist->GetYaxis()->SetLabelSize(0.05);
 		locHist->Draw();
 	}
+
+    return 1;
 }

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_SignalPeriod.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_SignalPeriod.C
@@ -81,4 +81,6 @@ int RFMacro_SignalPeriod(void)
 		locHist->GetYaxis()->SetLabelSize(0.05);
 		locHist->Draw();
 	}
+
+    return 1;
 }

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_TDCConversion.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_TDCConversion.C
@@ -80,4 +80,6 @@ int RFMacro_TDCConversion(void)
 		locHist->GetYaxis()->SetLabelSize(0.05);
 		locHist->Draw();
 	}
+
+    return 1;
 }

--- a/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_TaggerComparison.C
+++ b/src/plugins/monitoring/RF_online/calib_scripts/RFMacro_TaggerComparison.C
@@ -81,4 +81,6 @@ int RFMacro_TaggerComparison(void)
 		locHist->GetYaxis()->SetLabelSize(0.05);
 		locHist->Draw();
 	}
+
+    return 1;
 }

--- a/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_ADC.C
+++ b/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_ADC.C
@@ -92,7 +92,7 @@
   c2->Draw();
   c2->Update();
   if(!gPad) return;
-  TCanvas *c2 = gPad->GetCanvas();
+  c2 = gPad->GetCanvas();
   c2->Divide(3,2);
   // t_adc from hit object
   c2->cd(1);
@@ -152,7 +152,7 @@
   c3->Draw();
   c3->Update();
   if(!gPad) return;
-  TCanvas *c3 = gPad->GetCanvas();
+  c3 = gPad->GetCanvas();
   c3->Divide(3,2);
   // t_adc from hit object
   c3->cd(1);

--- a/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_Expert_Waveform.C
+++ b/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_Expert_Waveform.C
@@ -21,26 +21,27 @@
   for(unsigned int i = 0; i < NCHANNELS; i++)
     {
       // Grab 1D histograms for root file 
-      TH1I *h_amp_vs_sampl_chan[i]       = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan_%i", i+1));
-      TH1I *h_amp_vs_sampl_chan150[i]    = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan150_%i", i+1));
-      TH1I *h_amp_vs_sampl_chan1000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan1000_%i", i+1));
-      TH1I *h_amp_vs_sampl_chan2000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan2000_%i", i+1));
-      TH1I *h_amp_vs_sampl_chan3000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan3000_%i", i+1));
-      TH1I *h_amp_vs_sampl_chan4000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan4000_%i", i+1));
+      h_amp_vs_sampl_chan[i]       = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan_%i", i+1));
+      h_amp_vs_sampl_chan150[i]    = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan150_%i", i+1));
+      h_amp_vs_sampl_chan1000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan1000_%i", i+1));
+      h_amp_vs_sampl_chan2000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan2000_%i", i+1));
+      h_amp_vs_sampl_chan3000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan3000_%i", i+1));
+      h_amp_vs_sampl_chan4000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan4000_%i", i+1));
     }
 
 
   // Create the canvas c1
+  TCanvas *c1 = NULL;
   if(gPad == NULL)
     {
-      TCanvas *c1 = new TCanvas("c1","Start Counter Expert Waveform Histograms( 100 < Pulse height <= 150)", 200, 10, 600, 480);
+      c1 = new TCanvas("c1","Start Counter Expert Waveform Histograms( 100 < Pulse height <= 150)", 200, 10, 600, 480);
       c1->cd(0);
       c1->Draw();
       c1->Update();
     }
   
   if(!gPad) return;
-  TCanvas *c1 = gPad->GetCanvas();
+  c1 = gPad->GetCanvas();
   c1->Divide(5,6);
 
   for(unsigned int i = 0; i < NCHANNELS; i++)
@@ -78,7 +79,7 @@
   c2->Draw();
   c2->Update();  
   if(!gPad) return;
-  TCanvas *c2 = gPad->GetCanvas();
+  c2 = gPad->GetCanvas();
   c2->Divide(5,6);
 
   for(unsigned int i = 0; i < NCHANNELS; i++)
@@ -116,7 +117,7 @@
       c3->Draw();
       c3->Update();
       if(!gPad) return;
-      TCanvas *c3 = gPad->GetCanvas();
+      c3 = gPad->GetCanvas();
       c3->Divide(5,6);
       
       for(unsigned int i = 0; i < NCHANNELS; i++)
@@ -151,7 +152,7 @@
       c4->Draw();
       c4->Update();
       if(!gPad) return;
-      TCanvas *c4 = gPad->GetCanvas();
+      c4 = gPad->GetCanvas();
       c4->Divide(5,6);
       
       for(unsigned int i = 0; i < NCHANNELS; i++)
@@ -186,7 +187,7 @@
       c5->Draw();
       c5->Update();
       if(!gPad) return;
-      TCanvas *c5 = gPad->GetCanvas();
+      c5 = gPad->GetCanvas();
       c5->Divide(5,6);
       
       for(unsigned int i = 0; i < NCHANNELS; i++)
@@ -221,7 +222,7 @@
       c6->Draw();
       c6->Update();
       if(!gPad) return;
-      TCanvas *c6 = gPad->GetCanvas();
+      c6 = gPad->GetCanvas();
       c6->Divide(5,6);
       
       for(unsigned int i = 0; i < NCHANNELS; i++)

--- a/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_Hit.C
+++ b/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_Hit.C
@@ -87,7 +87,7 @@
   c2->Draw();
   c2->Update();
   if(!gPad) return;
-  TCanvas *c2 = gPad->GetCanvas();
+  c2 = gPad->GetCanvas();
   c2->Divide(2,2);
   // t_adc from hit object
   c2->cd(1);

--- a/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_Multi.C
+++ b/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_Multi.C
@@ -85,7 +85,7 @@
   c2->Draw();
   c2->Update();
   if(!gPad) return;
-  TCanvas *c2 = gPad->GetCanvas();
+  c2 = gPad->GetCanvas();
   c2->Divide(3,1);
   
   // Occupancy Histos 

--- a/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_Waveform_ch4.C
+++ b/src/plugins/monitoring/ST_online_lowlevel/ST_Monitoring_Waveform_ch4.C
@@ -20,13 +20,13 @@
   TH1I** h_amp_vs_sampl_chan4000 = new TH1I*[NCHANNELS];
   for(unsigned int i = 0; i < NCHANNELS; i++)
     {
-      // Grab 1D histograms for root file 
-      TH1I *h_amp_vs_sampl_chan[i]       = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan_%i", i+1));
-      TH1I *h_amp_vs_sampl_chan150[i]    = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan150_%i", i+1));
-      TH1I *h_amp_vs_sampl_chan1000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan1000_%i", i+1));
-      TH1I *h_amp_vs_sampl_chan2000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan2000_%i", i+1));
-      TH1I *h_amp_vs_sampl_chan3000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan3000_%i", i+1));
-      TH1I *h_amp_vs_sampl_chan4000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan4000_%i", i+1));
+        // Grab 1D histograms for root file 
+        h_amp_vs_sampl_chan[i]       = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan_%i", i+1));
+        h_amp_vs_sampl_chan150[i]    = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan150_%i", i+1));
+        h_amp_vs_sampl_chan1000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan1000_%i", i+1));
+        h_amp_vs_sampl_chan2000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan2000_%i", i+1));
+        h_amp_vs_sampl_chan3000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan3000_%i", i+1));
+        h_amp_vs_sampl_chan4000[i]   = (TH1I*)gDirectory->FindObjectAny(Form("amp_vs_sampl_chan4000_%i", i+1));
     }
 
 

--- a/src/plugins/monitoring/occupancy_online/TAGGER_occupancy.C
+++ b/src/plugins/monitoring/occupancy_online/TAGGER_occupancy.C
@@ -105,7 +105,7 @@
 	legend_s->Draw();
 	legend_n->Draw();
 
-	TVirtualPad *pad1 = c1->cd(2);
+	pad1 = c1->cd(2);
 	pad1->SetTicks();
 	pad1->SetGridy();
 	if(tagh_adc_occ) tagh_tdc_occ->Draw("BAR");


### PR DESCRIPTION
ROOT 6 has a new interpreted called "cling", which is fully C++11 compliant and does not allow some of the syntactic tricks that CINT did.

In preparation for the move to ROOT 6 as a default, this PR contains several commits to get monitoring/calibration ROOT scripts to compile under ROOT 6.  Several bugs were found and fixed. Note that the correctness of the scripts has not been checked yet.
