### PR TITLE
Remove bogus checks for TF1 in gDirectory.

### DIFF
--- a/src/plugins/Analysis/p2k_hists/DCustomAction_dEdxCut_p2k.cc
+++ b/src/plugins/Analysis/p2k_hists/DCustomAction_dEdxCut_p2k.cc
@@ -18,22 +18,12 @@ void DCustomAction_dEdxCut_p2k::Initialize(JEventLoop* locEventLoop)
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		string locFuncName = "df_dEdxCut_SelectHeavy"; //e.g. proton
-		if(gDirectory->Get(locFuncName.c_str()) != NULL) //already created by another thread
-			dFunc_dEdxCut_SelectHeavy = static_cast<TF1*>(gDirectory->Get(locFuncName.c_str()));
-		else
-		{
-			dFunc_dEdxCut_SelectHeavy = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-			dFunc_dEdxCut_SelectHeavy->SetParameters(3.93024, 3.0, 1.0);
-		}
+		dFunc_dEdxCut_SelectHeavy = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
+		dFunc_dEdxCut_SelectHeavy->SetParameters(3.93024, 3.0, 1.0);
 
 		locFuncName = "df_dEdxCut_SelectLight"; //e.g. pions, kaons
-		if(gDirectory->Get(locFuncName.c_str()) != NULL) //already created by another thread
-			dFunc_dEdxCut_SelectLight = static_cast<TF1*>(gDirectory->Get(locFuncName.c_str()));
-		else
-		{
-			dFunc_dEdxCut_SelectLight = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-			dFunc_dEdxCut_SelectLight->SetParameters(6.0, 2.80149, 2.55);
-		}
+		dFunc_dEdxCut_SelectLight = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
+		dFunc_dEdxCut_SelectLight->SetParameters(6.0, 2.80149, 2.55);
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_dEdxCut_p2pi.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_dEdxCut_p2pi.cc
@@ -18,22 +18,12 @@ void DCustomAction_dEdxCut_p2pi::Initialize(JEventLoop* locEventLoop)
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		string locFuncName = "df_dEdxCut_SelectHeavy"; //e.g. proton
-		if(gDirectory->Get(locFuncName.c_str()) != NULL) //already created by another thread
-			dFunc_dEdxCut_SelectHeavy = static_cast<TF1*>(gDirectory->Get(locFuncName.c_str()));
-		else
-		{
-			dFunc_dEdxCut_SelectHeavy = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-			dFunc_dEdxCut_SelectHeavy->SetParameters(3.93024, 3.0, 1.0);
-		}
+		dFunc_dEdxCut_SelectHeavy = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
+		dFunc_dEdxCut_SelectHeavy->SetParameters(3.93024, 3.0, 1.0);
 
 		locFuncName = "df_dEdxCut_SelectLight"; //e.g. pions, kaons
-		if(gDirectory->Get(locFuncName.c_str()) != NULL) //already created by another thread
-			dFunc_dEdxCut_SelectLight = static_cast<TF1*>(gDirectory->Get(locFuncName.c_str()));
-		else
-		{
-			dFunc_dEdxCut_SelectLight = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-			dFunc_dEdxCut_SelectLight->SetParameters(6.0, 2.80149, 2.55);
-		}
+		dFunc_dEdxCut_SelectLight = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
+		dFunc_dEdxCut_SelectLight->SetParameters(6.0, 2.80149, 2.55);
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_dEdxCut_p3pi.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_dEdxCut_p3pi.cc
@@ -18,22 +18,12 @@ void DCustomAction_dEdxCut_p3pi::Initialize(JEventLoop* locEventLoop)
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		string locFuncName = "df_dEdxCut_SelectHeavy"; //e.g. proton
-		if(gDirectory->Get(locFuncName.c_str()) != NULL) //already created by another thread
-			dFunc_dEdxCut_SelectHeavy = static_cast<TF1*>(gDirectory->Get(locFuncName.c_str()));
-		else
-		{
-			dFunc_dEdxCut_SelectHeavy = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-			dFunc_dEdxCut_SelectHeavy->SetParameters(3.93024, 3.0, 1.0);
-		}
+		dFunc_dEdxCut_SelectHeavy = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
+		dFunc_dEdxCut_SelectHeavy->SetParameters(3.93024, 3.0, 1.0);
 
 		locFuncName = "df_dEdxCut_SelectLight"; //e.g. pions, kaons
-		if(gDirectory->Get(locFuncName.c_str()) != NULL) //already created by another thread
-			dFunc_dEdxCut_SelectLight = static_cast<TF1*>(gDirectory->Get(locFuncName.c_str()));
-		else
-		{
-			dFunc_dEdxCut_SelectLight = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-			dFunc_dEdxCut_SelectLight->SetParameters(6.0, 2.80149, 2.55);
-		}
+		dFunc_dEdxCut_SelectLight = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
+		dFunc_dEdxCut_SelectLight->SetParameters(6.0, 2.80149, 2.55);
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_dEdxCut_trackeff.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_dEdxCut_trackeff.cc
@@ -18,22 +18,12 @@ void DCustomAction_dEdxCut_trackeff::Initialize(JEventLoop* locEventLoop)
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		string locFuncName = "df_dEdxCut_SelectHeavy"; //e.g. proton
-		if(gDirectory->Get(locFuncName.c_str()) != NULL) //already created by another thread
-			dFunc_dEdxCut_SelectHeavy = static_cast<TF1*>(gDirectory->Get(locFuncName.c_str()));
-		else
-		{
-			dFunc_dEdxCut_SelectHeavy = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-			dFunc_dEdxCut_SelectHeavy->SetParameters(3.93024, 3.0, 1.0);
-		}
+		dFunc_dEdxCut_SelectHeavy = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
+		dFunc_dEdxCut_SelectHeavy->SetParameters(3.93024, 3.0, 1.0);
 
 		locFuncName = "df_dEdxCut_SelectLight"; //e.g. pions, kaons
-		if(gDirectory->Get(locFuncName.c_str()) != NULL) //already created by another thread
-			dFunc_dEdxCut_SelectLight = static_cast<TF1*>(gDirectory->Get(locFuncName.c_str()));
-		else
-		{
-			dFunc_dEdxCut_SelectLight = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-			dFunc_dEdxCut_SelectLight->SetParameters(6.0, 2.80149, 2.55);
-		}
+		dFunc_dEdxCut_SelectLight = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
+		dFunc_dEdxCut_SelectLight->SetParameters(6.0, 2.80149, 2.55);
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }


### PR DESCRIPTION
They are actually stored in gROOT->GetListOfFunctions().

However, it's far easier and safer for each thread to have their own
copy, rather than have one instance shared amongst threads.

That is because a user could modify the (e.g.) dE/dx cut, but keep the
same name, and it could supercede another user's cuts.

Although this invalidates the content of this global TF1 list, this list is an abomination, and the fact
that it even exists and an affront to humankind, and should never be used.

Note that any existing user checks in gDirectory are still OK (just will always be false). 
