### PR TITLE
Change lapack3 to lapack in AddCERNLIB()-libs list

### DIFF
--- a/src/SBMS/sbms.py
+++ b/src/SBMS/sbms.py
@@ -745,7 +745,7 @@ def AddCERNLIB(env):
 	env.AppendUnique(CPPPATH   = CERN_FORTRANPATH)
 	env.AppendUnique(LIBPATH   = CERN_LIBPATH)
 	env.AppendUnique(LINKFLAGS = ['-rdynamic', '-Wl,--no-as-needed'])
-	env.AppendUnique(LIBS      = ['geant321', 'pawlib', 'lapack3', 'blas', 'graflib', 'grafX11', 'packlib', 'mathlib', 'kernlib', 'gfortran', 'X11', 'nsl', 'crypt', 'dl'])
+	env.AppendUnique(LIBS      = ['geant321', 'pawlib', 'lapack', 'blas', 'graflib', 'grafX11', 'packlib', 'mathlib', 'kernlib', 'gfortran', 'X11', 'nsl', 'crypt', 'dl'])
 	env.SetOption('warn', 'no-fortran-cxx-mix')  # supress warnings about linking fortran with c++
 
 


### PR DESCRIPTION
Avoid the need for
ln -s /usr/lib_/liblapack.a /usr/lib_/liblapack3.a
