### PR TITLE
Merge double hits (doubles) in the TAGH

### DIFF
--- a/src/libraries/TAGGER/DTAGHHit.h
+++ b/src/libraries/TAGGER/DTAGHHit.h
@@ -23,7 +23,7 @@ class DTAGHHit:public jana::JObject{
       double time_tdc;
       double time_fadc;
       double npe_fadc;
-      bool has_fADC,has_TDC;
+      bool has_fADC, has_TDC, is_double;
 
       void toStrings(vector<pair<string,string> > &items)const{
         AddString(items, "counter_id", "%d", counter_id);
@@ -36,6 +36,7 @@ class DTAGHHit:public jana::JObject{
         AddString(items, "npe_fadc", "%f", npe_fadc);
         AddString(items, "has_fADC", "%d", (int)has_fADC);
         AddString(items, "has_TDC", "%d", (int)has_TDC);
+        AddString(items, "is_double", "%d", (int)is_double);
       }
 };
 

--- a/src/libraries/TAGGER/DTAGHHit_factory.cc
+++ b/src/libraries/TAGGER/DTAGHHit_factory.cc
@@ -4,56 +4,36 @@
 // Created: Sat Aug  2 12:23:43 EDT 2014
 // Creator: jonesrt (on Linux gluex.phys.uconn.edu)
 //
-
+// nsparks moved original factory to DTAGHHit_factory_Calib.cc on Aug 3 2016.
 
 #include <iostream>
 #include <iomanip>
-#include <limits>
 using namespace std;
 
-#include "DTAGHDigiHit.h"
-#include "DTAGHTDCDigiHit.h"
-#include "DTAGHGeometry.h"
 #include "DTAGHHit_factory.h"
-#include <DAQ/Df250PulseIntegral.h>
-#include <DAQ/Df250PulsePedestal.h>
-
 using namespace jana;
-
-const int DTAGHHit_factory::k_counter_dead;
-const int DTAGHHit_factory::k_counter_good;
-const int DTAGHHit_factory::k_counter_bad;
-const int DTAGHHit_factory::k_counter_noisy;
 
 //------------------
 // init
 //------------------
 jerror_t DTAGHHit_factory::init(void)
 {
-   DELTA_T_ADC_TDC_MAX = 10.0; // ns
-   gPARMS->SetDefaultParameter("TAGHHit:DELTA_T_ADC_TDC_MAX", DELTA_T_ADC_TDC_MAX,
-   "Maximum difference in ns between a (calibrated) fADC time and"
-   " F1TDC time for them to be matched in a single hit");
-   ADC_THRESHOLD = 1000.0; // ADC integral counts
-   gPARMS->SetDefaultParameter("TAGHHit:ADC_THRESHOLD",ADC_THRESHOLD,
-   "pedestal-subtracted pulse integral threshold");
+    // Set default config. parameters
+    MERGE_DOUBLES = true; // Merge in-time hits of adjacent counters?
+    gPARMS->SetDefaultParameter("TAGHHit:MERGE_DOUBLES", MERGE_DOUBLES,
+    "Merge in-time hits of adjacent counters?");
+    DELTA_T_DOUBLES_MAX = 0.5; // ns
+    gPARMS->SetDefaultParameter("TAGHHit:DELTA_T_DOUBLES_MAX", DELTA_T_DOUBLES_MAX,
+    "Maximum time difference in ns between hits in adjacent counters"
+    " for them to be merged into a single hit");
+    COUNTER_ID_DOUBLES_MAX = 192;
+    gPARMS->SetDefaultParameter("TAGHHit:COUNTER_ID_DOUBLES_MAX", COUNTER_ID_DOUBLES_MAX,
+    "Maximum counter id of a double hit");
+    USE_SIDEBAND_DOUBLES = false;
+    gPARMS->SetDefaultParameter("TAGHHit:USE_SIDEBAND_DOUBLES", USE_SIDEBAND_DOUBLES,
+    "Use sideband to estimate accidental coincidences between neighbors");
 
-   // initialize calibration constants
-   fadc_a_scale = 0;
-   fadc_t_scale = 0;
-   t_base = 0;
-   t_tdc_base=0;
-
-   // calibration constants stored by counter index
-   for (int counter = 0; counter <= TAGH_MAX_COUNTER; ++counter) {
-      fadc_gains[counter] = 0;
-      fadc_pedestals[counter] = 0;
-      fadc_time_offsets[counter] = 0;
-      tdc_time_offsets[counter] = 0;
-      counter_quality[counter] = 0;
-   }
-
-   return NOERROR;
+    return NOERROR;
 }
 
 //------------------
@@ -61,51 +41,11 @@ jerror_t DTAGHHit_factory::init(void)
 //------------------
 jerror_t DTAGHHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 {
-    // Only print messages for one thread whenever run number change
-    static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
-    static set<int> runs_announced;
-    pthread_mutex_lock(&print_mutex);
-    bool print_messages = false;
-    if(runs_announced.find(runnumber) == runs_announced.end()){
-        print_messages = true;
-        runs_announced.insert(runnumber);
-    }
-    pthread_mutex_unlock(&print_mutex);
-
-   /// set the base conversion scales
-   fadc_a_scale    = 1.1;        // pixels per count
-   fadc_t_scale    = 0.0625;     // ns per count
-   t_base           = 0.;      // ns
-
-   if(print_messages) jout << "In DTAGHHit_factory, loading constants..." << std::endl;
-
-   // load base time offset
-   map<string,double> base_time_offset;
-   if (eventLoop->GetCalib("/PHOTON_BEAM/hodoscope/base_time_offset",base_time_offset))
-       jout << "Error loading /PHOTON_BEAM/hodoscope/base_time_offset !" << endl;
-   if (base_time_offset.find("TAGH_BASE_TIME_OFFSET") != base_time_offset.end())
-       t_base = base_time_offset["TAGH_BASE_TIME_OFFSET"];
-   else
-       jerr << "Unable to get TAGH_BASE_TIME_OFFSET from /PHOTON_BEAM/hodoscope/base_time_offset !" << endl;
-
-    if (base_time_offset.find("TAGH_TDC_BASE_TIME_OFFSET") != base_time_offset.end())
-       t_tdc_base = base_time_offset["TAGH_TDC_BASE_TIME_OFFSET"];
-   else
-       jerr << "Unable to get TAGH_TDC_BASE_TIME_OFFSET from /PHOTON_BEAM/hodoscope/base_time_offset !" << endl;
-
-   if (load_ccdb_constants("fadc_gains", "gain", fadc_gains) &&
-       load_ccdb_constants("fadc_pedestals", "pedestal", fadc_pedestals) &&
-       load_ccdb_constants("fadc_time_offsets", "offset", fadc_time_offsets) &&
-       load_ccdb_constants("tdc_time_offsets", "offset", tdc_time_offsets) &&
-       load_ccdb_constants("counter_quality", "code", counter_quality) &&
-       load_ccdb_constants("tdc_timewalk", "c0", tdc_twalk_c0) &&
-       load_ccdb_constants("tdc_timewalk", "c1", tdc_twalk_c1) &&
-       load_ccdb_constants("tdc_timewalk", "c2", tdc_twalk_c2) &&
-       load_ccdb_constants("tdc_timewalk", "c3", tdc_twalk_c3))
-   {
-      return NOERROR;
-   }
-   return UNRECOVERABLE_ERROR;
+    //RF Period
+    vector<double> locBeamPeriodVector;
+    eventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+    dBeamBunchPeriod = locBeamPeriodVector[0];
+    return NOERROR;
 }
 
 //------------------
@@ -113,139 +53,87 @@ jerror_t DTAGHHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 //------------------
 jerror_t DTAGHHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 {
-   /// Generate DTAGHHit object for each DTAGHDigiHit object.
-   /// This is where the first set of calibration constants
-   /// is applied to convert from digitzed units into natural
-   /// units.
-   ///
-   /// Note that this code does NOT get called for simulated
-   /// data in HDDM format. The HDDM event source will copy
-   /// the precalibrated values directly into the _data vector.
+    // A scattered (brems.) electron can hit two adjacent TAGH counters, due
+    // to multiple scattering and small geometric overlap between some counters.
+    // These neighboring, coincident hits should be merged to avoid double counting.
+    // This factory outputs hits after merging double hits (doubles).
 
-   // extract the TAGH geometry
-   vector<const DTAGHGeometry*> taghGeomVect;
-   eventLoop->Get( taghGeomVect );
-   if (taghGeomVect.size() < 1)
-      return OBJECT_NOT_AVAILABLE;
-   const DTAGHGeometry& taghGeom = *(taghGeomVect[0]);
+    // Get (calibrated) TAGH hits
+    vector<const DTAGHHit*> hits;
+    loop->Get(hits, "Calib");
+    // Copy data, skip hits with no ADC info.
+    for (const auto& hit : hits) {
+        if (!hit->has_fADC) continue;
+        DTAGHHit *h = new DTAGHHit;
+        *h = *hit;
+        _data.push_back(h);
+    }
+    // Merge any double hits
+    if (MERGE_DOUBLES && _data.size() > 1)
+        MergeDoubles();
 
-   const DTTabUtilities* locTTabUtilities = NULL;
-   loop->GetSingle(locTTabUtilities);
+    return NOERROR;
+}
 
-   // First loop over all TAGHDigiHits and make DTAGHHits out of them
-   vector<const DTAGHDigiHit*> digihits;
-   loop->Get(digihits);
-   for (unsigned int i=0; i < digihits.size(); i++) {
-      const DTAGHDigiHit *digihit = digihits[i];
-      int counter = digihit->counter_id;
+// Is the hit combo a double hit?
+bool DTAGHHit_factory::IsDoubleHit(int counter_id_diff, double tdiff) {
+    if (!USE_SIDEBAND_DOUBLES) {
+        return (abs(counter_id_diff) == 1) && (fabs(tdiff) < DELTA_T_DOUBLES_MAX);
+    } else {
+        return (abs(counter_id_diff) == 1) && (tdiff > -DELTA_T_DOUBLES_MAX - dBeamBunchPeriod)
+        && (tdiff < DELTA_T_DOUBLES_MAX - dBeamBunchPeriod);
+    }
+}
 
-      // throw away hits from bad or noisy counters
-      int quality = counter_quality[counter];
-      if (quality == k_counter_bad || quality == k_counter_noisy)
-          continue;
+// Find indices of adjacent, in-time hits
+pair<vector<size_t>, vector<size_t> > DTAGHHit_factory::FindDoubles() {
+    pair<vector<size_t>, vector<size_t> > indices;
+    for (size_t i = 0; i < _data.size()-1; i++) {
+        const DTAGHHit* hit1 = _data[i];
+        if (hit1->counter_id > COUNTER_ID_DOUBLES_MAX) continue;
+        for (size_t j = i+1; j < _data.size(); j++) {
+            const DTAGHHit* hit2 = _data[j];
+            int counter_id_diff = hit1->counter_id-hit2->counter_id;
+            double tdiff = hit1->t-hit2->t;
+            if (IsDoubleHit(counter_id_diff,tdiff)) {
+                if (counter_id_diff == -1) {
+                    indices.first.push_back(i); indices.second.push_back(j);
+                } else {
+                    indices.first.push_back(j); indices.second.push_back(i);
+                }
+            }
+        }
+    }
+    return indices;
+}
 
-      // Throw away hits where the fADC timing algorithm failed
-      //if (digihit->pulse_time == 0) continue;
-      // The following condition signals an error state in the flash algorithm
-      // Do not make hits out of these
-      const Df250PulsePedestal* PPobj = NULL;
-      digihit->GetSingle(PPobj);
-      double pulse_peak = 0.0;
-      if (PPobj != NULL){
-          if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
-          pulse_peak = PPobj->pulse_peak - PPobj->pedestal;
-      }
+// Is index in list?
+bool DTAGHHit_factory::In(vector<size_t> &indices, size_t index) {
+    for (const auto& val : indices) {
+        if (index == val) return true;
+    }
+    return false;
+}
 
-      // Get pedestal, prefer associated event pedestal if it exists,
-      // otherwise, use the average pedestal from CCDB
-      double pedestal = fadc_pedestals[counter];
-      const Df250PulseIntegral* PIobj = NULL;
-      digihit->GetSingle(PIobj);
-      if (PIobj != NULL) {
-          // the measured pedestal must be scaled by the ratio of the number
-          // of samples used to calculate the integral and the pedestal
-          // Changed to conform to D. Lawrence changes Dec. 4 2014
-          double ped_sum = (double)PIobj->pedestal;
-          double nsamples_integral = (double)PIobj->nsamples_integral;
-          double nsamples_pedestal = (double)PIobj->nsamples_pedestal;
-          pedestal          = ped_sum * nsamples_integral/nsamples_pedestal;
-      }
-
-      // Subtract pedestal from pulse integral
-      double A = digihit->pulse_integral;
-      A -= pedestal;
-      // Throw away hits with small pedestal-subtracted integrals
-      if (A < ADC_THRESHOLD) continue;
-
-      DTAGHHit *hit = new DTAGHHit;
-      hit->counter_id = counter;
-      double Elow = taghGeom.getElow(counter);
-      double Ehigh = taghGeom.getEhigh(counter);
-      hit->E = (Elow + Ehigh)/2;
-
-      // Apply calibration constants
-      double T = digihit->pulse_time;
-      hit->integral = A;
-      hit->pulse_peak = pulse_peak;
-      hit->npe_fadc = A * fadc_a_scale * fadc_gains[counter];
-      hit->time_fadc = T * fadc_t_scale - fadc_time_offsets[counter] + t_base;
-      hit->time_tdc = numeric_limits<double>::quiet_NaN();
-      hit->t = hit->time_fadc;
-      hit->has_fADC = true;
-      hit->has_TDC = false;
-
-      hit->AddAssociatedObject(digihit);
-      _data.push_back(hit);
-   }
-
-   // Next, loop over TDC hits, matching them to the existing fADC hits
-   // where possible and updating their time information. If no match is
-   // found, then create a new hit with just the TDC info.
-   vector<const DTAGHTDCDigiHit*> tdcdigihits;
-   loop->Get(tdcdigihits);
-   for (unsigned int i=0; i < tdcdigihits.size(); i++) {
-      const DTAGHTDCDigiHit *digihit = tdcdigihits[i];
-
-      // Apply calibration constants here
-      int counter = digihit->counter_id;
-      double T = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(digihit) - tdc_time_offsets[counter] + t_tdc_base;
-
-      // Look for existing hits to see if there is a match
-      // or create new one if there is no match
-      DTAGHHit *hit = 0;
-      for (unsigned int j=0; j < _data.size(); ++j) {
-          if (_data[j]->counter_id == counter &&
-              fabs(T - _data[j]->time_fadc) < DELTA_T_ADC_TDC_MAX)
-              {
-                  hit = _data[j];
-              }
-          }
-          if (hit == 0) {
-              hit = new DTAGHHit;
-              hit->counter_id = counter;
-              double Elow = taghGeom.getElow(counter);
-              double Ehigh = taghGeom.getEhigh(counter);
-              hit->E = (Elow + Ehigh)/2;
-              hit->time_fadc = numeric_limits<double>::quiet_NaN();
-              hit->integral = numeric_limits<double>::quiet_NaN();
-              hit->pulse_peak = numeric_limits<double>::quiet_NaN();
-              hit->npe_fadc = numeric_limits<double>::quiet_NaN();
-              hit->has_fADC = false;
-              _data.push_back(hit);
-          }
-          hit->time_tdc = T;
-          hit->has_TDC = true;
-          // apply time-walk corrections
-          double c0 = tdc_twalk_c0[counter]; double c1 = tdc_twalk_c1[counter];
-          double c2 = tdc_twalk_c2[counter]; double c3 = tdc_twalk_c3[counter];
-          double P = hit->pulse_peak;
-          if (P > 0.0) {
-              T -= (P <= c3 || c3 <= 0.0) ? c0 + c1/pow(P,c2) : c0 +  c1*(1.0+c2)/pow(c3,c2) - c1*c2*P/pow(c3,1.0+c2);
-          }
-          hit->t = T;
-          hit->AddAssociatedObject(digihit);
-   }
-   return NOERROR;
+// Merge adjacent, in-time hits
+void DTAGHHit_factory::MergeDoubles() {
+    pair<vector<size_t>, vector<size_t> > indices = FindDoubles();
+    if (indices.first.size() == 0) return; // Nothing to merge
+    vector<DTAGHHit*> new_data;
+    for (size_t i = 0; i < _data.size(); i++) {
+        if (!In(indices.first,i) && !In(indices.second,i)) new_data.push_back(_data[i]);
+    }
+    vector<DTAGHHit*> merged_data;
+    for (size_t i = 0; i < indices.first.size(); i++) {
+        DTAGHHit* hit1 = _data[indices.first[i]];
+        const DTAGHHit* hit2 = _data[indices.second[i]];
+        hit1->t = 0.5*(hit1->t + hit2->t); hit1->E = 0.5*(hit1->E + hit2->E);
+        hit1->is_double = true;
+        merged_data.push_back(hit1);
+    }
+    for (const auto& d : merged_data) new_data.push_back(d);
+    _data = new_data;
+    if (_data.size() > 1) MergeDoubles(); // Merge any new doubles
 }
 
 //------------------
@@ -262,26 +150,4 @@ jerror_t DTAGHHit_factory::erun(void)
 jerror_t DTAGHHit_factory::fini(void)
 {
     return NOERROR;
-}
-
-//---------------------
-// load_ccdb_constants
-//---------------------
-bool DTAGHHit_factory::load_ccdb_constants(
-   std::string table_name,
-   std::string column_name,
-   double result[TAGH_MAX_COUNTER+1])
-{
-   std::vector< std::map<std::string, double> > table;
-   std::string ccdb_key = "/PHOTON_BEAM/hodoscope/" + table_name;
-   if (eventLoop->GetCalib(ccdb_key, table))
-     {
-       jout << "Error loading " << ccdb_key << " from ccdb!" << std::endl;
-       return false;
-     }
-   for (unsigned int i=0; i < table.size(); ++i) {
-      int counter = (table[i])["id"];
-      result[counter] = (table[i])[column_name];
-   }
-   return true;
 }

--- a/src/libraries/TAGGER/DTAGHHit_factory.h
+++ b/src/libraries/TAGGER/DTAGHHit_factory.h
@@ -19,13 +19,12 @@ class DTAGHHit_factory: public jana::JFactory<DTAGHHit> {
         // config. parameters
         bool MERGE_DOUBLES;
         double DELTA_T_DOUBLES_MAX;
-        int COUNTER_ID_DOUBLES_MAX;
+        int ID_DOUBLES_MAX;
         bool USE_SIDEBAND_DOUBLES;
 
-        bool IsDoubleHit(int counter_id_diff, double tdiff);
-        pair<vector<size_t>, vector<size_t> > FindDoubles();
-        bool In(vector<size_t> &indices, size_t index);
-        void MergeDoubles();
+        bool IsDoubleHit(double tdiff);
+        void EraseHit(vector<DTAGHHit*> &v, DTAGHHit* hit);
+        void MergeDoubles(map<int, vector<DTAGHHit*> > hitsById, map<int, vector<DTAGHHit*> > &doublesById);
 
     private:
         jerror_t init(void);                                          ///< Called once at program start
@@ -35,6 +34,8 @@ class DTAGHHit_factory: public jana::JFactory<DTAGHHit> {
         jerror_t fini(void);                                          ///< Called after last event of last event source has been processed
 
         double dBeamBunchPeriod;
+        void Reset_Data(void);
+        vector<DTAGHHit*> dCreatedTAGHHits;
 };
 
 #endif // _DTAGHHit_factory_

--- a/src/libraries/TAGGER/DTAGHHit_factory.h
+++ b/src/libraries/TAGGER/DTAGHHit_factory.h
@@ -8,58 +8,33 @@
 #ifndef _DTAGHHit_factory_
 #define _DTAGHHit_factory_
 
-#include <vector>
-using namespace std;
-
 #include <JANA/JFactory.h>
-#include "TTAB/DTTabUtilities.h"
-
 #include "DTAGHHit.h"
-#include "DTAGHGeometry.h"
 
 class DTAGHHit_factory: public jana::JFactory<DTAGHHit> {
-   public:
-      DTAGHHit_factory() {};
-      ~DTAGHHit_factory() {};
+    public:
+        DTAGHHit_factory() {};
+        ~DTAGHHit_factory() {};
 
-      static const int k_counter_dead = 0;
-      static const int k_counter_good = 1;
-      static const int k_counter_bad = 2;
-      static const int k_counter_noisy = 3;
+        // config. parameters
+        bool MERGE_DOUBLES;
+        double DELTA_T_DOUBLES_MAX;
+        int COUNTER_ID_DOUBLES_MAX;
+        bool USE_SIDEBAND_DOUBLES;
 
-      // config. parameters
-      double DELTA_T_ADC_TDC_MAX;
-      double ADC_THRESHOLD;
+        bool IsDoubleHit(int counter_id_diff, double tdiff);
+        pair<vector<size_t>, vector<size_t> > FindDoubles();
+        bool In(vector<size_t> &indices, size_t index);
+        void MergeDoubles();
 
-      // fadc pulse integration window width (samples)
-      int fadc_pulse_window_size;
+    private:
+        jerror_t init(void);                                          ///< Called once at program start
+        jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);    ///< Called everytime a new run number is detected
+        jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);  ///< Called every event
+        jerror_t erun(void);                                          ///< Called everytime run number changes, if brun has been called
+        jerror_t fini(void);                                          ///< Called after last event of last event source has been processed
 
-      // overall scale factors
-      double fadc_a_scale;  // pixels per fADC pulse integral count
-      double fadc_t_scale;  // ns per fADC time count
-      double t_base;
-      double t_tdc_base;
-
-      // calibration constants stored in row, column format
-      double fadc_gains[TAGH_MAX_COUNTER+1];
-      double fadc_pedestals[TAGH_MAX_COUNTER+1];
-      double fadc_time_offsets[TAGH_MAX_COUNTER+1];
-      double tdc_time_offsets[TAGH_MAX_COUNTER+1];
-      double counter_quality[TAGH_MAX_COUNTER+1];
-      double tdc_twalk_c0[TAGH_MAX_COUNTER+1];
-      double tdc_twalk_c1[TAGH_MAX_COUNTER+1];
-      double tdc_twalk_c2[TAGH_MAX_COUNTER+1];
-      double tdc_twalk_c3[TAGH_MAX_COUNTER+1];
-
-      bool load_ccdb_constants(std::string table_name,
-                               std::string column_name,
-                               double table[TAGH_MAX_COUNTER+1]);
-   private:
-      jerror_t init(void);                                          ///< Called once at program start
-      jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);    ///< Called everytime a new run number is detected
-      jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);  ///< Called every event
-      jerror_t erun(void);                                          ///< Called everytime run number changes, if brun has been called
-      jerror_t fini(void);                                          ///< Called after last event of last event source has been processed
+        double dBeamBunchPeriod;
 };
 
 #endif // _DTAGHHit_factory_

--- a/src/libraries/TAGGER/DTAGHHit_factory_Calib.cc
+++ b/src/libraries/TAGGER/DTAGHHit_factory_Calib.cc
@@ -1,0 +1,290 @@
+// $Id$
+//
+//    File: DTAGHHit_factory_Calib.cc
+// Created: Wed Aug  3 12:55:19 EDT 2016
+// Creator: nsparks (on Linux cua2.jlab.org 3.10.0-327.22.2.el7.x86_64 x86_64)
+//
+
+
+#include <iostream>
+#include <iomanip>
+#include <limits>
+using namespace std;
+
+#include "DTAGHHit_factory_Calib.h"
+#include "DTAGHDigiHit.h"
+#include "DTAGHTDCDigiHit.h"
+#include "TTAB/DTTabUtilities.h"
+#include <DAQ/Df250PulseIntegral.h>
+#include <DAQ/Df250PulsePedestal.h>
+
+using namespace jana;
+
+const int DTAGHHit_factory_Calib::k_counter_dead;
+const int DTAGHHit_factory_Calib::k_counter_good;
+const int DTAGHHit_factory_Calib::k_counter_bad;
+const int DTAGHHit_factory_Calib::k_counter_noisy;
+
+//------------------
+// init
+//------------------
+jerror_t DTAGHHit_factory_Calib::init(void)
+{
+    // set default config. parameters
+    DELTA_T_ADC_TDC_MAX = 10.0; // ns
+    gPARMS->SetDefaultParameter("TAGHHit:DELTA_T_ADC_TDC_MAX", DELTA_T_ADC_TDC_MAX,
+    "Maximum difference in ns between a (calibrated) fADC time and"
+    " F1TDC time for them to be matched in a single hit");
+    ADC_THRESHOLD = 1000.0; // ADC integral counts
+    gPARMS->SetDefaultParameter("TAGHHit:ADC_THRESHOLD",ADC_THRESHOLD,
+    "pedestal-subtracted pulse integral threshold");
+
+    // initialize calibration constants
+    fadc_a_scale = 0;
+    fadc_t_scale = 0;
+    t_base = 0;
+    t_tdc_base=0;
+
+    // calibration constants stored by counter index
+    for (int counter = 0; counter <= TAGH_MAX_COUNTER; ++counter) {
+        fadc_gains[counter] = 0;
+        fadc_pedestals[counter] = 0;
+        fadc_time_offsets[counter] = 0;
+        tdc_time_offsets[counter] = 0;
+        counter_quality[counter] = 0;
+    }
+
+    return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t DTAGHHit_factory_Calib::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
+{
+    // Only print messages for one thread whenever run number change
+    static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
+    static set<int> runs_announced;
+    pthread_mutex_lock(&print_mutex);
+    bool print_messages = false;
+    if(runs_announced.find(runnumber) == runs_announced.end()){
+        print_messages = true;
+        runs_announced.insert(runnumber);
+    }
+    pthread_mutex_unlock(&print_mutex);
+
+    /// set the base conversion scales
+    fadc_a_scale    = 1.1;        // pixels per count
+    fadc_t_scale    = 0.0625;     // ns per count
+    t_base           = 0.;      // ns
+
+    if(print_messages) jout << "In DTAGHHit_factory, loading constants..." << std::endl;
+
+    // load base time offset
+    map<string,double> base_time_offset;
+    if (eventLoop->GetCalib("/PHOTON_BEAM/hodoscope/base_time_offset",base_time_offset))
+        jout << "Error loading /PHOTON_BEAM/hodoscope/base_time_offset !" << endl;
+    if (base_time_offset.find("TAGH_BASE_TIME_OFFSET") != base_time_offset.end())
+        t_base = base_time_offset["TAGH_BASE_TIME_OFFSET"];
+    else
+        jerr << "Unable to get TAGH_BASE_TIME_OFFSET from /PHOTON_BEAM/hodoscope/base_time_offset !" << endl;
+
+    if (base_time_offset.find("TAGH_TDC_BASE_TIME_OFFSET") != base_time_offset.end())
+        t_tdc_base = base_time_offset["TAGH_TDC_BASE_TIME_OFFSET"];
+    else
+        jerr << "Unable to get TAGH_TDC_BASE_TIME_OFFSET from /PHOTON_BEAM/hodoscope/base_time_offset !" << endl;
+
+    if (load_ccdb_constants("fadc_gains", "gain", fadc_gains) &&
+        load_ccdb_constants("fadc_pedestals", "pedestal", fadc_pedestals) &&
+        load_ccdb_constants("fadc_time_offsets", "offset", fadc_time_offsets) &&
+        load_ccdb_constants("tdc_time_offsets", "offset", tdc_time_offsets) &&
+        load_ccdb_constants("counter_quality", "code", counter_quality) &&
+        load_ccdb_constants("tdc_timewalk", "c0", tdc_twalk_c0) &&
+        load_ccdb_constants("tdc_timewalk", "c1", tdc_twalk_c1) &&
+        load_ccdb_constants("tdc_timewalk", "c2", tdc_twalk_c2) &&
+        load_ccdb_constants("tdc_timewalk", "c3", tdc_twalk_c3))
+    {
+        return NOERROR;
+    }
+    return UNRECOVERABLE_ERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t DTAGHHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
+{
+    /// Generate DTAGHHit object for each DTAGHDigiHit object.
+    /// This is where the first set of calibration constants
+    /// is applied to convert from digitzed units into natural
+    /// units.
+    ///
+    /// Note that this code does NOT get called for simulated
+    /// data in HDDM format. The HDDM event source will copy
+    /// the precalibrated values directly into the _data vector.
+
+    // extract the TAGH geometry
+    vector<const DTAGHGeometry*> taghGeomVect;
+    eventLoop->Get( taghGeomVect );
+    if (taghGeomVect.size() < 1)
+        return OBJECT_NOT_AVAILABLE;
+    const DTAGHGeometry& taghGeom = *(taghGeomVect[0]);
+
+    const DTTabUtilities* locTTabUtilities = NULL;
+    loop->GetSingle(locTTabUtilities);
+
+    // First loop over all TAGHDigiHits and make DTAGHHits out of them
+    vector<const DTAGHDigiHit*> digihits;
+    loop->Get(digihits);
+    for (unsigned int i=0; i < digihits.size(); i++) {
+        const DTAGHDigiHit *digihit = digihits[i];
+        int counter = digihit->counter_id;
+
+        // throw away hits from bad or noisy counters
+        int quality = counter_quality[counter];
+        if (quality == k_counter_bad || quality == k_counter_noisy)
+            continue;
+
+        // Throw away hits where the fADC timing algorithm failed
+        //if (digihit->pulse_time == 0) continue;
+        // The following condition signals an error state in the flash algorithm
+        // Do not make hits out of these
+        const Df250PulsePedestal* PPobj = NULL;
+        digihit->GetSingle(PPobj);
+        double pulse_peak = 0.0;
+        if (PPobj != NULL){
+            if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
+            pulse_peak = PPobj->pulse_peak - PPobj->pedestal;
+        }
+
+        // Get pedestal, prefer associated event pedestal if it exists,
+        // otherwise, use the average pedestal from CCDB
+        double pedestal = fadc_pedestals[counter];
+        const Df250PulseIntegral* PIobj = NULL;
+        digihit->GetSingle(PIobj);
+        if (PIobj != NULL) {
+            // the measured pedestal must be scaled by the ratio of the number
+            // of samples used to calculate the integral and the pedestal
+            // Changed to conform to D. Lawrence changes Dec. 4 2014
+            double ped_sum = (double)PIobj->pedestal;
+            double nsamples_integral = (double)PIobj->nsamples_integral;
+            double nsamples_pedestal = (double)PIobj->nsamples_pedestal;
+            pedestal          = ped_sum * nsamples_integral/nsamples_pedestal;
+        }
+
+        // Subtract pedestal from pulse integral
+        double A = digihit->pulse_integral;
+        A -= pedestal;
+        // Throw away hits with small pedestal-subtracted integrals
+        if (A < ADC_THRESHOLD) continue;
+
+        DTAGHHit *hit = new DTAGHHit;
+        hit->counter_id = counter;
+        double Elow = taghGeom.getElow(counter);
+        double Ehigh = taghGeom.getEhigh(counter);
+        hit->E = (Elow + Ehigh)/2;
+
+        // Apply calibration constants
+        double T = digihit->pulse_time;
+        hit->integral = A;
+        hit->pulse_peak = pulse_peak;
+        hit->npe_fadc = A * fadc_a_scale * fadc_gains[counter];
+        hit->time_fadc = T * fadc_t_scale - fadc_time_offsets[counter] + t_base;
+        hit->time_tdc = numeric_limits<double>::quiet_NaN();
+        hit->t = hit->time_fadc;
+        hit->has_fADC = true;
+        hit->has_TDC = false;
+        hit->is_double = false;
+
+        hit->AddAssociatedObject(digihit);
+        _data.push_back(hit);
+    }
+
+    // Next, loop over TDC hits, matching them to the existing fADC hits
+    // where possible and updating their time information. If no match is
+    // found, then create a new hit with just the TDC info.
+    vector<const DTAGHTDCDigiHit*> tdcdigihits;
+    loop->Get(tdcdigihits);
+    for (unsigned int i=0; i < tdcdigihits.size(); i++) {
+        const DTAGHTDCDigiHit *digihit = tdcdigihits[i];
+
+        // Apply calibration constants here
+        int counter = digihit->counter_id;
+        double T = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(digihit) - tdc_time_offsets[counter] + t_tdc_base;
+
+        // Look for existing hits to see if there is a match
+        // or create new one if there is no match
+        DTAGHHit *hit = 0;
+        for (unsigned int j=0; j < _data.size(); ++j) {
+            if (_data[j]->counter_id == counter &&
+                fabs(T - _data[j]->time_fadc) < DELTA_T_ADC_TDC_MAX)
+                {
+                    hit = _data[j];
+                }
+        }
+        if (hit == 0) {
+            hit = new DTAGHHit;
+            hit->counter_id = counter;
+            double Elow = taghGeom.getElow(counter);
+            double Ehigh = taghGeom.getEhigh(counter);
+            hit->E = (Elow + Ehigh)/2;
+            hit->time_fadc = numeric_limits<double>::quiet_NaN();
+            hit->integral = numeric_limits<double>::quiet_NaN();
+            hit->pulse_peak = numeric_limits<double>::quiet_NaN();
+            hit->npe_fadc = numeric_limits<double>::quiet_NaN();
+            hit->has_fADC = false;
+            hit->is_double = false;
+            _data.push_back(hit);
+        }
+        hit->time_tdc = T;
+        hit->has_TDC = true;
+        // apply time-walk corrections
+        double c0 = tdc_twalk_c0[counter]; double c1 = tdc_twalk_c1[counter];
+        double c2 = tdc_twalk_c2[counter]; double c3 = tdc_twalk_c3[counter];
+        double P = hit->pulse_peak;
+        if (P > 0.0) {
+            T -= (P <= c3 || c3 <= 0.0) ? c0 + c1/pow(P,c2) : c0 +  c1*(1.0+c2)/pow(c3,c2) - c1*c2*P/pow(c3,1.0+c2);
+        }
+        hit->t = T;
+        hit->AddAssociatedObject(digihit);
+    }
+    return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t DTAGHHit_factory_Calib::erun(void)
+{
+    return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t DTAGHHit_factory_Calib::fini(void)
+{
+    return NOERROR;
+}
+
+//---------------------
+// load_ccdb_constants
+//---------------------
+bool DTAGHHit_factory_Calib::load_ccdb_constants(
+    std::string table_name,
+    std::string column_name,
+    double result[TAGH_MAX_COUNTER+1])
+{
+    std::vector< std::map<std::string, double> > table;
+    std::string ccdb_key = "/PHOTON_BEAM/hodoscope/" + table_name;
+    if (eventLoop->GetCalib(ccdb_key, table))
+    {
+        jout << "Error loading " << ccdb_key << " from ccdb!" << std::endl;
+        return false;
+    }
+    for (unsigned int i=0; i < table.size(); ++i) {
+        int counter = (table[i])["id"];
+        result[counter] = (table[i])[column_name];
+    }
+    return true;
+}

--- a/src/libraries/TAGGER/DTAGHHit_factory_Calib.h
+++ b/src/libraries/TAGGER/DTAGHHit_factory_Calib.h
@@ -1,0 +1,59 @@
+// $Id$
+//
+//    File: DTAGHHit_factory_Calib.h
+// Created: Wed Aug  3 12:55:19 EDT 2016
+// Creator: nsparks (on Linux cua2.jlab.org 3.10.0-327.22.2.el7.x86_64 x86_64)
+//
+
+#ifndef _DTAGHHit_factory_Calib_
+#define _DTAGHHit_factory_Calib_
+
+#include <JANA/JFactory.h>
+#include "DTAGHHit.h"
+#include "DTAGHGeometry.h"
+
+class DTAGHHit_factory_Calib:public jana::JFactory<DTAGHHit>{
+    public:
+        DTAGHHit_factory_Calib(){};
+        ~DTAGHHit_factory_Calib(){};
+        const char* Tag(void){return "Calib";}
+
+        static const int k_counter_dead = 0;
+        static const int k_counter_good = 1;
+        static const int k_counter_bad = 2;
+        static const int k_counter_noisy = 3;
+
+        // config. parameters
+        double DELTA_T_ADC_TDC_MAX;
+        double ADC_THRESHOLD;
+
+        // overall scale factors
+        double fadc_a_scale;  // pixels per fADC pulse integral count
+        double fadc_t_scale;  // ns per fADC time count
+        double t_base;
+        double t_tdc_base;
+
+        // calibration constants stored in row, column format
+        double fadc_gains[TAGH_MAX_COUNTER+1];
+        double fadc_pedestals[TAGH_MAX_COUNTER+1];
+        double fadc_time_offsets[TAGH_MAX_COUNTER+1];
+        double tdc_time_offsets[TAGH_MAX_COUNTER+1];
+        double counter_quality[TAGH_MAX_COUNTER+1];
+        double tdc_twalk_c0[TAGH_MAX_COUNTER+1];
+        double tdc_twalk_c1[TAGH_MAX_COUNTER+1];
+        double tdc_twalk_c2[TAGH_MAX_COUNTER+1];
+        double tdc_twalk_c3[TAGH_MAX_COUNTER+1];
+
+        bool load_ccdb_constants(std::string table_name,
+            std::string column_name,
+            double table[TAGH_MAX_COUNTER+1]);
+
+    private:
+        jerror_t init(void);						///< Called once at program start.
+        jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+        jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+        jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+        jerror_t fini(void);						///< Called after last event of last event source has been processed.
+};
+
+#endif // _DTAGHHit_factory_Calib_

--- a/src/libraries/TAGGER/TAGGER_init.cc
+++ b/src/libraries/TAGGER/TAGGER_init.cc
@@ -15,6 +15,7 @@ using namespace jana;
 #include "DTAGHGeometry_factory.h"
 #include "DTAGMHit_factory.h"
 #include "DTAGHHit_factory.h"
+#include "DTAGHHit_factory_Calib.h"
 
 
 jerror_t TAGGER_init(JEventLoop *loop)
@@ -26,10 +27,11 @@ jerror_t TAGGER_init(JEventLoop *loop)
   loop->AddFactory(new JFactory<DTAGHTDCDigiHit>());
   loop->AddFactory(new DTAGMHit_factory());
   loop->AddFactory(new DTAGHHit_factory());
+  loop->AddFactory(new DTAGHHit_factory_Calib());
   loop->AddFactory(new JFactory<DTAGMHit>("TRUTH"));
   loop->AddFactory(new JFactory<DTAGHHit>("TRUTH"));
   loop->AddFactory(new DTAGMGeometry_factory());
   loop->AddFactory(new DTAGHGeometry_factory());
-  
+
   return NOERROR;
 }

--- a/src/plugins/Calibration/HLDetectorTiming/JEventProcessor_HLDetectorTiming.cc
+++ b/src/plugins/Calibration/HLDetectorTiming/JEventProcessor_HLDetectorTiming.cc
@@ -194,7 +194,7 @@ jerror_t JEventProcessor_HLDetectorTiming::evnt(JEventLoop *loop, uint64_t event
     loop->Get(tofHitVector);
     loop->Get(fcalHitVector);
     loop->Get(tagmHitVector);
-    loop->Get(taghHitVector);
+    loop->Get(taghHitVector, "Calib");
 
     // TTabUtilities object used for RF time conversion
     const DTTabUtilities* locTTabUtilities = NULL;

--- a/src/plugins/Calibration/TAGH_timewalk/JEventProcessor_TAGH_timewalk.cc
+++ b/src/plugins/Calibration/TAGH_timewalk/JEventProcessor_TAGH_timewalk.cc
@@ -102,7 +102,7 @@ jerror_t JEventProcessor_TAGH_timewalk::evnt(JEventLoop *loop, uint64_t eventnum
     // reconstruction algorithm) should be done outside of any mutex lock
     // since multiple threads may call this method at the same time.
     vector<const DTAGHHit*> taghhits;
-    loop->Get(taghhits);
+    loop->Get(taghhits, "Calib");
     const DRFTime* rfTime = NULL;
     vector <const DRFTime*> rfTimes;
     loop->Get(rfTimes,"TAGH");

--- a/src/plugins/monitoring/SConscript
+++ b/src/plugins/monitoring/SConscript
@@ -1,4 +1,4 @@
-
+import sbms
 Import('*')
 
 subdirs = [
@@ -50,5 +50,5 @@ if "llvm" not in env["OSNAME"]:
 		subdirs.append(directory)
 else: print "Apple Clang does not support thread_local at this time. Skipping\n", require_thread_local
 
-
+sbms.OptionallyBuild(env, ['TAGH_doubles'])
 SConscript(dirs=subdirs, exports='env osname', duplicate=0)

--- a/src/plugins/monitoring/TAGH_doubles/JEventProcessor_TAGH_doubles.cc
+++ b/src/plugins/monitoring/TAGH_doubles/JEventProcessor_TAGH_doubles.cc
@@ -1,0 +1,208 @@
+// $Id$
+//
+//    File: JEventProcessor_TAGH_doubles.cc
+// Created: Fri Apr 29 15:19:27 EDT 2016
+// Creator: nsparks (on Linux cua2.jlab.org 3.10.0-327.13.1.el7.x86_64 x86_64)
+//
+
+#include "JEventProcessor_TAGH_doubles.h"
+using namespace jana;
+using namespace std;
+
+// Routine used to create our JEventProcessor
+#include <JANA/JApplication.h>
+#include <JANA/JFactory.h>
+
+#include <TAGGER/DTAGHHit.h>
+#include <TAGGER/DTAGHGeometry.h>
+#include <TDirectory.h>
+#include <TH1.h>
+#include <TH2.h>
+
+const int Nslots = DTAGHGeometry::kCounterCount;
+const int NmultBins = 200; // number of bins for multiplicity histograms
+
+static TH2I *hBM_tdiffVsIDdiff;
+static TH2I *hAM_tdiffVsIDdiff;
+static TH1F *hBM1_Occupancy;
+static TH1F *hBM2_Occupancy;
+static TH1F *hAM1_Occupancy;
+static TH1F *hAM2_Occupancy;
+static TH1F *hAM3_Occupancy;
+static TH1F *hBM1_Energy;
+static TH1F *hBM2_Energy;
+static TH1F *hAM1_Energy;
+static TH1F *hAM2_Energy;
+static TH1F *hAM3_Energy;
+static TH1I *hBM_NHits;
+static TH1I *hAM_NHits;
+
+extern "C"{
+    void InitPlugin(JApplication *app){
+        InitJANAPlugin(app);
+        app->AddProcessor(new JEventProcessor_TAGH_doubles());
+    }
+} // "C"
+
+
+//------------------
+// JEventProcessor_TAGH_doubles (Constructor)
+//------------------
+JEventProcessor_TAGH_doubles::JEventProcessor_TAGH_doubles()
+{
+
+}
+
+//------------------
+// ~JEventProcessor_TAGH_doubles (Destructor)
+//------------------
+JEventProcessor_TAGH_doubles::~JEventProcessor_TAGH_doubles()
+{
+
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_TAGH_doubles::init(void)
+{
+    // This is called once at program startup.
+    TDirectory *mainDir = gDirectory;
+    TDirectory *taghDir = gDirectory->mkdir("TAGH_doubles");
+    taghDir->cd();
+    gDirectory->mkdir("BeforeMergingDoubles")->cd();
+    hBM_tdiffVsIDdiff = new TH2I("BM_tdiffVsIDdiff","TAGH 2-hit time difference vs. counter ID difference;counter ID difference;time difference [ns]",15,0.5,15.5,200,-5.0,5.0);
+    hBM_NHits = new TH1I("BM_NHits","TAGH multiplicity: All hits, before merging doubles;hits;events",NmultBins,0.5,0.5+NmultBins);
+    hBM1_Occupancy = new TH1F("BM1_Occupancy","TAGH occ.: All hits, before merging doubles;counter (slot) ID;hits / counter",Nslots,0.5,0.5+Nslots);
+    hBM2_Occupancy = new TH1F("BM2_Occupancy","TAGH occ.: Doubles only, before merging doubles;counter (slot) ID;hits / counter",Nslots,0.5,0.5+Nslots);
+    hBM1_Energy    = new TH1F("BM1_Energy","TAGH energy: All hits, before merging doubles;photon energy [GeV];hits / counter",180,3.0,12.0);
+    hBM2_Energy    = new TH1F("BM2_Energy","TAGH energy: Doubles only, before merging doubles;photon energy [GeV];hits / counter",180,3.0,12.0);
+    taghDir->cd();
+    gDirectory->mkdir("AfterMergingDoubles")->cd();
+    hAM_tdiffVsIDdiff = new TH2I("AM_tdiffVsIDdiff","TAGH 2-hit time difference vs. counter ID difference;counter ID difference;time difference [ns]",15,0.5,15.5,200,-5.0,5.0);
+    hAM_NHits = new TH1I("AM_NHits","TAGH multiplicity: All hits, after merging doubles;hits;events",NmultBins,0.5,0.5+NmultBins);
+    hAM1_Occupancy    = new TH1F("AM1_Occupancy","TAGH occ.: All hits, after merging doubles;counter (slot) ID;hits / counter",Nslots,0.5,0.5+Nslots);
+    hAM2_Occupancy    = new TH1F("AM2_Occupancy","TAGH occ.: Doubles only, after merging doubles;counter (slot) ID;hits / counter",Nslots,0.5,0.5+Nslots);
+    hAM3_Occupancy    = new TH1F("AM3_Occupancy","TAGH occ.: Doubles only w/ overlaps, after merging doubles;counter (slot) ID;hits / counter",Nslots,0.5,0.5+Nslots);
+    hAM1_Energy    = new TH1F("AM1_Energy","TAGH energy: All hits, after merging doubles;photon energy [GeV];hits / counter",180,3.0,12.0);
+    hAM2_Energy    = new TH1F("AM2_Energy","TAGH energy: Doubles only, after merging doubles;photon energy [GeV];hits / counter",180,3.0,12.0);
+    hAM3_Energy    = new TH1F("AM3_Energy","TAGH energy: Doubles only w/ overlaps, after merging doubles;photon energy [GeV];hits / counter",180,3.0,12.0);
+    // back to main dir
+    mainDir->cd();
+
+return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_TAGH_doubles::brun(JEventLoop *eventLoop, int32_t runnumber)
+{
+    // This is called whenever the run number changes
+    return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_TAGH_doubles::evnt(JEventLoop *loop, uint64_t eventnumber)
+{
+    // This is called for every event. Use of common resources like writing
+    // to a file or filling a histogram should be mutex protected. Using
+    // loop->Get(...) to get reconstructed objects (and thereby activating the
+    // reconstruction algorithm) should be done outside of any mutex lock
+    // since multiple threads may call this method at the same time.
+
+    // Get unmerged hits
+    vector<const DTAGHHit*> hits_c;
+    loop->Get(hits_c, "Calib");
+    // Get merged hits
+    vector<const DTAGHHit*> hits;
+    loop->Get(hits);
+
+    if (hits.size() == 0) return NOERROR;
+
+    // Extract the TAGH geometry
+    vector<const DTAGHGeometry*> taghGeomVect;
+    loop->Get(taghGeomVect);
+    if (taghGeomVect.size() < 1)
+        return OBJECT_NOT_AVAILABLE;
+    const DTAGHGeometry& taghGeom = *(taghGeomVect[0]);
+
+    japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+    // Before merging doubles
+    int BM_NHits = 0;
+    for (const auto& hit : hits_c) {
+        if (!hit->has_TDC||!hit->has_fADC) continue;
+        BM_NHits++;
+        hBM1_Occupancy->Fill(hit->counter_id);
+        hBM1_Energy->Fill(hit->E);
+        if (hit->is_double) hBM2_Occupancy->Fill(hit->counter_id);
+        if (hit->is_double) hBM2_Energy->Fill(hit->E);
+    }
+    hBM_NHits->Fill(BM_NHits);
+    if (hits_c.size() > 1) {
+        for (size_t i = 0; i < hits_c.size()-1; i++) {
+            const DTAGHHit* hit1 = hits_c[i];
+            if (!hit1->has_TDC||!hit1->has_fADC) continue;
+            for (size_t j = i+1; j < hits_c.size(); j++) {
+                const DTAGHHit* hit2 = hits_c[j];
+                if (!hit2->has_TDC||!hit2->has_fADC) continue;
+                hBM_tdiffVsIDdiff->Fill(abs(hit1->counter_id-hit2->counter_id),hit1->t-hit2->t);
+            }
+        }
+    }
+    // After merging doubles
+    int AM_NHits = 0;
+    for (const auto& hit : hits) {
+        if (!hit->has_TDC||!hit->has_fADC) continue;
+        AM_NHits++;
+        bool has_overlap = false;
+        if (hit->counter_id < 274) {
+            double El = taghGeom.getElow(hit->counter_id); double Eh1 = taghGeom.getEhigh(hit->counter_id+1);
+            has_overlap = (Eh1 > El);
+        }
+        hAM1_Occupancy->Fill(hit->counter_id);
+        hAM1_Energy->Fill(hit->E);
+        if (hit->is_double) hAM2_Occupancy->Fill(hit->counter_id);
+        if (hit->is_double) hAM2_Energy->Fill(hit->E);
+        if (hit->is_double && has_overlap) hAM3_Occupancy->Fill(hit->counter_id);
+        if (hit->is_double && has_overlap) hAM3_Energy->Fill(hit->E);
+    }
+    hAM_NHits->Fill(AM_NHits);
+    if (hits.size() > 1) {
+        for (size_t i = 0; i < hits.size()-1; i++) {
+            const DTAGHHit* hit1 = hits[i];
+            if (!hit1->has_TDC||!hit1->has_fADC) continue;
+            for (size_t j = i+1; j < hits.size(); j++) {
+                const DTAGHHit* hit2 = hits[j];
+                if (!hit2->has_TDC||!hit2->has_fADC) continue;
+                hAM_tdiffVsIDdiff->Fill(abs(hit1->counter_id-hit2->counter_id),hit1->t-hit2->t);
+            }
+        }
+    }
+    japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
+
+    return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_TAGH_doubles::erun(void)
+{
+    // This is called whenever the run number changes, before it is
+    // changed to give you a chance to clean up before processing
+    // events from the next run number.
+    return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t JEventProcessor_TAGH_doubles::fini(void)
+{
+    // Called before program exit after event processing is finished.
+    return NOERROR;
+}

--- a/src/plugins/monitoring/TAGH_doubles/JEventProcessor_TAGH_doubles.h
+++ b/src/plugins/monitoring/TAGH_doubles/JEventProcessor_TAGH_doubles.h
@@ -1,0 +1,27 @@
+// $Id$
+//
+//    File: JEventProcessor_TAGH_doubles.h
+// Created: Fri Apr 29 15:19:27 EDT 2016
+// Creator: nsparks (on Linux cua2.jlab.org 3.10.0-327.13.1.el7.x86_64 x86_64)
+//
+
+#ifndef _JEventProcessor_TAGH_doubles_
+#define _JEventProcessor_TAGH_doubles_
+
+#include <JANA/JEventProcessor.h>
+
+class JEventProcessor_TAGH_doubles:public jana::JEventProcessor{
+    public:
+        JEventProcessor_TAGH_doubles();
+        ~JEventProcessor_TAGH_doubles();
+        const char* className(void){return "JEventProcessor_TAGH_doubles";}
+
+    private:
+        jerror_t init(void);						///< Called once at program start.
+        jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+        jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+        jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+        jerror_t fini(void);						///< Called after last event of last event source has been processed.
+};
+
+#endif // _JEventProcessor_TAGH_doubles_

--- a/src/plugins/monitoring/TAGH_doubles/SConscript
+++ b/src/plugins/monitoring/TAGH_doubles/SConscript
@@ -1,0 +1,12 @@
+
+
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddDANA(env)
+sbms.plugin(env)
+
+

--- a/src/plugins/monitoring/TAGH_doubles/TAGH_doubles_E.C
+++ b/src/plugins/monitoring/TAGH_doubles/TAGH_doubles_E.C
@@ -1,0 +1,32 @@
+// Plot fraction of TAGH hits that are double hits vs. Energy
+
+void TAGH_doubles_E()
+{
+    TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("TAGH_doubles");
+    if(dir) dir->cd();
+
+    TH1F *doubles =(TH1F*)gDirectory->Get("BeforeMergingDoubles/BM2_Energy");
+    TH1F *total =(TH1F*)gDirectory->Get("BeforeMergingDoubles/BM1_Energy");
+
+    TH1F *f_doubles = (TH1F*)doubles->Clone();
+    f_doubles->Sumw2();
+    f_doubles->Divide(doubles, total);
+
+    if(gPad == NULL) {
+        TCanvas *c1 = new TCanvas("c1","TAGH double-hit fraction",150,10,990,660);
+        c1->cd(0);
+        c1->Draw();
+        c1->Update();
+    }
+
+    if(!gPad) return;
+    TCanvas* c1 = gPad->GetCanvas();
+
+    gStyle->SetOptStat("");
+    f_doubles->SetTitle("TAGH double-hit fraction vs. energy");
+    f_doubles->SetTitleSize(0.045, "XY");
+    f_doubles->GetXaxis()->SetTitle("TAGH energy [GeV]");
+    f_doubles->GetYaxis()->SetTitle("double-hit fraction");
+    f_doubles->SetAxisRange(0.0,1.0,"Y");
+    f_doubles->Draw();
+}

--- a/src/plugins/monitoring/TAGH_doubles/TAGH_doubles_ID.C
+++ b/src/plugins/monitoring/TAGH_doubles/TAGH_doubles_ID.C
@@ -1,0 +1,32 @@
+// Plot fraction of TAGH hits that are double hits vs. Counter ID
+
+void TAGH_doubles_ID()
+{
+    TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("TAGH_doubles");
+    if(dir) dir->cd();
+
+    TH1F *doubles =(TH1F*)gDirectory->Get("BeforeMergingDoubles/BM2_Occupancy");
+    TH1F *total =(TH1F*)gDirectory->Get("BeforeMergingDoubles/BM1_Occupancy");
+
+    TH1F *f_doubles = (TH1F*)doubles->Clone();
+    f_doubles->Sumw2();
+    f_doubles->Divide(doubles, total);
+
+    if(gPad == NULL) {
+        TCanvas *c1 = new TCanvas("c1","TAGH double-hit fraction",150,10,990,660);
+        c1->cd(0);
+        c1->Draw();
+        c1->Update();
+    }
+
+    if(!gPad) return;
+    TCanvas* c1 = gPad->GetCanvas();
+
+    gStyle->SetOptStat("");
+    f_doubles->SetTitle("TAGH double-hit fraction vs. counter ID");
+    f_doubles->SetTitleSize(0.045, "XY");
+    f_doubles->GetXaxis()->SetTitle("TAGH counter ID");
+    f_doubles->GetYaxis()->SetTitle("double-hit fraction");
+    f_doubles->SetAxisRange(0.0,1.0,"Y");
+    f_doubles->Draw();
+}

--- a/src/plugins/monitoring/TAGH_online/JEventProcessor_TAGH_online.cc
+++ b/src/plugins/monitoring/TAGH_online/JEventProcessor_TAGH_online.cc
@@ -273,7 +273,7 @@ jerror_t JEventProcessor_TAGH_online::evnt(JEventLoop *eventLoop, uint64_t event
 
     // get TAGH hits and digihits
     vector<const DTAGHHit*> hits;
-    eventLoop->Get(hits);
+    eventLoop->Get(hits, "Calib");
     vector<const DTAGHDigiHit*> digihits;
     eventLoop->Get(digihits);
     vector<const DTAGHTDCDigiHit*> tdcdigihits;


### PR DESCRIPTION
A scattered (brems.) electron can hit multiple TAGH counters due to
multiple scattering and small geometric overlaps between some TAGH
counters. Merge these time-coincident hits for neighboring counters.

The original TAGHHit factory has been moved to a factory with tag-name
"Calib", indicating that these (unmerged) hits have been calibrated.
The default TAGHHit factory now outputs hits after merging any doubles.
