### PR TITLE
Do not restrict compilation on Mac OS X due to thread_local not being supported

### DIFF
--- a/src/plugins/monitoring/SConscript
+++ b/src/plugins/monitoring/SConscript
@@ -38,20 +38,17 @@ subdirs = [
 'EPICS_dump',
 'CDC_Efficiency',
 'L1_online',
-'highlevel_online'
+'highlevel_online',
+'BCAL_Hadronic_Eff',
+'FCAL_Hadronic_Eff',
+'SC_Eff','TOF_Eff',
+'TS_scaler'
 ]
 
 #'L3_online',
 #'CODA_online',
 #'EVNT_online',
 
-# Apple LLVM/Clang does not support thread_local at this time
-# Skip plugins that require thread_local if Apple LLVM is detected
-require_thread_local = ['BCAL_Hadronic_Eff','FCAL_Hadronic_Eff','SC_Eff','TOF_Eff','TS_scaler']
-if "llvm" not in env["OSNAME"]:
-	for directory in require_thread_local:
-		subdirs.append(directory)
-else: print "Apple Clang does not support thread_local at this time. Skipping\n", require_thread_local
 
 sbms.OptionallyBuild(env, ['TAGH_doubles'])
 SConscript(dirs=subdirs, exports='env osname', duplicate=0)


### PR DESCRIPTION
Remove code that only compiles plugins using thread_local if not compiling on Mac OS X. The newest HDDM requires thread_local and now Apple supports it with Xcode 8.
