### PR TITLE
Fix bug where new parser would set non-zero value for exit code even when normal end of file encountered.

### DIFF
--- a/src/libraries/DAQ/JEventSource_EVIOpp.cc
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.cc
@@ -322,7 +322,7 @@ void JEventSource_EVIOpp::Dispatcher(void)
 					}
 				}else{
 					cout << hdevio->err_mess.str() << endl;
-					japp->SetExitCode(hdevio->err_code);
+					if(hdevio->err_code != HDEVIO::HDEVIO_EOF) japp->SetExitCode(hdevio->err_code);
 				}
 				break;
 			}else{


### PR DESCRIPTION
The fail and eof bits were being set when trying to read in the final EVIO 8 word header since we actually try reading in more than 8 words so as to get the first couple of words of the first evio event with it (for efficiency). This fix checks if there are exactly 8 words left in the file before reading a block header and if so, assumes it is the block header and returns code indicating clean end of file encountered.
