### PR TITLE
Tofmatch increase

### DIFF
--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -1357,9 +1357,9 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 			if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_FCAL))
 			{
 				dHistMap_PVsTheta_HasHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locP);
-				if(locP > 0.5)
+				if(locP > 1.0)
 					dHistMap_PhiVsTheta_HasHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locPhi);
-				if((locP > 0.5) && (dProjectedFCALRowColumnMap.find(locTrack) != dProjectedFCALRowColumnMap.end()))
+				if((locP > 1.0) && (dProjectedFCALRowColumnMap.find(locTrack) != dProjectedFCALRowColumnMap.end()))
 				{
 					pair<float, float>& locPositionPair = dProjectedFCALXYMap[locTrack];
 					dHistMap_TrackFCALYVsX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
@@ -1370,9 +1370,9 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 			else
 			{
 				dHistMap_PVsTheta_NoHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locP);
-				if(locP > 0.5)
+				if(locP > 1.0)
 					dHistMap_PhiVsTheta_NoHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locPhi);
-				if((locP > 0.5) && (dProjectedFCALRowColumnMap.find(locTrack) != dProjectedFCALRowColumnMap.end()))
+				if((locP > 1.0) && (dProjectedFCALRowColumnMap.find(locTrack) != dProjectedFCALRowColumnMap.end()))
 				{
 					pair<float, float>& locPositionPair = dProjectedFCALXYMap[locTrack];
 					dHistMap_TrackFCALYVsX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
@@ -1382,7 +1382,7 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 			}
 
 			//TOF Paddle
-			if((locP > 0.5) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
+			if((locP > 1.0) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
 			{
 				pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
 				pair<int, int>& locPaddlePair = dProjectedTOF2DPaddlesMap[locTrack]; //vertical, horizontal
@@ -1416,9 +1416,9 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 			if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_TOF))
 			{
 				dHistMap_PVsTheta_HasHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locP);
-				if(locP > 0.5)
+				if(locP > 1.0)
 					dHistMap_PhiVsTheta_HasHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locPhi);
-				if((locP > 0.5) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
+				if((locP > 1.0) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
 				{
 					pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
 					dHistMap_TrackTOFYVsX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
@@ -1429,9 +1429,9 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 			else
 			{
 				dHistMap_PVsTheta_NoHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locP);
-				if(locP > 0.5)
+				if(locP > 1.0)
 					dHistMap_PhiVsTheta_NoHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locPhi);
-				if((locP > 0.5) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
+				if((locP > 1.0) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
 				{
 					pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
 					dHistMap_TrackTOFYVsX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -1141,8 +1141,8 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 	}
 
 	//TRACK / TOF PADDLE CLOSEST MATCHES
-	map<const DKinematicData*, pair<const DTOFPaddleHit*, double> > locHorizontalTOFPaddleTrackDistanceMap; //double: delta-y
-	map<const DKinematicData*, pair<const DTOFPaddleHit*, double> > locVerticalTOFPaddleTrackDistanceMap; //double: delta-x
+	map<const DKinematicData*, pair<const DTOFPaddleHit*, pair<double, double> > > locHorizontalTOFPaddleTrackDistanceMap; //doubles: delta-y, distance
+	map<const DKinematicData*, pair<const DTOFPaddleHit*, pair<double, double> > > locVerticalTOFPaddleTrackDistanceMap; //doubles: delta-x, distance
 	for(locTrackIterator = locBestTrackMap.begin(); locTrackIterator != locBestTrackMap.end(); ++locTrackIterator)
 	{
 		const DKinematicData* locKinematicData = locTrackIterator->second;
@@ -1156,14 +1156,18 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 		else
 			break;
 
-		double locBestDeltaX = 999.9, locBestDeltaY = 999.9;
+		double locBestDeltaX = 999.9, locBestDeltaY = 999.9, locBestDistance_Vertical = 999.9, locBestDistance_Horizontal = 999.9;
 		double locStartTime = locParticleID->Calc_PropagatedRFTime(locKinematicData, locEventRFBunch);
-		const DTOFPaddleHit* locClosestTOFPaddleHit_Vertical = locParticleID->Get_ClosestTOFPaddleHit_Vertical(locReferenceTrajectory, locTOFPaddleHits, locStartTime, locBestDeltaX);
-		const DTOFPaddleHit* locClosestTOFPaddleHit_Horizontal = locParticleID->Get_ClosestTOFPaddleHit_Horizontal(locReferenceTrajectory, locTOFPaddleHits, locStartTime, locBestDeltaY);
+
+		const DTOFPaddleHit* locClosestTOFPaddleHit_Vertical = locParticleID->Get_ClosestTOFPaddleHit_Vertical(locReferenceTrajectory, locTOFPaddleHits, locStartTime, locBestDeltaX, locBestDistance_Vertical);
+		pair<double, double> locDistancePair_Vertical(locBestDeltaX, locBestDistance_Vertical);
 		if(locClosestTOFPaddleHit_Vertical != NULL)
-			locVerticalTOFPaddleTrackDistanceMap[locTrackIterator->second] = pair<const DTOFPaddleHit*, double>(locClosestTOFPaddleHit_Vertical, locBestDeltaX);
+			locVerticalTOFPaddleTrackDistanceMap[locTrackIterator->second] = pair<const DTOFPaddleHit*, pair<double, double> >(locClosestTOFPaddleHit_Vertical, locDistancePair_Vertical);
+
+		const DTOFPaddleHit* locClosestTOFPaddleHit_Horizontal = locParticleID->Get_ClosestTOFPaddleHit_Horizontal(locReferenceTrajectory, locTOFPaddleHits, locStartTime, locBestDeltaY, locBestDistance_Horizontal);
+		pair<double, double> locDistancePair_Horizontal(locBestDeltaY, locBestDistance_Horizontal);
 		if(locClosestTOFPaddleHit_Horizontal != NULL)
-			locHorizontalTOFPaddleTrackDistanceMap[locTrackIterator->second] = pair<const DTOFPaddleHit*, double>(locClosestTOFPaddleHit_Horizontal, locBestDeltaY);
+			locHorizontalTOFPaddleTrackDistanceMap[locTrackIterator->second] = pair<const DTOFPaddleHit*, pair<double, double> >(locClosestTOFPaddleHit_Horizontal, locDistancePair_Horizontal);
 	}
 
 	//TRACK / SC CLOSEST MATCHES
@@ -1256,18 +1260,18 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 
 		//TOF Paddle
 		//Horizontal
-		map<const DKinematicData*, pair<const DTOFPaddleHit*, double> >::iterator locTOFPaddleIterator = locHorizontalTOFPaddleTrackDistanceMap.begin();
+		auto locTOFPaddleIterator = locHorizontalTOFPaddleTrackDistanceMap.begin();
 		for(; locTOFPaddleIterator != locHorizontalTOFPaddleTrackDistanceMap.end(); ++locTOFPaddleIterator)
 		{
-			double locDistance = locTOFPaddleIterator->second.second;
-			dHistMap_TOFPaddleTrackDeltaY[locIsTimeBased]->Fill(locDistance);
+			double locDeltaY = locTOFPaddleIterator->second.second.first;
+			dHistMap_TOFPaddleTrackDeltaY[locIsTimeBased]->Fill(locDeltaY);
 		}
 		//Vertical
 		locTOFPaddleIterator = locVerticalTOFPaddleTrackDistanceMap.begin();
 		for(; locTOFPaddleIterator != locVerticalTOFPaddleTrackDistanceMap.end(); ++locTOFPaddleIterator)
 		{
-			double locDistance = locTOFPaddleIterator->second.second;
-			dHistMap_TOFPaddleTrackDeltaX[locIsTimeBased]->Fill(locDistance);
+			double locDeltaX = locTOFPaddleIterator->second.second.first;
+			dHistMap_TOFPaddleTrackDeltaX[locIsTimeBased]->Fill(locDeltaX);
 		}
 		
 		//TOF Point
@@ -1350,36 +1354,35 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 			}
 
 			//FCAL
-			if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_TOF))
+			if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_FCAL))
 			{
-				if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_FCAL))
-				{
-					dHistMap_PVsTheta_HasHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locP);
+				dHistMap_PVsTheta_HasHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locP);
+				if(locP > 0.5)
 					dHistMap_PhiVsTheta_HasHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locPhi);
-					if(dProjectedFCALRowColumnMap.find(locTrack) != dProjectedFCALRowColumnMap.end())
-					{
-						pair<float, float>& locPositionPair = dProjectedFCALXYMap[locTrack];
-						dHistMap_TrackFCALYVsX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
-						pair<int, int>& locElementPair = dProjectedFCALRowColumnMap[locTrack];
-						dHistMap_TrackFCALRowVsColumn_HasHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
-					}
-				}
-				else
+				if((locP > 0.5) && (dProjectedFCALRowColumnMap.find(locTrack) != dProjectedFCALRowColumnMap.end()))
 				{
-					dHistMap_PVsTheta_NoHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locP);
+					pair<float, float>& locPositionPair = dProjectedFCALXYMap[locTrack];
+					dHistMap_TrackFCALYVsX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
+					pair<int, int>& locElementPair = dProjectedFCALRowColumnMap[locTrack];
+					dHistMap_TrackFCALRowVsColumn_HasHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
+				}
+			}
+			else
+			{
+				dHistMap_PVsTheta_NoHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locP);
+				if(locP > 0.5)
 					dHistMap_PhiVsTheta_NoHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locPhi);
-					if(dProjectedFCALRowColumnMap.find(locTrack) != dProjectedFCALRowColumnMap.end())
-					{
-						pair<float, float>& locPositionPair = dProjectedFCALXYMap[locTrack];
-						dHistMap_TrackFCALYVsX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
-						pair<int, int>& locElementPair = dProjectedFCALRowColumnMap[locTrack];
-						dHistMap_TrackFCALRowVsColumn_NoHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
-					}
+				if((locP > 0.5) && (dProjectedFCALRowColumnMap.find(locTrack) != dProjectedFCALRowColumnMap.end()))
+				{
+					pair<float, float>& locPositionPair = dProjectedFCALXYMap[locTrack];
+					dHistMap_TrackFCALYVsX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
+					pair<int, int>& locElementPair = dProjectedFCALRowColumnMap[locTrack];
+					dHistMap_TrackFCALRowVsColumn_NoHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
 				}
 			}
 
 			//TOF Paddle
-			if((dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()) && locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_FCAL))
+			if((locP > 0.5) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
 			{
 				pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
 				pair<int, int>& locPaddlePair = dProjectedTOF2DPaddlesMap[locTrack]; //vertical, horizontal
@@ -1387,7 +1390,7 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 				//Horizontal
 				if(locHorizontalTOFPaddleTrackDistanceMap.find(locTrack) != locHorizontalTOFPaddleTrackDistanceMap.end())
 				{
-					double locDistance = locHorizontalTOFPaddleTrackDistanceMap[locTrack].second;
+					double locDistance = locHorizontalTOFPaddleTrackDistanceMap[locTrack].second.second;
 					if(locDistance <= dMinTOFPaddleMatchDistance) //match
 						dHistMap_TOFPaddleHorizontalPaddleVsTrackX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPaddlePair.second);
 					else //no match
@@ -1399,7 +1402,7 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 				//Vertical
 				if(locVerticalTOFPaddleTrackDistanceMap.find(locTrack) != locVerticalTOFPaddleTrackDistanceMap.end())
 				{
-					double locDistance = locVerticalTOFPaddleTrackDistanceMap[locTrack].second;
+					double locDistance = locVerticalTOFPaddleTrackDistanceMap[locTrack].second.second;
 					if(locDistance <= dMinTOFPaddleMatchDistance) //match
 						dHistMap_TOFPaddleTrackYVsVerticalPaddle_HasHit[locIsTimeBased]->Fill(locPaddlePair.first, locPositionPair.second);
 					else //no match
@@ -1410,31 +1413,30 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 			}
 
 			//TOF Point
-			if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_FCAL))
+			if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_TOF))
 			{
-				if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_TOF))
-				{
-					dHistMap_PVsTheta_HasHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locP);
+				dHistMap_PVsTheta_HasHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locP);
+				if(locP > 0.5)
 					dHistMap_PhiVsTheta_HasHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locPhi);
-					if(dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end())
-					{
-						pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
-						dHistMap_TrackTOFYVsX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
-						pair<int, int>& locElementPair = dProjectedTOF2DPaddlesMap[locTrack];
-						dHistMap_TrackTOF2DPaddles_HasHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
-					}
-				}
-				else
+				if((locP > 0.5) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
 				{
-					dHistMap_PVsTheta_NoHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locP);
+					pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
+					dHistMap_TrackTOFYVsX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
+					pair<int, int>& locElementPair = dProjectedTOF2DPaddlesMap[locTrack];
+					dHistMap_TrackTOF2DPaddles_HasHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
+				}
+			}
+			else
+			{
+				dHistMap_PVsTheta_NoHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locP);
+				if(locP > 0.5)
 					dHistMap_PhiVsTheta_NoHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locPhi);
-					if(dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end())
-					{
-						pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
-						dHistMap_TrackTOFYVsX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
-						pair<int, int>& locElementPair = dProjectedTOF2DPaddlesMap[locTrack];
-						dHistMap_TrackTOF2DPaddles_NoHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
-					}
+				if((locP > 0.5) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
+				{
+					pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
+					dHistMap_TrackTOFYVsX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
+					pair<int, int>& locElementPair = dProjectedTOF2DPaddlesMap[locTrack];
+					dHistMap_TrackTOF2DPaddles_NoHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
 				}
 			}
 

--- a/src/libraries/PID/DEventRFBunch_factory.cc
+++ b/src/libraries/PID/DEventRFBunch_factory.cc
@@ -95,7 +95,7 @@ void DEventRFBunch_factory::Select_GoodTracks(JEventLoop* locEventLoop, vector<c
 jerror_t DEventRFBunch_factory::Select_RFBunch(JEventLoop* locEventLoop, vector<const DTrackTimeBased*>& locTrackTimeBasedVector, const DRFTime* locRFTime)
 {
 	//If RF Time present:
-		//Use tracks with matching TOF hits. For those without, use SC hits instead.  If any.
+		//Use tracks with matching TOF hits (unless track is very slow (track projection out to TOF is bad)). For those without, use SC hits instead.  If any.
 		//If none, use tracks with matching hits in any detector, if any
 		//If none: Let neutral showers vote (assume PID = photon) on RF bunch
 		//If None: set DEventRFBunch::dTime to NaN
@@ -171,13 +171,14 @@ bool DEventRFBunch_factory::Find_TrackTimes_SCTOF(const DDetectorMatches* locDet
 	for(size_t loc_i = 0; loc_i < locTrackTimeBasedVector.size(); ++loc_i)
 	{
 		const DTrackTimeBased* locTrackTimeBased = locTrackTimeBasedVector[loc_i];
+		double locP = locTrackTimeBased->momentum().Mag();
 
 		//TOF resolution = 80ps, 3sigma = 240ps
 			//max PID delta-t = 762ps (assuming 499 MHz and no buffer)
 			//for pion-proton: delta-t is ~750ps at ~170 MeV/c or lower: cannot have proton this slow anyway
 			//for pion-kaon delta-t is ~750ps at ~80 MeV/c or lower: won't reconstruct these anyway, and not likely to be forward-going anyway
 		DTOFHitMatchParams locTOFHitMatchParams;
-		if(dParticleID->Get_BestTOFMatchParams(locTrackTimeBased, locDetectorMatches, locTOFHitMatchParams))
+		if((locP > 0.5) && dParticleID->Get_BestTOFMatchParams(locTrackTimeBased, locDetectorMatches, locTOFHitMatchParams))
 		{
 			double locPropagatedTime = locTOFHitMatchParams.dHitTime - locTOFHitMatchParams.dFlightTime + (dTargetCenter.Z() - locTrackTimeBased->z())/29.9792458;
 			locTimes.push_back(pair<double, const JObject*>(locPropagatedTime, locTrackTimeBased));

--- a/src/libraries/PID/DKinematicData.h
+++ b/src/libraries/PID/DKinematicData.h
@@ -293,6 +293,28 @@ public:
 			AddString(items, "p(GeV/c)", "%2.3f", momentum().Mag());
 			AddString(items, "theta(deg)", "%2.3f", momentum().Theta()*180.0/M_PI);
 			AddString(items, "phi(deg)", "%2.3f", momentum().Phi()*180.0/M_PI);
+/*
+			AddString(items, "v_px", "%2.3f", errorMatrix()(0, 0));
+			AddString(items, "v_py", "%2.3f", errorMatrix()(1, 1));
+			AddString(items, "v_pz", "%2.3f", errorMatrix()(2, 2));
+			AddString(items, "v_x", "%2.3f", errorMatrix()(3, 3));
+			AddString(items, "v_y", "%2.3f", errorMatrix()(4, 4));
+			AddString(items, "v_z", "%2.3f", errorMatrix()(5, 5));
+			AddString(items, "v_t", "%2.3f", errorMatrix()(6, 6));
+			AddString(items, "v_pxpy", "%2.3f", errorMatrix()(0, 1));
+			AddString(items, "v_pypx", "%2.3f", errorMatrix()(1, 0));
+			AddString(items, "v_xy", "%2.3f", errorMatrix()(3, 4));
+			AddString(items, "v_yx", "%2.3f", errorMatrix()(4, 3));
+*/
+			AddString(items, "v_00", "%2.3f", TrackingErrorMatrix()(0, 0));
+			AddString(items, "v_11", "%2.3f", TrackingErrorMatrix()(1, 1));
+			AddString(items, "v_22", "%2.3f", TrackingErrorMatrix()(2, 2));
+			AddString(items, "v_33", "%2.3f", TrackingErrorMatrix()(3, 3));
+			AddString(items, "v_44", "%2.3f", TrackingErrorMatrix()(4, 4));
+			AddString(items, "v_01", "%2.3f", TrackingErrorMatrix()(0, 1));
+			AddString(items, "v_10", "%2.3f", TrackingErrorMatrix()(1, 0));
+			AddString(items, "v_34", "%2.3f", TrackingErrorMatrix()(3, 4));
+			AddString(items, "v_43", "%2.3f", TrackingErrorMatrix()(4, 3));
 		}
 
 protected:

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -1671,11 +1671,11 @@ const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Horizontal(const DRefe
 				continue;
 			if(fabs(locDeltaY) > fabs(locBestDeltaY))
 				continue; //no info on delta-x, so make sure not unfair comparison
-			locBestDistance = locDeltaY;
+			locBestDistance = fabs(locDeltaY);
 		}
 		else
 		{
-			if(fabs(locDistance) > fabs(locBestDistance))
+			if(locDistance > locBestDistance)
 				continue;
 			locBestDistance = locDistance;
 		}
@@ -1749,11 +1749,11 @@ const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Vertical(const DRefere
 				continue;
 			if(fabs(locDeltaX) > fabs(locBestDeltaX))
 				continue; //no info on delta-x, so make sure not unfair comparison
-			locBestDistance = locDeltaX;
+			locBestDistance = fabs(locDeltaX);
 		}
 		else
 		{
-			if(fabs(locDistance) > fabs(locBestDistance))
+			if(locDistance > locBestDistance)
 				continue;
 			locBestDistance = locDistance;
 		}

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -695,7 +695,7 @@ bool DParticleID::MatchToTOF(const DKinematicData* locTrack, const DReferenceTra
 	//If the position in one dimension is not well-defined, compare distance only in the other direction
 	//Otherwise, cut in R
 	//y = e^(-A*x + B) + 6
-	double locP = locTrack->momentum().Mag();
+	double locP = proj_mom.Mag();
 	double locMatchCut_2D = exp(-1.0*TOF_CUT_PAR1*locP + TOF_CUT_PAR2) + TOF_CUT_PAR3;
 	double locMatchCut_1D = locMatchCut_2D;
 

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -106,6 +106,15 @@ DParticleID::DParticleID(JEventLoop *loop)
 	FCAL_CUT_PAR2=0.0;
 	gPARMS->SetDefaultParameter("FCAL:CUT_PAR2",FCAL_CUT_PAR2);
 
+	TOF_CUT_PAR1 = 1.1;
+	gPARMS->SetDefaultParameter("TOF:CUT_PAR1",TOF_CUT_PAR1);
+
+	TOF_CUT_PAR2 = 1.5;
+	gPARMS->SetDefaultParameter("TOF:CUT_PAR2",TOF_CUT_PAR2);
+
+	TOF_CUT_PAR3 = 6.15;
+	gPARMS->SetDefaultParameter("TOF:CUT_PAR3",TOF_CUT_PAR3);
+
 	BCAL_Z_CUT=50.;
 	gPARMS->SetDefaultParameter("BCAL:Z_CUT",BCAL_Z_CUT);
 
@@ -685,8 +694,10 @@ bool DParticleID::MatchToTOF(const DKinematicData* locTrack, const DReferenceTra
 
 	//If the position in one dimension is not well-defined, compare distance only in the other direction
 	//Otherwise, cut in R
-	double locMatchCut_1D = 6.15;
-	double locMatchCut_2D = 6.15;
+	//y = e^(-A*x + B) + 6
+	double locP = locTrack->momentum().Mag();
+	double locMatchCut_2D = exp(-1.0*TOF_CUT_PAR1*locP + TOF_CUT_PAR2) + TOF_CUT_PAR3;
+	double locMatchCut_1D = locMatchCut_2D;
 
 	double locDeltaX = locTOFPoint->Is_XPositionWellDefined() ? tof_pos.X() - proj_pos.X() : 999.0;
 	double locDeltaY = locTOFPoint->Is_YPositionWellDefined() ? tof_pos.Y() - proj_pos.Y() : 999.0;
@@ -1599,12 +1610,11 @@ const DTOFPoint* DParticleID::Get_ClosestToTrack_TOFPoint(const DKinematicData* 
 	return locClosestTOFPoint;
 }
 
-const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Horizontal(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaY) const
+const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Horizontal(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaY, double& locBestDistance) const
 {
 	if(locReferenceTrajectory == nullptr)
 		return nullptr;
 
-	// Evaluate matching solely by physical geometry of the paddle: NOT the distance along the paddle of the hit
 	DVector3 tof_pos(0.0, 0.0, dTOFGeometry->CenterHPlane); //a point on the TOF plane
 	DVector3 norm(0.0, 0.0, 1.0); //normal vector to TOF plane
 	DVector3 proj_pos, proj_mom;
@@ -1613,6 +1623,7 @@ const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Horizontal(const DRefe
 		return nullptr;
 
 	const DTOFPaddleHit* locClosestPaddleHit = nullptr;
+	locBestDistance = 999.0;
 	locBestDeltaY = 999.0;
 	for(auto& locTOFPaddleHit : locTOFPaddleHits)
 	{
@@ -1623,11 +1634,6 @@ const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Horizontal(const DRefe
 		bool locSouthIsGoodHitFlag = (locTOFPaddleHit->E_south > TOF_E_THRESHOLD);
 		if(!locNorthIsGoodHitFlag && !locSouthIsGoodHitFlag)
 			continue; //hit is junk
-
-		// Check geometric distance, if better than before
-		double locDeltaY = dTOFGeometry->bar2y(locTOFPaddleHit->bar) - proj_pos.Y();
-		if(fabs(locDeltaY) > fabs(locBestDeltaY))
-			continue;
 
 		// Check that the hit is not out of time with respect to the track
 
@@ -1654,6 +1660,26 @@ const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Horizontal(const DRefe
 		if(fabs(locDeltaT) > OUT_OF_TIME_CUT)
 			continue;
 
+		// Check geometric distance, continue only if better than before
+		double locDeltaY = dTOFGeometry->bar2y(locTOFPaddleHit->bar) - proj_pos.Y();
+		double locDeltaX = locTOFPaddleHit->pos - proj_pos.X();
+		double locDistance = sqrt(locDeltaY*locDeltaY + locDeltaX*locDeltaX);
+		if(locNorthIsGoodHitFlag != locSouthIsGoodHitFlag)
+		{
+			//no position information along paddle: use delta-y cut only
+			if(fabs(locDeltaY) > fabs(locBestDistance))
+				continue;
+			if(fabs(locDeltaY) > fabs(locBestDeltaY))
+				continue; //no info on delta-x, so make sure not unfair comparison
+			locBestDistance = locDeltaY;
+		}
+		else
+		{
+			if(fabs(locDistance) > fabs(locBestDistance))
+				continue;
+			locBestDistance = locDistance;
+		}
+
 		locBestDeltaY = locDeltaY;
 		locClosestPaddleHit = locTOFPaddleHit;
 	}
@@ -1661,7 +1687,7 @@ const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Horizontal(const DRefe
 	return locClosestPaddleHit;
 }
 
-const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Vertical(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaX) const
+const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Vertical(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaX, double& locBestDistance) const
 {
 	if(locReferenceTrajectory == nullptr)
 		return nullptr;
@@ -1675,6 +1701,7 @@ const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Vertical(const DRefere
 		return nullptr;
 
 	const DTOFPaddleHit* locClosestPaddleHit = nullptr;
+	locBestDistance = 999.0;
 	locBestDeltaX = 999.0;
 	for(auto& locTOFPaddleHit : locTOFPaddleHits)
 	{
@@ -1685,11 +1712,6 @@ const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Vertical(const DRefere
 		bool locSouthIsGoodHitFlag = (locTOFPaddleHit->E_south > TOF_E_THRESHOLD);
 		if(!locNorthIsGoodHitFlag && !locSouthIsGoodHitFlag)
 			continue; //hit is junk
-
-		// Check geometric distance, if better than before
-		double locDeltaX = dTOFGeometry->bar2y(locTOFPaddleHit->bar) - proj_pos.X();
-		if(fabs(locDeltaX) > fabs(locBestDeltaX))
-			continue;
 
 		// Check that the hit is not out of time with respect to the track
 
@@ -1715,6 +1737,26 @@ const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Vertical(const DRefere
 		double locDeltaT = locHitTime - locFlightTime - locInputStartTime;
 		if(fabs(locDeltaT) > OUT_OF_TIME_CUT)
 			continue;
+
+		// Check geometric distance, continue only if better than before
+		double locDeltaX = dTOFGeometry->bar2y(locTOFPaddleHit->bar) - proj_pos.X();
+		double locDeltaY = locTOFPaddleHit->pos - proj_pos.Y();
+		double locDistance = sqrt(locDeltaY*locDeltaY + locDeltaX*locDeltaX);
+		if(locNorthIsGoodHitFlag != locSouthIsGoodHitFlag)
+		{
+			//no position information along paddle: use delta-y cut only
+			if(fabs(locDeltaX) > fabs(locBestDistance))
+				continue;
+			if(fabs(locDeltaX) > fabs(locBestDeltaX))
+				continue; //no info on delta-x, so make sure not unfair comparison
+			locBestDistance = locDeltaX;
+		}
+		else
+		{
+			if(fabs(locDistance) > fabs(locBestDistance))
+				continue;
+			locBestDistance = locDistance;
+		}
 
 		locBestDeltaX = locDeltaX;
 		locClosestPaddleHit = locTOFPaddleHit;

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -124,9 +124,8 @@ class DParticleID:public jana::JObject{
 	const DTOFPoint* Get_ClosestToTrack_TOFPoint(const DKinematicData* locTrack, vector<const DTOFPoint*>& locTOFPoints, double& locBestDeltaX, double& locBestDeltaY) const;
 
 	//first in pair is vertical, second is horizontal // NULL If none / doesn't hit TOF
-	pair<const DTOFPaddleHit*, const DTOFPaddleHit*> Get_ClosestToTrack_TOFPaddles(const DKinematicData* locTrack, vector<const DTOFPaddleHit*>& locTOFPaddleHits, double& locBestDeltaX, double& locBestDeltaY, double locMaxDeltaT = -1.0) const;
-	const DTOFPaddleHit* Get_ClosestTOFPaddleHit_Horizontal(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaY) const;
-	const DTOFPaddleHit* Get_ClosestTOFPaddleHit_Vertical(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaX) const;
+	const DTOFPaddleHit* Get_ClosestTOFPaddleHit_Horizontal(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaY, double& locBestDistance) const;
+	const DTOFPaddleHit* Get_ClosestTOFPaddleHit_Vertical(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaX, double& locBestDistance) const;
 
 	double Calc_BCALFlightTimePCorrelation(const DKinematicData* locTrack, DDetectorMatches* locDetectorMatches) const;
 	double Calc_FCALFlightTimePCorrelation(const DKinematicData* locTrack, DDetectorMatches* locDetectorMatches) const;
@@ -162,6 +161,7 @@ class DParticleID:public jana::JObject{
 		double BCAL_Z_CUT,BCAL_PHI_CUT_PAR1,BCAL_PHI_CUT_PAR2;
 		double BCAL_PHI_CUT_PAR3;
 		double FCAL_CUT_PAR1,FCAL_CUT_PAR2;
+		double TOF_CUT_PAR1, TOF_CUT_PAR2, TOF_CUT_PAR3;
 
 		double DELTA_R_FCAL;
 		double C_EFFECTIVE; // start counter light propagation speed

--- a/src/plugins/monitoring/FCAL_Hadronic_Eff/JEventProcessor_FCAL_Hadronic_Eff.cc
+++ b/src/plugins/monitoring/FCAL_Hadronic_Eff/JEventProcessor_FCAL_Hadronic_Eff.cc
@@ -67,7 +67,7 @@ jerror_t JEventProcessor_FCAL_Hadronic_Eff::init(void)
 	DTreeBranchRegister locTreeBranchRegister;
 
 	//TRACK
-	locTreeBranchRegister.Register_Single<Int_t>("PID_PDG"); //gives charge, mass, beta
+	locTreeBranchRegister.Register_Single<Int_t>("PID_PDG"); //gives charge, mass, beta //is unknown if no TOF hit
 	locTreeBranchRegister.Register_Single<Float_t>("TrackVertexZ");
 	locTreeBranchRegister.Register_Single<TVector3>("TrackP3");
 	locTreeBranchRegister.Register_Single<UInt_t>("TrackCDCRings"); //rings correspond to bits (1 -> 28)

--- a/src/plugins/monitoring/FCAL_Hadronic_Eff/JEventProcessor_FCAL_Hadronic_Eff.cc
+++ b/src/plugins/monitoring/FCAL_Hadronic_Eff/JEventProcessor_FCAL_Hadronic_Eff.cc
@@ -165,7 +165,7 @@ jerror_t JEventProcessor_FCAL_Hadronic_Eff::evnt(jana::JEventLoop* locEventLoop,
 
 			//Need PID for beta-dependence, but cannot use FCAL info: would bias
 			if(!Cut_TOFTiming(locChargedTrackHypothesis))
-				continue; //also requires match to TOF: no need for separate check
+				continue;
 
 			const DTrackTimeBased* locTrackTimeBased = NULL;
 			locChargedTrackHypothesis->GetSingle(locTrackTimeBased);
@@ -236,7 +236,8 @@ jerror_t JEventProcessor_FCAL_Hadronic_Eff::evnt(jana::JEventLoop* locEventLoop,
 		japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 		//TRACK
-		dTreeFillData.Fill_Single<Int_t>("PID_PDG", PDGtype(locChargedTrackHypothesis->PID()));
+		Particle_t locPID = (locChargedTrackHypothesis->t1_detector() == SYS_TOF) ? locChargedTrackHypothesis->PID() : Unknown;
+		dTreeFillData.Fill_Single<Int_t>("PID_PDG", PDGtype(locPID));
 		dTreeFillData.Fill_Single<Float_t>("TrackVertexZ", locChargedTrackHypothesis->position().Z());
 		dTreeFillData.Fill_Single<UInt_t>("TrackCDCRings", locTrackTimeBased->dCDCRings);
 		dTreeFillData.Fill_Single<UInt_t>("TrackFDCPlanes", locTrackTimeBased->dFDCPlanes);
@@ -293,7 +294,7 @@ double JEventProcessor_FCAL_Hadronic_Eff::Calc_FCALTiming(const DChargedTrackHyp
 bool JEventProcessor_FCAL_Hadronic_Eff::Cut_TOFTiming(const DChargedTrackHypothesis* locChargedTrackHypothesis)
 {
 	if(locChargedTrackHypothesis->t1_detector() != SYS_TOF)
-		return false;
+		return true; //don't require TOF hit: limits reach of study
 
 	double locDeltaT = locChargedTrackHypothesis->time() - locChargedTrackHypothesis->t0();
 	return (fabs(locDeltaT) <= dMaxTOFDeltaT);

--- a/src/plugins/monitoring/TOF_Eff/JEventProcessor_TOF_Eff.cc
+++ b/src/plugins/monitoring/TOF_Eff/JEventProcessor_TOF_Eff.cc
@@ -123,9 +123,9 @@ jerror_t JEventProcessor_TOF_Eff::init(void)
 		//Nearest hit: //0 for none, 1 - 44 for both ends //101 - 144 for North/Top only, 201 - 244 for South/Bottom only (only = above threshold)
 		//Nearest: No time cut (yet?)
 	locTreeBranchRegister.Register_Single<UChar_t>("NearestTOFHit_Horizontal");
-	locTreeBranchRegister.Register_Single<Float_t>("HorizontalTOFHitDeltaY");
+	locTreeBranchRegister.Register_Single<Float_t>("HorizontalTOFHitDistance");
 	locTreeBranchRegister.Register_Single<UChar_t>("NearestTOFHit_Vertical");
-	locTreeBranchRegister.Register_Single<Float_t>("VerticalTOFHitDeltaX");
+	locTreeBranchRegister.Register_Single<Float_t>("VerticalTOFHitDistance");
 
 	//SEARCH TOF POINT //nearest: must be in time: PID:OUT_OF_TIME_CUT
 	locTreeBranchRegister.Register_Single<Float_t>("NearestTOFPointDeltaX");
@@ -347,9 +347,9 @@ jerror_t JEventProcessor_TOF_Eff::evnt(jana::JEventLoop* locEventLoop, uint64_t 
 
 		//SEARCH TOF PADDLE
 		dTreeFillData.Fill_Single<UChar_t>("NearestTOFHit_Horizontal", locNearestTOFHitHorizontal);
-		dTreeFillData.Fill_Single<Float_t>("HorizontalTOFHitDeltaY", locBestPaddleDeltaY);
+		dTreeFillData.Fill_Single<Float_t>("HorizontalTOFHitDistance", locBestPaddleDistance_Horizontal);
 		dTreeFillData.Fill_Single<UChar_t>("NearestTOFHit_Vertical", locNearestTOFHitVertical);
-		dTreeFillData.Fill_Single<Float_t>("VerticalTOFHitDeltaX", locBestPaddleDeltaX);
+		dTreeFillData.Fill_Single<Float_t>("VerticalTOFHitDistance", locBestPaddleDistance_Vertical);
 
 		//SEARCH TOF POINT
 		dTreeFillData.Fill_Single<Float_t>("NearestTOFPointDeltaX", locBestPointDeltaX);

--- a/src/plugins/monitoring/TOF_Eff/JEventProcessor_TOF_Eff.cc
+++ b/src/plugins/monitoring/TOF_Eff/JEventProcessor_TOF_Eff.cc
@@ -106,7 +106,7 @@ jerror_t JEventProcessor_TOF_Eff::init(void)
 	DTreeBranchRegister locTreeBranchRegister;
 
 	//TRACK
-	locTreeBranchRegister.Register_Single<Int_t>("PID_PDG"); //gives charge, mass, beta
+	locTreeBranchRegister.Register_Single<Int_t>("PID_PDG"); //gives charge, mass, beta //is unknown if no FCAL hit
 	locTreeBranchRegister.Register_Single<Float_t>("TrackVertexZ");
 	locTreeBranchRegister.Register_Single<TVector3>("TrackP3");
 	locTreeBranchRegister.Register_Single<UInt_t>("TrackCDCRings"); //rings correspond to bits (1 -> 28)

--- a/src/plugins/monitoring/TOF_Eff/JEventProcessor_TOF_Eff.cc
+++ b/src/plugins/monitoring/TOF_Eff/JEventProcessor_TOF_Eff.cc
@@ -265,11 +265,11 @@ jerror_t JEventProcessor_TOF_Eff::evnt(jana::JEventLoop* locEventLoop, uint64_t 
 		const DTOFPoint* locClosestTOFPoint = locParticleID->Get_ClosestToTrack_TOFPoint(locTrackTimeBased, locTOFPoints, locBestPointDeltaX, locBestPointDeltaY);
 
 		//Find closest TOF paddles
-		double locBestPaddleDeltaX = 999.9, locBestPaddleDeltaY = 999.9;
+		double locBestPaddleDeltaX = 999.9, locBestPaddleDeltaY = 999.9, locBestPaddleDistance_Vertical = 999.9, locBestPaddleDistance_Horizontal = 999.9;
 		//first in pair is vertical, second is horizontal // NULL If none / doesn't hit TOF
 		double locStartTime = locParticleID->Calc_PropagatedRFTime(locChargedTrackHypothesis, locEventRFBunch);
-		const DTOFPaddleHit* locClosestTOFPaddleHit_Vertical = locParticleID->Get_ClosestTOFPaddleHit_Vertical(locTrackTimeBased->rt, locTOFPaddleHits, locStartTime, locBestPaddleDeltaX);
-		const DTOFPaddleHit* locClosestTOFPaddleHit_Horizontal = locParticleID->Get_ClosestTOFPaddleHit_Horizontal(locTrackTimeBased->rt, locTOFPaddleHits, locStartTime, locBestPaddleDeltaY);
+		const DTOFPaddleHit* locClosestTOFPaddleHit_Vertical = locParticleID->Get_ClosestTOFPaddleHit_Vertical(locTrackTimeBased->rt, locTOFPaddleHits, locStartTime, locBestPaddleDeltaX, locBestPaddleDistance_Vertical);
+		const DTOFPaddleHit* locClosestTOFPaddleHit_Horizontal = locParticleID->Get_ClosestTOFPaddleHit_Horizontal(locTrackTimeBased->rt, locTOFPaddleHits, locStartTime, locBestPaddleDeltaY, locBestPaddleDistance_Horizontal);
 
 		//Is match to TOF point?
 		const DTOFHitMatchParams* locTOFHitMatchParams = locChargedTrackHypothesis->Get_TOFHitMatchParams();

--- a/src/plugins/monitoring/TOF_Eff/JEventProcessor_TOF_Eff.cc
+++ b/src/plugins/monitoring/TOF_Eff/JEventProcessor_TOF_Eff.cc
@@ -219,7 +219,7 @@ jerror_t JEventProcessor_TOF_Eff::evnt(jana::JEventLoop* locEventLoop, uint64_t 
 
 			//Need PID for beta-dependence, but cannot use TOF info: would bias
 			if(!Cut_FCALTiming(locChargedTrackHypothesis, locParticleID, locEventRFBunch))
-				continue; //also requires match to FCAL: no need for separate check
+				continue;
 
 			const DTrackTimeBased* locTrackTimeBased = NULL;
 			locChargedTrackHypothesis->GetSingle(locTrackTimeBased);
@@ -330,7 +330,8 @@ jerror_t JEventProcessor_TOF_Eff::evnt(jana::JEventLoop* locEventLoop, uint64_t 
 		japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 		//TRACK
-		dTreeFillData.Fill_Single<Int_t>("PID_PDG", PDGtype(locChargedTrackHypothesis->PID()));
+		Particle_t locPID = (locChargedTrackHypothesis->Get_FCALShowerMatchParams() != NULL) ? locChargedTrackHypothesis->PID() : Unknown;
+		dTreeFillData.Fill_Single<Int_t>("PID_PDG", PDGtype(locPID));
 		dTreeFillData.Fill_Single<Float_t>("TrackVertexZ", locChargedTrackHypothesis->position().Z());
 		dTreeFillData.Fill_Single<UInt_t>("TrackCDCRings", locTrackTimeBased->dCDCRings);
 		dTreeFillData.Fill_Single<UInt_t>("TrackFDCPlanes", locTrackTimeBased->dFDCPlanes);
@@ -388,7 +389,7 @@ bool JEventProcessor_TOF_Eff::Cut_FCALTiming(const DChargedTrackHypothesis* locC
 {
 	const DFCALShowerMatchParams* locFCALShowerMatchParams = locChargedTrackHypothesis->Get_FCALShowerMatchParams();
 	if(locFCALShowerMatchParams == NULL)
-		return false;
+		return true; //don't require FCAL hit: limits reach of study
 
 	double locStartTime = locParticleID->Calc_PropagatedRFTime(locChargedTrackHypothesis, locEventRFBunch);
 	const DFCALShower* locFCALShower = locFCALShowerMatchParams->dFCALShower;


### PR DESCRIPTION
Increase width of track/TOF match cut for low momentum tracks. 

For histing track/tof-plane matching, do a 2d matching cut rather than 1d.

Don't require TOF/FCAL hits for FCAL/TOF efficiency studies.
