### PR TITLE
 Rename dEdx cut actions so that they're unique for each plugin. 

### DIFF
--- a/src/plugins/Analysis/p2k_hists/DCustomAction_dEdxCut_p2k.cc
+++ b/src/plugins/Analysis/p2k_hists/DCustomAction_dEdxCut_p2k.cc
@@ -1,13 +1,13 @@
 // $Id$
 //
-//    File: DCustomAction_dEdxCut.cc
+//    File: DCustomAction_dEdxCut_p2k.cc
 // Created: Thu Oct  1 11:18:05 EDT 2015
 // Creator: pmatt (on Darwin Pauls-MacBook-Pro-2.local 13.4.0 i386)
 //
 
-#include "DCustomAction_dEdxCut.h"
+#include "DCustomAction_dEdxCut_p2k.h"
 
-void DCustomAction_dEdxCut::Initialize(JEventLoop* locEventLoop)
+void DCustomAction_dEdxCut_p2k::Initialize(JEventLoop* locEventLoop)
 {
 	//Optional: Create histograms and/or modify member variables.
 	//Create any histograms/trees/etc. within a ROOT lock. 
@@ -38,7 +38,7 @@ void DCustomAction_dEdxCut::Initialize(JEventLoop* locEventLoop)
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }
 
-bool DCustomAction_dEdxCut::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+bool DCustomAction_dEdxCut_p2k::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
 {
 	//Write custom code to perform an action on the INPUT DParticleCombo (DParticleCombo)
 	//NEVER: Grab DParticleCombo or DAnalysisResults objects (of any tag!) from the JEventLoop within this function
@@ -56,7 +56,7 @@ bool DCustomAction_dEdxCut::Perform_Action(JEventLoop* locEventLoop, const DPart
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }
 
-bool DCustomAction_dEdxCut::Cut_dEdx(const DChargedTrackHypothesis* locChargedTrackHypothesis) const
+bool DCustomAction_dEdxCut_p2k::Cut_dEdx(const DChargedTrackHypothesis* locChargedTrackHypothesis) const
 {
 	Particle_t locPID = locChargedTrackHypothesis->PID();
 
@@ -77,7 +77,7 @@ bool DCustomAction_dEdxCut::Cut_dEdx(const DChargedTrackHypothesis* locChargedTr
 	return true;
 }
 
-bool DCustomAction_dEdxCut::Cut_dEdx(Particle_t locPID, double locP, double locdEdx, bool locHasNoTimeInfoFlag) const
+bool DCustomAction_dEdxCut_p2k::Cut_dEdx(Particle_t locPID, double locP, double locdEdx, bool locHasNoTimeInfoFlag) const
 {
 	if(ParticleCharge(locPID) < 0)
 		return true; //only need to separate q+

--- a/src/plugins/Analysis/p2k_hists/DCustomAction_dEdxCut_p2k.h
+++ b/src/plugins/Analysis/p2k_hists/DCustomAction_dEdxCut_p2k.h
@@ -1,12 +1,12 @@
 // $Id$
 //
-//    File: DCustomAction_dEdxCut.h
+//    File: DCustomAction_dEdxCut_p2k.h
 // Created: Thu Oct  1 11:18:05 EDT 2015
 // Creator: pmatt (on Darwin Pauls-MacBook-Pro-2.local 13.4.0 i386)
 //
 
-#ifndef _DCustomAction_dEdxCut_
-#define _DCustomAction_dEdxCut_
+#ifndef _DCustomAction_dEdxCut_p2k_
+#define _DCustomAction_dEdxCut_p2k_
 
 #include <string>
 #include <iostream>
@@ -24,11 +24,11 @@
 using namespace std;
 using namespace jana;
 
-class DCustomAction_dEdxCut : public DAnalysisAction
+class DCustomAction_dEdxCut_p2k : public DAnalysisAction
 {
 	public:
 
-		DCustomAction_dEdxCut(const DReaction* locReaction, bool locMaxRejectionFlag = false, string locActionUniqueString = "") :
+		DCustomAction_dEdxCut_p2k(const DReaction* locReaction, bool locMaxRejectionFlag = false, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Custom_dEdxCut", false, locActionUniqueString),
 		dMaxRejectionFlag(locMaxRejectionFlag) {}
 
@@ -55,4 +55,4 @@ class DCustomAction_dEdxCut : public DAnalysisAction
 		TF1* dFunc_dEdxCut_SelectLight; //e.g. pion, kaon //if dMaxRejectionFlag = true, then used to cut all light
 };
 
-#endif // _DCustomAction_dEdxCut_
+#endif // _DCustomAction_dEdxCut_p2k_

--- a/src/plugins/Analysis/p2k_hists/DReaction_factory_p2k_hists.cc
+++ b/src/plugins/Analysis/p2k_hists/DReaction_factory_p2k_hists.cc
@@ -6,7 +6,7 @@
 //
 
 #include "DReaction_factory_p2k_hists.h"
-#include "DCustomAction_dEdxCut.h"
+#include "DCustomAction_dEdxCut_p2k.h"
 
 //------------------
 // brun
@@ -83,7 +83,7 @@ jerror_t DReaction_factory_p2k_hists::evnt(JEventLoop* locEventLoop, uint64_t lo
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, Proton, SYS_FCAL)); //cut at delta-t +/- 1.0 //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_NoPIDHit(locReaction, KPlus));
 	locReaction->Add_AnalysisAction(new DCutAction_NoPIDHit(locReaction, KMinus));
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, false)); //false: focus on keeping signal
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_p2k(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
 
 	// Custom histograms for p2k (no KinFit cut)
@@ -147,7 +147,7 @@ jerror_t DReaction_factory_p2k_hists::evnt(JEventLoop* locEventLoop, uint64_t lo
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, Proton, SYS_FCAL)); //cut at delta-t +/- 1.0 //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_NoPIDHit(locReaction, KPlus));
 	locReaction->Add_AnalysisAction(new DCutAction_NoPIDHit(locReaction, KMinus));
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, false)); //false: focus on keeping signal
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_p2k(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
 
 	//MASSES

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_dEdxCut_p2pi.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_dEdxCut_p2pi.cc
@@ -1,13 +1,13 @@
 // $Id$
 //
-//    File: DCustomAction_dEdxCut.cc
+//    File: DCustomAction_dEdxCut_p2pi.cc
 // Created: Thu Oct  1 11:18:05 EDT 2015
 // Creator: pmatt (on Darwin Pauls-MacBook-Pro-2.local 13.4.0 i386)
 //
 
-#include "DCustomAction_dEdxCut.h"
+#include "DCustomAction_dEdxCut_p2pi.h"
 
-void DCustomAction_dEdxCut::Initialize(JEventLoop* locEventLoop)
+void DCustomAction_dEdxCut_p2pi::Initialize(JEventLoop* locEventLoop)
 {
 	//Optional: Create histograms and/or modify member variables.
 	//Create any histograms/trees/etc. within a ROOT lock. 
@@ -38,7 +38,7 @@ void DCustomAction_dEdxCut::Initialize(JEventLoop* locEventLoop)
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }
 
-bool DCustomAction_dEdxCut::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+bool DCustomAction_dEdxCut_p2pi::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
 {
 	//Write custom code to perform an action on the INPUT DParticleCombo (DParticleCombo)
 	//NEVER: Grab DParticleCombo or DAnalysisResults objects (of any tag!) from the JEventLoop within this function
@@ -56,7 +56,7 @@ bool DCustomAction_dEdxCut::Perform_Action(JEventLoop* locEventLoop, const DPart
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }
 
-bool DCustomAction_dEdxCut::Cut_dEdx(const DChargedTrackHypothesis* locChargedTrackHypothesis) const
+bool DCustomAction_dEdxCut_p2pi::Cut_dEdx(const DChargedTrackHypothesis* locChargedTrackHypothesis) const
 {
 	Particle_t locPID = locChargedTrackHypothesis->PID();
 
@@ -77,7 +77,7 @@ bool DCustomAction_dEdxCut::Cut_dEdx(const DChargedTrackHypothesis* locChargedTr
 	return true;
 }
 
-bool DCustomAction_dEdxCut::Cut_dEdx(Particle_t locPID, double locP, double locdEdx, bool locHasNoTimeInfoFlag) const
+bool DCustomAction_dEdxCut_p2pi::Cut_dEdx(Particle_t locPID, double locP, double locdEdx, bool locHasNoTimeInfoFlag) const
 {
 	if(ParticleCharge(locPID) < 0)
 		return true; //only need to separate q+

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_dEdxCut_p2pi.h
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_dEdxCut_p2pi.h
@@ -1,12 +1,12 @@
 // $Id$
 //
-//    File: DCustomAction_dEdxCut.h
+//    File: DCustomAction_dEdxCut_p2pi.h
 // Created: Thu Oct  1 11:18:05 EDT 2015
 // Creator: pmatt (on Darwin Pauls-MacBook-Pro-2.local 13.4.0 i386)
 //
 
-#ifndef _DCustomAction_dEdxCut_
-#define _DCustomAction_dEdxCut_
+#ifndef _DCustomAction_dEdxCut_p2pi_
+#define _DCustomAction_dEdxCut_p2pi_
 
 #include <string>
 #include <iostream>
@@ -24,11 +24,11 @@
 using namespace std;
 using namespace jana;
 
-class DCustomAction_dEdxCut : public DAnalysisAction
+class DCustomAction_dEdxCut_p2pi : public DAnalysisAction
 {
 	public:
 
-		DCustomAction_dEdxCut(const DReaction* locReaction, bool locMaxRejectionFlag = false, string locActionUniqueString = "") :
+		DCustomAction_dEdxCut_p2pi(const DReaction* locReaction, bool locMaxRejectionFlag = false, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Custom_dEdxCut", false, locActionUniqueString),
 		dMaxRejectionFlag(locMaxRejectionFlag) {}
 
@@ -55,4 +55,4 @@ class DCustomAction_dEdxCut : public DAnalysisAction
 		TF1* dFunc_dEdxCut_SelectLight; //e.g. pion, kaon //if dMaxRejectionFlag = true, then used to cut all light
 };
 
-#endif // _DCustomAction_dEdxCut_
+#endif // _DCustomAction_dEdxCut_p2pi_

--- a/src/plugins/Analysis/p2pi_hists/DReaction_factory_p2pi_hists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DReaction_factory_p2pi_hists.cc
@@ -5,7 +5,7 @@
 // Creator: jrsteven (on Linux halldw1.jlab.org 2.6.32-504.8.1.el6.x86_64 x86_64)
 //
 
-#include "DCustomAction_dEdxCut.h"
+#include "DCustomAction_dEdxCut_p2pi.h"
 #include "DReaction_factory_p2pi_hists.h"
 
 //------------------
@@ -82,7 +82,7 @@ jerror_t DReaction_factory_p2pi_hists::evnt(JEventLoop* locEventLoop, uint64_t l
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, PiMinus, SYS_TOF));
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiMinus, SYS_BCAL));
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, PiMinus, SYS_FCAL));
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, false)); //false: focus on keeping signal
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_p2pi(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
 
 	// Custom histograms for p2pi
@@ -153,7 +153,7 @@ jerror_t DReaction_factory_p2pi_hists::evnt(JEventLoop* locEventLoop, uint64_t l
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, PiMinus, SYS_TOF));
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiMinus, SYS_BCAL));
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, PiMinus, SYS_FCAL));
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, false)); //false: focus on keeping signal
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_p2pi(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
 
 	//MASSES

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraTrackPID.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraTrackPID.cc
@@ -15,7 +15,7 @@ void DCustomAction_CutExtraTrackPID::Initialize(JEventLoop* locEventLoop)
 	dPIDCuts[SYS_BCAL] = 1.0;
 	dPIDCuts[SYS_FCAL] = 2.0;
 
-	ddEdxCutAction = new DCustomAction_dEdxCut(Get_Reaction(), false); //false: focus on keeping signal
+	ddEdxCutAction = new DCustomAction_dEdxCut_p3pi(Get_Reaction(), false); //false: focus on keeping signal
 	ddEdxCutAction->Initialize(locEventLoop);
 }
 

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraTrackPID.h
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraTrackPID.h
@@ -19,7 +19,7 @@
 #include "ANALYSIS/DParticleCombo.h"
 #include "ANALYSIS/DAnalysisUtilities.h"
 
-#include "DCustomAction_dEdxCut.h"
+#include "DCustomAction_dEdxCut_p3pi.h"
 
 using namespace std;
 using namespace jana;
@@ -38,7 +38,7 @@ class DCustomAction_CutExtraTrackPID : public DAnalysisAction
 
 		Particle_t dExtraTrackTargetPID;
 		map<DetectorSystem_t, double> dPIDCuts;
-		DCustomAction_dEdxCut* ddEdxCutAction;
+		DCustomAction_dEdxCut_p3pi* ddEdxCutAction;
 
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_dEdxCut_p3pi.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_dEdxCut_p3pi.cc
@@ -1,20 +1,20 @@
 // $Id$
 //
-//    File: DCustomAction_dEdxCut.cc
+//    File: DCustomAction_dEdxCut_p3pi.cc
 // Created: Thu Oct  1 11:18:05 EDT 2015
 // Creator: pmatt (on Darwin Pauls-MacBook-Pro-2.local 13.4.0 i386)
 //
 
-#include "DCustomAction_dEdxCut.h"
+#include "DCustomAction_dEdxCut_p3pi.h"
 
-void DCustomAction_dEdxCut::Initialize(JEventLoop* locEventLoop)
+void DCustomAction_dEdxCut_p3pi::Initialize(JEventLoop* locEventLoop)
 {
 	//Optional: Create histograms and/or modify member variables.
 	//Create any histograms/trees/etc. within a ROOT lock. 
 		//This is so that when running multithreaded, only one thread is writing to the ROOT file at a time. 
 
-	//CREATE THE HISTOGRAMS
-	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
+	//CREATE THE FUNCTIONS
+	//Since we are creating functions, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		string locFuncName = "df_dEdxCut_SelectHeavy"; //e.g. proton
@@ -38,7 +38,7 @@ void DCustomAction_dEdxCut::Initialize(JEventLoop* locEventLoop)
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }
 
-bool DCustomAction_dEdxCut::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+bool DCustomAction_dEdxCut_p3pi::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
 {
 	//Write custom code to perform an action on the INPUT DParticleCombo (DParticleCombo)
 	//NEVER: Grab DParticleCombo or DAnalysisResults objects (of any tag!) from the JEventLoop within this function
@@ -56,7 +56,7 @@ bool DCustomAction_dEdxCut::Perform_Action(JEventLoop* locEventLoop, const DPart
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }
 
-bool DCustomAction_dEdxCut::Cut_dEdx(const DChargedTrackHypothesis* locChargedTrackHypothesis) const
+bool DCustomAction_dEdxCut_p3pi::Cut_dEdx(const DChargedTrackHypothesis* locChargedTrackHypothesis) const
 {
 	Particle_t locPID = locChargedTrackHypothesis->PID();
 
@@ -77,7 +77,7 @@ bool DCustomAction_dEdxCut::Cut_dEdx(const DChargedTrackHypothesis* locChargedTr
 	return true;
 }
 
-bool DCustomAction_dEdxCut::Cut_dEdx(Particle_t locPID, double locP, double locdEdx, bool locHasNoTimeInfoFlag) const
+bool DCustomAction_dEdxCut_p3pi::Cut_dEdx(Particle_t locPID, double locP, double locdEdx, bool locHasNoTimeInfoFlag) const
 {
 	if(ParticleCharge(locPID) < 0)
 		return true; //only need to separate q+

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_dEdxCut_p3pi.h
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_dEdxCut_p3pi.h
@@ -1,12 +1,12 @@
 // $Id$
 //
-//    File: DCustomAction_dEdxCut.h
+//    File: DCustomAction_dEdxCut_p3pi.h
 // Created: Thu Oct  1 11:18:05 EDT 2015
 // Creator: pmatt (on Darwin Pauls-MacBook-Pro-2.local 13.4.0 i386)
 //
 
-#ifndef _DCustomAction_dEdxCut_
-#define _DCustomAction_dEdxCut_
+#ifndef _DCustomAction_dEdxCut_p3pi_
+#define _DCustomAction_dEdxCut_p3pi_
 
 #include <string>
 #include <iostream>
@@ -24,11 +24,11 @@
 using namespace std;
 using namespace jana;
 
-class DCustomAction_dEdxCut : public DAnalysisAction
+class DCustomAction_dEdxCut_p3pi : public DAnalysisAction
 {
 	public:
 
-		DCustomAction_dEdxCut(const DReaction* locReaction, bool locMaxRejectionFlag = false, string locActionUniqueString = "") :
+		DCustomAction_dEdxCut_p3pi(const DReaction* locReaction, bool locMaxRejectionFlag = false, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Custom_dEdxCut", false, locActionUniqueString),
 		dMaxRejectionFlag(locMaxRejectionFlag) {}
 
@@ -55,4 +55,4 @@ class DCustomAction_dEdxCut : public DAnalysisAction
 		TF1* dFunc_dEdxCut_SelectLight; //e.g. pion, kaon //if dMaxRejectionFlag = true, then used to cut all light
 };
 
-#endif // _DCustomAction_dEdxCut_
+#endif // _DCustomAction_dEdxCut_p3pi_

--- a/src/plugins/Analysis/p3pi_hists/DReaction_factory_p3pi_hists.cc
+++ b/src/plugins/Analysis/p3pi_hists/DReaction_factory_p3pi_hists.cc
@@ -8,7 +8,7 @@
 
 #include "DReaction_factory_p3pi_hists.h"
 #include "DCustomAction_HistOmegaVsMissProton.h"
-#include "DCustomAction_dEdxCut.h"
+#include "DCustomAction_dEdxCut_p3pi.h"
 #include "DCustomAction_CutExtraPi0.h"
 #include "DCustomAction_CutExtraTrackPID.h"
 
@@ -113,7 +113,7 @@ jerror_t DReaction_factory_p3pi_hists::evnt(JEventLoop* locEventLoop, uint64_t l
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, PiMinus, SYS_FCAL));
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, Gamma, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, Gamma, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, false)); //false: focus on keeping signal
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_p3pi(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
 
 	// Pi0
@@ -183,7 +183,7 @@ jerror_t DReaction_factory_p3pi_hists::evnt(JEventLoop* locEventLoop, uint64_t l
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, PiMinus, SYS_FCAL));
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, Gamma, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, Gamma, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, false)); //false: focus on keeping signal
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_p3pi(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
 
 	// Pi0
@@ -253,7 +253,7 @@ jerror_t DReaction_factory_p3pi_hists::evnt(JEventLoop* locEventLoop, uint64_t l
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, PiMinus, SYS_FCAL));
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, Gamma, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, Gamma, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, false)); //false: focus on keeping signal
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_p3pi(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
 
 	// Pi0
@@ -321,7 +321,7 @@ jerror_t DReaction_factory_p3pi_hists::evnt(JEventLoop* locEventLoop, uint64_t l
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, PiMinus, SYS_FCAL));
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, Gamma, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, Gamma, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, false)); //false: focus on keeping signal
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_p3pi(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
 
 	// Pi0
@@ -389,7 +389,7 @@ jerror_t DReaction_factory_p3pi_hists::evnt(JEventLoop* locEventLoop, uint64_t l
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, PiMinus, SYS_FCAL));
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, Gamma, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, Gamma, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, false)); //false: focus on keeping signal
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_p3pi(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
 
 	// MASSES

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_dEdxCut_trackeff.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_dEdxCut_trackeff.cc
@@ -1,20 +1,20 @@
 // $Id$
 //
-//    File: DCustomAction_dEdxCut.cc
+//    File: DCustomAction_dEdxCut_trackeff.cc
 // Created: Thu Oct  1 11:18:05 EDT 2015
 // Creator: pmatt (on Darwin Pauls-MacBook-Pro-2.local 13.4.0 i386)
 //
 
-#include "DCustomAction_dEdxCut.h"
+#include "DCustomAction_dEdxCut_trackeff.h"
 
-void DCustomAction_dEdxCut::Initialize(JEventLoop* locEventLoop)
+void DCustomAction_dEdxCut_trackeff::Initialize(JEventLoop* locEventLoop)
 {
 	//Optional: Create histograms and/or modify member variables.
 	//Create any histograms/trees/etc. within a ROOT lock. 
 		//This is so that when running multithreaded, only one thread is writing to the ROOT file at a time. 
 
-	//CREATE THE FUNCTIONS
-	//Since we are creating functions, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		string locFuncName = "df_dEdxCut_SelectHeavy"; //e.g. proton
@@ -38,7 +38,7 @@ void DCustomAction_dEdxCut::Initialize(JEventLoop* locEventLoop)
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }
 
-bool DCustomAction_dEdxCut::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+bool DCustomAction_dEdxCut_trackeff::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
 {
 	//Write custom code to perform an action on the INPUT DParticleCombo (DParticleCombo)
 	//NEVER: Grab DParticleCombo or DAnalysisResults objects (of any tag!) from the JEventLoop within this function
@@ -56,7 +56,7 @@ bool DCustomAction_dEdxCut::Perform_Action(JEventLoop* locEventLoop, const DPart
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }
 
-bool DCustomAction_dEdxCut::Cut_dEdx(const DChargedTrackHypothesis* locChargedTrackHypothesis) const
+bool DCustomAction_dEdxCut_trackeff::Cut_dEdx(const DChargedTrackHypothesis* locChargedTrackHypothesis) const
 {
 	Particle_t locPID = locChargedTrackHypothesis->PID();
 
@@ -77,7 +77,7 @@ bool DCustomAction_dEdxCut::Cut_dEdx(const DChargedTrackHypothesis* locChargedTr
 	return true;
 }
 
-bool DCustomAction_dEdxCut::Cut_dEdx(Particle_t locPID, double locP, double locdEdx, bool locHasNoTimeInfoFlag) const
+bool DCustomAction_dEdxCut_trackeff::Cut_dEdx(Particle_t locPID, double locP, double locdEdx, bool locHasNoTimeInfoFlag) const
 {
 	if(ParticleCharge(locPID) < 0)
 		return true; //only need to separate q+

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_dEdxCut_trackeff.h
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_dEdxCut_trackeff.h
@@ -1,12 +1,12 @@
 // $Id$
 //
-//    File: DCustomAction_dEdxCut.h
+//    File: DCustomAction_dEdxCut_trackeff.h
 // Created: Thu Oct  1 11:18:05 EDT 2015
 // Creator: pmatt (on Darwin Pauls-MacBook-Pro-2.local 13.4.0 i386)
 //
 
-#ifndef _DCustomAction_dEdxCut_
-#define _DCustomAction_dEdxCut_
+#ifndef _DCustomAction_dEdxCut_trackeff_
+#define _DCustomAction_dEdxCut_trackeff_
 
 #include <string>
 #include <iostream>
@@ -24,11 +24,11 @@
 using namespace std;
 using namespace jana;
 
-class DCustomAction_dEdxCut : public DAnalysisAction
+class DCustomAction_dEdxCut_trackeff : public DAnalysisAction
 {
 	public:
 
-		DCustomAction_dEdxCut(const DReaction* locReaction, bool locMaxRejectionFlag = false, string locActionUniqueString = "") :
+		DCustomAction_dEdxCut_trackeff(const DReaction* locReaction, bool locMaxRejectionFlag = false, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Custom_dEdxCut", false, locActionUniqueString),
 		dMaxRejectionFlag(locMaxRejectionFlag) {}
 
@@ -55,4 +55,4 @@ class DCustomAction_dEdxCut : public DAnalysisAction
 		TF1* dFunc_dEdxCut_SelectLight; //e.g. pion, kaon //if dMaxRejectionFlag = true, then used to cut all light
 };
 
-#endif // _DCustomAction_dEdxCut_
+#endif // _DCustomAction_dEdxCut_trackeff_

--- a/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
+++ b/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
@@ -9,7 +9,7 @@
 #include "DCustomAction_TrackingEfficiency.h"
 #include "DCustomAction_CutExtraPi0.h"
 #include "DCustomAction_CutExtraShowers.h"
-#include "DCustomAction_dEdxCut.h"
+#include "DCustomAction_dEdxCut_trackeff.h"
 
 //------------------
 // brun
@@ -91,7 +91,7 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
 
 	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, true)); //true: focus on rejecting background
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiPlus, SYS_TOF)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiPlus, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiPlus, SYS_FCAL)); //false: measured data
@@ -183,7 +183,7 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
 
 	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, true)); //true: focus on rejecting background
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, Proton, SYS_TOF)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.8, Proton, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Proton, SYS_FCAL)); //false: measured data
@@ -276,7 +276,7 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
 
 	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, true)); //true: focus on rejecting background
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, Proton, SYS_TOF)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.8, Proton, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Proton, SYS_FCAL)); //false: measured data
@@ -369,7 +369,7 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
 
 	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, true)); //true: focus on rejecting background
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiPlus, SYS_TOF)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiPlus, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiPlus, SYS_FCAL)); //false: measured data
@@ -465,7 +465,7 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
 
 	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, true)); //true: focus on rejecting background
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, Proton, SYS_TOF)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.8, Proton, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Proton, SYS_FCAL)); //false: measured data
@@ -557,7 +557,7 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
 
 	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, true)); //true: focus on rejecting background
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, Proton, SYS_TOF)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.8, Proton, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Proton, SYS_FCAL)); //false: measured data
@@ -648,7 +648,7 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
 
 	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, true)); //true: focus on rejecting background
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiPlus, SYS_TOF)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiPlus, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiPlus, SYS_FCAL)); //false: measured data
@@ -727,7 +727,7 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
 
 	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, true)); //true: focus on rejecting background
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, Proton, SYS_TOF)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.8, Proton, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Proton, SYS_FCAL)); //false: measured data
@@ -805,7 +805,7 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
 
 	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, true)); //true: focus on rejecting background
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, Proton, SYS_TOF)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.8, Proton, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Proton, SYS_FCAL)); //false: measured data
@@ -894,7 +894,7 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
 
 	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut(locReaction, true)); //true: focus on rejecting background
+	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, Gamma, SYS_BCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, Gamma, SYS_FCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCutAction_TrackFCALShowerEOverP(locReaction, false, 0.5)); //false: measured data //value: cut e+/e- below this, tracks above this


### PR DESCRIPTION
This helps avoid odd linking problems when plugins are loaded.

It seems that when an object with the same name is defined in different
plugins, only the first-loaded object is used (for ALL plugins).
