### PR TITLE
In the loop that tries to match a track to the start counter nose reg…

### DIFF
--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -1122,6 +1122,7 @@ bool DParticleID::MatchToSC(const DKinematicData* locTrack, const DReferenceTraj
 
 			if (fabs(dphi) > sc_dphi_cut)
 				return false;
+			break;
 		}
 
 		// Check for intersection point beyond nose


### PR DESCRIPTION
…ion, we need to break out of the loop when we have found the right intersection plane.
