### PR TITLE
* programs/Simulation/HDGeant/gelhad/gtgama.F [rtj]

### DIFF
--- a/src/programs/Simulation/HDGeant/gelhad/gtgama.F
+++ b/src/programs/Simulation/HDGeant/gelhad/gtgama.F
@@ -367,8 +367,8 @@ c      endif
          xcoef2 = q(jcoef+i1+1)
          xcoef3 = q(jcoef+i1+2)
          if(xcoef1.ne.0.) then
-            stopmx = REAL(-xcoef2+sign(one,xcoef1)*sqrt(xcoef2**2 - (xcoef3-
-     +      gekin/xcoef1)))
+            stopmx = REAL(-xcoef2+sign(one,xcoef1)*sqrt(xcoef2**2
+     +                    - (xcoef3-gekin/xcoef1)))
          else
             stopmx = REAL(- (xcoef3-gekin)/xcoef2)
          endif


### PR DESCRIPTION
- fix a line in legacy code that has characters extending past
   column 72, has been tolerated by the gfortran compiler in the
   past, but now is generating a warning.
