### PR TITLE
Remove factory tag from DPSGeometry()

### DIFF
--- a/src/libraries/PAIR_SPECTROMETER/DPSGeometry.cc
+++ b/src/libraries/PAIR_SPECTROMETER/DPSGeometry.cc
@@ -9,54 +9,46 @@
 //---------------------------------
 // DPSGeometry    (Constructor)
 //---------------------------------
-DPSGeometry::DPSGeometry(JEventLoop *loop, std::string tag, int32_t runnumber)
+DPSGeometry::DPSGeometry(JEventLoop *loop)
 {
-  // read PS hodoscope counter energy bounds from calibdb
-  char dbname[80];
-  if (tag == "")
-    sprintf(dbname, "/PHOTON_BEAM/pair_spectrometer/fine/energy_range:%d",
-	    runnumber);
-  else
-    sprintf(dbname, "/PHOTON_BEAM/pair_spectrometer/fine/energy_range:%d:%s",
-	    runnumber, tag.c_str());
-  std::vector<std::map<string,double> > result;
-  loop->GetCalib(dbname, result);
-  if ((int)result.size() != NUM_FINE_COLUMNS) {
-    jerr << "Error in DPSGeometry constructor: "
-	 << "failed to read fine PS energy_range table "
-	 << "from calibdb at " << dbname
-	 << std::endl;
-    for (int arm=0; arm < NUM_ARMS; ++arm) {
-      for (int i=0; i < NUM_FINE_COLUMNS; ++i) {
-	m_energy_low[arm][i] = 0;
-	m_energy_high[arm][i] = 0;
-      }
+    // read PS hodoscope counter energy bounds from calibdb
+    std::vector<std::map<string,double> > result;
+    loop->GetCalib("/PHOTON_BEAM/pair_spectrometer/fine/energy_range", result);
+    if ((int)result.size() != NUM_FINE_COLUMNS) {
+        jerr << "Error in DPSGeometry constructor: "
+        << "failed to read fine PS energy_range table "
+        << "from calibdb at /PHOTON_BEAM/pair_spectrometer/fine/energy_range" << std::endl;
+        for (int arm=0; arm < NUM_ARMS; ++arm) {
+            for (int i=0; i < NUM_FINE_COLUMNS; ++i) {
+                m_energy_low[arm][i] = 0;
+                m_energy_high[arm][i] = 0;
+            }
+        }
     }
-  }
-  else {
-    for (int i=0; i < (int)result.size(); ++i) {
-      m_energy_low[0][i] = (result[i])["Elow_north"];
-      m_energy_high[0][i] = (result[i])["Ehigh_north"];
-      m_energy_low[1][i] = (result[i])["Elow_south"];
-      m_energy_high[1][i] = (result[i])["Ehigh_south"];
+    else {
+        for (unsigned int i=0; i < result.size(); ++i) {
+            m_energy_low[0][i] = (result[i])["Elow_north"];
+            m_energy_high[0][i] = (result[i])["Ehigh_north"];
+            m_energy_low[1][i] = (result[i])["Elow_south"];
+            m_energy_high[1][i] = (result[i])["Ehigh_south"];
+        }
     }
-  }
 }
 
 DPSGeometry::~DPSGeometry() { }
 
 double DPSGeometry::getElow(int arm,int column) const
 {
-  if (arm >=0 && arm <=1 && column > 0 && column <= NUM_FINE_COLUMNS)
-    return m_energy_low[arm][column-1];
-  else
-    return 0;
+    if (arm >=0 && arm <=1 && column > 0 && column <= NUM_FINE_COLUMNS)
+        return m_energy_low[arm][column-1];
+    else
+        return 0;
 }
 
 double DPSGeometry::getEhigh(int arm,int column) const
 {
-  if (arm >=0 && arm <=1 && column > 0 && column <= NUM_FINE_COLUMNS)
-    return m_energy_high[arm][column-1];
-  else
-    return 0;
+    if (arm >=0 && arm <=1 && column > 0 && column <= NUM_FINE_COLUMNS)
+        return m_energy_high[arm][column-1];
+    else
+        return 0;
 }

--- a/src/libraries/PAIR_SPECTROMETER/DPSGeometry.h
+++ b/src/libraries/PAIR_SPECTROMETER/DPSGeometry.h
@@ -14,7 +14,7 @@ class DPSGeometry : public JObject {
   
   JOBJECT_PUBLIC(DPSGeometry);
   
-  DPSGeometry(JEventLoop *loop, std::string tag, int32_t runnumber);
+  DPSGeometry(JEventLoop *loop);
   ~DPSGeometry();
 
   enum Arm { kNorth, kSouth };

--- a/src/libraries/PAIR_SPECTROMETER/DPSGeometry_factory.cc
+++ b/src/libraries/PAIR_SPECTROMETER/DPSGeometry_factory.cc
@@ -14,7 +14,7 @@ jerror_t DPSGeometry_factory::brun(JEventLoop *loop, int32_t runnumber)
     }
 
   flags = PERSISTANT;
-  _data.push_back( new DPSGeometry(loop, factory_tag, runnumber) );
+  _data.push_back( new DPSGeometry(loop) );
    
   return NOERROR;
 }

--- a/src/libraries/PAIR_SPECTROMETER/DPSGeometry_factory.h
+++ b/src/libraries/PAIR_SPECTROMETER/DPSGeometry_factory.h
@@ -7,17 +7,14 @@ using namespace jana;
 
 #include "DPSGeometry.h"
 
-class DPSGeometry_factory:public JFactory<DPSGeometry>{
+class DPSGeometry_factory:public JFactory<DPSGeometry> {
  public:
- DPSGeometry_factory(const char *tag="") :
-  JFactory<DPSGeometry>(tag), factory_tag(tag) {}
+  DPSGeometry_factory(){}
   ~DPSGeometry_factory(){}
 
  private:
-  jerror_t brun(JEventLoop *loop, int32_t runnumber);   
-  jerror_t erun(void);   
-	
-  std::string factory_tag;
+  jerror_t brun(JEventLoop *loop, int32_t runnumber);
+  jerror_t erun(void);
 };
 
 #endif // _DPSGeometry_factory_

--- a/src/libraries/PAIR_SPECTROMETER/PAIR_SPECTROMETER_init.cc
+++ b/src/libraries/PAIR_SPECTROMETER/PAIR_SPECTROMETER_init.cc
@@ -3,7 +3,6 @@
 #include <JANA/JEventLoop.h>
 using namespace jana;
 
-//#include "DPSCTruthHit.h"
 #include "DPSDigiHit.h"
 #include "DPSHit_factory.h"
 #include "DPSCDigiHit.h"


### PR DESCRIPTION
Handle the PS geometry in the same manner as the tagger geometries.
See commit 015a36b.
