### PR TITLE
Remove double-counting due to TAGM/TAGH overlaps

### DIFF
--- a/src/libraries/PID/DBeamPhoton_factory.cc
+++ b/src/libraries/PID/DBeamPhoton_factory.cc
@@ -17,6 +17,14 @@ using namespace jana;
 //------------------
 jerror_t DBeamPhoton_factory::init(void)
 {
+    DELTA_T_DOUBLES_MAX = 1.5; // ns
+    gPARMS->SetDefaultParameter("BeamPhoton:DELTA_T_DOUBLES_MAX", DELTA_T_DOUBLES_MAX,
+    "Maximum time difference in ns between a TAGM-TAGH pair of beam photons"
+    " for them to be merged into a single photon");
+    DELTA_E_DOUBLES_MAX = 0.05; // GeV
+    gPARMS->SetDefaultParameter("BeamPhoton:DELTA_E_DOUBLES_MAX", DELTA_E_DOUBLES_MAX,
+    "Maximum energy difference in GeV between a TAGM-TAGH pair of beam photons"
+    " for them to be merged into a single photon");
     return NOERROR;
 }
 
@@ -38,26 +46,15 @@ jerror_t DBeamPhoton_factory::brun(jana::JEventLoop *locEventLoop, int32_t runnu
 //------------------
 jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t eventnumber)
 {
-    DVector3 pos(0.0, 0.0, dTargetCenterZ);
-
     vector<const DTAGMHit*> tagm_hits;
     locEventLoop->Get(tagm_hits);
 
     for (unsigned int ih=0; ih < tagm_hits.size(); ++ih)
     {
-        if (!tagm_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)		
-	if (tagm_hits[ih]->row > 0) continue; // Skip individual fiber readouts
-        DVector3 mom(0.0, 0.0, tagm_hits[ih]->E);
+        if (!tagm_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)
+        if (tagm_hits[ih]->row > 0) continue; // Skip individual fiber readouts
         DBeamPhoton *gamma = new DBeamPhoton;
-        gamma->setPID(Gamma);
-        gamma->setMomentum(mom);
-        gamma->setPosition(pos);
-        gamma->setCharge(0);
-        gamma->setMass(0);
-        gamma->setTime(tagm_hits[ih]->t);
-        gamma->setT0(tagm_hits[ih]->t, 0.200, SYS_TAGM);
-        gamma->dCounter = tagm_hits[ih]->column;
-        gamma->AddAssociatedObject(tagm_hits[ih]);
+        Set_BeamPhoton(gamma, tagm_hits[ih]);
         _data.push_back(gamma);
     }
 
@@ -67,21 +64,59 @@ jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t even
     for (unsigned int ih=0; ih < tagh_hits.size(); ++ih)
     {
         if (!tagh_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)
-        DVector3 mom(0.0, 0.0, tagh_hits[ih]->E);
-        DBeamPhoton *gamma = new DBeamPhoton;
-        gamma->setPID(Gamma);
-        gamma->setMomentum(mom);
-        gamma->setPosition(pos);
-        gamma->setCharge(0);
-        gamma->setMass(0);
-        gamma->setTime(tagh_hits[ih]->t);
-        gamma->setT0(tagh_hits[ih]->t, 0.350, SYS_TAGH);
-        gamma->dCounter = tagh_hits[ih]->counter_id;
-        gamma->AddAssociatedObject(tagh_hits[ih]);
-        _data.push_back(gamma);
+        DBeamPhoton *gamma = nullptr;
+        for (unsigned int jh=0; jh < _data.size(); ++jh)
+        {
+            if (fabs(_data[jh]->momentum().Mag() - tagh_hits[ih]->E) < DELTA_E_DOUBLES_MAX
+            && fabs(_data[jh]->time() - tagh_hits[ih]->t) < DELTA_T_DOUBLES_MAX)
+            {
+                gamma = _data[jh];
+                if (_data[jh]->momentum().Mag() < tagh_hits[ih]->E)
+                {
+                    gamma->Reset();
+                    Set_BeamPhoton(gamma, tagh_hits[ih]);
+                }
+            }
+        }
+        if (gamma == nullptr)
+        {
+            gamma = new DBeamPhoton;
+            Set_BeamPhoton(gamma, tagh_hits[ih]);
+            _data.push_back(gamma);
+        }
     }
 
     return NOERROR;
+}
+
+void DBeamPhoton_factory::Set_BeamPhoton(DBeamPhoton* gamma, const DTAGMHit* hit)
+{
+    DVector3 pos(0.0, 0.0, dTargetCenterZ);
+    DVector3 mom(0.0, 0.0, hit->E);
+    gamma->setPID(Gamma);
+    gamma->setMomentum(mom);
+    gamma->setPosition(pos);
+    gamma->setCharge(0);
+    gamma->setMass(0);
+    gamma->setTime(hit->t);
+    gamma->setT0(hit->t, 0.200, SYS_TAGM);
+    gamma->dCounter = hit->column;
+    gamma->AddAssociatedObject(hit);
+}
+
+void DBeamPhoton_factory::Set_BeamPhoton(DBeamPhoton* gamma, const DTAGHHit* hit)
+{
+    DVector3 pos(0.0, 0.0, dTargetCenterZ);
+    DVector3 mom(0.0, 0.0, hit->E);
+    gamma->setPID(Gamma);
+    gamma->setMomentum(mom);
+    gamma->setPosition(pos);
+    gamma->setCharge(0);
+    gamma->setMass(0);
+    gamma->setTime(hit->t);
+    gamma->setT0(hit->t, 0.350, SYS_TAGH);
+    gamma->dCounter = hit->counter_id;
+    gamma->AddAssociatedObject(hit);
 }
 
 //------------------

--- a/src/libraries/PID/DBeamPhoton_factory.h
+++ b/src/libraries/PID/DBeamPhoton_factory.h
@@ -27,6 +27,13 @@ class DBeamPhoton_factory:public jana::JFactory<DBeamPhoton>{
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
 		double dTargetCenterZ;
+
+		// config. parameters
+		double DELTA_T_DOUBLES_MAX;
+		double DELTA_E_DOUBLES_MAX;
+
+		void Set_BeamPhoton(DBeamPhoton* gamma, const DTAGHHit* hit);
+		void Set_BeamPhoton(DBeamPhoton* gamma, const DTAGMHit* hit);
 };
 
 #endif // _DBeamPhoton_factory_

--- a/src/libraries/TAGGER/DTAGHHit_factory.cc
+++ b/src/libraries/TAGGER/DTAGHHit_factory.cc
@@ -138,10 +138,10 @@ void DTAGHHit_factory::MergeDoubles(map<int, vector<DTAGHHit*> > hitsById, map<i
 }
 
 void DTAGHHit_factory::EraseHit(vector<DTAGHHit*> &v, DTAGHHit* hit) {
-    int index = -1; bool flag = false; double eps = 1e-5;
+    int index = -1; bool flag = false;
     for (auto&& i : v) {
         index++;
-        if (fabs(i->t-hit->t) < eps && fabs(i->E-hit->E) < eps) {
+        if ((i->t == hit->t) && (i->E == hit->E)) {
             flag = true; break;
         }
     }

--- a/src/libraries/TAGGER/DTAGHHit_factory_Calib.cc
+++ b/src/libraries/TAGGER/DTAGHHit_factory_Calib.cc
@@ -130,7 +130,7 @@ jerror_t DTAGHHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
         return OBJECT_NOT_AVAILABLE;
     const DTAGHGeometry& taghGeom = *(taghGeomVect[0]);
 
-    const DTTabUtilities* locTTabUtilities = NULL;
+    const DTTabUtilities* locTTabUtilities = nullptr;
     loop->GetSingle(locTTabUtilities);
 
     // First loop over all TAGHDigiHits and make DTAGHHits out of them
@@ -149,10 +149,10 @@ jerror_t DTAGHHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
         //if (digihit->pulse_time == 0) continue;
         // The following condition signals an error state in the flash algorithm
         // Do not make hits out of these
-        const Df250PulsePedestal* PPobj = NULL;
+        const Df250PulsePedestal* PPobj = nullptr;
         digihit->GetSingle(PPobj);
         double pulse_peak = 0.0;
-        if (PPobj != NULL){
+        if (PPobj != nullptr){
             if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
             pulse_peak = PPobj->pulse_peak - PPobj->pedestal;
         }
@@ -160,9 +160,9 @@ jerror_t DTAGHHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
         // Get pedestal, prefer associated event pedestal if it exists,
         // otherwise, use the average pedestal from CCDB
         double pedestal = fadc_pedestals[counter];
-        const Df250PulseIntegral* PIobj = NULL;
+        const Df250PulseIntegral* PIobj = nullptr;
         digihit->GetSingle(PIobj);
-        if (PIobj != NULL) {
+        if (PIobj != nullptr) {
             // the measured pedestal must be scaled by the ratio of the number
             // of samples used to calculate the integral and the pedestal
             // Changed to conform to D. Lawrence changes Dec. 4 2014
@@ -214,7 +214,7 @@ jerror_t DTAGHHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
 
         // Look for existing hits to see if there is a match
         // or create new one if there is no match
-        DTAGHHit *hit = 0;
+        DTAGHHit *hit = nullptr;
         for (unsigned int j=0; j < _data.size(); ++j) {
             if (_data[j]->counter_id == counter &&
                 fabs(T - _data[j]->time_fadc) < DELTA_T_ADC_TDC_MAX)
@@ -222,7 +222,7 @@ jerror_t DTAGHHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
                     hit = _data[j];
                 }
         }
-        if (hit == 0) {
+        if (hit == nullptr) {
             hit = new DTAGHHit;
             hit->counter_id = counter;
             double Elow = taghGeom.getElow(counter);

--- a/src/libraries/TAGGER/DTAGMHit_factory.cc
+++ b/src/libraries/TAGGER/DTAGMHit_factory.cc
@@ -64,8 +64,6 @@ jerror_t DTAGMHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 	vector<const DTAGMHit*> hits;
 	loop->Get(hits, "Calib");
 
-	if (!hits.size() > 0) return NOERROR;
-
 	sort(hits.begin(), hits.end(), SortByCol);
 
 	set<uint32_t> locHitIndexUsedSoFar;

--- a/src/libraries/TAGGER/DTAGMHit_factory_Calib.cc
+++ b/src/libraries/TAGGER/DTAGMHit_factory_Calib.cc
@@ -133,7 +133,7 @@ jerror_t DTAGMHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
         return OBJECT_NOT_AVAILABLE;
     const DTAGMGeometry& tagmGeom = *(tagmGeomVect[0]);
 
-    const DTTabUtilities* locTTabUtilities = NULL;
+    const DTTabUtilities* locTTabUtilities = nullptr;
     loop->GetSingle(locTTabUtilities);
 
     // First loop over all TAGMDigiHits and make DTAGMHits out of them
@@ -144,9 +144,9 @@ jerror_t DTAGMHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
 
         // The following condition signals an error state in the flash algorithm
         // Do not make hits out of these
-        const Df250PulsePedestal* PPobj = NULL;
+        const Df250PulsePedestal* PPobj = nullptr;
         digihit->GetSingle(PPobj);
-        if (PPobj != NULL){
+        if (PPobj != nullptr){
             if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
         }
         else continue;
@@ -155,9 +155,9 @@ jerror_t DTAGMHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
         // otherwise, use the average pedestal from CCDB
         double pedestal = fadc_pedestals[digihit->row][digihit->column];
 
-        const Df250PulseIntegral* PIobj = NULL;
+        const Df250PulseIntegral* PIobj = nullptr;
         digihit->GetSingle(PIobj);
-        if (PIobj != NULL) {
+        if (PIobj != nullptr) {
             // the measured pedestal must be scaled by the ratio of the number
             // of samples used to calculate the pedestal and the actual pulse
             // Changed to match D. Lawrence Dec 4 2014 changes
@@ -182,11 +182,11 @@ jerror_t DTAGMHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
         double A = digihit->pulse_integral;
         double T = digihit->pulse_time;
         A -= pedestal;
-	int row = digihit->row;
+        int row = digihit->row;
         int column = digihit->column;
         if (A < CUT_FACTOR*int_cuts[row][column]) continue;
 
-	DTAGMHit *hit = new DTAGMHit;    
+        DTAGMHit *hit = new DTAGMHit;    
         hit->row = row;
         hit->column = column;
         double Elow = tagmGeom.getElow(column);
@@ -220,7 +220,7 @@ jerror_t DTAGMHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
 
         // Look for existing hits to see if there is a match
         // or create new one if there is no match
-        DTAGMHit *hit = 0;
+        DTAGMHit *hit = nullptr;
         for (unsigned int j=0; j < _data.size(); ++j) {
             if (_data[j]->row == row && _data[j]->column == column &&
             fabs(T - _data[j]->time_fadc) < DELTA_T_ADC_TDC_MAX)
@@ -228,19 +228,19 @@ jerror_t DTAGMHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
             hit = _data[j];
           }
         }
-        if (hit == 0) {
+        if (hit == nullptr) {
             hit = new DTAGMHit;
-        hit->row = row;
-        hit->column = column;
-        double Elow = tagmGeom.getElow(column);
-        double Ehigh = tagmGeom.getEhigh(column);
-        hit->E = (Elow + Ehigh)/2;
-        hit->time_fadc = 0;
-        hit->npix_fadc = 0;
-        hit->integral = 0;
-        hit->pulse_peak = 0;
-        hit->has_fADC=false;
-        _data.push_back(hit);
+            hit->row = row;
+            hit->column = column;
+            double Elow = tagmGeom.getElow(column);
+            double Ehigh = tagmGeom.getEhigh(column);
+            hit->E = (Elow + Ehigh)/2;
+            hit->time_fadc = 0;
+            hit->npix_fadc = 0;
+            hit->integral = 0;
+            hit->pulse_peak = 0;
+            hit->has_fADC=false;
+            _data.push_back(hit);
         }
         hit->time_tdc=T;
         hit->has_TDC=true;

--- a/src/plugins/monitoring/TAGH_doubles/JEventProcessor_TAGH_doubles.cc
+++ b/src/plugins/monitoring/TAGH_doubles/JEventProcessor_TAGH_doubles.cc
@@ -124,8 +124,6 @@ jerror_t JEventProcessor_TAGH_doubles::evnt(JEventLoop *loop, uint64_t eventnumb
     vector<const DTAGHHit*> hits;
     loop->Get(hits);
 
-    if (hits.size() == 0) return NOERROR;
-
     // Extract the TAGH geometry
     vector<const DTAGHGeometry*> taghGeomVect;
     loop->Get(taghGeomVect);
@@ -147,15 +145,13 @@ jerror_t JEventProcessor_TAGH_doubles::evnt(JEventLoop *loop, uint64_t eventnumb
         if (hit->is_double) hBM2_PulseHeightVsID->Fill(hit->counter_id,hit->pulse_peak);
     }
     hBM_NHits->Fill(BM_NHits);
-    if (hits_c.size() > 1) {
-        for (size_t i = 0; i < hits_c.size()-1; i++) {
-            const DTAGHHit* hit1 = hits_c[i];
-            if (!hit1->has_TDC||!hit1->has_fADC) continue;
-            for (size_t j = i+1; j < hits_c.size(); j++) {
-                const DTAGHHit* hit2 = hits_c[j];
-                if (!hit2->has_TDC||!hit2->has_fADC) continue;
-                hBM_tdiffVsIDdiff->Fill(abs(hit1->counter_id-hit2->counter_id),hit1->t-hit2->t);
-            }
+    for (size_t i = 0; i < hits_c.size(); i++) {
+        const DTAGHHit* hit1 = hits_c[i];
+        if (!hit1->has_TDC||!hit1->has_fADC) continue;
+        for (size_t j = i+1; j < hits_c.size(); j++) {
+            const DTAGHHit* hit2 = hits_c[j];
+            if (!hit2->has_TDC||!hit2->has_fADC) continue;
+            hBM_tdiffVsIDdiff->Fill(abs(hit1->counter_id-hit2->counter_id),hit1->t-hit2->t);
         }
     }
     // After merging doubles
@@ -176,15 +172,13 @@ jerror_t JEventProcessor_TAGH_doubles::evnt(JEventLoop *loop, uint64_t eventnumb
         if (hit->is_double && has_overlap) hAM3_Energy->Fill(hit->E);
     }
     hAM_NHits->Fill(AM_NHits);
-    if (hits.size() > 1) {
-        for (size_t i = 0; i < hits.size()-1; i++) {
-            const DTAGHHit* hit1 = hits[i];
-            if (!hit1->has_TDC||!hit1->has_fADC) continue;
-            for (size_t j = i+1; j < hits.size(); j++) {
-                const DTAGHHit* hit2 = hits[j];
-                if (!hit2->has_TDC||!hit2->has_fADC) continue;
-                hAM_tdiffVsIDdiff->Fill(abs(hit1->counter_id-hit2->counter_id),hit1->t-hit2->t);
-            }
+    for (size_t i = 0; i < hits.size(); i++) {
+        const DTAGHHit* hit1 = hits[i];
+        if (!hit1->has_TDC||!hit1->has_fADC) continue;
+        for (size_t j = i+1; j < hits.size(); j++) {
+            const DTAGHHit* hit2 = hits[j];
+            if (!hit2->has_TDC||!hit2->has_fADC) continue;
+            hAM_tdiffVsIDdiff->Fill(abs(hit1->counter_id-hit2->counter_id),hit1->t-hit2->t);
         }
     }
     japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK

--- a/src/plugins/monitoring/TAGM_clusters/JEventProcessor_TAGM_clusters.cc
+++ b/src/plugins/monitoring/TAGM_clusters/JEventProcessor_TAGM_clusters.cc
@@ -58,10 +58,10 @@ jerror_t JEventProcessor_TAGM_clusters::init(void)
 	// This is called once at program startup. 
 
    TDirectory *mainDir = gDirectory;
-
+   TDirectory *tagmDir = gDirectory->mkdir("TAGM_clusters");
+   tagmDir->cd();
    // Before
-   TDirectory *bDir = gDirectory->mkdir("Before");
-   bDir->cd();
+   gDirectory->mkdir("Before")->cd();
    h_occupancy_b = new TH1D("occupancy_b","Histogram of occupancy",100,1,101);
    h_mult_b = new TH1I("mult_b","Multiplicity before",40,0.,40.);
    h_E_b = new TH1I("E_b","Energy before merging",110,8.2,9.3);
@@ -72,18 +72,19 @@ jerror_t JEventProcessor_TAGM_clusters::init(void)
                              100,-10.,10.);
    }
 
-   mainDir->cd();
+   tagmDir->cd();
 
    // After
-   TDirectory *aDir = gDirectory->mkdir("After");
-   aDir->cd();
+   gDirectory->mkdir("After")->cd();
    h_occupancy_a = new TH1D("occupancy_a","Histogram of occupancy",100,1,101);
    h_mult_a = new TH1I("mult_a","Multiplicity after",40,0.,40.);
    h_E_a = new TH1I("E_a","Energy after merging",110,8.2,9.3);
 
-   mainDir->cd();
+   tagmDir->cd();
 
    h_occupancy_ind = new TH1D("occupancy_ind","Histogram of occupancy",20,1,21);
+   // back to main dir
+   mainDir->cd();
 
 	return NOERROR;
 }


### PR DESCRIPTION
TAGM/TAGH beam-photon pairs are now merged if (both):
1. Energy difference is less than 50 MeV.
2. Time difference is less than 1.5 ns.

No averaging is done at this time.
The data from the most upstream hit is used.
