### PR TITLE
Remove carriage returns from ROOT macros when generating C++ source for rootspy.

### DIFF
--- a/src/SBMS/sbms.py
+++ b/src/SBMS/sbms.py
@@ -850,6 +850,7 @@ def RootSpyMacroCodeGen(target, source, env):
 	fout.write('static string macro_data=""\n')
 	for line in fin:
 		line = line.replace('"', '\\\"')
+		line = line.replace('\r', '')
 		fout.write('"%s\\n"\n' % line[:-1])
 	fout.write(';\n')
 	fout.write('class %s{\n' % class_name)


### PR DESCRIPTION
This fixes the compilation errors recently seen with CDC_gains_rootspy_macro.cc. This is a file generated from a root macro (.C suffix). This particular macro had bot carriage return and line feed in it: "\r\n" which led to the problem. The fix removes the carriage returns when copying the contents into the new C++ source file so that each line makes a well-formed string.
