### PR TITLE
Trackeff covs

### DIFF
--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_TrackingEfficiency.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_TrackingEfficiency.cc
@@ -41,21 +41,38 @@ void DCustomAction_TrackingEfficiency::Initialize(JEventLoop* locEventLoop)
 	//CHANNEL INFO
 	locBranchRegister.Register_Single<Float_t>("BeamEnergy");
 	locBranchRegister.Register_Single<Float_t>("BeamRFDeltaT");
-	locBranchRegister.Register_Single<TLorentzVector>("MeasuredMissingP4");
-	if(Get_UseKinFitResultsFlag())
-		locBranchRegister.Register_Single<TVector3>("KinFitMissingP3"); //is kinfit if kinfit
 	locBranchRegister.Register_Single<Float_t>("ComboVertexZ");
 	locBranchRegister.Register_Single<UChar_t>("NumExtraTracks");
+	locBranchRegister.Register_Single<Float_t>("KinFitChiSq"); //is -1 if no kinfit or failed to converge
+	locBranchRegister.Register_Single<UInt_t>("KinFitNDF"); //is 0 if no kinfit or failed to converged 
+	locBranchRegister.Register_Single<TVector3>("MissingP3"); //is kinfit if kinfit (& converged)
+
+	//MISSING P3 ERROR MATRIX //is kinfit if kinfit (& converged)
+	locBranchRegister.Register_Single<Float_t>("MissingP3_CovPxPx");
+	locBranchRegister.Register_Single<Float_t>("MissingP3_CovPxPy");
+	locBranchRegister.Register_Single<Float_t>("MissingP3_CovPxPz");
+	locBranchRegister.Register_Single<Float_t>("MissingP3_CovPyPy");
+	locBranchRegister.Register_Single<Float_t>("MissingP3_CovPyPz");
+	locBranchRegister.Register_Single<Float_t>("MissingP3_CovPzPz");
 
 	//TRACKING INFO: //"Recon:" Time-based track
 	locBranchRegister.Register_Single<Float_t>("ReconMatchFOM_WireBased"); //FOM < 0 if nothing, no-match
 	locBranchRegister.Register_Single<Float_t>("ReconTrackingFOM_WireBased"); //FOM < 0 if nothing, no-match
-	locBranchRegister.Register_Single<Float_t>("ReconMatchFOM"); //FOM < 0 if nothing, no-match
-	locBranchRegister.Register_Single<Float_t>("ReconTrackingFOM"); //FOM < 0 if nothing, no-match
 	locBranchRegister.Register_Single<TVector3>("ReconP3_WireBased"); //wire-based
-	locBranchRegister.Register_Single<TVector3>("ReconP3"); //time-based
+	locBranchRegister.Register_Single<Float_t>("ReconMatchFOM"); //FOM < 0 if nothing, no-match (time-based)
+	locBranchRegister.Register_Single<Float_t>("ReconTrackingFOM"); //FOM < 0 if nothing, no-match (time-based)
+	locBranchRegister.Register_Single<TVector3>("ReconP3"); //time-based (time-based)
+	locBranchRegister.Register_Single<Float_t>("MeasuredMissingE"); //includes recon time-based track if found, else is -999.0
 	locBranchRegister.Register_Single<UInt_t>("TrackCDCRings"); //rings correspond to bits (1 -> 28)
 	locBranchRegister.Register_Single<UInt_t>("TrackFDCPlanes"); //planes correspond to bits (1 -> 24)
+
+	//RECON P3 ERROR MATRIX
+	locBranchRegister.Register_Single<Float_t>("ReconP3_CovPxPx");
+	locBranchRegister.Register_Single<Float_t>("ReconP3_CovPxPy");
+	locBranchRegister.Register_Single<Float_t>("ReconP3_CovPxPz");
+	locBranchRegister.Register_Single<Float_t>("ReconP3_CovPyPy");
+	locBranchRegister.Register_Single<Float_t>("ReconP3_CovPyPz");
+	locBranchRegister.Register_Single<Float_t>("ReconP3_CovPzPz");
 
 	//HADRONIC BCAL SHOWER EFFICIENCY: TIMING, MATCHING //cannot get accurate PID without missing-track study
 	locBranchRegister.Register_Single<UChar_t>("ProjectedBCALSector"); //4*(module - 1) + sector: 1 -> 192 //0 if proj to miss
@@ -88,6 +105,7 @@ bool DCustomAction_TrackingEfficiency::Perform_Action(JEventLoop* locEventLoop, 
 	dAnalysisUtilities->Get_UnusedChargedTracks(locEventLoop, locParticleCombo, locUnusedChargedTracks);
 
 	const DEventRFBunch* locEventRFBunch = locParticleCombo->Get_EventRFBunch();
+	const DKinFitResults* locKinFitResults = locParticleCombo->Get_KinFitResults();
 
 	/*********************************************** MISSING PARTICLE INFO ***********************************************/
 
@@ -104,7 +122,7 @@ bool DCustomAction_TrackingEfficiency::Perform_Action(JEventLoop* locEventLoop, 
 	DVector3 locMissingP3 = locMeasuredMissingP4.Vect();
 	DMatrixDSym locMissingCovarianceMatrix(3);
 	const DKinematicData* locBeamParticle = NULL;
-	if(locMissingParticle == NULL) //measured, or kinfit failed
+	if(locKinFitResults == NULL) //no kinfit (yet?), or kinfit failed
 	{
 		locMissingCovarianceMatrix = dAnalysisUtilities->Calc_MissingP3Covariance(locParticleCombo);
 		locBeamParticle = locParticleComboStep->Get_InitialParticle_Measured();
@@ -131,16 +149,33 @@ bool DCustomAction_TrackingEfficiency::Perform_Action(JEventLoop* locEventLoop, 
 			++locNumExtraTracks;
 	}
 
+	//kinfit results are unique for each DParticleCombo: no need to check for duplicates
+
 	//FILL CHANNEL INFO
 	dTreeFillData.Fill_Single<Float_t>("BeamEnergy", locBeamParticle->energy());
 	dTreeFillData.Fill_Single<Float_t>("BeamRFDeltaT", locBeamRFDeltaT);
 	dTreeFillData.Fill_Single<UChar_t>("NumExtraTracks", (UChar_t)locNumExtraTracks);
-	TLorentzVector locTMeasuredMissingP4(locMeasuredMissingP4.Px(), locMeasuredMissingP4.Py(), locMeasuredMissingP4.Pz(), locMeasuredMissingP4.E());
-	dTreeFillData.Fill_Single<TLorentzVector>("MeasuredMissingP4", locTMeasuredMissingP4);
-	TVector3 locTMissingP3(locMissingP3.Px(), locMissingP3.Py(), locMissingP3.Pz());
-	if(Get_UseKinFitResultsFlag())
-		dTreeFillData.Fill_Single<TVector3>("KinFitMissingP3", locTMissingP3); //is kinfit if kinfit
 	dTreeFillData.Fill_Single<Float_t>("ComboVertexZ", locVertexZ);
+	if(locKinFitResults == NULL) //is true if no kinfit or failed to converged
+	{
+		dTreeFillData.Fill_Single<Float_t>("KinFitChiSq", -1.0);
+		dTreeFillData.Fill_Single<UInt_t>("KinFitNDF", 0);
+	}
+	else
+	{
+		dTreeFillData.Fill_Single<Float_t>("KinFitChiSq", locKinFitResults->Get_ChiSq());
+		dTreeFillData.Fill_Single<UInt_t>("KinFitNDF", locKinFitResults->Get_NDF());
+	}
+	TVector3 locTMissingP3(locMissingP3.Px(), locMissingP3.Py(), locMissingP3.Pz());
+	dTreeFillData.Fill_Single<TVector3>("MissingP3", locTMissingP3); //is kinfit if kinfit
+
+	//MISSING P3 ERROR MATRIX //is kinfit if kinfit (& converged)
+	dTreeFillData.Fill_Single<Float_t>("MissingP3_CovPxPx", locMissingCovarianceMatrix(0, 0));
+	dTreeFillData.Fill_Single<Float_t>("MissingP3_CovPxPy", locMissingCovarianceMatrix(0, 1));
+	dTreeFillData.Fill_Single<Float_t>("MissingP3_CovPxPz", locMissingCovarianceMatrix(0, 2));
+	dTreeFillData.Fill_Single<Float_t>("MissingP3_CovPyPy", locMissingCovarianceMatrix(1, 1));
+	dTreeFillData.Fill_Single<Float_t>("MissingP3_CovPyPz", locMissingCovarianceMatrix(1, 2));
+	dTreeFillData.Fill_Single<Float_t>("MissingP3_CovPzPz", locMissingCovarianceMatrix(2, 2));
 
 	/************************************************* WIRE-BASED TRACKS *************************************************/
 
@@ -185,8 +220,17 @@ bool DCustomAction_TrackingEfficiency::Perform_Action(JEventLoop* locEventLoop, 
 		dTreeFillData.Fill_Single<TVector3>("ReconP3_WireBased", TVector3());
 		dTreeFillData.Fill_Single<Float_t>("ReconTrackingFOM", -1.0);
 		dTreeFillData.Fill_Single<TVector3>("ReconP3", TVector3());
+		dTreeFillData.Fill_Single<Float_t>("MeasuredMissingE", -999.0);
 		dTreeFillData.Fill_Single<UInt_t>("TrackCDCRings", 0);
 		dTreeFillData.Fill_Single<UInt_t>("TrackFDCPlanes", 0);
+
+		//RECON P3 ERROR MATRIX
+		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPx", -1.0);
+		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPy", -1.0);
+		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPz", -1.0);
+		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPyPy", -1.0);
+		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPyPz", -1.0);
+		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPzPz", -1.0);
 
 		//HADRONIC BCAL SHOWER EFFICIENCY: TIMING, MATCHING
 		dTreeFillData.Fill_Single<Float_t>("ProjectedBCALHitPhi", 0.0);
@@ -251,9 +295,17 @@ bool DCustomAction_TrackingEfficiency::Perform_Action(JEventLoop* locEventLoop, 
 	{
 		dTreeFillData.Fill_Single<Float_t>("ReconTrackingFOM", -1.0);
 		dTreeFillData.Fill_Single<TVector3>("ReconP3", TVector3());
-		dTreeFillData.Fill_Single<TVector3>("ReconP3_WireBased", TVector3());
+		dTreeFillData.Fill_Single<Float_t>("MeasuredMissingE", -999.0);
 		dTreeFillData.Fill_Single<UInt_t>("TrackCDCRings", 0);
 		dTreeFillData.Fill_Single<UInt_t>("TrackFDCPlanes", 0);
+
+		//RECON P3 ERROR MATRIX
+		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPx", -1.0);
+		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPy", -1.0);
+		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPz", -1.0);
+		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPyPy", -1.0);
+		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPyPz", -1.0);
+		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPzPz", -1.0);
 
 		//HADRONIC BCAL SHOWER EFFICIENCY: TIMING, MATCHING
 		dTreeFillData.Fill_Single<Float_t>("ProjectedBCALHitPhi", 0.0);
@@ -276,8 +328,19 @@ bool DCustomAction_TrackingEfficiency::Perform_Action(JEventLoop* locEventLoop, 
 	DVector3 locDP3 = locBestTrackTimeBased->momentum();
 	TVector3 locP3(locDP3.X(), locDP3.Y(), locDP3.Z());
 	dTreeFillData.Fill_Single<TVector3>("ReconP3", locP3);
+	DLorentzVector locTotalMeasuredMissingP4 = locMeasuredMissingP4 - locBestTrackTimeBased->lorentzMomentum();
+	dTreeFillData.Fill_Single<Float_t>("MeasuredMissingE", locTotalMeasuredMissingP4.E());
 	dTreeFillData.Fill_Single<UInt_t>("TrackCDCRings", locBestTrackTimeBased->dCDCRings);
 	dTreeFillData.Fill_Single<UInt_t>("TrackFDCPlanes", locBestTrackTimeBased->dFDCPlanes);
+
+	//RECON P3 ERROR MATRIX
+	DMatrixDSym locCovarianceMatrix = locBestTrackTimeBased->errorMatrix();
+	dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPx", locCovarianceMatrix(0, 0));
+	dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPy", locCovarianceMatrix(0, 1));
+	dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPz", locCovarianceMatrix(0, 2));
+	dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPyPy", locCovarianceMatrix(1, 1));
+	dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPyPz", locCovarianceMatrix(1, 2));
+	dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPzPz", locCovarianceMatrix(2, 2));
 
 	/********************************************* BCAL SHOWER RECONSTRUCTION ********************************************/
 

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_TrackingEfficiency.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_TrackingEfficiency.cc
@@ -212,47 +212,20 @@ bool DCustomAction_TrackingEfficiency::Perform_Action(JEventLoop* locEventLoop, 
 		}
 	}
 
-	//FILL TRACKING INFO:
+	//FILL WIRE-BASED TRACKING INFO:
 	dTreeFillData.Fill_Single<Float_t>("ReconMatchFOM_WireBased", locBestWireBasedMatchFOM); //FOM < 0 if nothing, no-match
 	if(locBestTrackWireBased == nullptr)
 	{
 		dTreeFillData.Fill_Single<Float_t>("ReconTrackingFOM_WireBased", -1.0);
 		dTreeFillData.Fill_Single<TVector3>("ReconP3_WireBased", TVector3());
-		dTreeFillData.Fill_Single<Float_t>("ReconTrackingFOM", -1.0);
-		dTreeFillData.Fill_Single<TVector3>("ReconP3", TVector3());
-		dTreeFillData.Fill_Single<Float_t>("MeasuredMissingE", -999.0);
-		dTreeFillData.Fill_Single<UInt_t>("TrackCDCRings", 0);
-		dTreeFillData.Fill_Single<UInt_t>("TrackFDCPlanes", 0);
-
-		//RECON P3 ERROR MATRIX
-		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPx", -1.0);
-		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPy", -1.0);
-		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPz", -1.0);
-		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPyPy", -1.0);
-		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPyPz", -1.0);
-		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPzPz", -1.0);
-
-		//HADRONIC BCAL SHOWER EFFICIENCY: TIMING, MATCHING
-		dTreeFillData.Fill_Single<Float_t>("ProjectedBCALHitPhi", 0.0);
-		dTreeFillData.Fill_Single<Float_t>("ProjectedBCALHitZ", 0.0);
-		dTreeFillData.Fill_Single<UChar_t>("ProjectedBCALSector", 0);
-		dTreeFillData.Fill_Single<Float_t>("NearestShowerEnergy", 0.0);
-		dTreeFillData.Fill_Single<Float_t>("TrackDeltaPhiToShower", 0.0);
-		dTreeFillData.Fill_Single<Float_t>("TrackDeltaZToShower", 0.0);
-		dTreeFillData.Fill_Single<Bool_t>("IsMatchedToBCALShower", false);
-		dTreeFillData.Fill_Single<Float_t>("BCALDeltaT", 0.0);
-		dTreeFillData.Fill_Single<Float_t>("BCALTimeFOM", -1.0);
-
-		//FILL TTREE
-		dTreeInterface->Fill(dTreeFillData);
-		return true;
 	}
-
-	//RESUME FILLING TRACKING INFO:
-	dTreeFillData.Fill_Single<Float_t>("ReconTrackingFOM_WireBased", locBestTrackWireBased->FOM);
-	DVector3 locWireBasedDP3 = locBestTrackWireBased->momentum();
-	TVector3 locWireBasedP3(locWireBasedDP3.X(), locWireBasedDP3.Y(), locWireBasedDP3.Z());
-	dTreeFillData.Fill_Single<TVector3>("ReconP3_WireBased", locWireBasedP3);
+	else
+	{
+		dTreeFillData.Fill_Single<Float_t>("ReconTrackingFOM_WireBased", locBestTrackWireBased->FOM);
+		DVector3 locWireBasedDP3 = locBestTrackWireBased->momentum();
+		TVector3 locWireBasedP3(locWireBasedDP3.X(), locWireBasedDP3.Y(), locWireBasedDP3.Z());
+		dTreeFillData.Fill_Single<TVector3>("ReconP3_WireBased", locWireBasedP3);
+	}
 
 	/************************************************* TIME-BASED TRACKS *************************************************/
 


### PR DESCRIPTION
 Add p3 cov matrix for missing & found.

This should be able to help in extracting the true tracking resolutions.
And also monitoring the reconstructed cov matrix.

Also, save only measured missing E (to check beam energy) instead of entire p4.
