### PR TITLE
Update PS timing-offset scripts

### DIFF
--- a/src/plugins/Calibration/PS_timing/JEventProcessor_PS_timing.cc
+++ b/src/plugins/Calibration/PS_timing/JEventProcessor_PS_timing.cc
@@ -12,6 +12,7 @@ using namespace jana;
 
 #include <PAIR_SPECTROMETER/DPSCPair.h>
 #include <PAIR_SPECTROMETER/DPSPair.h>
+#include <TAGGER/DTAGHHit.h>
 #include <RF/DRFTime.h>
 
 // Routine used to create our JEventProcessor
@@ -23,9 +24,12 @@ using namespace jana;
 
 const int NC_PSC = 16; // number of PSC modules (counters)
 const int NC_PS = 290; // number of PS columns (tiles)
+const int NC_TAGH = 274; // number of TAGH counter slots
+
 static TH2I *hPSC_tdcadcTimeDiffVsID;
 static TH2I *hPSCRF_tdcTimeDiffVsID;
 static TH2I *hPSRF_adcTimeDiffVsID;
+static TH2I *hTAGHRF_tdcTimeDiffVsID;
 
 extern "C"{
     void InitPlugin(JApplication *app){
@@ -69,6 +73,7 @@ jerror_t JEventProcessor_PS_timing::init(void)
     hPSC_tdcadcTimeDiffVsID = new TH2I("PSC_tdcadcTimeDiffVsID","PSC TDC-ADC time difference vs. counter ID;counter ID;time(TDC) - time(ADC) [ns]",NC_PSC,0.5,0.5+NC_PSC,NTb,Tl,Th);
     hPSCRF_tdcTimeDiffVsID = new TH2I("PSCRF_tdcTimeDiffVsID","PSC-RF TDC time difference vs. counter ID;counter ID;time(TDC) - time(RF) [ns]",NC_PSC,0.5,0.5+NC_PSC,NTb,Tl,Th);
     hPSRF_adcTimeDiffVsID = new TH2I("PSRF_adcTimeDiffVsID","PS-RF ADC time difference vs. counter ID;counter ID;time(ADC) - time(RF) [ns]",NC_PS,0.5,0.5+NC_PS,NTb,Tl,Th);
+    hTAGHRF_tdcTimeDiffVsID = new TH2I("TAGHRF_tdcTimeDiffVsID","TAGH-RF TDC time difference vs. counter ID;counter ID;time(TDC) - time(RF) [ns]",NC_TAGH,0.5,0.5+NC_TAGH,NTb,Tl,Th);
     mainDir->cd();
 
     return NOERROR;
@@ -97,35 +102,40 @@ jerror_t JEventProcessor_PS_timing::evnt(JEventLoop *loop, uint64_t eventnumber)
     loop->Get(cpairs);
     vector<const DPSPair*> fpairs;
     loop->Get(fpairs);
-    const DRFTime* rfTime = NULL;
+
+    vector<const DTAGHHit*> taghhits;
+    loop->Get(taghhits, "Calib");
+
+    const DRFTime* rfTime = nullptr;
     vector <const DRFTime*> rfTimes;
-    loop->Get(rfTimes,"PSC");
+    loop->Get(rfTimes, "PSC");
     if (rfTimes.size() > 0)
         rfTime = rfTimes[0];
     else
         return NOERROR;
 
-	// FILL HISTOGRAMS
-	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+    // FILL HISTOGRAMS
+    // Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
+    japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
     double t_RF = rfTime->dTime;
-    if (cpairs.size()>=1) { // PSC
+    if (cpairs.size() >= 1) { // PSC
         const DPSCHit* clhit = cpairs[0]->ee.first; // left hit in coarse PS
         const DPSCHit* crhit = cpairs[0]->ee.second;// right hit in coarse PS
         hPSC_tdcadcTimeDiffVsID->Fill(clhit->module,clhit->t-clhit->time_fadc);
         hPSCRF_tdcTimeDiffVsID->Fill(clhit->module,clhit->t-t_RF);
         hPSC_tdcadcTimeDiffVsID->Fill(crhit->module+8,crhit->t-crhit->time_fadc);
         hPSCRF_tdcTimeDiffVsID->Fill(crhit->module+8,crhit->t-t_RF);
-        if (fpairs.size()>=1) { // PS
-          const DPSHit* flhit = fpairs[0]->ee.first;  // left hit in fine PS
-          const DPSHit* frhit = fpairs[0]->ee.second; // right hit in fine PS
-          hPSRF_adcTimeDiffVsID->Fill(flhit->column,flhit->t-t_RF);
-          hPSRF_adcTimeDiffVsID->Fill(frhit->column+145,frhit->t-t_RF);
-      }
+        for (const auto& h : taghhits) hTAGHRF_tdcTimeDiffVsID->Fill(h->counter_id,h->t-t_RF);
+        if (fpairs.size() >= 1) { // PS
+            const DPSHit* flhit = fpairs[0]->ee.first;  // left hit in fine PS
+            const DPSHit* frhit = fpairs[0]->ee.second; // right hit in fine PS
+            hPSRF_adcTimeDiffVsID->Fill(flhit->column,flhit->t-t_RF);
+            hPSRF_adcTimeDiffVsID->Fill(frhit->column+145,frhit->t-t_RF);
+        }
     }
 
-	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+    japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
     return NOERROR;
 }

--- a/src/plugins/Calibration/PS_timing/scripts/README.md
+++ b/src/plugins/Calibration/PS_timing/scripts/README.md
@@ -1,9 +1,14 @@
 # PS/PSC Timing Offsets
-Follow these steps after running `hd_root` with the **PS_timing** plugin; The JANA configuration parameter `PSCHit:DELTA_T_ADC_TDC_MAX` should initially be set to a large value, such as 500 ns.
+Follow these steps after running `hd_root` with the **PS_timing** plugin.
 
-1. `root -b -q 'fits.C("hd_root.root",true)'`
-2. `root -b -q 'offsets.C("fits-csv")'`
-3. `ccdb add /PHOTON_BEAM/pair_spectrometer/base_time_offset -v default -r $RunNo-$RunNo offsets/base_time_offset.txt`
-4. `ccdb add /PHOTON_BEAM/pair_spectrometer/coarse/tdc_timing_offsets -v default -r $RunNo-$RunNo offsets/tdc_timing_offsets_psc.txt`
-5. `ccdb add /PHOTON_BEAM/pair_spectrometer/coarse/adc_timing_offsets -v default -r $RunNo-$RunNo offsets/adc_timing_offsets_psc.txt`
-6. `ccdb add /PHOTON_BEAM/pair_spectrometer/fine/adc_timing_offsets -v default -r $RunNo-$RunNo offsets/adc_timing_offsets_ps.txt`
+The JANA configuration parameter `PSCHit:DELTA_T_ADC_TDC_MAX` should initially be set to a large value, such as 500 ns.
+
+`run.sh` assumes that the ROOT scripts are in the same directory.
+
+To run the ROOT scripts:
+
+`bash run.sh 11367 hd_root.root`
+
+To publish the results to the ccdb:
+
+`bash publish.sh 11367`

--- a/src/plugins/Calibration/PS_timing/scripts/fits.C
+++ b/src/plugins/Calibration/PS_timing/scripts/fits.C
@@ -1,12 +1,21 @@
 using namespace RooFit;
-TH1* GetHistogram(TFile *f,TString hname,TString htype,int counter) {
+TH1* GetHistogram(TFile *f, TString hname, TString htype, int counter) {
     stringstream ss; ss << counter;
     TH2I *h2 = (TH2I*)f->Get("PS_timing/"+hname);
-    if (htype!="PSC"&&htype!="PS"&&htype!="TDCADC") cerr << "Unsupported histogram type: Choose 'PS', 'PSC', or 'TDCADC'" << endl;
+    if (htype != "PSC" && htype != "PS" && htype != "TDCADC") {
+        cerr << "Unsupported histogram type: Choose 'PS', 'PSC', or 'TDCADC'" << endl;
+    }
     TH1 *h = h2->ProjectionY(TString(h2->GetName())+"_"+TString(ss.str()),counter,counter);
-    TString title = (htype=="TDCADC") ? "PSC counter "+TString(ss.str()):htype+" counter "+TString(ss.str());
+    TString title = (htype == "TDCADC") ? "PSC counter "+TString(ss.str()) : htype+" counter "+TString(ss.str());
     h->SetTitle(title);
     h->GetXaxis()->SetTitle(h2->GetYaxis()->GetTitle());
+    return h;
+}
+TH1* GetTaggerHistogram(TFile *f) {
+    TH2I *h2 = (TH2I*)f->Get("PS_timing/TAGHRF_tdcTimeDiffVsID");
+    const int N = 127; // Use upstream counters (relative to microscope)
+    TH1 *h = h2->ProjectionY(TString(h2->GetName()),1,N+1);
+    h->GetXaxis()->SetTitle("time(TDC) - time(RF) [ns]");
     return h;
 }
 double GetMode(TH1 *h) {
@@ -16,14 +25,14 @@ double GetMode(TH1 *h) {
     if (max < 7.0) return 999.0;
     return h->GetBinCenter(max_bin);
 }
-void WriteFitResults(ofstream &fout,TH1 *h,TString htype,int counter) {
+void WriteFitResults(ofstream &fout, TH1 *h, TString htype, int counter) {
     TString sep = ",";
     double max = h->GetBinContent(h->GetMaximumBin());
     if (h->GetEntries() < 100.0 || GetMode(h) == 999.0) {
         fout << counter << sep << max << sep << 0.0 << sep << 0.0 << sep << 0.0 << endl;
         return;
     }
-    double w = (htype=="TDCADC") ? 1.0:0.75;
+    double w = (htype == "TDCADC") ? 1.25 : 0.75;
     double xlow = GetMode(h) - w;
     double xhigh = GetMode(h) + w;
     RooRealVar x("TDC time difference","TDC time difference [ns]",xlow,xhigh);
@@ -32,13 +41,13 @@ void WriteFitResults(ofstream &fout,TH1 *h,TString htype,int counter) {
     RooRealVar mean("mean","mean",GetMode(h),xlow,xhigh);
     RooRealVar sigma("sigma","sigma",0.2,0.01,0.5);
     RooGaussian gauss("gauss","gauss",x,mean,sigma);
-    gauss.fitTo(data);
-    // make plot
+    gauss.fitTo(data,PrintLevel(-1));
+    // Make plot
     TCanvas *canvas = new TCanvas("c","c",800,500);
     RooPlot *plot = x.frame();
     plot->SetTitle(h->GetTitle());
     plot->SetXTitle(h->GetXaxis()->GetTitle());
-    TString ytitle = (htype=="PS") ? "PS hits":"PSC hits";
+    TString ytitle = (htype == "PS") ? "PS hits" : "PSC hits";
     plot->SetYTitle(ytitle);
     plot->SetTitleSize(0.0474,"XY");
     data.plotOn(plot);
@@ -52,21 +61,69 @@ void WriteFitResults(ofstream &fout,TH1 *h,TString htype,int counter) {
     delete canvas; delete plot;
     fout << counter << sep << max << sep << mean.getVal() << sep << mean.getError() << sep << sigma.getVal() << endl;
 }
-int fits(TString rootFile,bool doAllFits) {
+void WriteFitResults2(ofstream &fout, TH1 *h, TString htype, int counter) {
+    TString sep = ",";
+    if (h->GetEntries() < 100.0 || GetMode(h) == 999.0) {
+        if (counter > 0) fout << counter << sep << h->GetEntries() << sep << 0.0 << sep << 0.0 << sep << 0.0 << endl;
+        return;
+    }
+    double max = h->GetBinContent(h->GetMaximumBin());
+    double xlow = GetMode(h) - 1.0;
+    double xhigh = GetMode(h) + 1.0;
+    RooRealVar x("TDC time difference","TDC time difference [ns]",xlow,xhigh);
+    RooDataHist data("data","data",RooArgList(x),h);
+    // model: add a narrow and wide gaussian with same mean
+    RooRealVar mean("mean","mean",GetMode(h),xlow,xhigh);
+    RooRealVar sigma1("sigma1","sigma1",0.2,0.01,0.4);//0.01,0.6
+    RooGaussian gauss1("gauss1","gauss1",x,mean,sigma1);
+    RooRealVar sigma2("sigma2","sigma2",0.7,0.3,2.5);//0.1,2.5
+    RooGaussian gauss2("gauss2","gauss2",x,mean,sigma2);
+    // f1: fraction of entries in first gaussian
+    RooRealVar f1("f1","f1",0.75,0.01,1.);
+    RooAddPdf doubleGauss("doubleGauss","doubleGauss",RooArgList(gauss1,gauss2),RooArgList(f1));
+    doubleGauss.fitTo(data,PrintLevel(-1));
+    // Make plot
+    TCanvas *canvas = new TCanvas("c","c",800,500);
+    RooPlot *plot = x.frame();
+    plot->SetTitle(h->GetTitle());
+    plot->SetXTitle(h->GetXaxis()->GetTitle());
+    TString ytitle = (htype == "PS") ? "PS hits" : "PSC hits";
+    if (htype == "TAGH") ytitle = "TAGH hits";
+    plot->SetYTitle(ytitle);
+    plot->SetTitleSize(0.0474,"XY");
+    data.plotOn(plot);
+    doubleGauss.plotOn(plot,LineColor(kRed));
+    plot->Draw();
+    doubleGauss.plotOn(plot,Components("gauss1"),LineColor(kBlue),LineStyle(kDashed));
+    doubleGauss.plotOn(plot,Components("gauss2"),LineColor(kGreen),LineStyle(kDashed));
+    doubleGauss.paramOn(plot,Layout(0.15,0.45,0.9),Format("NEU",AutoPrecision(1)));
+    plot->Draw();
+    stringstream ss; ss << counter;
+    system(TString("mkdir -p fits_"+htype).Data());
+    canvas->Print("fits_"+htype+"/counter_"+TString(ss.str())+".gif");
+    delete canvas; delete plot;
+    if (counter > 0) fout << counter << sep << max << sep << mean.getVal() << sep << mean.getError() << sep << sigma1.getVal() << endl;
+}
+int fits(TString rootFile, bool doAllFits) {
     TFile *f = new TFile(rootFile,"read");
     TString hnames[] = {"PSC_tdcadcTimeDiffVsID","PSCRF_tdcTimeDiffVsID","PSRF_adcTimeDiffVsID"};
     TString htypes[] = {"TDCADC","PSC","PS"};
     int N_htypes = 2;
     if (doAllFits) N_htypes = 3;
-    for (int htype=0;htype<N_htypes;htype++) {
+    for (int htype = 0; htype < N_htypes; htype++) {
         system("mkdir -p fits-csv");
         ofstream fout; fout.open("fits-csv/results_"+htypes[htype]+".txt");
-        const int N = (htypes[htype]=="PS") ? 290:16;
-        for (int i=1;i<=N;i++) { // counters
+        const int N = (htypes[htype] == "PS") ? 290 : 16;
+        for (int i = 1; i <= N; i++) { // counters
             TH1 *h = GetHistogram(f,hnames[htype],htypes[htype],i);
-            WriteFitResults(fout,h,htypes[htype],i);
+            if (htypes[htype] != "PSC") WriteFitResults(fout,h,htypes[htype],i);
+            else WriteFitResults2(fout,h,htypes[htype],i);
         }
         fout.close();
     }
+    ofstream fout; fout.open("fits-csv/results_base.txt");
+    TH1 *h = GetTaggerHistogram(f);
+    WriteFitResults2(fout,h,"TAGH",1);
+    fout.close();
     return 0;
 }

--- a/src/plugins/Calibration/PS_timing/scripts/offsets.C
+++ b/src/plugins/Calibration/PS_timing/scripts/offsets.C
@@ -1,54 +1,119 @@
-void GetData(TString fname,double *y,double &mean,const int N) {
+void GetData(TString fname, double *y, double &mean, const int N) {
     ifstream fin(fname);
     double prod = 0.0; double sum = 0.0;
-    for (int i=0;i<N;i++) {
-        char sep;int n; double w,t,dt,sigma;
+    for (int i = 0; i < N; i++) {
+        char sep; int n; double w, t, dt, sigma;
         fin >> n >> sep >> w >> sep >> t >> sep >> dt >> sep >> sigma;
         y[i] = t;
         prod += w*t;
         sum += w;
     }
-    if (sum>0.0) mean = prod/sum;
-    for (int i=0;i<N;i++) {if (y[i]==0.0) y[i] = mean;}
+    if (sum > 0.0) {
+        mean = prod/sum;
+    }
+    for (int i = 0; i < N; i++) {if (y[i] == 0.0) y[i] = mean;}
     fin.close();
 }
-void WriteBaseOffsets(double base_tdc,double base_tdcadc,double base_ps) {
+double GetBaseOffset(TString fname) {
+    ifstream fin(fname);
+    char sep; int n; double w, t, dt, sigma;
+    fin >> n >> sep >> w >> sep >> t >> sep >> dt >> sep >> sigma;
+    fin.close();
+    return t;
+}
+void GetCCDBOffsetsBase(double &adc_offset_psc, double &tdc_offset_psc, double &adc_offset_ps) {
+    ifstream fin("offsets/base_time_offset_ccdb.txt");
+    char sep;
+    fin >> sep;
+    fin >> adc_offset_psc >> tdc_offset_psc >> adc_offset_ps;
+    fin.close();
+}
+void GetPSCCCDBOffsetsTDC(double* tdc_offsets, const int N) {
+    ifstream fin("offsets/tdc_timing_offsets_psc_ccdb.txt");
+    char sep; int n;
+    fin >> sep;
+    for (int i = 0; i < N; i++) {
+        fin >> tdc_offsets[i];
+    }
+    fin.close();
+}
+void GetPSCCCDBOffsetsADC(double* adc_offsets, const int N) {
+    ifstream fin("offsets/adc_timing_offsets_psc_ccdb.txt");
+    char sep; int n;
+    fin >> sep;
+    for (int i = 0; i < N; i++) {
+        fin >> adc_offsets[i];
+    }
+    fin.close();
+}
+void GetPSCCDBOffsetsADC(double* adc_offsets_l, double* adc_offsets_r, const int N) {
+    ifstream fin("offsets/adc_timing_offsets_ps_ccdb.txt");
+    char sep; int n;
+    fin >> sep;
+    for (int i = 0; i < N; i++) {
+        fin >> adc_offsets_l[i] >> adc_offsets_r[i];
+    }
+    fin.close();
+}
+void WriteBaseOffsets(double TAGH_mu, double tdc_mu, double tdcadc_mu, double ps_mu) {
+    double adc_ccdb_psc; double tdc_ccdb_psc; double adc_ccdb_ps;
+    GetCCDBOffsetsBase(adc_ccdb_psc,tdc_ccdb_psc,adc_ccdb_ps);
     ofstream fout; fout.open("offsets/base_time_offset.txt");
     TString sep = "        ";
-    fout << -base_tdc + base_tdcadc << sep << -base_tdc << sep << -base_ps << endl;
+    double adc_mu = tdc_mu - tdcadc_mu; // mean PSC ADC time
+    fout << adc_ccdb_psc - adc_mu + TAGH_mu << sep << tdc_ccdb_psc - tdc_mu + TAGH_mu << sep << adc_ccdb_ps - ps_mu + TAGH_mu << endl;
     fout.close();
 }
-void WritePSCTDCOffsets(double *y,double mean,const int N) {
+void WritePSCTDCOffsets(double *y, double mean, const int N) {
+    double y_ccdb[N];
+    GetPSCCCDBOffsetsTDC(y_ccdb,N);
     ofstream fout; fout.open("offsets/tdc_timing_offsets_psc.txt");
     TString sep = "        ";
-    for (int i=0;i<N;i++) fout << y[i]-mean << endl;
+    for (int i = 0; i < N; i++) fout << y_ccdb[i] + y[i] - mean << endl;
+    fout.close();
+    fout.open("offsets/tdc_timing_offsets_psc_diff.txt");
+    for (int i = 0; i < N; i++) fout << y[i] - mean << endl;
     fout.close();
 }
-void WritePSCADCOffsets(double *y_tdcadc,double mean_tdcadc,double *y,double mean,const int N) {
+void WritePSCADCOffsets(double *y_tdcadc, double mean_tdcadc, double *y, double mean, const int N) {
+    double y_ccdb[N];
+    GetPSCCCDBOffsetsADC(y_ccdb,N);
     ofstream fout; fout.open("offsets/adc_timing_offsets_psc.txt");
     TString sep = "        ";
-    for (int i=0;i<N;i++) fout << y[i]-mean-(y_tdcadc[i]-mean_tdcadc) << endl;
+    for (int i = 0; i < N; i++) fout << y_ccdb[i] + y[i] - mean - (y_tdcadc[i] - mean_tdcadc) << endl;
+    fout.close();
+    fout.open("offsets/adc_timing_offsets_psc_diff.txt");
+    for (int i = 0; i < N; i++) fout << y[i] - mean - (y_tdcadc[i] - mean_tdcadc) << endl;
     fout.close();
 }
-void WritePSADCOffsets(double *y,double mean,const int N) {
+void WritePSADCOffsets(double *y, double mean, const int N) {
+    double yl_ccdb[int(N/2)]; double yr_ccdb[int(N/2)];
+    GetPSCCDBOffsetsADC(yl_ccdb,yr_ccdb,int(N/2));
     ofstream fout; fout.open("offsets/adc_timing_offsets_ps.txt");
     TString sep = "        ";
-    for (int i=0;i<int(N/2);i++) fout << y[i]-mean << sep << y[i+145]-mean << endl;
+    for (int i = 0; i < int(N/2); i++) fout << yl_ccdb[i] + y[i] - mean << sep << yr_ccdb[i] + y[i+145] - mean << endl;
+    fout.close();
+    fout.open("offsets/adc_timing_offsets_ps_diff.txt");
+    for (int i = 0; i < int(N/2); i++) fout << y[i] - mean << sep << y[i+145] - mean << endl;
     fout.close();
 }
 int offsets(TString dir) {
     system("mkdir -p offsets");
-    const int N = 16; // counters for PSC offsets
+    // PSC offsets
+    const int N = 16; // counters
     double y[N]; double mean_tdc = 0.0;
     GetData(dir+"/results_PSC.txt",y,mean_tdc,N);
     WritePSCTDCOffsets(y,mean_tdc,N);
     double y_tdcadc[N]; double mean_tdcadc = 0.0;
     GetData(dir+"/results_TDCADC.txt",y_tdcadc,mean_tdcadc,N);
     WritePSCADCOffsets(y_tdcadc,mean_tdcadc,y,mean_tdc,N);
-    const int N_ps = 290; // counters for PS offsets
+    // PS offsets
+    const int N_ps = 290; // counters
     double y_ps[N_ps]; double mean_ps = 0.0;
     GetData(dir+"/results_PS.txt",y_ps,mean_ps,N_ps);
     WritePSADCOffsets(y_ps,mean_ps,N_ps);
-    WriteBaseOffsets(mean_tdc,mean_tdcadc,mean_ps);
+    // Base offsets
+    double PSCTAGH_offset = GetBaseOffset(dir+"/results_base.txt");
+    WriteBaseOffsets(PSCTAGH_offset,mean_tdc,mean_tdcadc,mean_ps);
     return 0;
 }

--- a/src/plugins/Calibration/PS_timing/scripts/publish.sh
+++ b/src/plugins/Calibration/PS_timing/scripts/publish.sh
@@ -1,0 +1,6 @@
+RunNo=$1
+Dir=OUTPUT/${RunNo}/offsets
+ccdb add /PHOTON_BEAM/pair_spectrometer/base_time_offset -v default -r ${RunNo}-${RunNo} ${Dir}/base_time_offset.txt
+ccdb add /PHOTON_BEAM/pair_spectrometer/coarse/tdc_timing_offsets -v default -r ${RunNo}-${RunNo} ${Dir}/tdc_timing_offsets_psc.txt
+ccdb add /PHOTON_BEAM/pair_spectrometer/coarse/adc_timing_offsets -v default -r ${RunNo}-${RunNo} ${Dir}/adc_timing_offsets_psc.txt
+ccdb add /PHOTON_BEAM/pair_spectrometer/fine/adc_timing_offsets -v default -r ${RunNo}-${RunNo} ${Dir}/adc_timing_offsets_ps.txt

--- a/src/plugins/Calibration/PS_timing/scripts/run.sh
+++ b/src/plugins/Calibration/PS_timing/scripts/run.sh
@@ -1,0 +1,14 @@
+RunNo=$1
+OutputDir=OUTPUT/${RunNo}
+InputFile=$2
+cp -p ${InputFile} hd_root.root
+mkdir -p offsets
+ccdb dump /PHOTON_BEAM/pair_spectrometer/base_time_offset:${RunNo} > offsets/base_time_offset_ccdb.txt
+ccdb dump /PHOTON_BEAM/pair_spectrometer/coarse/tdc_timing_offsets:${RunNo} > offsets/tdc_timing_offsets_psc_ccdb.txt
+ccdb dump /PHOTON_BEAM/pair_spectrometer/coarse/adc_timing_offsets:${RunNo} > offsets/adc_timing_offsets_psc_ccdb.txt
+ccdb dump /PHOTON_BEAM/pair_spectrometer/fine/adc_timing_offsets:${RunNo} > offsets/adc_timing_offsets_ps_ccdb.txt
+root -b -q 'fits.C("hd_root.root",true)'
+root -b -q 'offsets.C("fits-csv")'
+rm -f hd_root.root
+mkdir -p ${OutputDir}
+mv offsets ${OutputDir}; mv fits-csv ${OutputDir}; mv fits_* ${OutputDir}


### PR DESCRIPTION
1. Allow for starting with non-zero ccdb values.
2. Align PS times with tagger hodoscope.
