### PR TITLE
* DEventSourceHDDM.cc, DEventSourceREST.cc [rtj]

### DIFF
--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -106,10 +106,16 @@ jerror_t DEventSourceHDDM::GetEvent(JEvent &event)
       return NO_MORE_EVENTS_IN_SOURCE;
    }
    
-   ++Nevents_read;
-   
    hddm_s::HDDM *record = new hddm_s::HDDM();
-   *fin >> *record;
+   if (! (*fin >> *record)) {
+      delete fin;
+      fin = NULL;
+      delete ifs;
+      ifs = NULL;
+      return NO_MORE_EVENTS_IN_SOURCE;
+   }
+
+   ++Nevents_read;
 
    int event_number = -1;
    int run_number = -1;

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -96,20 +96,19 @@ jerror_t DEventSourceREST::GetEvent(JEvent &event)
 
    hddm_r::HDDM *record = new hddm_r::HDDM();
    try{
-      *fin >> *record;
+      if (! (*fin >> *record)) {
+         delete fin;
+         fin = NULL;
+         delete ifs;
+         ifs = NULL;
+	     return NO_MORE_EVENTS_IN_SOURCE;
+      }
    }catch(std::runtime_error &e){
       cerr << "Exception caught while trying to read REST file!" << endl;
 	  cerr << e.what() << endl;
 	  _DBG__;
-	  // returning now is the right thing to do but at the moment,
-	  // a bug in HDDM causes it to throw exceptions even when the data
-	  // for the event is read in OK. I sent an e-mail to Richard on
-	  // 8/8/2014 describing this. Once he's had a chance to fix that,
-	  // the following line can be uncommented.
-	  // 8/17/2014  DL
-	  //return NO_MORE_EVENTS_IN_SOURCE;
+	  return NO_MORE_EVENTS_IN_SOURCE;
    }
-
 
    // Copy the reference info into the JEvent object
    while (true) {
@@ -141,7 +140,14 @@ jerror_t DEventSourceREST::GetEvent(JEvent &event)
              gPARMS->SetDefaultParameter("REST:JANACALIBCONTEXT", REST_JANA_CALIB_CONTEXT);
          }
 
-         *fin >> *record;
+         if (! (*fin >> *record)) {
+            delete fin;
+            fin = NULL;
+            delete ifs;
+            ifs = NULL;
+	        return NO_MORE_EVENTS_IN_SOURCE;
+         }
+
          continue;
       }
       event.SetEventNumber(re.getEventNo());


### PR DESCRIPTION
- introduce conventional STL semantics for checking if an istream
   input operation succeeded or not, by testing the boolean value of
   the stream after the operation returns. When I introduced parallel
   io support to hddm, I also implemented the STL semantics for eof
   handling on input. This propagates the change to the event sources.
