### PR TITLE
DTAGHHit_factory: Remove some unnecessary code

### DIFF
--- a/src/libraries/TAGGER/DTAGHHit_factory.cc
+++ b/src/libraries/TAGGER/DTAGHHit_factory.cc
@@ -70,7 +70,7 @@ jerror_t DTAGHHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 
     // Sort TAGH hits by counter id by putting them in a map
     map<int, vector<DTAGHHit*> > hitsById;
-    for (auto& hit : hits) {
+    for (auto&& hit : hits) {
         if (!hit->has_fADC) continue; // Skip hits that have no ADC info.
         hitsById[hit->counter_id].push_back(const_cast<DTAGHHit*>(hit));
     }
@@ -81,17 +81,15 @@ jerror_t DTAGHHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
         MergeDoubles(hitsById, doublesById);
 
     // Add double hits to _data
-    for (auto& p : doublesById) {
-        for (auto& h : p.second) {
-            DTAGHHit *hit = new DTAGHHit;
-            dCreatedTAGHHits.push_back(hit);
-            *hit = *h;
-            _data.push_back(hit);
+    for (auto&& p : doublesById) {
+        for (auto&& h : p.second) {
+            _data.push_back(h);
         }
     }
+
     // Add single-counter hits to _data
-    for (auto& p : hitsById) {
-        for (auto& h : p.second) {
+    for (auto&& p : hitsById) {
+        for (auto&& h : p.second) {
             if (!h->is_double) _data.push_back(h);
         }
     }
@@ -111,12 +109,12 @@ bool DTAGHHit_factory::IsDoubleHit(double tdiff) {
 void DTAGHHit_factory::MergeDoubles(map<int, vector<DTAGHHit*> > hitsById, map<int, vector<DTAGHHit*> > &doublesById) {
     int prev_id = -1; bool has_doubles = false;
     vector<DTAGHHit*> prev_hits;
-    for (auto& p : hitsById) {
+    for (auto&& p : hitsById) {
         int id = p.first;
         if (id > ID_DOUBLES_MAX) continue;
         if (id - prev_id == 1) {
-            for (auto& h1 : prev_hits) {
-                for (auto& h2 : p.second) {
+            for (auto&& h1 : prev_hits) {
+                for (auto&& h2 : p.second) {
                     if (IsDoubleHit(h1->t-h2->t)) {
                         has_doubles = true;
                         if (h1->is_double && h2->is_double) {
@@ -141,7 +139,7 @@ void DTAGHHit_factory::MergeDoubles(map<int, vector<DTAGHHit*> > hitsById, map<i
 
 void DTAGHHit_factory::EraseHit(vector<DTAGHHit*> &v, DTAGHHit* hit) {
     int index = -1; bool flag = false; double eps = 1e-5;
-    for (auto& i : v) {
+    for (auto&& i : v) {
         index++;
         if (fabs(i->t-hit->t) < eps && fabs(i->E-hit->E) < eps) {
             flag = true; break;
@@ -153,8 +151,8 @@ void DTAGHHit_factory::EraseHit(vector<DTAGHHit*> &v, DTAGHHit* hit) {
 void DTAGHHit_factory::Reset_Data(void)
 {
     //delete objects that this factory created (since the NOT_OBJECT_OWNER flag is set)
-    for(size_t loc_i = 0; loc_i < dCreatedTAGHHits.size(); ++loc_i)
-        delete dCreatedTAGHHits[loc_i];
+    for (auto&& hit : dCreatedTAGHHits)
+        delete hit;
     _data.clear();
     dCreatedTAGHHits.clear();
 }

--- a/src/libraries/TAGGER/DTAGHHit_factory.h
+++ b/src/libraries/TAGGER/DTAGHHit_factory.h
@@ -16,26 +16,26 @@ class DTAGHHit_factory: public jana::JFactory<DTAGHHit> {
         DTAGHHit_factory() {};
         ~DTAGHHit_factory() {};
 
+    private:
         // config. parameters
         bool MERGE_DOUBLES;
         double DELTA_T_DOUBLES_MAX;
         int ID_DOUBLES_MAX;
         bool USE_SIDEBAND_DOUBLES;
 
+        double dBeamBunchPeriod;
+        vector<DTAGHHit*> dCreatedTAGHHits;
+
+        void Reset_Data(void);
         bool IsDoubleHit(double tdiff);
         void EraseHit(vector<DTAGHHit*> &v, DTAGHHit* hit);
         void MergeDoubles(map<int, vector<DTAGHHit*> > hitsById, map<int, vector<DTAGHHit*> > &doublesById);
 
-    private:
         jerror_t init(void);                                          ///< Called once at program start
         jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);    ///< Called everytime a new run number is detected
         jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);  ///< Called every event
         jerror_t erun(void);                                          ///< Called everytime run number changes, if brun has been called
         jerror_t fini(void);                                          ///< Called after last event of last event source has been processed
-
-        double dBeamBunchPeriod;
-        void Reset_Data(void);
-        vector<DTAGHHit*> dCreatedTAGHHits;
 };
 
 #endif // _DTAGHHit_factory_

--- a/src/plugins/monitoring/TAGH_doubles/JEventProcessor_TAGH_doubles.cc
+++ b/src/plugins/monitoring/TAGH_doubles/JEventProcessor_TAGH_doubles.cc
@@ -36,6 +36,8 @@ static TH1F *hAM2_Energy;
 static TH1F *hAM3_Energy;
 static TH1I *hBM_NHits;
 static TH1I *hAM_NHits;
+static TH2I *hBM1_PulseHeightVsID;
+static TH2I *hBM2_PulseHeightVsID;
 
 extern "C"{
     void InitPlugin(JApplication *app){
@@ -77,6 +79,8 @@ jerror_t JEventProcessor_TAGH_doubles::init(void)
     hBM2_Occupancy = new TH1F("BM2_Occupancy","TAGH occ.: Doubles only, before merging doubles;counter (slot) ID;hits / counter",Nslots,0.5,0.5+Nslots);
     hBM1_Energy    = new TH1F("BM1_Energy","TAGH energy: All hits, before merging doubles;photon energy [GeV];hits / counter",180,3.0,12.0);
     hBM2_Energy    = new TH1F("BM2_Energy","TAGH energy: Doubles only, before merging doubles;photon energy [GeV];hits / counter",180,3.0,12.0);
+    hBM1_PulseHeightVsID = new TH2I("BM1_PulseHeightVsID","TAGH ADC pulse height vs. ID: All hits;counter (slot) ID;pulse height",Nslots,0.5,0.5+Nslots,410,0.0,4100.0);
+    hBM2_PulseHeightVsID = new TH2I("BM2_PulseHeightVsID","TAGH ADC pulse height vs. ID: Doubles only;counter (slot) ID;pulse height",Nslots,0.5,0.5+Nslots,410,0.0,4100.0);
     taghDir->cd();
     gDirectory->mkdir("AfterMergingDoubles")->cd();
     hAM_tdiffVsIDdiff = new TH2I("AM_tdiffVsIDdiff","TAGH 2-hit time difference vs. counter ID difference;counter ID difference;time difference [ns]",15,0.5,15.5,200,-5.0,5.0);
@@ -137,8 +141,10 @@ jerror_t JEventProcessor_TAGH_doubles::evnt(JEventLoop *loop, uint64_t eventnumb
         BM_NHits++;
         hBM1_Occupancy->Fill(hit->counter_id);
         hBM1_Energy->Fill(hit->E);
+        hBM1_PulseHeightVsID->Fill(hit->counter_id,hit->pulse_peak);
         if (hit->is_double) hBM2_Occupancy->Fill(hit->counter_id);
         if (hit->is_double) hBM2_Energy->Fill(hit->E);
+        if (hit->is_double) hBM2_PulseHeightVsID->Fill(hit->counter_id,hit->pulse_peak);
     }
     hBM_NHits->Fill(BM_NHits);
     if (hits_c.size() > 1) {


### PR DESCRIPTION
1. Allocate memory for new DTAGHHit objects once, instead of twice.
2. Move data members and methods to private section.

Additional change:
Add pulse height histograms to TAGH_doubles plugin.
