### PR TITLE
Davidl macosx minor

### DIFF
--- a/src/libraries/KINFITTER/DKinFitConstraint_Spacetime.h
+++ b/src/libraries/KINFITTER/DKinFitConstraint_Spacetime.h
@@ -42,7 +42,7 @@ class DKinFitConstraint_Spacetime : public DKinFitConstraint_Vertex
 		void Reset(void);
 
 		void Set_CommonTime(double locTime);
-		void Set_CommonVertex(TVector3& locVertex);
+		void Set_CommonVertex(const TVector3& locVertex);
 		void Set_CommonSpacetime(TLorentzVector& locSpacetime);
 
 		void Set_CommonTParamIndex(int locCommonTParamIndex);
@@ -111,7 +111,7 @@ inline void DKinFitConstraint_Spacetime::Set_CommonTime(double locTime)
 		(*locIterator)->Set_CommonTime(locTime);
 }
 
-inline void DKinFitConstraint_Spacetime::Set_CommonVertex(TVector3& locVertex)
+inline void DKinFitConstraint_Spacetime::Set_CommonVertex(const TVector3& locVertex)
 {
 	DKinFitConstraint_Vertex::Set_CommonVertex(locVertex);
 	set<DKinFitParticle*>::iterator locIterator = dOnlyConstrainTimeParticles.begin();

--- a/src/libraries/TAGGER/DTAGHHit_factory.cc
+++ b/src/libraries/TAGGER/DTAGHHit_factory.cc
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <cmath>
 using namespace std;
 
 #include "DTAGHHit_factory.h"


### PR DESCRIPTION
Two relatively minor changes:

1.) Add #include<cmath> to DTAGHHit_factory.cc since fabs requires it

2.) Make argument of DKinFitConstraint_Spacetime::Set_CommonVertex to be const so that it matches base class and avoids compiler warnings.
