### PR TITLE
Update mcsmear CCDB variation warning

### DIFF
--- a/src/programs/Simulation/mcsmear/mcsmear.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear.cc
@@ -47,29 +47,6 @@ DRandom2 gDRandom(0); // declared extern in DRandom2.h
 
 
 //-----------
-// PrintCCDBWarning
-//-----------
-void PrintCCDBWarning(string context)
-{
-	jout << endl;
-	jout << "===============================================================================" << endl;
-	jout << "                            !!!!! WARNING !!!!!" << endl;
-	jout << "You have either not specified a CCDB variation, or specified a variation" << endl;
-	jout << "that appears inconsistent with processing simulated data." << endl;
-	jout << "Be sure that this is what you want to do!" << endl;
-	jout << endl;
-	jout << "  JANA_CALIB_CONTEXT = " << context << endl;
-	jout << endl;
-	jout << "For a more detailed list of CCDB variations used for simulations" << endl;
-	jout << "see the following wiki page:" << endl;
-	jout << endl;
-	jout << "   https://halldweb.jlab.org/wiki/index.php/Simulations#Simulation_Conditions" << endl;
-	jout << "===============================================================================" << endl;
-	jout << endl;
-}
-
-
-//-----------
 // main
 //-----------
 int main(int narg,char* argv[])
@@ -77,31 +54,10 @@ int main(int narg,char* argv[])
    mcsmear_config_t *config = new mcsmear_config_t();
    ParseCommandLineArguments(narg, argv, config);
 
-   // Generally, simulations should be generated and analyzed with a non-default
-   // set of calibrations, since the calibrations needed for simulations are
-   // different than those needed for data.  
-   // Conventionally, the CCDB variations needed for simulations start with the 
-   // string "mc".  To guard against accidentally not setting the variation correctly
-   // we check to see if the variation is set and if it contains the string "mc".
-   // Note that for now, we only print a warning and do not exit immediately.
-   // It might be advisable to apply some tougher love.
-   if( getenv("JANA_CALIB_CONTEXT")!= NULL ) {
-      string context = getenv("JANA_CALIB_CONTEXT");
-      
-      // Really we should parse the context string, but since "mc" shouldn't show up
-      // outside of the context, we just search the whole string.
-      // Also make sure that the variation is being set
-      if( (!context.find("variation") == string::npos) || (!context.find("mc") == string::npos) ) {
-         PrintCCDBWarning(context);
-      }
-   } else {
-      PrintCCDBWarning("");
-   }
-
    // Create DApplication object
    DApplication dapp(narg, argv);
    dapp.AddFactoryGenerator(new JFactoryGenerator_ThreadCancelHandler());
-   
+
    TFile *hfile = new TFile("smear.root","RECREATE","smearing histograms");  // note: not used for anything right now
 
    MyProcessor myproc(config);   


### PR DESCRIPTION
Move check on CCDB variation from program open to the first brun()
call so that we can properly check the variation stored in the
JCalibration object, since it can be set in multiple way
(environment variable, command line, ...)
