### PR TITLE
Mask off NSA trig path for f250 BOR when copying into digihit.

### DIFF
--- a/src/libraries/DAQ/Df250BORConfig.h
+++ b/src/libraries/DAQ/Df250BORConfig.h
@@ -41,7 +41,8 @@ class Df250BORConfig:public jana::JObject, public f250config{
 			AddString(items, "ptw"       , "%d", adc_ptw);
 			AddString(items, "pl"        , "%d", adc_pl);
 			AddString(items, "nsb"       , "%d", adc_nsb);
-			AddString(items, "nsa"       , "%d", adc_nsa);
+			AddString(items, "nsa"       , "%d", adc_nsa&0x1FF);
+			AddString(items, "nsa_trig"  , "%d", adc_nsa>>9);
 			AddString(items, "nped"      , "%d", nped);
 		}
 

--- a/src/libraries/DAQ/LinkAssociations.h
+++ b/src/libraries/DAQ/LinkAssociations.h
@@ -98,7 +98,7 @@ inline void LinkModule(vector<T*> &a, vector<U*> &b)
 // LinkModuleBORSamplesCopy
 template<class T, class U>
 inline void LinkModuleBORSamplesCopy(vector<T*> &a, vector<U*> &b)
-{ MatchModuleF(a, b, [](T *a, U *b){b->AddAssociatedObject(a); b->nsamples_integral = a->adc_nsa+a->adc_nsb; b->nsamples_pedestal = a->nped;}); }
+{ MatchModuleF(a, b, [](T *a, U *b){b->AddAssociatedObject(a); b->nsamples_integral = (a->adc_nsa&0x1FF)+(a->adc_nsb&0x0F); b->nsamples_pedestal = a->nped;}); }
 
 // LinkChannel
 template<class T, class U>


### PR DESCRIPTION
The new firmware packs both trig path NSA and data NSA into the readback of NSA register. This is propagated to the BOR. This is left in the BOR, but the higher order bits masked off when copying into nsamples_integral in the digihit.
