### PR TITLE
RootSpy was crashing when asking for cdc_axes in macro. It seems fine…

### DIFF
--- a/src/plugins/monitoring/occupancy_online/CDC_occupancy.C
+++ b/src/plugins/monitoring/occupancy_online/CDC_occupancy.C
@@ -3,6 +3,7 @@
 // which histograms to fetch for the macro.
 //
 // hnamepath: /occupancy/cdc_num_events
+// hnamepath: /occupancy/cdc_axes
 // hnamepath: /occupancy/cdc_occ_ring_00
 // hnamepath: /occupancy/cdc_occ_ring_01
 // hnamepath: /occupancy/cdc_occ_ring_02
@@ -45,6 +46,8 @@
 	double Nevents = 1.0;
 	TH1I *cdc_num_events = (TH1I*)gDirectory->FindObjectAny("cdc_num_events");
 	if(cdc_num_events) Nevents = (double)cdc_num_events->GetBinContent(1);
+ 	TH2D *cdc_axes = (TH2D *)gDirectory->FindObjectAny("cdc_axes");
+ 	if(!cdc_axes) return;
 
 	// Just for testing
 	if(gPad == NULL){
@@ -53,15 +56,13 @@
 		c1->Draw();
 		c1->Update();
 	}
-	if(!gPad) {savedir->cd(); return;}
+	if(!gPad) return;
 
 	TCanvas *c1 = gPad->GetCanvas();
+	if(!c1) return;
 	c1->cd(0);
 
 	// Draw axes
-	TH2D *cdc_axes = (TH2D *)dir->Get("cdc_axes");
-	if(!cdc_axes) cdc_axes = new TH2D("cdc_axes", "CDC Occupancy", 100, -65.0, 65.0, 100, -65.0, 65.0);
-
 	double minScale = 0.0, maxScale = 0.10;
 	cdc_axes->SetStats(0);
 	cdc_axes->Fill(100,100); // without this, the color ramp is not drawn
@@ -84,9 +85,9 @@
 	
 	char str[256];
 	sprintf(str,"%0.0f events", Nevents);
-	TLatex lat(0.0, 68.0, str);
+	TLatex lat;
 	lat.SetTextAlign(22);
 	lat.SetTextSize(0.035);
-	lat.Draw();
+	lat.DrawLatex(0.0, 68.0, str);
 
 }

--- a/src/plugins/monitoring/occupancy_online/JEventProcessor_occupancy_online.cc
+++ b/src/plugins/monitoring/occupancy_online/JEventProcessor_occupancy_online.cc
@@ -139,6 +139,7 @@ jerror_t JEventProcessor_occupancy_online::init(void)
 		cdc_occ_ring[iring] = new TH2F(hname, "", Nstraws[iring], phi_start, phi_end, 1, r_start, r_end);
 	}
 	cdc_num_events = new TH1I("cdc_num_events", "CDC number of events", 1, 0.0, 1.0);
+	new TH2D("cdc_axes", "CDC Occupancy", 100, -65.0, 65.0, 100, -65.0, 65.0);
     
 	//------------------------ FCAL -----------------------
 	fcal_occ = new TH2F("fcal_occ", "FCAL Occupancy; column; row", 61, -1.5, 59.5, 61, -1.5, 59.5);


### PR DESCRIPTION
… when it is made by plugin and transferred via rootspy (??).
