### PR TITLE
Pp evio fixes rtj

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -808,6 +808,17 @@ void DEVIOWorkerThread::ParseDataBank(uint32_t* &iptr, uint32_t *iend)
 }
 
 //----------------
+// ParseTIBank
+//----------------
+void DEVIOWorkerThread::ParseTIBank(uint32_t rocid, uint32_t* &iptr, uint32_t* iend)
+{
+    while(iptr<iend && ((*iptr) & 0xF8000000) != 0x88000000) iptr++; // Skip to JLab block trailer
+    iptr++; // advance past JLab block trailer
+    while(iptr<iend && *iptr == 0xF8000000) iptr++; // skip filler words after block trailer
+    //iptr = iend;
+}
+
+//----------------
 // ParseCAEN1190
 //----------------
 void DEVIOWorkerThread::ParseCAEN1190(uint32_t rocid, uint32_t* &iptr, uint32_t *iend)
@@ -1090,7 +1101,7 @@ void DEVIOWorkerThread::ParseJLabModuleData(uint32_t rocid, uint32_t* &iptr, uin
                 break;
 
            case DModuleType::TID:
-//                ParseTIBank(rocid, iptr, iend);
+                ParseTIBank(rocid, iptr, iend);
                 break;
 
             case DModuleType::UNKNOWN:

--- a/src/libraries/DAQ/DEVIOWorkerThread.h
+++ b/src/libraries/DAQ/DEVIOWorkerThread.h
@@ -108,6 +108,7 @@ class DEVIOWorkerThread{
 		void         ParseDataBank(uint32_t* &iptr, uint32_t *iend);
 
 		void        ParseJLabModuleData(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
+		void                ParseTIBank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
 		void              ParseCAEN1190(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
 		void   ParseModuleConfiguration(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
 		void              Parsef250Bank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);

--- a/src/libraries/DAQ/HDEVIO.cc
+++ b/src/libraries/DAQ/HDEVIO.cc
@@ -799,6 +799,22 @@ void HDEVIO::MapEvents(BLOCKHEADER_t &bh, EVIOBlockRecord &br)
 			ifs.seekg(sizeof(EVENTHEADER_t), ios_base::cur);
 		}
 
+		if (eh->event_len < 2) {
+			// Before disabling this warning (or hiding it behind a VERBOSE flag)
+			// you should ask yourself the question, "Is this something that we
+			// should simply be ignoring, garbage bytes in the input evio file?"
+			std::cout << "HDEVIO::MapEvents warning - "
+                      << "Attempt to swap bank with len<2" << std::endl;
+			Nbad_events++;
+			Nerrors++;
+			--i;
+			streampos delta = (streampos)((eh->event_len+1)<<2) - 
+                              (streampos)sizeof(EVENTHEADER_t);
+			ifs.seekg(delta, ios_base::cur);
+			pos += (streampos)((eh->event_len+1)<<2);
+			continue;
+		}
+
 		EVIOEventRecord er;
 		er.pos = pos;
 		er.event_len   = eh->event_len + 1; // +1 to include length word


### PR DESCRIPTION
- libraries/DAQ/DEVIOWorkerThread.cc, libraries/DAQ/DEVIOWorkerThread.h[rtj]
  - added support for bank type TID; a hook was present in the earlier
    code version but it was commented out. For some reason, the original
    raw evio files are readable without this patch, but PS skims are not.
- libraries/DAQ/HDEVIO.cc [rtj]  …
  - add a check in MapEvents() for zero-length events within a multi-event
    evio block, and skip over them with a warning. These only appear in
    PS skims at the moment. Prior to this patch, the JEventSource_EVIO
    reader would skip these null events, but the JEventSource_EVIOpp reader
    would choke on them. I implemented a non-maskable warning message to
    remind everyone that these null events may represent a real problem
    with the input file, even though the older JEventSource_EVIO parser
    would skip them silently unless -PEVIO:VERBOSE was set to non-zero.
    The new warning message is the same as the one issued by the older
    parser in VERBOSE mode, but this one is NOT maskable.
