### PR TITLE
Davidl bor and memleak

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -534,6 +534,9 @@ void DEVIOWorkerThread::ParseBORbank(uint32_t* &iptr, uint32_t *iend)
 			// in case we are processing data from older firmware
 			for(uint32_t i=0; i<sizeof_dest; i++) *dest++ = i<module_len ? (*src++):0;
 
+			// Extract certain derived values to fill in convenience members
+			if(f250conf    ) f250conf->FillDerived();
+
 			// Store object for use in this and subsequent events
 			if(f250conf    ) borptrs->vDf250BORConfig.push_back(f250conf);
 			if(f125conf    ) borptrs->vDf125BORConfig.push_back(f125conf);

--- a/src/libraries/DAQ/Df250BORConfig.h
+++ b/src/libraries/DAQ/Df250BORConfig.h
@@ -31,10 +31,24 @@ class Df250BORConfig:public jana::JObject, public f250config{
 		
 		uint32_t NSA;      // extracted from adc_nsa
 		uint32_t NSA_trig; // extracted from adc_nsa
-		uint32_t NSB;      // extracted from adc_nsb
+		 int32_t NSB;      // extracted from adc_nsb
 		uint32_t NPED;     // extracted from config7
 		uint32_t MaxPed;   // extracted from config7
-		uint32_t NSAT;     // extraced from adc_config[0]
+		uint32_t NSAT;     // extracted from adc_config[0]
+		
+		/// Extract values as read from config registers
+		/// and fill in the derived members defined above.
+		/// This is called from DEVIOWorkerThread::ParseBORbank
+		void FillDerived(void){
+			
+			NSA      = (adc_nsa>> 0) & 0x1FF;
+			NSA_trig = (adc_nsa>> 9) & 0x3F;
+			NSB      = (adc_nsb>> 0) & 0x07;
+			if(adc_nsb&0x08) NSB = -NSB;
+			NPED     = (config7>>10) & 0xF;
+			MaxPed   = (config7>> 0) & 0x3FF;
+			NSAT     = (adc_config[0]>>10)&0x3;
+		}
 		
 		// This method is used primarily for pretty printing
 		// the second argument to AddString is printf style format

--- a/src/libraries/DAQ/Df250BORConfig.h
+++ b/src/libraries/DAQ/Df250BORConfig.h
@@ -29,6 +29,13 @@ class Df250BORConfig:public jana::JObject, public f250config{
 		Df250BORConfig(){}
 		virtual ~Df250BORConfig(){}
 		
+		uint32_t NSA;      // extracted from adc_nsa
+		uint32_t NSA_trig; // extracted from adc_nsa
+		uint32_t NSB;      // extracted from adc_nsb
+		uint32_t NPED;     // extracted from config7
+		uint32_t MaxPed;   // extracted from config7
+		uint32_t NSAT;     // extraced from adc_config[0]
+		
 		// This method is used primarily for pretty printing
 		// the second argument to AddString is printf style format
 		void toStrings(vector<pair<string,string> > &items)const{
@@ -40,10 +47,12 @@ class Df250BORConfig:public jana::JObject, public f250config{
 			AddString(items, "blk_level" , "%d", blk_level);
 			AddString(items, "ptw"       , "%d", adc_ptw);
 			AddString(items, "pl"        , "%d", adc_pl);
-			AddString(items, "nsb"       , "%d", adc_nsb);
-			AddString(items, "nsa"       , "%d", adc_nsa&0x1FF);
-			AddString(items, "nsa_trig"  , "%d", adc_nsa>>9);
-			AddString(items, "nped"      , "%d", nped);
+			AddString(items, "NSB"       , "%d", NSB);
+			AddString(items, "NSA"       , "%d", NSA);
+			AddString(items, "NSA_trig"  , "%d", NSA_trig);
+			AddString(items, "NPED"      , "%d", NPED);
+			AddString(items, "MaxPed"    , "%d", MaxPed);
+			AddString(items, "NSAT"      , "%d", NSAT);
 		}
 
 };

--- a/src/libraries/DAQ/LinkAssociations.h
+++ b/src/libraries/DAQ/LinkAssociations.h
@@ -98,7 +98,7 @@ inline void LinkModule(vector<T*> &a, vector<U*> &b)
 // LinkModuleBORSamplesCopy
 template<class T, class U>
 inline void LinkModuleBORSamplesCopy(vector<T*> &a, vector<U*> &b)
-{ MatchModuleF(a, b, [](T *a, U *b){b->AddAssociatedObject(a); b->nsamples_integral = (a->adc_nsa&0x1FF)+(a->adc_nsb&0x0F); b->nsamples_pedestal = a->nped;}); }
+{ MatchModuleF(a, b, [](T *a, U *b){b->AddAssociatedObject(a); b->nsamples_integral = a->NSA+a->NSB; b->nsamples_pedestal = a->NPED;}); }
 
 // LinkChannel
 template<class T, class U>

--- a/src/libraries/DAQ/bor_roc.h
+++ b/src/libraries/DAQ/bor_roc.h
@@ -90,7 +90,9 @@ typedef struct{
 	uint32_t adc_nsa;          // 0x0128
 	uint16_t adc_thres[16];    // 0x012C - 0x0148
 	uint32_t adc_pedestal[16]; // 0x0158 - 0x0194
-	uint32_t nped;             // 0x0150 (labeled config7 in documentation)
+	uint32_t config6;          // 0x014C
+	uint32_t config7;          // 0x0150
+	uint32_t config3;          // 0x0198
 }f250config;
 
 typedef struct {


### PR DESCRIPTION
This contains 2 updates:
1. The BOR format is modified to handle what should be written to files after run 20750. Part of this includes new derived data members in the Df250BORConfig class that are filled in from data in the BOR itself. This change allows registers to be written to the BOR exactly as they are read, and have the bits masked/shifted when read in during later playback.
2. A memory leak in the parser for both the f250 and f125 Window Raw Data formats was plugged. This leak was due to using an in place constructor as part of a pool mechanism for those objects which overwrote the underlying data pointer in the samples vector. The fix was to delete all pool objects for those data types every event. The very small drop in efficiency due to this should not be noticed.
