### PR TITLE
In the recycle_points method, use the m_points vector that is part of…

### DIFF
--- a/src/libraries/BCAL/DBCALCluster.cc
+++ b/src/libraries/BCAL/DBCALCluster.cc
@@ -15,7 +15,6 @@ DBCALCluster::DBCALCluster( const DBCALPoint* point, double z_target_center )
   : m_points ( 0 ),  m_hit_E_unattenuated_sum(0.0),  m_z_target_center(z_target_center) {
 
   m_points.push_back( point );
-  AddAssociatedObject( point );
   makeFromPoints();
 }
 
@@ -45,7 +44,6 @@ DBCALCluster::addPoint( const DBCALPoint* point ){
   }
   
   m_points.push_back( point );
-  AddAssociatedObject( point );
   
   makeFromPoints();
 }
@@ -63,8 +61,7 @@ if( phi() > point->phi() ){
   }
 
   if(find(m_points.begin(),m_points.end(),point) != m_points.end()) m_points.erase( find(m_points.begin(),m_points.end(),point ));
-  RemoveAssociatedObject( point );
-
+ 
   // We should only be removing points from clusters during the recycle_points routine, where they are also added to a different cluster.
 
   makeFromPoints();
@@ -101,7 +98,6 @@ DBCALCluster::mergeClust( const DBCALCluster& clust ){
     }
     
     m_points.push_back( *pt );
-    AddAssociatedObject( *pt );
   }
 
   vector<pair<const DBCALUnifiedHit*,double> > otherHits = clust.hits();

--- a/src/libraries/BCAL/DBCALCluster.h
+++ b/src/libraries/BCAL/DBCALCluster.h
@@ -66,6 +66,8 @@ public:
   void addHit ( const DBCALUnifiedHit* hit, double hit_E_unattenuated );
   void mergeClust( const DBCALCluster& clust );
   void removePoint( const DBCALPoint* point ); 
+
+  vector<const DBCALPoint*>getPoints(void) const {return m_points;};
  
   // this prints out info
   void toStrings( vector< pair < string, string > > &items ) const;

--- a/src/libraries/BCAL/DBCALCluster_factory.cc
+++ b/src/libraries/BCAL/DBCALCluster_factory.cc
@@ -135,7 +135,10 @@ DBCALCluster_factory::evnt( JEventLoop *loop, uint64_t eventnumber ){
 			delete *clust;
 			continue;
 		}
-
+		vector<const DBCALPoint*>points=(**clust).getPoints();
+		for (unsigned int i=0;i<points.size();i++){
+		  (**clust).AddAssociatedObject(points[i]);
+		}
 		_data.push_back(*clust);
 	}
 
@@ -317,9 +320,7 @@ DBCALCluster_factory::recycle_points( vector<const DBCALPoint*> usedPoints, vect
 			bool clust_match;
 			bool point_match;
 			int best_clust = 0;
-			vector<const DBCALPoint*> associated_points;
-			associated_points.clear();
-			(**clust).Get(associated_points);
+			vector<const DBCALPoint*>associated_points=(**clust).getPoints();
 			float deltaTheta = fabs( (**clust).theta() - (*usedpt)->theta() );
 			float deltaPhi = (**clust).phi() - (*usedpt)->phi();
 			float deltaPhiAlt = ( (**clust).phi() > (*usedpt)->phi() ?


### PR DESCRIPTION
… the class instead of getting the list of points from the associated objects.  Add the points that survive the reshuffling to the cluster at the end just before pushing back to _data
