### PR TITLE
Davidl eventtag l1filter

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -308,7 +308,6 @@ void DEVIOWorkerThread::ParseBank(void)
 //_DBG_ << "tag=" << hex << tag << dec << endl;
 
 		switch(tag){
-			case 0x0056:    ParseEventTagBank(iptr, iend);    break;
 			case 0x0060:       ParseEPICSbank(iptr, iend);    break;
 			case 0x0070:         ParseBORbank(iptr, iend);    break;
 
@@ -757,6 +756,10 @@ void DEVIOWorkerThread::ParseDataBank(uint32_t* &iptr, uint32_t *iend)
 
 			case 0x55:
 				ParseModuleConfiguration(rocid, iptr, iend_data_block_bank);
+				break;
+
+			case 0x56:
+				ParseEventTagBank(iptr, iend_data_block_bank);
 				break;
 
 			case 0:

--- a/src/libraries/TRIGGER/DL3Trigger_factory.h
+++ b/src/libraries/TRIGGER/DL3Trigger_factory.h
@@ -19,6 +19,8 @@ class DL3Trigger_factory:public jana::JFactory<DL3Trigger>{
 		double FRACTION_TO_KEEP;
 		bool DO_WIRE_BASED_TRACKING;
 		bool DO_BCAL_CLUSTER;
+		uint32_t L1_TRIG_MASK;
+		uint32_t L1_FP_TRIG_MASK;
 
 	private:
 		jerror_t init(void);						///< Called once at program start.


### PR DESCRIPTION
- Implement L3:L1_TRIG_MASK and L3:L1_FP_TRIG_MASK config parameters to allow one to filter out events not matching a L1 trigger when writing disentangled events.
- Event Tag bank moved into physics event data bank. (previously was top level bank like EPICS and BOR, but this was not the right place for it.)
