### PR TITLE
Highlevel + mcthrown_tree

### DIFF
--- a/src/plugins/Analysis/SConscript
+++ b/src/plugins/Analysis/SConscript
@@ -3,7 +3,7 @@ import sbms
 
 Import('*')
 
-subdirs = ['acceptance_hists', 'b1pi_hists', 'cdc_hists', 'DAQTree', 'DAQTreeBCAL', 'fcal_hists', 'mcthrown_hists', 'trackeff_hists', 'monitoring_hists','dc_alignment','p2pi_hists','p3pi_hists','p4pi_hists','p2k_hists','p2gamma_hists','ppi0gamma_hists','p2pi0_hists','fcal_charged','TPOL_tree']
+subdirs = ['acceptance_hists', 'b1pi_hists', 'cdc_hists', 'DAQTree', 'DAQTreeBCAL', 'fcal_hists', 'mcthrown_hists', 'trackeff_hists', 'monitoring_hists','dc_alignment','p2pi_hists','p3pi_hists','p4pi_hists','p2k_hists','p2gamma_hists','ppi0gamma_hists','p2pi0_hists','fcal_charged','TPOL_tree','mcthrown_tree']
 sbms.OptionallyBuild(env, ['phys_tree', 'pedestals','bcal_calib','bcal_calib_cosmic_cdc'])
 SConscript(dirs=subdirs, exports='env osname', duplicate=0)
 

--- a/src/plugins/Analysis/mcthrown_tree/DEventProcessor_mcthrown_tree.cc
+++ b/src/plugins/Analysis/mcthrown_tree/DEventProcessor_mcthrown_tree.cc
@@ -1,0 +1,73 @@
+// $Id$
+//
+// File: DEventProcessor_mcthrown_tree.cc
+// Created: Thu Sep 28 11:38:03 EDT 2011
+// Creator: pmatt (on Darwin swire-b241.jlab.org 8.4.0 powerpc)
+//
+
+#include "DEventProcessor_mcthrown_tree.h"
+
+// The executable should define the ROOTfile global variable. It will
+// be automatically linked when dlopen is called.
+extern TFile *ROOTfile;
+
+// Routine used to create our DEventProcessor
+extern "C"
+{
+	void InitPlugin(JApplication *app)
+	{
+		InitJANAPlugin(app);
+		app->AddProcessor(new DEventProcessor_mcthrown_tree());
+	}
+} // "C"
+
+//------------------
+// init
+//------------------
+jerror_t DEventProcessor_mcthrown_tree::init(void)
+{
+	return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t DEventProcessor_mcthrown_tree::brun(JEventLoop *locEventLoop, int32_t runnumber)
+{
+	const DEventWriterROOT* locEventWriterROOT = NULL;
+	locEventLoop->GetSingle(locEventWriterROOT);
+	locEventWriterROOT->Create_ThrownTree(locEventLoop, "tree_thrown.root");
+
+	return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t DEventProcessor_mcthrown_tree::evnt(JEventLoop *locEventLoop, uint64_t eventnumber)
+{
+	const DEventWriterROOT* locEventWriterROOT = NULL;
+	locEventLoop->GetSingle(locEventWriterROOT);
+	locEventWriterROOT->Fill_ThrownTree(locEventLoop);
+
+	return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t DEventProcessor_mcthrown_tree::erun(void)
+{
+	// Any final calculations on histograms (like dividing them)
+	// should be done here. This may get called more than once.
+	return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t DEventProcessor_mcthrown_tree::fini(void)
+{
+	return NOERROR;
+}
+

--- a/src/plugins/Analysis/mcthrown_tree/DEventProcessor_mcthrown_tree.h
+++ b/src/plugins/Analysis/mcthrown_tree/DEventProcessor_mcthrown_tree.h
@@ -1,0 +1,33 @@
+// $Id$
+//
+//    File: DEventProcessor_mcthrown_tree.h
+// Created: Mon Apr  3 11:38:03 EDT 2006
+// Creator: pmatt (on Darwin swire-b241.jlab.org 8.4.0 powerpc)
+//
+
+#ifndef _DEventProcessor_mcthrown_tree_
+#define _DEventProcessor_mcthrown_tree_
+
+#include "JANA/JEventProcessor.h"
+#include "DANA/DApplication.h"
+#include <ANALYSIS/DEventWriterROOT.h>
+
+using namespace jana;
+
+class DEventProcessor_mcthrown_tree : public JEventProcessor
+{
+	public:
+		DEventProcessor_mcthrown_tree(){};
+		~DEventProcessor_mcthrown_tree(){};
+		const char* className(void){return "DEventProcessor_mcthrown_tree";}
+
+	private:
+		jerror_t init(void);						///< Called once at program start.
+		jerror_t brun(JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+		jerror_t evnt(JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+};
+
+#endif // _DEventProcessor_mcthrown_tree_
+

--- a/src/plugins/Analysis/mcthrown_tree/SConscript
+++ b/src/plugins/Analysis/mcthrown_tree/SConscript
@@ -1,0 +1,13 @@
+
+
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddDANA(env)
+sbms.AddROOT(env)
+sbms.plugin(env)
+
+

--- a/src/plugins/monitoring/SConscript
+++ b/src/plugins/monitoring/SConscript
@@ -37,7 +37,9 @@ subdirs = [
 'CDC_Cosmics',
 'EPICS_dump',
 'CDC_Efficiency',
-'L1_online']
+'L1_online',
+'highlevel_online'
+]
 
 #'L3_online',
 #'CODA_online',

--- a/src/plugins/monitoring/highlevel_online/HistMacro_Beam.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_Beam.C
@@ -1,0 +1,49 @@
+// hnamepath: /highlevel/RFBeamBunchPeriod
+// hnamepath: /highlevel/BeamEnergy
+
+{
+	TDirectory *locTopDirectory = gDirectory;
+
+	//Goto Beam Path
+	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("highlevel");
+	if(!locDirectory)
+		return;
+	locDirectory->cd();
+
+	TH1* locHist_RFBeamBunchPeriod = (TH1*)gDirectory->Get("RFBeamBunchPeriod");
+	TH1* locHist_BeamEnergy = (TH1*)gDirectory->Get("BeamEnergy");
+
+	//Get/Make Canvas
+	TCanvas *locCanvas = NULL;
+	if(TVirtualPad::Pad() == NULL)
+		locCanvas = new TCanvas("Beam", "Beam", 1200, 600); //for testing
+	else
+		locCanvas = gPad->GetCanvas();
+	locCanvas->Divide(2, 1);
+
+	//Draw
+	locCanvas->cd(1);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	if(locHist_RFBeamBunchPeriod != NULL)
+	{
+		locHist_RFBeamBunchPeriod->GetXaxis()->SetRangeUser(30.0, 90.0);
+		locHist_RFBeamBunchPeriod->GetXaxis()->SetTitleSize(0.05);
+		locHist_RFBeamBunchPeriod->GetXaxis()->SetLabelSize(0.05);
+		locHist_RFBeamBunchPeriod->GetYaxis()->SetLabelSize(0.04);
+		locHist_RFBeamBunchPeriod->Draw();
+	}
+
+	locCanvas->cd(2);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	if(locHist_BeamEnergy != NULL)
+	{
+		locHist_BeamEnergy->Rebin(5);
+		locHist_BeamEnergy->GetXaxis()->SetTitleSize(0.05);
+		locHist_BeamEnergy->GetXaxis()->SetLabelSize(0.05);
+		locHist_BeamEnergy->GetYaxis()->SetLabelSize(0.04);
+		locHist_BeamEnergy->Draw();
+	}
+}
+

--- a/src/plugins/monitoring/highlevel_online/HistMacro_Kinematics.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_Kinematics.C
@@ -1,0 +1,48 @@
+// hnamepath: /highlevel/PVsTheta_Tracks
+// hnamepath: /highlevel/PhiVsTheta_Tracks
+
+{
+	TDirectory *locTopDirectory = gDirectory;
+
+	//Goto Beam Path
+	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("highlevel");
+	if(!locDirectory)
+		return;
+	locDirectory->cd();
+
+	TH2* locHist_PVsTheta_Tracks = (TH2*)gDirectory->Get("PVsTheta_Tracks");
+	TH2* locHist_PhiVsTheta_Tracks = (TH2*)gDirectory->Get("PhiVsTheta_Tracks");
+
+	//Get/Make Canvas
+	TCanvas *locCanvas = NULL;
+	if(TVirtualPad::Pad() == NULL)
+		locCanvas = new TCanvas("Kinematics", "Kinematics", 1200, 600); //for testing
+	else
+		locCanvas = gPad->GetCanvas();
+	locCanvas->Divide(2, 1);
+
+	//Draw
+	locCanvas->cd(1);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	if(locHist_PVsTheta_Tracks != NULL)
+	{
+		locHist_PVsTheta_Tracks->GetXaxis()->SetTitleSize(0.05);
+		locHist_PVsTheta_Tracks->GetYaxis()->SetTitleSize(0.05);
+		locHist_PVsTheta_Tracks->GetXaxis()->SetLabelSize(0.05);
+		locHist_PVsTheta_Tracks->GetYaxis()->SetLabelSize(0.05);
+		locHist_PVsTheta_Tracks->Draw("colz");
+	}
+
+	locCanvas->cd(2);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	if(locHist_PhiVsTheta_Tracks != NULL)
+	{
+		locHist_PhiVsTheta_Tracks->GetXaxis()->SetTitleSize(0.05);
+		locHist_PhiVsTheta_Tracks->GetYaxis()->SetTitleSize(0.05);
+		locHist_PhiVsTheta_Tracks->GetXaxis()->SetLabelSize(0.05);
+		locHist_PhiVsTheta_Tracks->GetYaxis()->SetLabelSize(0.05);
+		locHist_PhiVsTheta_Tracks->Draw("colz");
+	}
+}

--- a/src/plugins/monitoring/highlevel_online/HistMacro_NumHighLevelObjects.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_NumHighLevelObjects.C
@@ -1,0 +1,33 @@
+// hnamepath: /highlevel/NumHighLevelObjects
+
+{
+	TDirectory* locCurrentDir = gDirectory;
+
+	//Goto Path
+	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("highlevel");
+	if(!locDirectory)
+		return;
+	locDirectory->cd();
+
+	//Get Histograms
+	TH2* locHist_NumHighLevel = (TH2*)gDirectory->Get("NumHighLevelObjects");
+
+	//Get/Make Canvas
+	TCanvas *locCanvas = NULL;
+	if(TVirtualPad::Pad() == NULL)
+		locCanvas = new TCanvas("NumHighLevelObjects", "NumHighLevelObjects", 1200, 800); //for testing
+	else
+		locCanvas = gPad->GetCanvas();
+
+	//Draw
+	locCanvas->cd(1);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	if(locHist_NumHighLevel != NULL)
+		locHist_NumHighLevel->Draw("COLZ");
+	gPad->SetLogz();
+	gPad->Update();
+
+	locCurrentDir->cd();
+}
+

--- a/src/plugins/monitoring/highlevel_online/HistMacro_Trigger.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_Trigger.C
@@ -1,0 +1,62 @@
+// hnamepath: /highlevel/L1GTPRate
+// hnamepath: /highlevel/BCALVsFCAL_TrigBit1
+// hnamepath: /highlevel/BCALVsFCAL_TrigBit6
+
+{
+	TDirectory *locTopDirectory = gDirectory;
+
+	//Goto Beam Path
+	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("highlevel");
+	if(!locDirectory)
+		return;
+	locDirectory->cd();
+
+	TH2* locHist_L1GTPRate = (TH2*)gDirectory->Get("L1GTPRate");
+	TH2* locHist_BCALVsFCAL_TrigBit1 = (TH2*)gDirectory->Get("BCALVsFCAL_TrigBit1");
+	TH2* locHist_BCALVsFCAL_TrigBit6 = (TH2*)gDirectory->Get("BCALVsFCAL_TrigBit6");
+
+	//Get/Make Canvas
+	TCanvas *locCanvas = NULL;
+	if(TVirtualPad::Pad() == NULL)
+		locCanvas = new TCanvas("Kinematics", "Kinematics", 1200, 400); //for testing
+	else
+		locCanvas = gPad->GetCanvas();
+	locCanvas->Divide(3, 1);
+
+	//Draw
+	locCanvas->cd(1);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	if(locHist_L1GTPRate != NULL)
+	{
+		locHist_L1GTPRate->GetXaxis()->SetTitleSize(0.05);
+		locHist_L1GTPRate->GetYaxis()->SetTitleSize(0.05);
+		locHist_L1GTPRate->GetXaxis()->SetLabelSize(0.05);
+		locHist_L1GTPRate->GetYaxis()->SetLabelSize(0.05);
+		locHist_L1GTPRate->Draw("colz");
+	}
+
+	locCanvas->cd(2);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	if(locHist_BCALVsFCAL_TrigBit1 != NULL)
+	{
+		locHist_BCALVsFCAL_TrigBit1->GetXaxis()->SetTitleSize(0.05);
+		locHist_BCALVsFCAL_TrigBit1->GetYaxis()->SetTitleSize(0.05);
+		locHist_BCALVsFCAL_TrigBit1->Draw("colz");
+		gPad->SetLogz();
+		gPad->Update();
+	}
+
+	locCanvas->cd(3);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	if(locHist_BCALVsFCAL_TrigBit6 != NULL)
+	{
+		locHist_BCALVsFCAL_TrigBit6->GetXaxis()->SetTitleSize(0.05);
+		locHist_BCALVsFCAL_TrigBit6->GetYaxis()->SetTitleSize(0.05);
+		locHist_BCALVsFCAL_TrigBit6->Draw("colz");
+		gPad->SetLogz();
+		gPad->Update();
+	}
+}

--- a/src/plugins/monitoring/highlevel_online/HistMacro_Vertex.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_Vertex.C
@@ -1,0 +1,53 @@
+// hnamepath: /highlevel/EventVertexZ
+// hnamepath: /highlevel/EventVertexYVsX
+
+//EventVertexZ
+//EventVertexYVsX
+
+{
+	TDirectory *locTopDirectory = gDirectory;
+
+	//Goto Beam Path
+	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("highlevel");
+	if(!locDirectory)
+		return;
+	locDirectory->cd();
+
+	TH1* locHist_EventVertexZ = (TH1*)gDirectory->Get("EventVertexZ");
+	TH2* locHist_EventVertexYVsX = (TH2*)gDirectory->Get("EventVertexYVsX");
+
+	//Get/Make Canvas
+	TCanvas *locCanvas = NULL;
+	if(TVirtualPad::Pad() == NULL)
+		locCanvas = new TCanvas("Vertex", "Vertex", 1200, 600); //for testing
+	else
+		locCanvas = gPad->GetCanvas();
+	locCanvas->Divide(2, 1);
+
+	//Draw
+	locCanvas->cd(1);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	if(locHist_EventVertexZ != NULL)
+	{
+		locHist_EventVertexZ->GetXaxis()->SetTitleSize(0.05);
+		locHist_EventVertexZ->GetYaxis()->SetTitleSize(0.05);
+		locHist_EventVertexZ->GetXaxis()->SetLabelSize(0.05);
+		locHist_EventVertexZ->GetYaxis()->SetLabelSize(0.05);
+		locHist_EventVertexZ->Draw();
+	}
+
+	locCanvas->cd(2);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	if(locHist_EventVertexYVsX != NULL)
+	{
+		locHist_EventVertexYVsX->GetXaxis()->SetTitleSize(0.05);
+		locHist_EventVertexYVsX->GetYaxis()->SetTitleSize(0.05);
+		locHist_EventVertexYVsX->GetXaxis()->SetLabelSize(0.05);
+		locHist_EventVertexYVsX->GetYaxis()->SetLabelSize(0.05);
+		locHist_EventVertexYVsX->Draw("colz");
+		gPad->SetLogz();
+		gPad->Update();
+	}
+}

--- a/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
+++ b/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
@@ -1,0 +1,324 @@
+#include "JEventProcessor_highlevel_online.h"
+using namespace jana;
+
+// Routine used to create our JEventProcessor
+#include <JANA/JApplication.h>
+#include <JANA/JFactory.h>
+extern "C"{
+  void InitPlugin(JApplication *app){
+    InitJANAPlugin(app);
+    app->AddProcessor(new JEventProcessor_highlevel_online());
+  }
+} // "C"
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_highlevel_online::init(void)
+{
+	// All histograms go in the "highlevel" directory
+	TDirectory *main = gDirectory;
+
+	gDirectory->mkdir("highlevel")->cd();
+
+	/***************************************************************** RF *****************************************************************/
+
+	dHist_BeamBunchPeriod = new TH1I("RFBeamBunchPeriod", ";TAGH #Deltat (Within Same Counter) (ns)", 1000, 0.0, 200.0);
+
+	/*************************************************************** TRIGGER **************************************************************/
+
+	dHist_L1GTPRate = new TH2F("L1GTPRate",";Trigger Bit;L1 GTP Rate", 32, 0.5, 32.5, 1000, 0.0, 100.0);
+
+	dHist_BCALVsFCAL_TrigBit1 = new TH2I("BCALVsFCAL_TrigBit1","TRIG BIT 1;E (FCAL) (count);E (BCAL) (count)", 200, 0., 10000, 200, 0., 50000);
+	dHist_BCALVsFCAL_TrigBit6 = new TH2I("BCALVsFCAL_TrigBit6","TRIG BIT 6;E (FCAL) (count);E (BCAL) (count)", 200, 0., 10000, 200, 0., 50000);
+
+	/****************************************************** NUM RECONSTRUCTED OBJECTS *****************************************************/
+
+	//2D Summary
+	dHist_NumHighLevelObjects = new TH2I("NumHighLevelObjects", ";;# Objects / Event", 12, 0.5, 12.5, 101, -0.5, 100.5);
+	dHist_NumHighLevelObjects->GetXaxis()->SetBinLabel(1, "DSCHit");
+	dHist_NumHighLevelObjects->GetXaxis()->SetBinLabel(2, "DTOFPoint");
+	dHist_NumHighLevelObjects->GetXaxis()->SetBinLabel(3, "DBCALShower");
+	dHist_NumHighLevelObjects->GetXaxis()->SetBinLabel(4, "DFCALShower");
+	dHist_NumHighLevelObjects->GetXaxis()->SetBinLabel(5, "DTimeBasedTrack");
+	dHist_NumHighLevelObjects->GetXaxis()->SetBinLabel(6, "TrackSCMatches");
+	dHist_NumHighLevelObjects->GetXaxis()->SetBinLabel(7, "TrackTOFMatches");
+	dHist_NumHighLevelObjects->GetXaxis()->SetBinLabel(8, "TrackBCALMatches");
+	dHist_NumHighLevelObjects->GetXaxis()->SetBinLabel(9, "TrackFCALMatches");
+	dHist_NumHighLevelObjects->GetXaxis()->SetBinLabel(10, "DBeamPhoton");
+	dHist_NumHighLevelObjects->GetXaxis()->SetBinLabel(11, "DChargedTrack");
+	dHist_NumHighLevelObjects->GetXaxis()->SetBinLabel(12, "DNeutralShower");
+
+	/************************************************************* KINEMATICS *************************************************************/
+
+	// Beam Energy
+	dHist_BeamEnergy = new TH1I("BeamEnergy", ";Beam Energy (GeV)", 1200, 0.0, 12.0);
+
+	// PVsTheta Time-Based Tracks
+	dHist_PVsTheta_Tracks = new TH2I("PVsTheta_Tracks", ";#theta#circ;p (GeV/c)", 280, 0.0, 140.0, 300, 0.0, 12.0);
+
+	// PhiVsTheta Time-Based Tracks
+	dHist_PhiVsTheta_Tracks = new TH2I("PhiVsTheta_Tracks", ";#phi#circ;p (GeV/c)", 280, 0.0, 140.0, 360, -180.0, 180.0);
+
+	/*************************************************************** VERTEX ***************************************************************/
+
+	// Event Vertex-Z
+	dEventVertexZ = new TH1I("EventVertexZ", ";Event Vertex-Z (cm)", 600, 0.0, 200.0);
+
+	// Event Vertex-Y Vs Vertex-X
+	dEventVertexYVsX = new TH2I("EventVertexYVsX", ";Event Vertex-X (cm);Event Vertex-Y (cm)", 400, -10.0, 10.0, 400, -10.0, 10.0);
+
+	// back to main dir
+	main->cd();
+  
+	return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_highlevel_online::brun(JEventLoop *locEventLoop, int32_t runnumber)
+{
+  // This is called whenever the run number changes
+
+	fcal_cell_thr  =  64;
+	bcal_cell_thr  =  20;
+
+	fcal_row_mask_min = 26;
+	fcal_row_mask_max = 32;
+	fcal_col_mask_min = 26;
+	fcal_col_mask_max = 32;
+
+	if( runnumber < 11127 )
+	{
+		fcal_row_mask_min = 24;
+		fcal_row_mask_max = 34;
+		fcal_col_mask_min = 24;
+		fcal_col_mask_max = 34;
+	}
+
+	return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_highlevel_online::evnt(JEventLoop *locEventLoop, uint64_t eventnumber)
+{
+	vector<const DTrackTimeBased*> locTrackTimeBasedVector;
+	locEventLoop->Get(locTrackTimeBasedVector);
+
+	vector<const DBeamPhoton*> locBeamPhotons;
+	locEventLoop->Get(locBeamPhotons);
+
+	vector<const DFCALShower*> locFCALShowers;
+	locEventLoop->Get(locFCALShowers);
+
+	vector<const DBCALShower*> locBCALShowers;
+	locEventLoop->Get(locBCALShowers);
+
+	vector<const DNeutralShower*> locNeutralShowers;
+	locEventLoop->Get(locNeutralShowers);
+
+	vector<const DTOFPoint*> locTOFPoints;
+	locEventLoop->Get(locTOFPoints);
+
+	vector<const DSCHit*> locSCHits;
+	locEventLoop->Get(locSCHits);
+
+	vector<const DTAGHHit*> locTAGHHits;
+	locEventLoop->Get(locTAGHHits);
+
+    vector<const DBCALDigiHit*> locBCALDigiHits;
+    locEventLoop->Get(locBCALDigiHits);
+
+    vector<const DFCALDigiHit*> locFCALDigiHits;
+    locEventLoop->Get(locFCALDigiHits);
+
+	const DDetectorMatches* locDetectorMatches = NULL;
+	locEventLoop->GetSingle(locDetectorMatches);
+
+	const DVertex* locVertex = NULL;
+	locEventLoop->GetSingle(locVertex);
+
+	vector<const DL1Trigger*> locL1Triggers;
+	locEventLoop->Get(locL1Triggers);
+	const DL1Trigger* locL1Trigger = locL1Triggers.empty() ? NULL : locL1Triggers[0];
+
+	vector<const DChargedTrack*> locChargedTracks;
+	locEventLoop->Get(locChargedTracks, "PreSelect");
+
+	/********************************************************* PREPARE TAGGER HITS ********************************************************/
+
+	//organize TAGH hits
+	map<int, set<double> > locTAGHHitMap; //double: TAGH tdc times (set allows time sorting)
+	for(size_t loc_i = 0; loc_i < locTAGHHits.size(); ++loc_i)
+	{
+		if(locTAGHHits[loc_i]->has_TDC)
+			locTAGHHitMap[locTAGHHits[loc_i]->counter_id].insert(locTAGHHits[loc_i]->time_tdc);
+	}
+
+	//collect TAGH delta-t's for RF beam bunch histogram
+	map<int, set<double> >::iterator locTAGHIterator = locTAGHHitMap.begin();
+	vector<double> locTAGHDeltaTs;
+	for(; locTAGHIterator != locTAGHHitMap.end(); ++locTAGHIterator)
+	{
+		set<double>& locCounterHits = locTAGHIterator->second;
+		if(locCounterHits.size() < 2)
+			continue;
+		set<double>::iterator locSetIterator = locCounterHits.begin();
+		set<double>::iterator locPreviousSetIterator = locSetIterator;
+		for(++locSetIterator; locSetIterator != locCounterHits.end(); ++locSetIterator, ++locPreviousSetIterator)
+			locTAGHDeltaTs.push_back(*locSetIterator - *locPreviousSetIterator);
+	}
+
+	/********************************************************* PREPARE TRIGGER INFO *******************************************************/
+
+	vector<unsigned int> locTrigBits(32, 0); //bit 1 -> 32 is index 0 -> 31
+
+	if(locL1Trigger != NULL)
+	{
+		for(unsigned int bit = 0; bit < 32; ++bit)
+			locTrigBits[bit] = (locL1Trigger->trig_mask & (1 << bit)) ? 1 : 0;
+	}
+
+	//Get total FCAL energy
+	int fcal_tot_en = 0;
+    for(unsigned int jj = 0; jj < locFCALDigiHits.size(); jj++)
+    {
+		const DFCALDigiHit *fcal_hit = locFCALDigiHits[jj];
+
+		int row = fcal_hit->row;
+		int col = fcal_hit->column;
+		if((row >= fcal_row_mask_min && row <= fcal_row_mask_max) && (col >= fcal_col_mask_min && col <= fcal_col_mask_max))
+			continue;
+
+		uint32_t adc_time = (fcal_hit->pulse_time & 0x7FC0) >> 6;
+		if(!((adc_time > 20) && (adc_time < 70)))
+			continue;
+
+		Int_t pulse_int = fcal_hit->pulse_integral - fcal_hit->nsamples_integral*100;
+		if(pulse_int < 0)
+			continue;
+
+		const Df250PulsePedestal *pulsepedestal = NULL;
+		fcal_hit->GetSingle(pulsepedestal);
+
+
+		Int_t pulse_peak = -10;
+		if(pulsepedestal)
+			pulse_peak = pulsepedestal->pulse_peak - 100;
+
+		if(pulse_peak <= fcal_cell_thr)
+			continue;
+
+		fcal_tot_en += pulse_int;
+	}
+
+	//Get total BCAL energy
+	int bcal_tot_en = 0;
+	for(unsigned int jj = 0; jj < locBCALDigiHits.size(); ++jj)
+	{
+		const DBCALDigiHit *bcal_hit = locBCALDigiHits[jj];
+		Int_t pulse_int = bcal_hit->pulse_integral - bcal_hit->nsamples_integral*100;
+
+		const Df250PulsePedestal *pulsepedestal;
+		bcal_hit->GetSingle(pulsepedestal);
+
+		Int_t pulse_peak = -10;
+		if(pulsepedestal)
+			pulse_peak = pulsepedestal->pulse_peak - 100;
+		if(pulse_peak <= bcal_cell_thr)
+			continue;
+
+		bcal_tot_en += pulse_int;
+	}
+
+    /***************************************************************** RF *****************************************************************/
+
+	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+
+	for(size_t loc_i = 0; loc_i < locTAGHDeltaTs.size(); ++loc_i)
+		dHist_BeamBunchPeriod->Fill(locTAGHDeltaTs[loc_i]);
+
+	/*************************************************************** TRIGGER **************************************************************/
+
+	if(locL1Trigger != NULL)
+	{
+		if(locTrigBits[0] == 1) //bit 1
+			dHist_BCALVsFCAL_TrigBit1->Fill(Float_t(fcal_tot_en), Float_t(bcal_tot_en));
+		if(locTrigBits[5] == 1) //bit 6
+			dHist_BCALVsFCAL_TrigBit6->Fill(Float_t(fcal_tot_en), Float_t(bcal_tot_en));
+
+		// Sync Events
+		if(!locL1Trigger->gtp_rate.empty())
+		{
+			for(unsigned int ii = 0; ii < 8; ++ii)
+				dHist_L1GTPRate->Fill(ii + 1, Float_t(locL1Trigger->gtp_rate[ii])/1000.0);
+		}
+	}
+
+	/****************************************************** NUM RECONSTRUCTED OBJECTS *****************************************************/
+
+	//# High-Level Objects
+	dHist_NumHighLevelObjects->Fill(1, (Double_t)locSCHits.size());
+	dHist_NumHighLevelObjects->Fill(2, (Double_t)locTOFPoints.size());
+	dHist_NumHighLevelObjects->Fill(3, (Double_t)locBCALShowers.size());
+	dHist_NumHighLevelObjects->Fill(4, (Double_t)locFCALShowers.size());
+	dHist_NumHighLevelObjects->Fill(5, (Double_t)locTrackTimeBasedVector.size());
+	dHist_NumHighLevelObjects->Fill(6, (Double_t)locDetectorMatches->Get_NumTrackSCMatches());
+	dHist_NumHighLevelObjects->Fill(7, (Double_t)locDetectorMatches->Get_NumTrackTOFMatches());
+	dHist_NumHighLevelObjects->Fill(8, (Double_t)locDetectorMatches->Get_NumTrackBCALMatches());
+	dHist_NumHighLevelObjects->Fill(9, (Double_t)locDetectorMatches->Get_NumTrackFCALMatches());
+	dHist_NumHighLevelObjects->Fill(10, (Double_t)locBeamPhotons.size());
+	dHist_NumHighLevelObjects->Fill(11, (Double_t)locChargedTracks.size());
+	dHist_NumHighLevelObjects->Fill(12, (Double_t)locNeutralShowers.size());
+
+	/************************************************************* KINEMATICS *************************************************************/
+
+	for(size_t loc_i = 0; loc_i < locBeamPhotons.size(); ++loc_i)
+		dHist_BeamEnergy->Fill(locBeamPhotons[loc_i]->energy());
+
+	for(size_t loc_i = 0; loc_i < locChargedTracks.size(); ++loc_i)
+	{
+		auto locChargedHypo = locChargedTracks[loc_i]->Get_BestTrackingFOM();
+		double locP = locChargedHypo->momentum().Mag();
+		double locTheta = locChargedHypo->momentum().Theta()*180.0/TMath::Pi();
+		double locPhi = locChargedHypo->momentum().Phi()*180.0/TMath::Pi();
+		dHist_PVsTheta_Tracks->Fill(locTheta, locP);
+		dHist_PhiVsTheta_Tracks->Fill(locTheta, locPhi);
+	}
+
+	/*************************************************************** VERTEX ***************************************************************/
+
+	if(locChargedTracks.size() >= 2)
+	{
+		dEventVertexZ->Fill(locVertex->dSpacetimeVertex.Z());
+		dEventVertexYVsX->Fill(locVertex->dSpacetimeVertex.X(), locVertex->dSpacetimeVertex.Y());
+	}
+
+	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
+	return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_highlevel_online::erun(void)
+{
+  // This is called whenever the run number changes, before it is
+  // changed to give you a chance to clean up before processing
+  // events from the next run number.
+  return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t JEventProcessor_highlevel_online::fini(void)
+{
+  // Called before program exit after event processing is finished.
+  return NOERROR;
+}
+

--- a/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
+++ b/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
@@ -27,7 +27,7 @@ jerror_t JEventProcessor_highlevel_online::init(void)
 
 	/*************************************************************** TRIGGER **************************************************************/
 
-	dHist_L1GTPRate = new TH2F("L1GTPRate",";Trigger Bit;L1 GTP Rate", 32, 0.5, 32.5, 1000, 0.0, 100.0);
+	dHist_L1GTPRate = new TH2F("L1GTPRate",";Trigger Bit;L1 GTP Rate (kHz)", 8, 0.5, 8.5, 1000, 0.0, 100.0);
 
 	dHist_BCALVsFCAL_TrigBit1 = new TH2I("BCALVsFCAL_TrigBit1","TRIG BIT 1;E (FCAL) (count);E (BCAL) (count)", 200, 0., 10000, 200, 0., 50000);
 	dHist_BCALVsFCAL_TrigBit6 = new TH2I("BCALVsFCAL_TrigBit6","TRIG BIT 6;E (FCAL) (count);E (BCAL) (count)", 200, 0., 10000, 200, 0., 50000);
@@ -58,7 +58,7 @@ jerror_t JEventProcessor_highlevel_online::init(void)
 	dHist_PVsTheta_Tracks = new TH2I("PVsTheta_Tracks", ";#theta#circ;p (GeV/c)", 280, 0.0, 140.0, 300, 0.0, 12.0);
 
 	// PhiVsTheta Time-Based Tracks
-	dHist_PhiVsTheta_Tracks = new TH2I("PhiVsTheta_Tracks", ";#phi#circ;p (GeV/c)", 280, 0.0, 140.0, 360, -180.0, 180.0);
+	dHist_PhiVsTheta_Tracks = new TH2I("PhiVsTheta_Tracks", ";#theta#circ;#phi#circ", 280, 0.0, 140.0, 360, -180.0, 180.0);
 
 	/*************************************************************** VERTEX ***************************************************************/
 

--- a/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.h
+++ b/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.h
@@ -1,0 +1,67 @@
+#ifndef _JEventProcessor_highlevel_online_
+#define _JEventProcessor_highlevel_online_
+
+#include <JANA/JEventProcessor.h>
+
+#include <TDirectory.h>
+#include <TH2.h>
+#include <TH1.h>
+#include <TMath.h>
+
+#include <TRACKING/DTrackTimeBased.h>
+#include <PID/DBeamPhoton.h>
+#include <FCAL/DFCALShower.h>
+#include <PID/DChargedTrack.h>
+#include <BCAL/DBCALShower.h>
+#include <PID/DNeutralShower.h>
+#include <TOF/DTOFPoint.h>
+#include <START_COUNTER/DSCHit.h>
+#include <PID/DDetectorMatches.h>
+#include <PID/DVertex.h>
+#include <TRIGGER/DL1Trigger.h>
+#include <TAGGER/DTAGHHit.h>
+#include <BCAL/DBCALDigiHit.h>
+#include <FCAL/DFCALDigiHit.h>
+#include <DAQ/Df250PulsePedestal.h>
+
+using namespace jana;
+using namespace std;
+
+class JEventProcessor_highlevel_online:public jana::JEventProcessor
+{
+	public:
+		JEventProcessor_highlevel_online(){};
+		~JEventProcessor_highlevel_online(){};
+		const char* className(void){return "JEventProcessor_highlevel_online";}
+
+		TH1I* dHist_BeamBunchPeriod;
+
+		TH2F* dHist_L1GTPRate;
+
+		TH2I* dHist_BCALVsFCAL_TrigBit1;
+		TH2I* dHist_BCALVsFCAL_TrigBit6;
+
+		TH2I* dHist_NumHighLevelObjects;
+
+		TH1I* dHist_BeamEnergy;
+
+		TH2I* dHist_PVsTheta_Tracks;
+		TH2I* dHist_PhiVsTheta_Tracks;
+
+		TH1I* dEventVertexZ;
+		TH2I* dEventVertexYVsX;
+
+	private:
+		jerror_t init(void);
+		jerror_t brun(jana::JEventLoop *locEventLoop, int32_t runnumber);
+		jerror_t evnt(jana::JEventLoop *locEventLoop, uint64_t eventnumber);
+		jerror_t erun(void);
+		jerror_t fini(void);
+
+	    int fcal_cell_thr;
+	    int bcal_cell_thr;
+	    int fcal_row_mask_min, fcal_row_mask_max, fcal_col_mask_min, fcal_col_mask_max;
+};
+
+#endif // _JEventProcessor_highlevel_online_
+

--- a/src/plugins/monitoring/highlevel_online/SConscript
+++ b/src/plugins/monitoring/highlevel_online/SConscript
@@ -1,0 +1,13 @@
+
+
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddROOTSpyMacros(env)
+sbms.AddDANA(env)
+sbms.plugin(env)
+
+


### PR DESCRIPTION
Add 2 plugins: highlevel_online and mcthrown_tree.

The first is to histogram high-level things in the counting house. 
The second is to fill an analysis tree with the thrown information.  Useful for acceptance corrections. 
