### PR TITLE
-Moved original DTAGMHit_factory to tagged DTAGMHit_factory_Calib

### DIFF
--- a/src/libraries/TAGGER/DTAGMHit_factory.cc
+++ b/src/libraries/TAGGER/DTAGMHit_factory.cc
@@ -5,55 +5,37 @@
 // Creator: jonesrt (on Linux gluex.phys.uconn.edu)
 //
 
+// aebarnes moved original factory to DTAGMHit_factory_Calib.cc on August 11, 2016.
 
 #include <iostream>
 #include <iomanip>
+#include <TAGGER/DTAGMHit.h>
 using namespace std;
 
-#include "DTAGMDigiHit.h"
-#include "DTAGMTDCDigiHit.h"
-#include "DTAGMGeometry.h"
+// Sort by column
+bool SortByCol(const DTAGMHit* a, const DTAGMHit* b)
+{
+	return a->column < b->column;
+}
+
 #include "DTAGMHit_factory.h"
-#include <DAQ/Df250PulseIntegral.h>
-#include <DAQ/Df250PulsePedestal.h>
-#include <DAQ/Df250Config.h>
 
 using namespace jana;
-
-const int DTAGMHit_factory::k_fiber_good;
-const int DTAGMHit_factory::k_fiber_bad;
-const int DTAGMHit_factory::k_fiber_noisy;
 
 //------------------
 // init
 //------------------
 jerror_t DTAGMHit_factory::init(void)
 {
-    DELTA_T_ADC_TDC_MAX = 10.0; // ns
-    USE_ADC = 0;
-    CUT_FACTOR = 1;
-    gPARMS->SetDefaultParameter("TAGMHit:DELTA_T_ADC_TDC_MAX", DELTA_T_ADC_TDC_MAX,
-                "Maximum difference in ns between a (calibrated) fADC time and"
-                " F1TDC time for them to be matched in a single hit");
-    gPARMS->SetDefaultParameter("TAGMHit:CUT_FACTOR", CUT_FACTOR, "TAGM pulse integral cut factor, 0 = no cut");
-    gPARMS->SetDefaultParameter("TAGMHit:USE_ADC", USE_ADC, "Use ADC times in TAGM");
+    // Set default configuration parameters
+    DELTA_T_CLUSTER_MAX = 5;
+    gPARMS->SetDefaultParameter("TAGMHit:DELTA_T_CLUSTER_MAX",DELTA_T_CLUSTER_MAX,
+                                "Maximum time difference in ns between hits in adjacent"
+                                " columns to be merged");
 
-    // initialize calibration constants
-    fadc_a_scale = 0;
-    fadc_t_scale = 0;
-    t_base = 0;
-    t_tdc_base=0;
-
-    // calibration constants stored in row, column format
-    for (int row = 0; row <= TAGM_MAX_ROW; ++row) {
-        for (int col = 0; col <= TAGM_MAX_COLUMN; ++col) {
-            fadc_gains[row][col] = 0;
-            fadc_pedestals[row][col] = 0;
-            fadc_time_offsets[row][col] = 0;
-            tdc_time_offsets[row][col] = 0;
-            fiber_quality[row][col] = 0;
-        }
-    }
+    // Setting this flag makes it so that JANA does not delete the objects in _data.
+    // This factory will manage this memory.
+    SetFactoryFlag(NOT_OBJECT_OWNER);
 
     return NOERROR;
 }
@@ -63,53 +45,7 @@ jerror_t DTAGMHit_factory::init(void)
 //------------------
 jerror_t DTAGMHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 {
-    // Only print messages for one thread whenever run number change
-    static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
-    static set<int> runs_announced;
-    pthread_mutex_lock(&print_mutex);
-    bool print_messages = false;
-    if(runs_announced.find(runnumber) == runs_announced.end()){
-        print_messages = true;
-        runs_announced.insert(runnumber);
-    }
-    pthread_mutex_unlock(&print_mutex);
-
-    /// set the base conversion scales
-    fadc_a_scale    = 1.1;        // pixels per count
-    fadc_t_scale    = 0.0625;     // ns per count
-    t_base           = 0.;      // ns
-
-    pthread_mutex_unlock(&print_mutex);
-    if(print_messages) jout << "In DTAGMHit_factory, loading constants..." << std::endl;
-
-    // load base time offset
-    map<string,double> base_time_offset;
-    if (eventLoop->GetCalib("/PHOTON_BEAM/microscope/base_time_offset",base_time_offset))
-        jout << "Error loading /PHOTON_BEAM/microscope/base_time_offset !" << endl;
-    if (base_time_offset.find("TAGM_BASE_TIME_OFFSET") != base_time_offset.end())
-        t_base = base_time_offset["TAGM_BASE_TIME_OFFSET"];
-    else
-        jerr << "Unable to get TAGM_BASE_TIME_OFFSET from /PHOTON_BEAM/microscope/base_time_offset !" << endl;
-    if (base_time_offset.find("TAGM_TDC_BASE_TIME_OFFSET") != base_time_offset.end())
-        t_tdc_base = base_time_offset["TAGM_TDC_BASE_TIME_OFFSET"];
-    else
-        jerr << "Unable to get TAGM_TDC_BASE_TIME_OFFSET from /PHOTON_BEAM/microscope/base_time_offset !" << endl;
-
-    if (load_ccdb_constants("fadc_gains", "gain", fadc_gains) &&
-    load_ccdb_constants("fadc_pedestals", "pedestal", fadc_pedestals) &&
-    load_ccdb_constants("fadc_time_offsets", "offset", fadc_time_offsets) &&
-    load_ccdb_constants("tdc_time_offsets", "offset", tdc_time_offsets) &&
-    load_ccdb_constants("fiber_quality", "code", fiber_quality) &&
-    load_ccdb_constants("tdc_timewalk_corrections", "c0", tw_c0) &&
-    load_ccdb_constants("tdc_timewalk_corrections", "c1", tw_c1) &&
-    load_ccdb_constants("tdc_timewalk_corrections", "c2", tw_c2) &&
-    load_ccdb_constants("tdc_timewalk_corrections", "threshold", tw_c3) &&
-    load_ccdb_constants("tdc_timewalk_corrections", "reference", ref) &&
-    load_ccdb_constants("integral_cuts", "integral", int_cuts))
-    {
-        return NOERROR;
-    }
-    return UNRECOVERABLE_ERROR;
+    return NOERROR;
 }
 
 //------------------
@@ -117,156 +53,64 @@ jerror_t DTAGMHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 //------------------
 jerror_t DTAGMHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 {
-    /// Generate DTAGMHit object for each DTAGMDigiHit object.
-    /// This is where the first set of calibration constants
-    /// is applied to convert from digitzed units into natural
-    /// units.
-    ///
-    /// Note that this code does NOT get called for simulated
-    /// data in HDDM format. The HDDM event source will copy
-    /// the precalibrated values directly into the _data vector.
+	// Free memory allocated for DTAGMHit pointers in previous event
+	Reset_Data();
 
-    // extract the TAGM geometry
-    vector<const DTAGMGeometry*> tagmGeomVect;
-    eventLoop->Get( tagmGeomVect );
-    if (tagmGeomVect.size() < 1)
-        return OBJECT_NOT_AVAILABLE;
-    const DTAGMGeometry& tagmGeom = *(tagmGeomVect[0]);
+	// Get (calibrated) TAGM hits
+	vector<const DTAGMHit*> hits;
+	loop->Get(hits, "Calib");
 
-    const DTTabUtilities* locTTabUtilities = NULL;
-    loop->GetSingle(locTTabUtilities);
+	if (!hits.size() > 0) return NOERROR;
 
-    // First loop over all TAGMDigiHits and make DTAGMHits out of them
-    vector<const DTAGMDigiHit*> digihits;
-    loop->Get(digihits);
-    for (unsigned int i=0; i < digihits.size(); i++) {
-        const DTAGMDigiHit *digihit = digihits[i];
+	sort(hits.begin(), hits.end(), SortByCol);
 
-        // The following condition signals an error state in the flash algorithm
-        // Do not make hits out of these
-        const Df250PulsePedestal* PPobj = NULL;
-        digihit->GetSingle(PPobj);
-        if (PPobj != NULL){
-            if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
-        }
-        else continue;
+	set<uint32_t> locColUsedSoFar;
 
-        // Get pedestal, prefer associated event pedestal if it exists,
-        // otherwise, use the average pedestal from CCDB
-        double pedestal = fadc_pedestals[digihit->row][digihit->column];
+	//for(uint32_t i = 0; i < hits.size() - 1; ++i)
+	for(uint32_t i = 0; i < hits.size(); ++i)
+	{
+		const DTAGMHit *hit_i = hits[i];
 
-        const Df250PulseIntegral* PIobj = NULL;
-        digihit->GetSingle(PIobj);
-        if (PIobj != NULL) {
-            // the measured pedestal must be scaled by the ratio of the number
-            // of samples used to calculate the pedestal and the actual pulse
-            // Changed to match D. Lawrence Dec 4 2014 changes
-            double single_sample_ped = (double)PIobj->pedestal;
-            double nsamples_integral = (double)PIobj->nsamples_integral;
-            double nsamples_pedestal = (double)PIobj->nsamples_pedestal;
-            pedestal          = single_sample_ped * nsamples_integral/nsamples_pedestal;
-        }
+		if (!hit_i->has_fADC) continue;
+		if (hit_i->row > 0)
+		{
+			_data.push_back(const_cast<DTAGMHit*>(hit_i));
+			continue;
+		}
 
-        // throw away hits from bad or noisy fibers
-        int quality = fiber_quality[digihit->row][digihit->column];
-        if (quality == k_fiber_bad || quality == k_fiber_noisy)
-            continue;
+		// check if column has been paired
+		if (locColUsedSoFar.find(hit_i->column) != locColUsedSoFar.end()) continue;
 
-        // Skip events where fADC algorithm fails
-        //if (digihit->pulse_time == 0) continue; // Should already be caught above
+		for (uint32_t j = i+1; j < hits.size(); ++j)
+		{
+			const DTAGMHit *hit_j = hits[j];
 
-        // Skip digihit if pulse peak is lower than cut value
-        double P = PPobj->pulse_peak - PPobj->pedestal;
+			if (!hit_j->has_fADC) continue;
+			if (hit_j->row > 0) continue;
 
-        // Apply calibration constants
-        double A = digihit->pulse_integral;
-        double T = digihit->pulse_time;
-        A -= pedestal;
-	int row = digihit->row;
-        int column = digihit->column;
-        if (A < CUT_FACTOR*int_cuts[row][column]) continue;
+			int colDiff = hit_i->column - hit_j->column;
+			double deltaT = hit_i->t - hit_j->t;
 
-	DTAGMHit *hit = new DTAGMHit;    
-        hit->row = row;
-        hit->column = column;
-        double Elow = tagmGeom.getElow(column);
-        double Ehigh = tagmGeom.getEhigh(column);
-        hit->E = (Elow + Ehigh)/2;
+			if (fabs(colDiff) == 1 && fabs(deltaT) <= DELTA_T_CLUSTER_MAX)
+			{
+				locColUsedSoFar.insert(hit_j->column);
+				break;
+			}
+		}
+		_data.push_back(const_cast<DTAGMHit*>(hit_i));
+	}
 
-        hit->integral = A;
-        hit->pulse_peak = P;
-        hit->npix_fadc = A * fadc_a_scale * fadc_gains[row][column];
-        hit->time_fadc = T * fadc_t_scale - fadc_time_offsets[row][column] + t_base;
-        hit->t=hit->time_fadc;
-        hit->has_TDC=false;
-        hit->has_fADC=true;
-
-        hit->AddAssociatedObject(digihit);
-        _data.push_back(hit);
-    }
-
-    // Next, loop over TDC hits, matching them to the existing fADC hits
-    // where possible and updating their time information. If no match is
-    // found, then create a new hit with just the TDC info.
-    vector<const DTAGMTDCDigiHit*> tdcdigihits;
-    loop->Get(tdcdigihits);
-    for (unsigned int i=0; i < tdcdigihits.size(); i++) {
-        const DTAGMTDCDigiHit *digihit = tdcdigihits[i];
-
-        // Apply calibration constants here
-        int row = digihit->row;
-        int column = digihit->column;
-        double T = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(digihit) - tdc_time_offsets[row][column] + t_tdc_base;
-
-        // Look for existing hits to see if there is a match
-        // or create new one if there is no match
-        DTAGMHit *hit = 0;
-        for (unsigned int j=0; j < _data.size(); ++j) {
-            if (_data[j]->row == row && _data[j]->column == column &&
-            fabs(T - _data[j]->time_fadc) < DELTA_T_ADC_TDC_MAX)
-          {
-            hit = _data[j];
-          }
-        }
-        if (hit == 0) {
-            hit = new DTAGMHit;
-        hit->row = row;
-        hit->column = column;
-        double Elow = tagmGeom.getElow(column);
-        double Ehigh = tagmGeom.getEhigh(column);
-        hit->E = (Elow + Ehigh)/2;
-        hit->time_fadc = 0;
-        hit->npix_fadc = 0;
-        hit->integral = 0;
-        hit->pulse_peak = 0;
-        hit->has_fADC=false;
-        _data.push_back(hit);
-        }
-        hit->time_tdc=T;
-        hit->has_TDC=true;
-
-        // apply time-walk corrections
-        double P = hit->pulse_peak;
-        double c0 = tw_c0[row][column];
-        double c1 = tw_c1[row][column];
-        double c2 = tw_c2[row][column];
-        //double TH = thresh[row][column];
-        double c3 = tw_c3[row][column];
-        double t0 = ref[row][column];
-        //pp_0 = TH*pow((pp_0-c0)/c1,1/c2);
-        if (P > 0) {
-           //T -= c1*(pow(P/TH,c2)-pow(pp_0/TH,c2));
-           T -= c1*pow(1/(P+c3),c2) - (t0 - c0);
-        }
-
-        // Optionally only use ADC times
-        if (USE_ADC && hit->has_fADC) hit->t = hit->time_fadc;
-        else  hit->t = T;
-        
-        hit->AddAssociatedObject(digihit);
-    }
 
     return NOERROR;
+}
+
+//------------------
+// Reset_Data()
+//------------------
+void DTAGMHit_factory::Reset_Data(void)
+{
+	// delete objects that this factory created (since the NOT_OBJECT_OWNER flag is set)
+	_data.clear();
 }
 
 //------------------
@@ -283,27 +127,4 @@ jerror_t DTAGMHit_factory::erun(void)
 jerror_t DTAGMHit_factory::fini(void)
 {
     return NOERROR;
-}
-
-//---------------------
-// load_ccdb_constants
-//---------------------
-bool DTAGMHit_factory::load_ccdb_constants(
-        std::string table_name,
-        std::string column_name,
-        double result[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1])
-{
-    std::vector< std::map<std::string, double> > table;
-    std::string ccdb_key = "/PHOTON_BEAM/microscope/" + table_name;
-    if (eventLoop->GetCalib(ccdb_key, table))
-    {
-        jout << "Error loading " << ccdb_key << " from ccdb!" << std::endl;
-        return false;
-    }
-    for (unsigned int i=0; i < table.size(); ++i) {
-        int row = (table[i])["row"];
-        int col = (table[i])["column"];
-        result[row][col] = (table[i])[column_name];
-    }
-    return true;
 }

--- a/src/libraries/TAGGER/DTAGMHit_factory.h
+++ b/src/libraries/TAGGER/DTAGMHit_factory.h
@@ -22,44 +22,17 @@ class DTAGMHit_factory: public jana::JFactory<DTAGMHit> {
       DTAGMHit_factory() {};
       ~DTAGMHit_factory() {};
 
-      static const int k_fiber_dead = 0;
-      static const int k_fiber_good = 1;
-      static const int k_fiber_bad = 2;
-      static const int k_fiber_noisy = 3;
-
       // config. parameter
-      double DELTA_T_ADC_TDC_MAX; 
-      //int USE_ADC, PEAK_CUT;
-      int USE_ADC, CUT_FACTOR;
+      double DELTA_T_CLUSTER_MAX;
 
-      // overall scale factors
-      double fadc_a_scale;  // pixels per fADC pulse integral count
-      double fadc_t_scale;  // ns per fADC time count
-      double t_base;
-      double t_tdc_base;
-
-      // calibration constants stored in row, column format
-      double fadc_gains[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
-      double fadc_pedestals[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
-      double fadc_time_offsets[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
-      double tdc_time_offsets[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
-      double fiber_quality[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
-      double tw_c0[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
-      double tw_c1[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
-      double tw_c2[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
-      double tw_c3[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
-      double ref[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
-      double int_cuts[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
-
-      bool load_ccdb_constants(std::string table_name,
-                               std::string column_name,
-                               double table[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1]);
    private:
       jerror_t init(void);                                          ///< Called once at program start
       jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);    ///< Called everytime a new run number is detected
       jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);  ///< Called every event
       jerror_t erun(void);                                          ///< Called everytime run number changes, if brun has been called
       jerror_t fini(void);                                          ///< Called after last event of last event source has been processed
+
+      void Reset_Data(void);
 };
 
 #endif // _DTAGMHit_factory_

--- a/src/libraries/TAGGER/DTAGMHit_factory_Calib.cc
+++ b/src/libraries/TAGGER/DTAGMHit_factory_Calib.cc
@@ -1,0 +1,309 @@
+// $Id$
+//
+//    File: DTAGMHit_factory_Calib.cc
+// Created: Sat Aug  2 12:23:43 EDT 2014
+// Creator: jonesrt (on Linux gluex.phys.uconn.edu)
+//
+
+
+#include <iostream>
+#include <iomanip>
+using namespace std;
+
+#include "DTAGMDigiHit.h"
+#include "DTAGMTDCDigiHit.h"
+#include "DTAGMGeometry.h"
+#include "DTAGMHit_factory_Calib.h"
+#include <DAQ/Df250PulseIntegral.h>
+#include <DAQ/Df250PulsePedestal.h>
+#include <DAQ/Df250Config.h>
+
+using namespace jana;
+
+const int DTAGMHit_factory_Calib::k_fiber_good;
+const int DTAGMHit_factory_Calib::k_fiber_bad;
+const int DTAGMHit_factory_Calib::k_fiber_noisy;
+
+//------------------
+// init
+//------------------
+jerror_t DTAGMHit_factory_Calib::init(void)
+{
+    DELTA_T_ADC_TDC_MAX = 10.0; // ns
+    USE_ADC = 0;
+    CUT_FACTOR = 1;
+    gPARMS->SetDefaultParameter("TAGMHit:DELTA_T_ADC_TDC_MAX", DELTA_T_ADC_TDC_MAX,
+                "Maximum difference in ns between a (calibrated) fADC time and"
+                " F1TDC time for them to be matched in a single hit");
+    gPARMS->SetDefaultParameter("TAGMHit:CUT_FACTOR", CUT_FACTOR, "TAGM pulse integral cut factor, 0 = no cut");
+    gPARMS->SetDefaultParameter("TAGMHit:USE_ADC", USE_ADC, "Use ADC times in TAGM");
+
+    // initialize calibration constants
+    fadc_a_scale = 0;
+    fadc_t_scale = 0;
+    t_base = 0;
+    t_tdc_base=0;
+
+    // calibration constants stored in row, column format
+    for (int row = 0; row <= TAGM_MAX_ROW; ++row) {
+        for (int col = 0; col <= TAGM_MAX_COLUMN; ++col) {
+            fadc_gains[row][col] = 0;
+            fadc_pedestals[row][col] = 0;
+            fadc_time_offsets[row][col] = 0;
+            tdc_time_offsets[row][col] = 0;
+            fiber_quality[row][col] = 0;
+        }
+    }
+
+    return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t DTAGMHit_factory_Calib::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
+{
+    // Only print messages for one thread whenever run number change
+    static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
+    static set<int> runs_announced;
+    pthread_mutex_lock(&print_mutex);
+    bool print_messages = false;
+    if(runs_announced.find(runnumber) == runs_announced.end()){
+        print_messages = true;
+        runs_announced.insert(runnumber);
+    }
+    pthread_mutex_unlock(&print_mutex);
+
+    /// set the base conversion scales
+    fadc_a_scale    = 1.1;        // pixels per count
+    fadc_t_scale    = 0.0625;     // ns per count
+    t_base           = 0.;      // ns
+
+    pthread_mutex_unlock(&print_mutex);
+    if(print_messages) jout << "In DTAGMHit_factory_Calib, loading constants..." << std::endl;
+
+    // load base time offset
+    map<string,double> base_time_offset;
+    if (eventLoop->GetCalib("/PHOTON_BEAM/microscope/base_time_offset",base_time_offset))
+        jout << "Error loading /PHOTON_BEAM/microscope/base_time_offset !" << endl;
+    if (base_time_offset.find("TAGM_BASE_TIME_OFFSET") != base_time_offset.end())
+        t_base = base_time_offset["TAGM_BASE_TIME_OFFSET"];
+    else
+        jerr << "Unable to get TAGM_BASE_TIME_OFFSET from /PHOTON_BEAM/microscope/base_time_offset !" << endl;
+    if (base_time_offset.find("TAGM_TDC_BASE_TIME_OFFSET") != base_time_offset.end())
+        t_tdc_base = base_time_offset["TAGM_TDC_BASE_TIME_OFFSET"];
+    else
+        jerr << "Unable to get TAGM_TDC_BASE_TIME_OFFSET from /PHOTON_BEAM/microscope/base_time_offset !" << endl;
+
+    if (load_ccdb_constants("fadc_gains", "gain", fadc_gains) &&
+    load_ccdb_constants("fadc_pedestals", "pedestal", fadc_pedestals) &&
+    load_ccdb_constants("fadc_time_offsets", "offset", fadc_time_offsets) &&
+    load_ccdb_constants("tdc_time_offsets", "offset", tdc_time_offsets) &&
+    load_ccdb_constants("fiber_quality", "code", fiber_quality) &&
+    load_ccdb_constants("tdc_timewalk_corrections", "c0", tw_c0) &&
+    load_ccdb_constants("tdc_timewalk_corrections", "c1", tw_c1) &&
+    load_ccdb_constants("tdc_timewalk_corrections", "c2", tw_c2) &&
+    load_ccdb_constants("tdc_timewalk_corrections", "threshold", tw_c3) &&
+    load_ccdb_constants("tdc_timewalk_corrections", "reference", ref) &&
+    load_ccdb_constants("integral_cuts", "integral", int_cuts))
+    {
+        return NOERROR;
+    }
+    return UNRECOVERABLE_ERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t DTAGMHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
+{
+    /// Generate DTAGMHit object for each DTAGMDigiHit object.
+    /// This is where the first set of calibration constants
+    /// is applied to convert from digitzed units into natural
+    /// units.
+    ///
+    /// Note that this code does NOT get called for simulated
+    /// data in HDDM format. The HDDM event source will copy
+    /// the precalibrated values directly into the _data vector.
+
+    // extract the TAGM geometry
+    vector<const DTAGMGeometry*> tagmGeomVect;
+    eventLoop->Get( tagmGeomVect );
+    if (tagmGeomVect.size() < 1)
+        return OBJECT_NOT_AVAILABLE;
+    const DTAGMGeometry& tagmGeom = *(tagmGeomVect[0]);
+
+    const DTTabUtilities* locTTabUtilities = NULL;
+    loop->GetSingle(locTTabUtilities);
+
+    // First loop over all TAGMDigiHits and make DTAGMHits out of them
+    vector<const DTAGMDigiHit*> digihits;
+    loop->Get(digihits);
+    for (unsigned int i=0; i < digihits.size(); i++) {
+        const DTAGMDigiHit *digihit = digihits[i];
+
+        // The following condition signals an error state in the flash algorithm
+        // Do not make hits out of these
+        const Df250PulsePedestal* PPobj = NULL;
+        digihit->GetSingle(PPobj);
+        if (PPobj != NULL){
+            if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
+        }
+        else continue;
+
+        // Get pedestal, prefer associated event pedestal if it exists,
+        // otherwise, use the average pedestal from CCDB
+        double pedestal = fadc_pedestals[digihit->row][digihit->column];
+
+        const Df250PulseIntegral* PIobj = NULL;
+        digihit->GetSingle(PIobj);
+        if (PIobj != NULL) {
+            // the measured pedestal must be scaled by the ratio of the number
+            // of samples used to calculate the pedestal and the actual pulse
+            // Changed to match D. Lawrence Dec 4 2014 changes
+            double single_sample_ped = (double)PIobj->pedestal;
+            double nsamples_integral = (double)PIobj->nsamples_integral;
+            double nsamples_pedestal = (double)PIobj->nsamples_pedestal;
+            pedestal          = single_sample_ped * nsamples_integral/nsamples_pedestal;
+        }
+
+        // throw away hits from bad or noisy fibers
+        int quality = fiber_quality[digihit->row][digihit->column];
+        if (quality == k_fiber_bad || quality == k_fiber_noisy)
+            continue;
+
+        // Skip events where fADC algorithm fails
+        //if (digihit->pulse_time == 0) continue; // Should already be caught above
+
+        // Skip digihit if pulse peak is lower than cut value
+        double P = PPobj->pulse_peak - PPobj->pedestal;
+
+        // Apply calibration constants
+        double A = digihit->pulse_integral;
+        double T = digihit->pulse_time;
+        A -= pedestal;
+	int row = digihit->row;
+        int column = digihit->column;
+        if (A < CUT_FACTOR*int_cuts[row][column]) continue;
+
+	DTAGMHit *hit = new DTAGMHit;    
+        hit->row = row;
+        hit->column = column;
+        double Elow = tagmGeom.getElow(column);
+        double Ehigh = tagmGeom.getEhigh(column);
+        hit->E = (Elow + Ehigh)/2;
+
+        hit->integral = A;
+        hit->pulse_peak = P;
+        hit->npix_fadc = A * fadc_a_scale * fadc_gains[row][column];
+        hit->time_fadc = T * fadc_t_scale - fadc_time_offsets[row][column] + t_base;
+        hit->t=hit->time_fadc;
+        hit->has_TDC=false;
+        hit->has_fADC=true;
+
+        hit->AddAssociatedObject(digihit);
+        _data.push_back(hit);
+    }
+
+    // Next, loop over TDC hits, matching them to the existing fADC hits
+    // where possible and updating their time information. If no match is
+    // found, then create a new hit with just the TDC info.
+    vector<const DTAGMTDCDigiHit*> tdcdigihits;
+    loop->Get(tdcdigihits);
+    for (unsigned int i=0; i < tdcdigihits.size(); i++) {
+        const DTAGMTDCDigiHit *digihit = tdcdigihits[i];
+
+        // Apply calibration constants here
+        int row = digihit->row;
+        int column = digihit->column;
+        double T = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(digihit) - tdc_time_offsets[row][column] + t_tdc_base;
+
+        // Look for existing hits to see if there is a match
+        // or create new one if there is no match
+        DTAGMHit *hit = 0;
+        for (unsigned int j=0; j < _data.size(); ++j) {
+            if (_data[j]->row == row && _data[j]->column == column &&
+            fabs(T - _data[j]->time_fadc) < DELTA_T_ADC_TDC_MAX)
+          {
+            hit = _data[j];
+          }
+        }
+        if (hit == 0) {
+            hit = new DTAGMHit;
+        hit->row = row;
+        hit->column = column;
+        double Elow = tagmGeom.getElow(column);
+        double Ehigh = tagmGeom.getEhigh(column);
+        hit->E = (Elow + Ehigh)/2;
+        hit->time_fadc = 0;
+        hit->npix_fadc = 0;
+        hit->integral = 0;
+        hit->pulse_peak = 0;
+        hit->has_fADC=false;
+        _data.push_back(hit);
+        }
+        hit->time_tdc=T;
+        hit->has_TDC=true;
+
+        // apply time-walk corrections
+        double P = hit->pulse_peak;
+        double c0 = tw_c0[row][column];
+        double c1 = tw_c1[row][column];
+        double c2 = tw_c2[row][column];
+        //double TH = thresh[row][column];
+        double c3 = tw_c3[row][column];
+        double t0 = ref[row][column];
+        //pp_0 = TH*pow((pp_0-c0)/c1,1/c2);
+        if (P > 0) {
+           //T -= c1*(pow(P/TH,c2)-pow(pp_0/TH,c2));
+           T -= c1*pow(1/(P+c3),c2) - (t0 - c0);
+        }
+
+        // Optionally only use ADC times
+        if (USE_ADC && hit->has_fADC) hit->t = hit->time_fadc;
+        else  hit->t = T;
+        
+        hit->AddAssociatedObject(digihit);
+    }
+
+    return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t DTAGMHit_factory_Calib::erun(void)
+{
+    return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t DTAGMHit_factory_Calib::fini(void)
+{
+    return NOERROR;
+}
+
+//---------------------
+// load_ccdb_constants
+//---------------------
+bool DTAGMHit_factory_Calib::load_ccdb_constants(
+        std::string table_name,
+        std::string column_name,
+        double result[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1])
+{
+    std::vector< std::map<std::string, double> > table;
+    std::string ccdb_key = "/PHOTON_BEAM/microscope/" + table_name;
+    if (eventLoop->GetCalib(ccdb_key, table))
+    {
+        jout << "Error loading " << ccdb_key << " from ccdb!" << std::endl;
+        return false;
+    }
+    for (unsigned int i=0; i < table.size(); ++i) {
+        int row = (table[i])["row"];
+        int col = (table[i])["column"];
+        result[row][col] = (table[i])[column_name];
+    }
+    return true;
+}

--- a/src/libraries/TAGGER/DTAGMHit_factory_Calib.h
+++ b/src/libraries/TAGGER/DTAGMHit_factory_Calib.h
@@ -1,0 +1,66 @@
+// $Id$
+//
+//    File: DTAGMHit_factory_Calib.h
+// Created: Sat Aug  2 12:23:43 EDT 2014
+// Creator: jonesrt (on Linux gluey.phys.uconn.edu)
+//
+
+#ifndef _DTAGMHit_factory_Calib_
+#define _DTAGMHit_factory_Calib_
+
+#include <vector>
+using namespace std;
+
+#include <JANA/JFactory.h>
+#include "TTAB/DTTabUtilities.h"
+
+#include "DTAGMHit.h"
+#include "DTAGMGeometry.h"
+
+class DTAGMHit_factory_Calib: public jana::JFactory<DTAGMHit> {
+   public:
+      DTAGMHit_factory_Calib() {};
+      ~DTAGMHit_factory_Calib() {};
+      const char* Tag(void){return "Calib";}
+
+      static const int k_fiber_dead = 0;
+      static const int k_fiber_good = 1;
+      static const int k_fiber_bad = 2;
+      static const int k_fiber_noisy = 3;
+
+      // config. parameter
+      double DELTA_T_ADC_TDC_MAX; 
+      //int USE_ADC, PEAK_CUT;
+      int USE_ADC, CUT_FACTOR;
+
+      // overall scale factors
+      double fadc_a_scale;  // pixels per fADC pulse integral count
+      double fadc_t_scale;  // ns per fADC time count
+      double t_base;
+      double t_tdc_base;
+
+      // calibration constants stored in row, column format
+      double fadc_gains[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+      double fadc_pedestals[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+      double fadc_time_offsets[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+      double tdc_time_offsets[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+      double fiber_quality[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+      double tw_c0[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+      double tw_c1[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+      double tw_c2[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+      double tw_c3[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+      double ref[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+      double int_cuts[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+
+      bool load_ccdb_constants(std::string table_name,
+                               std::string column_name,
+                               double table[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1]);
+   private:
+      jerror_t init(void);                                          ///< Called once at program start
+      jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);    ///< Called everytime a new run number is detected
+      jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);  ///< Called every event
+      jerror_t erun(void);                                          ///< Called everytime run number changes, if brun has been called
+      jerror_t fini(void);                                          ///< Called after last event of last event source has been processed
+};
+
+#endif // _DTAGMHit_factory_Calib_

--- a/src/libraries/TAGGER/TAGGER_init.cc
+++ b/src/libraries/TAGGER/TAGGER_init.cc
@@ -14,6 +14,7 @@ using namespace jana;
 #include "DTAGMGeometry_factory.h"
 #include "DTAGHGeometry_factory.h"
 #include "DTAGMHit_factory.h"
+#include "DTAGMHit_factory_Calib.h"
 #include "DTAGHHit_factory.h"
 #include "DTAGHHit_factory_Calib.h"
 
@@ -26,6 +27,7 @@ jerror_t TAGGER_init(JEventLoop *loop)
   loop->AddFactory(new JFactory<DTAGHDigiHit>());
   loop->AddFactory(new JFactory<DTAGHTDCDigiHit>());
   loop->AddFactory(new DTAGMHit_factory());
+  loop->AddFactory(new DTAGMHit_factory_Calib());
   loop->AddFactory(new DTAGHHit_factory());
   loop->AddFactory(new DTAGHHit_factory_Calib());
   loop->AddFactory(new JFactory<DTAGMHit>("TRUTH"));

--- a/src/plugins/Calibration/HLDetectorTiming/JEventProcessor_HLDetectorTiming.cc
+++ b/src/plugins/Calibration/HLDetectorTiming/JEventProcessor_HLDetectorTiming.cc
@@ -193,7 +193,7 @@ jerror_t JEventProcessor_HLDetectorTiming::evnt(JEventLoop *loop, uint64_t event
     loop->Get(bcalUnifiedHitVector);
     loop->Get(tofHitVector);
     loop->Get(fcalHitVector);
-    loop->Get(tagmHitVector);
+    loop->Get(tagmHitVector, "Calib");
     loop->Get(taghHitVector, "Calib");
 
     // TTabUtilities object used for RF time conversion

--- a/src/plugins/Calibration/TAGM_TW/JEventProcessor_TAGM_TW.cc
+++ b/src/plugins/Calibration/TAGM_TW/JEventProcessor_TAGM_TW.cc
@@ -89,7 +89,7 @@ jerror_t JEventProcessor_TAGM_TW::evnt(JEventLoop *loop, uint64_t eventnumber)
 {
 
    vector<const DTAGMHit*>      hits;
-   loop->Get(hits);
+   loop->Get(hits, "Calib");
 
    // FILL HISTOGRAMS
    // Since we are filling histograms local to this plugin, it will not interfere

--- a/src/plugins/monitoring/SConscript
+++ b/src/plugins/monitoring/SConscript
@@ -24,6 +24,7 @@ subdirs = [
 'TAGGER_online',
 'TAGH_online',
 'TAGM_online',
+'TAGM_clusters',
 'TOF_online',
 'TRIG_online',
 'TPOL_online',

--- a/src/plugins/monitoring/TAGM_clusters/JEventProcessor_TAGM_clusters.cc
+++ b/src/plugins/monitoring/TAGM_clusters/JEventProcessor_TAGM_clusters.cc
@@ -1,0 +1,238 @@
+// $Id$
+//
+//    File: JEventProcessor_TAGM_clusters.cc
+// Created: Tue Jul  5 21:19:22 EDT 2016
+// Creator: barnes (on Linux gluey.phys.uconn.edu 2.6.32-573.22.1.el6.x86_64 x86_64)
+//
+
+#include "JEventProcessor_TAGM_clusters.h"
+using namespace jana;
+
+#include <TH1.h>
+#include <TH2.h>
+#include <TDirectory.h>
+
+#include <TAGGER/DTAGMHit.h>
+
+static TH1D *h_occupancy_b;	// occupancy before merging
+static TH1D *h_occupancy_a;	// occupancy after merging
+static TH1D *h_occupancy_ind;	// occupancy of ind. channels
+static TH1I *h_deltaT[10];	// delta T of neighbors before merging
+static TH1I *h_mult_b;		// multiplicity before merging
+static TH1I *h_mult_a;		// multiplicity after merging
+static TH1I *h_E_b;		// energy before merging
+static TH1I *h_E_a;		// energy after merging
+
+// Routine used to create our JEventProcessor
+#include <JANA/JApplication.h>
+#include <JANA/JFactory.h>
+extern "C"{
+void InitPlugin(JApplication *app){
+	InitJANAPlugin(app);
+	app->AddProcessor(new JEventProcessor_TAGM_clusters());
+}
+} // "C"
+
+
+//------------------
+// JEventProcessor_TAGM_clusters (Constructor)
+//------------------
+JEventProcessor_TAGM_clusters::JEventProcessor_TAGM_clusters()
+{
+
+}
+
+//------------------
+// ~JEventProcessor_TAGM_clusters (Destructor)
+//------------------
+JEventProcessor_TAGM_clusters::~JEventProcessor_TAGM_clusters()
+{
+
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_TAGM_clusters::init(void)
+{
+	// This is called once at program startup. 
+
+   TDirectory *mainDir = gDirectory;
+
+   // Before
+   TDirectory *bDir = gDirectory->mkdir("Before");
+   bDir->cd();
+   h_occupancy_b = new TH1D("occupancy_b","Histogram of occupancy",100,1,101);
+   h_mult_b = new TH1I("mult_b","Multiplicity before",40,0.,40.);
+   h_E_b = new TH1I("E_b","Energy before merging",110,8.2,9.3);
+   for (uint32_t i = 0; i < 10; ++i)
+   {
+      h_deltaT[i] = new TH1I(Form("deltaT_%i",i+1),
+                             Form("#Deltat of neighboring hits, group %i",i+1),
+                             100,-10.,10.);
+   }
+
+   mainDir->cd();
+
+   // After
+   TDirectory *aDir = gDirectory->mkdir("After");
+   aDir->cd();
+   h_occupancy_a = new TH1D("occupancy_a","Histogram of occupancy",100,1,101);
+   h_mult_a = new TH1I("mult_a","Multiplicity after",40,0.,40.);
+   h_E_a = new TH1I("E_a","Energy after merging",110,8.2,9.3);
+
+   mainDir->cd();
+
+   h_occupancy_ind = new TH1D("occupancy_ind","Histogram of occupancy",20,1,21);
+
+	return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_TAGM_clusters::brun(JEventLoop *eventLoop, int32_t runnumber)
+{
+	// This is called whenever the run number changes
+	return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_TAGM_clusters::evnt(JEventLoop *loop, uint64_t eventnumber)
+{
+	// This is called for every event. Use of common resources like writing
+	// to a file or filling a histogram should be mutex protected. Using
+	// loop->Get(...) to get reconstructed objects (and thereby activating the
+	// reconstruction algorithm) should be done outside of any mutex lock
+	// since multiple threads may call this method at the same time.
+	// Here's an example:
+	//
+	// vector<const MyDataClass*> mydataclasses;
+	// loop->Get(mydataclasses);
+	//
+	// japp->RootFillLock(this);
+	//  ... fill historgrams or trees ...
+	// japp->RootFillUnLock(this);
+
+   vector<const DTAGMHit*>	tagm_hits;
+   loop->Get(tagm_hits, "Calib");
+   vector<const DTAGMHit*>	tagm_merged_hits;
+   loop->Get(tagm_merged_hits);
+
+   japp->RootFillLock(this);
+
+   // Get occupancies and multiplicities before merging
+   int mult_b = 0;
+   for (uint32_t i = 0; i < tagm_hits.size(); ++i)
+   {
+      if (!tagm_hits[i]->has_fADC) continue;
+      if (tagm_hits[i]->row > 0) continue;
+
+      h_occupancy_b->Fill(tagm_hits[i]->column);
+      h_E_b->Fill(tagm_hits[i]->E);
+      mult_b++;
+   }
+   h_mult_b->Fill(mult_b);
+
+   // Get occupancies and multiplicities after merging
+   int mult_a = 0;
+   for (uint32_t i = 0; i < tagm_merged_hits.size(); ++i)
+   {
+      if (!tagm_merged_hits[i]->has_fADC) continue;
+      //if (tagm_merged_hits[i]->row > 0) continue;
+      if (tagm_merged_hits[i]->row > 0) 
+      {
+         int col = tagm_merged_hits[i]->column;
+         int row = tagm_merged_hits[i]->row;
+         if (col == 9)
+            h_occupancy_ind->Fill(row);
+         else if (col == 27)
+            h_occupancy_ind->Fill(5+row);
+         else if (col == 81)
+            h_occupancy_ind->Fill(10+row);
+         else if (col == 99)
+            h_occupancy_ind->Fill(15+row);
+         continue;
+      }
+
+      h_occupancy_a->Fill(tagm_merged_hits[i]->column);
+      h_E_a->Fill(tagm_merged_hits[i]->E);
+      mult_a++;
+   }
+   h_mult_a->Fill(mult_a);
+
+   // Check time differences between pre-merge neighbors
+   set<uint32_t> locColUsedSoFar;
+   for (uint32_t i = 0; i < tagm_hits.size(); ++i)
+   {
+      if (!tagm_hits[i]->has_fADC) continue;
+      if (tagm_hits[i]->row > 0) continue;
+
+      // check if column has been paired
+      if (locColUsedSoFar.find(tagm_hits[i]->column) != locColUsedSoFar.end()) continue;
+
+      for (uint32_t j = i+1; j < tagm_hits.size(); ++j)
+      {
+         if (!tagm_hits[j]->has_fADC) continue;
+         if (tagm_hits[j]->row > 0) continue;
+
+         int diff = tagm_hits[i]->column - tagm_hits[j]->column;
+         double deltaT = tagm_hits[i]->t - tagm_hits[j]->t;
+         if (fabs(diff) == 1)
+         {
+            if (tagm_hits[i]->column < 11)
+               h_deltaT[0]->Fill(deltaT);
+            else if (tagm_hits[i]->column < 21)
+               h_deltaT[1]->Fill(deltaT);
+            else if (tagm_hits[i]->column < 31)
+               h_deltaT[2]->Fill(deltaT);
+            else if (tagm_hits[i]->column < 41)
+               h_deltaT[3]->Fill(deltaT);
+            else if (tagm_hits[i]->column < 51)
+               h_deltaT[4]->Fill(deltaT);
+            else if (tagm_hits[i]->column < 61)
+               h_deltaT[5]->Fill(deltaT);
+            else if (tagm_hits[i]->column < 71)
+               h_deltaT[6]->Fill(deltaT);
+            else if (tagm_hits[i]->column < 81)
+               h_deltaT[7]->Fill(deltaT);
+            else if (tagm_hits[i]->column < 91)
+               h_deltaT[8]->Fill(deltaT);
+            else
+               h_deltaT[9]->Fill(deltaT);
+         }
+         if (fabs(diff) == 1 && fabs(deltaT) <= 5)
+         {
+            locColUsedSoFar.insert(tagm_hits[j]->column);
+            break;
+         }
+      }
+   }
+
+   japp->RootFillUnLock(this);
+
+	return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_TAGM_clusters::erun(void)
+{
+	// This is called whenever the run number changes, before it is
+	// changed to give you a chance to clean up before processing
+	// events from the next run number.
+	return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t JEventProcessor_TAGM_clusters::fini(void)
+{
+	// Called before program exit after event processing is finished.
+	return NOERROR;
+}
+

--- a/src/plugins/monitoring/TAGM_clusters/JEventProcessor_TAGM_clusters.h
+++ b/src/plugins/monitoring/TAGM_clusters/JEventProcessor_TAGM_clusters.h
@@ -1,0 +1,29 @@
+// $Id$
+//
+//    File: JEventProcessor_TAGM_clusters.h
+// Created: Tue Jul  5 21:19:22 EDT 2016
+// Creator: barnes (on Linux gluey.phys.uconn.edu 2.6.32-573.22.1.el6.x86_64 x86_64)
+//
+
+#ifndef _JEventProcessor_TAGM_clusters_
+#define _JEventProcessor_TAGM_clusters_
+
+#include <JANA/JEventProcessor.h>
+#include <TAGGER/DTAGMHit.h>
+
+class JEventProcessor_TAGM_clusters:public jana::JEventProcessor{
+	public:
+		JEventProcessor_TAGM_clusters();
+		~JEventProcessor_TAGM_clusters();
+		const char* className(void){return "JEventProcessor_TAGM_clusters";}
+
+	private:
+		jerror_t init(void);						///< Called once at program start.
+		jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+};
+
+#endif // _JEventProcessor_TAGM_clusters_
+

--- a/src/plugins/monitoring/TAGM_clusters/SConscript
+++ b/src/plugins/monitoring/TAGM_clusters/SConscript
@@ -1,0 +1,13 @@
+
+
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddROOTSpyMacros(env)
+sbms.AddDANA(env)
+sbms.plugin(env)
+
+

--- a/src/plugins/monitoring/TAGM_clusters/TAGM_clusters_E.C
+++ b/src/plugins/monitoring/TAGM_clusters/TAGM_clusters_E.C
@@ -1,0 +1,34 @@
+// This macro will plot the difference between before and after merging
+// for the occupancy and energy plots
+
+#include <TH1.h>
+#include <TCanvas.h>
+#include <TFile.h>
+#include <TPaveText.h>
+#include <TPaveLabel.h>
+
+#include <sstream>
+#include <iostream>
+
+TFile *f;
+TH1I *hEb;
+TH1I *hEa;
+
+void TAGM_clusters_E(char* inputFile) {
+   
+   TCanvas *c1;
+   c1 = new TCanvas("c1","c1",600,500);
+   gStyle->SetOptStat(0);
+
+   f = new TFile(inputFile);
+
+   hEb = (TH1I*)f->Get("Before/E_b")->Clone();
+   hEa = (TH1I*)f->Get("After/E_a")->Clone();
+
+   hEb->SetTitle("Energy occupancy before - after");
+   hEb->GetXaxis()->SetTitle("Energy (GeV)");
+
+   hEb->Add(hEa,-1);
+   hEb->Draw();
+
+}      

--- a/src/plugins/monitoring/TAGM_clusters/TAGM_clusters_occ.C
+++ b/src/plugins/monitoring/TAGM_clusters/TAGM_clusters_occ.C
@@ -1,0 +1,34 @@
+// This macro will plot the difference between before and after merging
+// for the occupancy and energy plots
+
+#include <TH1.h>
+#include <TCanvas.h>
+#include <TFile.h>
+#include <TPaveText.h>
+#include <TPaveLabel.h>
+
+#include <sstream>
+#include <iostream>
+
+TFile *f;
+TH1I *h_occ_b;
+TH1I *h_occ_a;
+
+void TAGM_clusters_occ(char* inputFile) {
+   
+   TCanvas *c1;
+   c1 = new TCanvas("c1","c1",600,500);
+   gStyle->SetOptStat(0);
+
+   f = new TFile(inputFile);
+
+   h_occ_b = (TH1I*)f->Get("Before/occupancy_b")->Clone();
+   h_occ_a = (TH1I*)f->Get("After/occupancy_a")->Clone();
+
+   h_occ_b->SetTitle("Occupancy before - after");
+   h_occ_b->GetXaxis()->SetTitle("Column number");
+
+   h_occ_b->Add(h_occ_a,-1);
+   h_occ_b->Draw();
+
+}      

--- a/src/plugins/monitoring/TAGM_clusters/TAGM_clusters_t.C
+++ b/src/plugins/monitoring/TAGM_clusters/TAGM_clusters_t.C
@@ -1,0 +1,33 @@
+// This macro displays the pre-merge time difference
+// between adjacent columns
+
+#include <TH1.h>
+#include <TCanvas.h>
+#include <TFile.h>
+#include <TPaveText.h>
+#include <TPaveLabel.h>
+
+#include <sstream>
+#include <iostream>
+
+TFile *f;
+TH1I *h_t[10];
+
+void TAGM_clusters_t(char* inputFile) {
+   
+   TCanvas *c1;
+   c1 = new TCanvas("c1","c1",1200,800);
+   gStyle->SetOptStat(0);
+   c1->Divide(5,2);
+
+   f = new TFile(inputFile);
+
+   for (Int_t i = 0; i < 10; ++i)
+   {
+      h_t[i] = (TH1I*)f->Get(Form("Before/deltaT_%i",i+1));
+      h_t[i]->SetTitle(Form("delta t, %i-%i",10*i+1,10*i+10));
+      h_t[i]->GetXaxis()->SetTitle("#deltat (ns)");
+      c1->cd(i+1);
+      h_t[i]->Draw();
+   }
+}      

--- a/src/plugins/monitoring/TAGM_online/JEventProcessor_TAGM_online.cc
+++ b/src/plugins/monitoring/TAGM_online/JEventProcessor_TAGM_online.cc
@@ -584,7 +584,7 @@ jerror_t JEventProcessor_TAGM_online::evnt(JEventLoop *eventLoop, uint64_t event
   std::vector<const DTAGMHit*> hits;                     // hits
   eventLoop->Get(digihits);
   eventLoop->Get(tdcdigihits);
-  eventLoop->Get(hits);
+  eventLoop->Get(hits, "Calib");
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock


### PR DESCRIPTION
-DTAGMHit_factory uses the "Calib" tag to find and merge hits
-TAGM_online, TAGM_TW, and HLDetectorTiming now use the "Calib" tag to use unmerged hits
-Added TAGM_clusters plugin to monitor hit merging
