### PR TITLE
Sc eff update

### DIFF
--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -99,7 +99,7 @@ class DParticleID:public jana::JObject{
 	bool MatchToBCAL(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DBCALShower* locBCALShower, double locInputStartTime, DBCALShowerMatchParams& locShowerMatchParams) const;
 	bool MatchToTOF(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DTOFPoint* locTOFPoint, double locInputStartTime, DTOFHitMatchParams& locTOFHitMatchParams) const;
 	bool MatchToFCAL(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DFCALShower* locFCALShower, double locInputStartTime, DFCALShowerMatchParams& locShowerMatchParams) const;
-	bool MatchToSC(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DSCHit* locSCHit, double locInputStartTime, DSCHitMatchParams& locSCHitMatchParams, bool locIsTimeBased=false, DVector3 *IntersectionPoint=NULL, DVector3 *IntersectionDir=NULL) const;
+	bool MatchToSC(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DSCHit* locSCHit, double locInputStartTime, DSCHitMatchParams& locSCHitMatchParams, bool locIsTimeBased=false, const float* locInputDeltaPhiCut=NULL, DVector3 *IntersectionPoint=NULL, DVector3 *IntersectionDir=NULL) const;
 
 	//select "best" matches //called by several factories
 	bool Get_BestSCMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DSCHitMatchParams& locBestMatchParams) const;

--- a/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.cc
+++ b/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.cc
@@ -296,7 +296,7 @@ jerror_t JEventProcessor_ST_Propagation_Time::evnt(JEventLoop *loop, uint64_t ev
                                                 st_params[0].dSCHit, 
                                                 st_params[0].dSCHit->t, 
                                                 locSCHitMatchParams, 
-                                                true,
+                                                true, NULL,
                                                 &IntersectionPoint, &IntersectionDir);      
           if(!sc_match_pid) continue;
           // For each paddle calculate the hit time, flight time, intersection point (z), and t0 from TOF

--- a/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.cc
+++ b/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.cc
@@ -214,7 +214,7 @@ jerror_t JEventProcessor_ST_Tresolution::evnt(JEventLoop *loop, uint64_t eventnu
                                                  st_params[0].dSCHit, 
                                                  st_params[0].dSCHit->t, 
                                                  locSCHitMatchParams, 
-                                                 true,
+                                                 true, NULL,
                                                  &IntersectionPoint, &IntersectionDir); 
       if(!sc_match_pid) continue; 
       // Cut on the number of particle votes to find the best RF time

--- a/src/plugins/monitoring/SC_Eff/JEventProcessor_SC_Eff.h
+++ b/src/plugins/monitoring/SC_Eff/JEventProcessor_SC_Eff.h
@@ -56,6 +56,7 @@ class JEventProcessor_SC_Eff : public jana::JEventProcessor
 		int dMinHitRingsPerCDCSuperlayer, dMinHitPlanesPerFDCPackage;
 		DCutAction_TrackHitPattern* dCutAction_TrackHitPattern;
 		map<DetectorSystem_t, double> dMaxPIDDeltaTMap;
+		float* dLooseSCDeltaPhiCut;
 
 		//HISTOGRAMS
 		TH2I* dHist_HitFound;

--- a/src/plugins/monitoring/SC_Eff/JEventProcessor_SC_Eff.h
+++ b/src/plugins/monitoring/SC_Eff/JEventProcessor_SC_Eff.h
@@ -56,7 +56,7 @@ class JEventProcessor_SC_Eff : public jana::JEventProcessor
 		int dMinHitRingsPerCDCSuperlayer, dMinHitPlanesPerFDCPackage;
 		DCutAction_TrackHitPattern* dCutAction_TrackHitPattern;
 		map<DetectorSystem_t, double> dMaxPIDDeltaTMap;
-		float* dLooseSCDeltaPhiCut;
+		float dLooseSCDeltaPhiCut;
 
 		//HISTOGRAMS
 		TH2I* dHist_HitFound;

--- a/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.cc
+++ b/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.cc
@@ -205,7 +205,7 @@ jerror_t JEventProcessor_ST_online_Tresolution::evnt(JEventLoop *loop, uint64_t 
 					    st_params[0].dSCHit, 
 					    st_params[0].dSCHit->t, 
 					    locSCHitMatchParams, 
-					    true,
+					    true, NULL,
 					    &IntersectionPoint, &IntersectionDir); 
       if(!sc_match_pid) continue; 
       // Cut on the number of particle votes to find the best RF time

--- a/src/plugins/monitoring/ST_online_tracking/JEventProcessor_ST_online_tracking.cc
+++ b/src/plugins/monitoring/ST_online_tracking/JEventProcessor_ST_online_tracking.cc
@@ -214,7 +214,7 @@ jerror_t JEventProcessor_ST_online_tracking::evnt(JEventLoop *eventLoop, uint64_
 						 st_params[0].dSCHit, 
 						 st_params[0].dSCHit->t, 
 						 locSCHitMatchParams, 
-						 true,
+						 true, NULL,
 						 &IntersectionPoint, &IntersectionDir);      
       if(!st_match_pid) continue;  
 


### PR DESCRIPTION
In the SC eff plugin, now save matching results for all SC hits within the out of time window (hit sector, delta-phi, delta-t, is-matched). This allows out-of-time and sideband subtraction cuts. 

To calculate this, allow custom (super-wide) delta-phi cut in DParticleID::MatchToSC()
