### PR TITLE
Add wire-based info to trackeff_missing

### DIFF
--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -3239,6 +3239,8 @@ void DHistogramAction_NumReconstructedObjects::Initialize(JEventLoop* locEventLo
 			dHist_NumFDCWireHits = GetOrCreate_Histogram<TH1I>(locHistName, ";# Wire DFDCHit", dMaxNumFDCHits/2 + 1, -0.5, (float)dMaxNumFDCHits - 0.5 + 2.0);
 			locHistName = "NumFDCCathodeHits";
 			dHist_NumFDCCathodeHits = GetOrCreate_Histogram<TH1I>(locHistName, ";# Cathode DFDCHit", dMaxNumFDCHits/2 + 1, -0.5, (float)dMaxNumFDCHits - 0.5 + 2.0);
+			locHistName = "NumFDCPseudoHits";
+			dHist_NumFDCPseudoHits = GetOrCreate_Histogram<TH1I>(locHistName, ";# FDC Pseudo Hits", dMaxNumFDCHits/2 + 1, -0.5, (float)dMaxNumFDCHits - 0.5 + 2.0);
 
 			locHistName = "NumTOFHits";
 			dHist_NumTOFHits = GetOrCreate_Histogram<TH1I>(locHistName, ";# DTOFHit", dMaxNumTOFCalorimeterHits + 1, -0.5, (float)dMaxNumTOFCalorimeterHits + 0.5);
@@ -3306,6 +3308,7 @@ bool DHistogramAction_NumReconstructedObjects::Perform_Action(JEventLoop* locEve
 	vector<const DFCALHit*> locFCALHits;
 	vector<const DTAGMHit*> locTAGMHits;
 	vector<const DTAGHHit*> locTAGHHits;
+	vector<const DFDCPseudo*> locFDCPseudoHits;
 	vector<const DRFDigiTime*> locRFDigiTimes;
 	vector<const DRFTDCDigiTime*> locRFTDCDigiTimes;
 
@@ -3318,6 +3321,7 @@ bool DHistogramAction_NumReconstructedObjects::Perform_Action(JEventLoop* locEve
 		locEventLoop->Get(locTrackCandidates_FDC, "FDCCathodes");
 		locEventLoop->Get(locCDCHits);
 		locEventLoop->Get(locFDCHits);
+		locEventLoop->Get(locFDCPseudoHits);
 		locEventLoop->Get(locTOFHits);
 		locEventLoop->Get(locBCALHits);
 		locEventLoop->Get(locFCALHits);
@@ -3465,6 +3469,7 @@ bool DHistogramAction_NumReconstructedObjects::Perform_Action(JEventLoop* locEve
 			dHist_NumCDCHits->Fill((Double_t)locCDCHits.size());
 			dHist_NumFDCWireHits->Fill((Double_t)locNumFDCWireHits);
 			dHist_NumFDCCathodeHits->Fill((Double_t)locNumFDCCathodeHits);
+			dHist_NumFDCPseudoHits->Fill((Double_t)locFDCPseudoHits.size());
 			dHist_NumTOFHits->Fill((Double_t)locTOFHits.size());
 			dHist_NumBCALHits->Fill((Double_t)locBCALHits.size());
 			dHist_NumFCALHits->Fill((Double_t)locFCALHits.size());

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.h
@@ -30,6 +30,7 @@
 #include "TAGGER/DTAGMHit.h"
 #include "CDC/DCDCHit.h"
 #include "FDC/DFDCHit.h"
+#include "FDC/DFDCPseudo.h"
 #include "TOF/DTOFPoint.h"
 #include "TOF/DTOFHit.h"
 #include "TOF/DTOFPaddleHit.h"
@@ -811,6 +812,7 @@ class DHistogramAction_NumReconstructedObjects : public DAnalysisAction
 		TH1I* dHist_NumCDCHits;
 		TH1I* dHist_NumFDCWireHits;
 		TH1I* dHist_NumFDCCathodeHits;
+		TH1I* dHist_NumFDCPseudoHits;
 		TH1I* dHist_NumTOFHits;
 		TH1I* dHist_NumBCALHits;
 		TH1I* dHist_NumFCALHits;

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -286,6 +286,7 @@ jerror_t DTrackTimeBased_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 	timebased_track->AddAssociatedObject(fdchits[k]);
       }
 
+      timebased_track->AddAssociatedObject(track);
       _data.push_back(timebased_track);
 
     }
@@ -376,6 +377,7 @@ jerror_t DTrackTimeBased_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 	  // Compute the figure-of-merit based on tracking
 	  timebased_track->FOM = TMath::Prob(timebased_track->chisq, timebased_track->Ndof);
 	  
+      timebased_track->AddAssociatedObject(track);
 	  _data.push_back(timebased_track);
 	}
       } 
@@ -895,7 +897,6 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
 	timebased_track->AddAssociatedObject(myfdchits[m]); 
       for(unsigned int m=0; m<mycdchits.size(); m++)
 	timebased_track->AddAssociatedObject(mycdchits[m]);
-      timebased_track->AddAssociatedObject(track);
 
       // dEdx
       double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdx_CDC;
@@ -910,6 +911,7 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
       timebased_track->dNumHitsUsedFordEdx_CDC = locNumHitsUsedFordEdx_CDC;
       timebased_track->setdEdx((locNumHitsUsedFordEdx_CDC >= locNumHitsUsedFordEdx_FDC) ? locdEdx_CDC : locdEdx_FDC);
       
+      timebased_track->AddAssociatedObject(track);
       _data.push_back(timebased_track);
       
       return true;
@@ -1092,7 +1094,7 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
   // Add DTrack object as associate object
   vector<const DTrackWireBased*>wire_based_track;
   src_track->GetT(wire_based_track);
-  //  timebased_track->AddAssociatedObject(wire_based_track[0]);
+  timebased_track->AddAssociatedObject(wire_based_track[0]);
 
   // dEdx
   double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdx_CDC;


### PR DESCRIPTION
Also, make sure wirebased track is always added as associated object to time-based.
Also, add DFDCPseudo hits histogram (# hits).
