### PR TITLE
Change what hypos are saved to the tree.

### DIFF
--- a/src/libraries/ANALYSIS/DChargedTrackHypothesis_factory_KinFit.cc
+++ b/src/libraries/ANALYSIS/DChargedTrackHypothesis_factory_KinFit.cc
@@ -101,7 +101,11 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory_KinFit::Build_ChargedTr
  	vector<const JObject*> locObjects;
 	locChargedTrackHypothesis->GetT(locObjects);
 	for(size_t loc_i = 0; loc_i < locObjects.size(); ++loc_i)
+	{
+		if(dynamic_cast<const DChargedTrackHypothesis*>(locObjects[loc_i]) != NULL)
+			continue; //don't save: won't be able to keep track of which is which! (combo or default factory)
 		locNewChargedTrackHypothesis->AddAssociatedObject(locObjects[loc_i]);
+	}
 
 	//p3 & v3
 	TVector3 locFitMomentum = locKinFitParticle->Get_Momentum();

--- a/src/libraries/ANALYSIS/DChargedTrackHypothesis_factory_KinFit.cc
+++ b/src/libraries/ANALYSIS/DChargedTrackHypothesis_factory_KinFit.cc
@@ -114,6 +114,7 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory_KinFit::Build_ChargedTr
 	double locPathLengthUncertainty = sqrt(locPathLengthUncertainty_Orig*locPathLengthUncertainty_Orig + locPathLengthUncertainty_KinFit*locPathLengthUncertainty_KinFit);
 	locNewChargedTrackHypothesis->setPathLength(locPathLength, locPathLengthUncertainty);
 
+	//for this calc: if rf time part of timing constraint, don't use locKinFitParticle->Get_Time() for chisq calc!!!
 	dPIDAlgorithm->Calc_ChargedPIDFOM(locNewChargedTrackHypothesis, locParticleCombo->Get_EventRFBunch());
 
 	return locNewChargedTrackHypothesis;

--- a/src/libraries/ANALYSIS/DChargedTrackHypothesis_factory_KinFit.cc
+++ b/src/libraries/ANALYSIS/DChargedTrackHypothesis_factory_KinFit.cc
@@ -103,8 +103,13 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory_KinFit::Build_ChargedTr
 	for(size_t loc_i = 0; loc_i < locObjects.size(); ++loc_i)
 		locNewChargedTrackHypothesis->AddAssociatedObject(locObjects[loc_i]);
 
-	locNewChargedTrackHypothesis->setMomentum(DVector3(locKinFitParticle->Get_Momentum().X(),locKinFitParticle->Get_Momentum().Y(),locKinFitParticle->Get_Momentum().Z()));
-	locNewChargedTrackHypothesis->setPosition(DVector3(locKinFitParticle->Get_Position().X(),locKinFitParticle->Get_Position().Y(),locKinFitParticle->Get_Position().Z()));
+	//p3 & v3
+	TVector3 locFitMomentum = locKinFitParticle->Get_Momentum();
+	TVector3 locFitVertex = locKinFitParticle->Get_Position();
+	locNewChargedTrackHypothesis->setMomentum(DVector3(locFitMomentum.X(), locFitMomentum.Y(), locFitMomentum.Z()));
+	locNewChargedTrackHypothesis->setPosition(DVector3(locFitVertex.X(), locFitVertex.Y(), locFitVertex.Z()));
+
+	//t & error matrix
 	locNewChargedTrackHypothesis->setTime(locKinFitParticle->Get_Time());
 	locNewChargedTrackHypothesis->setErrorMatrix(*locKinFitParticle->Get_CovarianceMatrix());
 

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -1825,7 +1825,7 @@ void DEventWriterROOT::Fill_ComboStepData(DTreeFillData* locTreeFillData, const 
 			const DTrackTimeBased* locTrackTimeBased = NULL;
 			locMeasuredChargedHypo->GetSingle(locTrackTimeBased);
 			pair<oid_t, Particle_t> locTrackPair(locTrackTimeBased->id, locMeasuredChargedHypo->PID());
-			size_t locChargedIndex = locObjectToArrayIndexMap.find(locMeasuredChargedHypo)->second;
+			size_t locChargedIndex = locObjectToArrayIndexMap.find(locTrackPair)->second;
 
 			Fill_ComboChargedData(locTreeFillData, locComboIndex, locParticleBranchName, locMeasuredChargedHypo, locChargedHypo, locChargedIndex, locKinFitType);
 		}

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -909,9 +909,8 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 		return;
 	}
 
-	bool locSaveUnusedFlag = locReaction->Get_SaveUnusedFlag();
+	/***************************************************** GET THROWN INFO *****************************************************/
 
-	//GET THROWN INFO
 	vector<const DMCThrown*> locMCThrowns_FinalState;
 	locEventLoop->Get(locMCThrowns_FinalState, "FinalState");
 
@@ -926,55 +925,18 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 	locEventLoop->Get(locMCReactions);
 	const DMCReaction* locMCReaction = locMCReactions.empty() ? NULL : locMCReactions[0];
 
-	//Pre-compute
+	//Pre-compute thrown info
 	ULong64_t locNumPIDThrown_FinalState = 0, locPIDThrown_Decaying = 0;
 	Compute_ThrownPIDInfo(locMCThrowns_FinalState, locMCThrowns_Decaying, locNumPIDThrown_FinalState, locPIDThrown_Decaying);
 
-	//Pre-compute
+	//Pre-compute thrown info
 	vector<const DMCThrown*> locMCThrownsToSave;
 	map<const DMCThrown*, unsigned int> locThrownIndexMap;
 	Group_ThrownParticles(locMCThrowns_FinalState, locMCThrowns_Decaying, locMCThrownsToSave, locThrownIndexMap);
 
-	//GET DETECTOR MATCHES
-	const DDetectorMatches* locDetectorMatches = NULL;
-	locEventLoop->GetSingle(locDetectorMatches);
+	/****************************************************** GET PARTICLES ******************************************************/
 
-	//GET DVERTEX
-	const DVertex* locVertex = NULL;
-	locEventLoop->GetSingle(locVertex);
-
-	//GET TRIGGER
-	const DTrigger* locTrigger = NULL;
-	locEventLoop->GetSingle(locTrigger);
-
-	//Check whether beam is used in the combo
-	bool locBeamUsedFlag = (locReaction->Get_ReactionStep(0)->Get_TargetParticleID() != Unknown);
-
-	//GET BEAM PHOTONS
-		//however, only fill with beam particles that are in the combos
-	set<const DBeamPhoton*> locBeamPhotonSet;
-	vector<const DBeamPhoton*> locBeamPhotons;
-	for(size_t loc_j = 0; loc_j < locParticleCombos.size(); ++loc_j)
-	{
-		const DParticleComboStep* locParticleComboStep = locParticleCombos[loc_j]->Get_ParticleComboStep(0);
-		const DKinematicData* locKinematicData = locParticleComboStep->Get_InitialParticle_Measured();
-		if(locKinematicData == NULL)
-			continue;
-		const DBeamPhoton* locBeamPhoton = dynamic_cast<const DBeamPhoton*>(locKinematicData);
-		if(locBeamPhoton == NULL)
-			continue;
-		if(locBeamPhotonSet.find(locBeamPhoton) != locBeamPhotonSet.end())
-			continue; //already included
-		locBeamPhotonSet.insert(locBeamPhoton);
-		locBeamPhotons.push_back(locBeamPhoton);
-	}
-
-	//create map of particles to array index: //beam now, will fill others in Get_*Hypotheses functions
-		//used for pointing combo particles to the appropriate measured-particle array index
-		//for hypos, they are the preselect versions if they exist, else the combo versions (e.g. PID not in REST)
-	map<string, map<oid_t, int> > locObjectToArrayIndexMap;
-	for(size_t loc_i = 0; loc_i < locBeamPhotons.size(); ++loc_i)
-		locObjectToArrayIndexMap["DBeamPhoton"][locBeamPhotons[loc_i]->id] = loc_i;
+	bool locSaveUnusedFlag = locReaction->Get_SaveUnusedFlag();
 
 	//Get PIDs need for reaction
 	set<Particle_t> locReactionPIDs;
@@ -989,16 +951,67 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 	vector<const DNeutralParticleHypothesis*> locNeutralParticleHypotheses;
 	if(locSaveUnusedFlag)
 	{
-		locChargedTrackHypotheses = Get_ChargedHypotheses(locEventLoop, locReactionPIDs, locObjectToArrayIndexMap["DChargedTrackHypothesis"]);
-		locNeutralParticleHypotheses = Get_NeutralHypotheses(locEventLoop, locReactionPIDs, locObjectToArrayIndexMap["DNeutralParticleHypothesis"]);
+		locChargedTrackHypotheses = Get_ChargedHypotheses(locEventLoop, locReactionPIDs);
+		locNeutralParticleHypotheses = Get_NeutralHypotheses(locEventLoop, locReactionPIDs);
 	}
 	else
 	{
-		locChargedTrackHypotheses = Get_ChargedHypotheses_Used(locEventLoop, locParticleCombos, locObjectToArrayIndexMap["DChargedTrackHypothesis"]);
-		locNeutralParticleHypotheses = Get_NeutralHypotheses_Used(locEventLoop, locParticleCombos, locObjectToArrayIndexMap["DNeutralParticleHypothesis"]);
+		locChargedTrackHypotheses = Get_ChargedHypotheses_Used(locEventLoop, locParticleCombos);
+		locNeutralParticleHypotheses = Get_NeutralHypotheses_Used(locEventLoop, locParticleCombos);
 	}
 
-	//EXECUTE ANALYSIS ACTIONS
+	//GET BEAM PHOTONS
+	bool locBeamUsedFlag = (locReaction->Get_ReactionStep(0)->Get_TargetParticleID() != Unknown);
+	vector<const DBeamPhoton*> locBeamPhotons = Get_BeamPhotons(locParticleCombos);
+
+	//create map of particles to array index:
+		//used for pointing combo particles to the appropriate measured-particle array index
+		//for hypos, they are the preselect versions if they exist, else the combo versions (e.g. PID not in REST)
+
+	//indices: beam
+	map<pair<oid_t, Particle_t>, size_t> locObjectToArrayIndexMap; //particle_t necessary for neutral showers!
+	for(size_t loc_i = 0; loc_i < locBeamPhotons.size(); ++loc_i)
+	{
+		pair<oid_t, Particle_t> locBeamPair(locBeamPhotons[loc_i]->id, locBeamPhotons[loc_i]->Get_PID());
+		locObjectToArrayIndexMap[locBeamPair] = loc_i;
+	}
+
+	//indices: charged
+	for(size_t loc_i = 0; loc_i < locChargedTrackHypotheses.size(); ++loc_i)
+	{
+		const DTrackTimeBased* locTrackTimeBased = NULL;
+		locChargedTrackHypotheses[loc_i]->GetSingle(locTrackTimeBased);
+
+		pair<oid_t, Particle_t> locTrackPair(locTrackTimeBased->id, locTrackTimeBased->Get_PID());
+		locObjectToArrayIndexMap[locTrackPair] = loc_i;
+	}
+
+	//indices: neutral
+	for(size_t loc_i = 0; loc_i < locNeutralParticleHypotheses.size(); ++loc_i)
+	{
+		const DNeutralShower* locNeutralShower = NULL;
+		locNeutralParticleHypotheses[loc_i]->GetSingle(locNeutralShower);
+
+		pair<oid_t, Particle_t> locShowerPair(locNeutralShower->id, locNeutralParticleHypotheses[loc_i]->Get_PID());
+		locObjectToArrayIndexMap[locShowerPair] = loc_i;
+	}
+
+	/**************************************************** GET MISCELLANEOUS ****************************************************/
+
+	//GET DETECTOR MATCHES
+	const DDetectorMatches* locDetectorMatches = NULL;
+	locEventLoop->GetSingle(locDetectorMatches);
+
+	//GET DVERTEX
+	const DVertex* locVertex = NULL;
+	locEventLoop->GetSingle(locVertex);
+
+	//GET TRIGGER
+	const DTrigger* locTrigger = NULL;
+	locEventLoop->GetSingle(locTrigger);
+
+	/************************************************* EXECUTE ANALYSIS ACTIONS ************************************************/
+
 	Bool_t locIsThrownTopologyFlag = kFALSE;
 	vector<Bool_t> locIsTrueComboFlags;
 	vector<Bool_t> locIsBDTSignalComboFlags;
@@ -1016,10 +1029,10 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 		}
 	}
 
+	/***************************************************** FILL TTREE DATA *****************************************************/
+
 	//Get tree fill data
 	DTreeFillData* locTreeFillData = dTreeFillDataMap.find(locReaction)->second;
-
-	/***************************************************** FILL TTREE DATA *****************************************************/
 
 	//PRIMARY EVENT INFO
 	locTreeFillData->Fill_Single<UInt_t>("RunNumber", locEventLoop->GetJEvent().GetRunNumber());
@@ -1034,7 +1047,7 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 	//THROWN INFORMATION
 	if(locMCReaction != NULL)
 	{
-		Fill_ThrownInfo(locTreeFillData, locMCReaction, locMCThrownsToSave, locThrownIndexMap, locNumPIDThrown_FinalState, locPIDThrown_Decaying, locMCThrownMatching, locObjectToArrayIndexMap);
+		Fill_ThrownInfo(locTreeFillData, locMCReaction, locMCThrownsToSave, locThrownIndexMap, locNumPIDThrown_FinalState, locPIDThrown_Decaying, locMCThrownMatching);
 		locTreeFillData->Fill_Single<Bool_t>("IsThrownTopology", locIsThrownTopologyFlag);
 	}
 
@@ -1077,15 +1090,34 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 	locTreeInterface->Fill(*locTreeFillData);
 }
 
-vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses(JEventLoop* locEventLoop, map<oid_t, int>& locObjectToArrayIndexMap) const
+vector<const DBeamPhoton*> DEventWriterROOT::Get_BeamPhotons(const deque<const DParticleCombo*>& locParticleCombos) const
+{
+	//however, only fill with beam particles that are in the combos
+	set<const DBeamPhoton*> locBeamPhotonSet;
+	vector<const DBeamPhoton*> locBeamPhotons;
+	for(size_t loc_j = 0; loc_j < locParticleCombos.size(); ++loc_j)
+	{
+		const DParticleComboStep* locParticleComboStep = locParticleCombos[loc_j]->Get_ParticleComboStep(0);
+		const DKinematicData* locKinematicData = locParticleComboStep->Get_InitialParticle_Measured();
+		if(locKinematicData == NULL)
+			continue;
+		const DBeamPhoton* locBeamPhoton = dynamic_cast<const DBeamPhoton*>(locKinematicData);
+		if(locBeamPhoton == NULL)
+			continue;
+		if(locBeamPhotonSet.find(locBeamPhoton) != locBeamPhotonSet.end())
+			continue; //already included
+		locBeamPhotonSet.insert(locBeamPhoton);
+		locBeamPhotons.push_back(locBeamPhoton);
+	}
+
+	return locBeamPhotons;
+}
+
+vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs) const
 {
 	//For default/preselect, save all
 	//For combo, of new PIDs ONLY, save one of each for each track
 		//save the one with the same RF bunch as the common bunch
-	//for index map, save mapping of these
-	//map is from oid_t (pointer) of DTrackTimeBased to array index
-
-//BEWARE FOR NEUTRAL: Should be DNeutralShower + PID (or just don't change)
 
 	vector<const DChargedTrack*> locChargedTracks;
 	locEventLoop->Get(locChargedTracks, dTrackSelectionTag.c_str());
@@ -1108,8 +1140,11 @@ vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses(J
 	map<const DChargedTrack*, map<Particle_t, const DChargedTrackHypothesis*> > locNewChargedHypothesesMap;
 	for(auto locChargedHypo : locComboChargedTrackHypotheses)
 	{
-		if(locReconPIDs.find(locChargedHypo->Get_PID()) != locReconPIDs.end())
+		Particle_t locPID = locChargedHypo->PID();
+		if(locReconPIDs.find(locPID) != locReconPIDs.end())
 			continue; //already have PID for this track
+		if(locReactionPIDs.find(locPID) == locReactionPIDs.end())
+			continue; //PID not needed for this DReaction, don't bother
 
 		const DEventRFBunch* locEventRFBunch_Hypo = NULL;
 		locChargedHypo->GetSingle(locEventRFBunch_Hypo);
@@ -1141,93 +1176,50 @@ vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses(J
 			locChargedHyposToSave.push_back(locHypoPair.second);
 	}
 
-	//Register array indices (by DTrackTimeBased)
-	for(size_t loc_i = 0; loc_i < locChargedHyposToSave.size(); ++loc_i)
-	{
-		const DTrackTimeBased* locTrackTimeBased = NULL;
-		locChargedHyposToSave[loc_i]->GetSingle(locTrackTimeBased);
-		locObjectToArrayIndexMap[locTrackTimeBased->id] = loc_i;
-	}
-
 	return locChargedHyposToSave;
 }
 
-vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses_Used(JEventLoop* locEventLoop, deque<const DParticleCombo*>& locParticleCombos, map<oid_t, int>& locObjectToArrayIndexMap) const
+vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses_Used(JEventLoop* locEventLoop, const deque<const DParticleCombo*>& locParticleCombos) const
 {
-	set<const DChargedTrackHypothesis*> locFoundHypos;
+	//get all hypos
+	vector<const DChargedTrackHypothesis*> locAllHypos = Get_ChargedHypotheses(locEventLoop);
+
+	//get used time-based tracks
+	set<const DTrackTimeBased*> locUsedTimeBasedTracks;
 	for(auto locCombo : locParticleCombos)
 	{
 		deque<const DKinematicData*> locChargedParticles;
 		locCombo->Get_DetectedFinalChargedParticles_Measured(locChargedParticles);
 
 		for(auto locParticle : locChargedParticles)
-			locFoundHypos.insert(static_cast<const DChargedTrackHypothesis*>(locParticle));
-	}
-
-	const DEventRFBunch* locEventRFBunch = NULL;
-	locEventLoop->GetSingle(locEventRFBunch);
-
-	//Search for hypotheses with PIDs that were needed for the DReaction but that weren't reconstructed:
-	map<const DChargedTrack*, map<Particle_t, const DChargedTrackHypothesis*> > locNewChargedHypothesesMap;
-
-	//hypos not-findable in PreSelect, but not saved either //not saved: different RF time than main, or #-votes different
-	set<const DChargedTrackHypothesis*> locUnsavedNonPreselectHypotheses;
-
-	vector<const DChargedTrackHypothesis*> locIndependentChargedTrackHypotheses;
-	set<const DChargedTrackHypothesis*> locSavedHypos;
-	for(auto locChargedHypo : locFoundHypos)
-	{
-		Particle_t locPID = locChargedHypo->PID();
-		const DChargedTrackHypothesis* locOrigChargedTrackHypothesis = NULL;
-		locChargedHypo->GetSingle(locOrigChargedTrackHypothesis);
-
-		//see if PID in REST file
-		if(locOrigChargedTrackHypothesis != NULL)
 		{
-			//yes, save this (if not already)
-			if(locSavedHypos.find(locOrigChargedTrackHypothesis) != locSavedHypos.end())
-				continue;
-			locIndependentChargedTrackHypotheses.push_back(locOrigChargedTrackHypothesis);
-			locSavedHypos.insert(locOrigChargedTrackHypothesis);
-			locObjectToArrayIndexMap[locOrigChargedTrackHypothesis->id] = locIndependentChargedTrackHypotheses.size() - 1;
-			continue;
+			const DTrackTimeBased* locTrackTimeBased = NULL;
+			locParticle->GetSingle(locTrackTimeBased);
+			locUsedTimeBasedTracks.insert(locTrackTimeBased);
 		}
-
-		//Get original DChargedTrack
-		const DChargedTrack* locOrigChargedTrack = NULL;
-		locChargedHypo->GetSingle(locOrigChargedTrack);
-
-		//Of these hypos, choose only one: can be multiple (different #-votes): Make sure haven't saved one already
-		map<Particle_t, const DChargedTrackHypothesis*>& locNewChargedHyposPIDMap = locNewChargedHypothesesMap[locOrigChargedTrack];
-		if(locNewChargedHyposPIDMap.find(locPID) != locNewChargedHyposPIDMap.end())
-		{
-			locUnsavedNonPreselectHypotheses.insert(locChargedHypo);
-			continue; //already found for this PID //different #-votes
-		}
-
-		//unique! save!
-		locNewChargedHyposPIDMap[locPID] = locChargedHypo;
-		locIndependentChargedTrackHypotheses.push_back(locChargedHypo);
-		locSavedHypos.insert(locChargedHypo);
-		locObjectToArrayIndexMap[locChargedHypo->id] = locIndependentChargedTrackHypotheses.size() - 1;
 	}
 
-	//Register array indices for the not-directly-saved hypos (point to other saved ones)
-	set<const DChargedTrackHypothesis*>::iterator locSetIterator = locUnsavedNonPreselectHypotheses.begin();
-	for(; locSetIterator != locUnsavedNonPreselectHypotheses.end(); ++locSetIterator)
+	//loop through "all" hypos, removing those that weren't used
+	for(auto locIterator = locAllHypos.begin(); locIterator != locAllHypos.end();)
 	{
-		const DChargedTrack* locOrigChargedTrack = NULL;
-		(*locSetIterator)->GetSingle(locOrigChargedTrack);
-		oid_t locSourceID = locNewChargedHypothesesMap[locOrigChargedTrack][(*locSetIterator)->PID()]->id;
-		locObjectToArrayIndexMap[(*locSetIterator)->id] = locObjectToArrayIndexMap[locSourceID];
+		const DTrackTimeBased* locTrackTimeBased = NULL;
+		(*locIterator)->GetSingle(locTrackTimeBased);
+
+		if(locUsedTimeBasedTracks.find(locTrackTimeBased) != locUsedTimeBasedTracks.end())
+			++locIterator;
+		else
+		   locIterator = locAllHypos.erase(locIterator); 
 	}
 
-	return locIndependentChargedTrackHypotheses;
+	return locAllHypos;
 }
 
-vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs, map<oid_t, int>& locObjectToArrayIndexMap) const
+vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs) const
 {
-	//Want to save all "PreSelect" hypotheses to the tree, plus hypos from PIDs that were reconstructed later
+	//For default/preselect, save all
+	//For combo, of new PIDs ONLY, save one of each for each shower
+		//save the one with the same RF bunch as the common bunch
+
 	vector<const DNeutralParticle*> locNeutralParticles;
 	locEventLoop->Get(locNeutralParticles, dShowerSelectionTag.c_str());
 
@@ -1237,151 +1229,90 @@ vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypothese
 	const DEventRFBunch* locEventRFBunch = NULL;
 	locEventLoop->GetSingle(locEventRFBunch);
 
-	//Search for hypotheses with PIDs that were needed for the DReaction but that weren't reconstructed:
-	map<const DNeutralParticle*, map<Particle_t, const DNeutralParticleHypothesis*> > locNewNeutralHypothesesMap;
-
-	//hypos not-findable in PreSelect, but not saved either //not saved: different RF time than main, or #-votes different
-	set<const DNeutralParticleHypothesis*> locUnsavedNonPreselectHypotheses;
-	for(size_t loc_i = 0; loc_i < locComboNeutralParticleHypotheses.size(); ++loc_i)
+	//Find which PIDs were used for basic recon
+	set<Particle_t> locReconPIDs; 
+	for(auto locNeutralParticle : locNeutralParticles)
 	{
-		Particle_t locPID = locComboNeutralParticleHypotheses[loc_i]->PID();
+		for(auto locNeutralHypo : locNeutralParticle->dNeutralParticleHypotheses)
+			locReconPIDs.insert(locNeutralHypo->Get_PID());
+	}
+
+	//comb through combo hypos for the ones we actually need: non-recon PIDs (with the right RF bunch)
+	map<const DNeutralParticle*, map<Particle_t, const DNeutralParticleHypothesis*> > locNewNeutralHypothesesMap;
+	for(auto locNeutralHypo : locComboNeutralParticleHypotheses)
+	{
+		Particle_t locPID = locNeutralHypo->PID();
+		if(locReconPIDs.find(locPID) != locReconPIDs.end())
+			continue; //already have PID for this particle
 		if(locReactionPIDs.find(locPID) == locReactionPIDs.end())
 			continue; //PID not needed for this DReaction, don't bother
 
-		//find Neutral hypotheses not derived from the PreSelect factory
-		const DNeutralParticleHypothesis* locOrigNeutralParticleHypothesis = NULL;
-		locComboNeutralParticleHypotheses[loc_i]->GetSingle(locOrigNeutralParticleHypothesis);
-		if(locOrigNeutralParticleHypothesis != NULL)
-			continue; //PID in REST file
+		const DEventRFBunch* locEventRFBunch_Hypo = NULL;
+		locNeutralHypo->GetSingle(locEventRFBunch_Hypo);
 
-		//OK, this hypo must at least be registered in locObjectToArrayIndexMap
-
-		//Of these, choose the ones with the RF bunch time identical to the "main" one
-		const DEventRFBunch* locComboEventRFBunch = NULL;
-		locComboNeutralParticleHypotheses[loc_i]->GetSingle(locComboEventRFBunch);
-		if(fabs(locComboEventRFBunch->dTime - locEventRFBunch->dTime) > 0.01)
-		{
-			locUnsavedNonPreselectHypotheses.insert(locComboNeutralParticleHypotheses[loc_i]);
-			continue; //not the same one!
-		}
+		//Of the hypos with this PID, choose only one the one with the right RF time
+		if(fabs(locEventRFBunch_Hypo->dTime - locEventRFBunch->dTime) > 0.001)
+			continue;
 
 		//Get original DNeutralParticle
 		const DNeutralParticle* locOrigNeutralParticle = NULL;
-		locComboNeutralParticleHypotheses[loc_i]->GetSingle(locOrigNeutralParticle);
+		locNeutralHypo->GetSingle(locOrigNeutralParticle);
 
-		//Of these hypos, choose only one: can be multiple (different #-votes): Make sure haven't saved one already
+		//can be multiple of these (different #-votes): Make sure haven't saved one already
 		map<Particle_t, const DNeutralParticleHypothesis*>& locNewNeutralHyposPIDMap = locNewNeutralHypothesesMap[locOrigNeutralParticle];
-		if(locNewNeutralHyposPIDMap.find(locPID) != locNewNeutralHyposPIDMap.end())
-		{
-			locUnsavedNonPreselectHypotheses.insert(locComboNeutralParticleHypotheses[loc_i]);
-			continue; //already found for this PID //different #-votes
-		}
-
-		//unique! save!
-		locNewNeutralHyposPIDMap[locPID] = locComboNeutralParticleHypotheses[loc_i];
+		if(locNewNeutralHyposPIDMap.find(locPID) == locNewNeutralHyposPIDMap.end())
+			locNewNeutralHyposPIDMap[locPID] = locNeutralHypo;
 	}
 
-	//Build vector of combo-independent Neutral hypotheses to save
-	vector<const DNeutralParticleHypothesis*> locIndependentNeutralParticleHypotheses;
-	for(size_t loc_i = 0; loc_i < locNeutralParticles.size(); ++loc_i)
+	//Build vector of combo-independent neutral hypotheses to save
+	vector<const DNeutralParticleHypothesis*> locNeutralHyposToSave;
+	for(auto locNeutralParticle : locNeutralParticles)
 	{
-		const vector<const DNeutralParticleHypothesis*>& locParticleHypoVector = locNeutralParticles[loc_i]->dNeutralParticleHypotheses;
-		locIndependentNeutralParticleHypotheses.insert(locIndependentNeutralParticleHypotheses.end(), locParticleHypoVector.begin(), locParticleHypoVector.end());
+		//first the recon'd PIDs
+		auto& locNeutralHypos = locNeutralParticle->dNeutralParticleHypotheses;
+		locNeutralHyposToSave.insert(locNeutralHyposToSave.end(), locNeutralHypos.begin(), locNeutralHypos.end());
 
-		map<Particle_t, const DNeutralParticleHypothesis*>& locNewNeutralHyposPIDMap = locNewNeutralHypothesesMap[locNeutralParticles[loc_i]];
-		map<Particle_t, const DNeutralParticleHypothesis*>::iterator locMapIterator = locNewNeutralHyposPIDMap.begin();
-		for(; locMapIterator != locNewNeutralHyposPIDMap.end(); ++locMapIterator)
-			locIndependentNeutralParticleHypotheses.push_back(locMapIterator->second);
+		//then the new PIDs
+		for(auto locHypoPair : locNewNeutralHypothesesMap[locNeutralParticle])
+			locNeutralHyposToSave.push_back(locHypoPair.second);
 	}
 
-	//Register array indices for the main (directly-saved, measured) hypos
-	for(size_t loc_i = 0; loc_i < locIndependentNeutralParticleHypotheses.size(); ++loc_i)
-		locObjectToArrayIndexMap[locIndependentNeutralParticleHypotheses[loc_i]->id] = loc_i;
-
-	//Register array indices for the not-directly-saved hypos (point to other saved ones)
-	set<const DNeutralParticleHypothesis*>::iterator locSetIterator = locUnsavedNonPreselectHypotheses.begin();
-	for(; locSetIterator != locUnsavedNonPreselectHypotheses.end(); ++locSetIterator)
-	{
-		const DNeutralParticle* locOrigNeutralParticle = NULL;
-		(*locSetIterator)->GetSingle(locOrigNeutralParticle);
-		oid_t locSourceID = locNewNeutralHypothesesMap[locOrigNeutralParticle][(*locSetIterator)->PID()]->id;
-		locObjectToArrayIndexMap[(*locSetIterator)->id] = locObjectToArrayIndexMap[locSourceID];
-	}
-
-	return locIndependentNeutralParticleHypotheses;
+	return locNeutralHyposToSave;
 }
 
-vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypotheses_Used(JEventLoop* locEventLoop, deque<const DParticleCombo*>& locParticleCombos, map<oid_t, int>& locObjectToArrayIndexMap) const
+vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypotheses_Used(JEventLoop* locEventLoop, const deque<const DParticleCombo*>& locParticleCombos) const
 {
-	set<const DNeutralParticleHypothesis*> locFoundHypos;
+	//get all hypos
+	vector<const DNeutralParticleHypothesis*> locAllHypos = Get_NeutralHypotheses(locEventLoop);
+
+	//get used showers
+	set<const DNeutralShower*> locUsedNeutralShowers;
 	for(auto locCombo : locParticleCombos)
 	{
 		deque<const DKinematicData*> locNeutralParticles;
 		locCombo->Get_DetectedFinalNeutralParticles_Measured(locNeutralParticles);
 
 		for(auto locParticle : locNeutralParticles)
-			locFoundHypos.insert(static_cast<const DNeutralParticleHypothesis*>(locParticle));
-	}
-
-	const DEventRFBunch* locEventRFBunch = NULL;
-	locEventLoop->GetSingle(locEventRFBunch);
-
-	//Search for hypotheses with PIDs that were needed for the DReaction but that weren't reconstructed:
-	map<const DNeutralParticle*, map<Particle_t, const DNeutralParticleHypothesis*> > locNewNeutralHypothesesMap;
-
-	//hypos not-findable in PreSelect, but not saved either //not saved: different RF time than main, or #-votes different
-	set<const DNeutralParticleHypothesis*> locUnsavedNonPreselectHypotheses;
-
-	vector<const DNeutralParticleHypothesis*> locIndependentNeutralParticleHypotheses;
-	set<const DNeutralParticleHypothesis*> locSavedHypos;
-	for(auto locNeutralHypo : locFoundHypos)
-	{
-		Particle_t locPID = locNeutralHypo->PID();
-		const DNeutralParticleHypothesis* locOrigNeutralParticleHypothesis = NULL;
-		locNeutralHypo->GetSingle(locOrigNeutralParticleHypothesis);
-
-		//see if PID in REST file
-		if(locOrigNeutralParticleHypothesis != NULL)
 		{
-			//yes, save this (if not already)
-			if(locSavedHypos.find(locOrigNeutralParticleHypothesis) != locSavedHypos.end())
-				continue;
-			locIndependentNeutralParticleHypotheses.push_back(locOrigNeutralParticleHypothesis);
-			locSavedHypos.insert(locOrigNeutralParticleHypothesis);
-			locObjectToArrayIndexMap[locOrigNeutralParticleHypothesis->id] = locIndependentNeutralParticleHypotheses.size() - 1;
-			continue;
+			const DNeutralShower* locNeutralShower = NULL;
+			locParticle->GetSingle(locNeutralShower);
+			locUsedNeutralShowers.insert(locNeutralShower);
 		}
-
-		//Get original DNeutralParticle
-		const DNeutralParticle* locOrigNeutralParticle = NULL;
-		locNeutralHypo->GetSingle(locOrigNeutralParticle);
-
-		//Of these hypos, choose only one: can be multiple (different #-votes): Make sure haven't saved one already
-		map<Particle_t, const DNeutralParticleHypothesis*>& locNewNeutralHyposPIDMap = locNewNeutralHypothesesMap[locOrigNeutralParticle];
-		if(locNewNeutralHyposPIDMap.find(locPID) != locNewNeutralHyposPIDMap.end())
-		{
-			locUnsavedNonPreselectHypotheses.insert(locNeutralHypo);
-			continue; //already found for this PID //different #-votes
-		}
-
-		//unique! save!
-		locNewNeutralHyposPIDMap[locPID] = locNeutralHypo;
-		locIndependentNeutralParticleHypotheses.push_back(locNeutralHypo);
-		locSavedHypos.insert(locNeutralHypo);
-		locObjectToArrayIndexMap[locNeutralHypo->id] = locIndependentNeutralParticleHypotheses.size() - 1;
 	}
 
-	//Register array indices for the not-directly-saved hypos (point to other saved ones)
-	set<const DNeutralParticleHypothesis*>::iterator locSetIterator = locUnsavedNonPreselectHypotheses.begin();
-	for(; locSetIterator != locUnsavedNonPreselectHypotheses.end(); ++locSetIterator)
+	//loop through "all" hypos, removing those that weren't used
+	for(auto locIterator = locAllHypos.begin(); locIterator != locAllHypos.end();)
 	{
-		const DNeutralParticle* locOrigNeutralParticle = NULL;
-		(*locSetIterator)->GetSingle(locOrigNeutralParticle);
-		oid_t locSourceID = locNewNeutralHypothesesMap[locOrigNeutralParticle][(*locSetIterator)->PID()]->id;
-		locObjectToArrayIndexMap[(*locSetIterator)->id] = locObjectToArrayIndexMap[locSourceID];
+		const DNeutralShower* locNeutralShower = NULL;
+		(*locIterator)->GetSingle(locNeutralShower);
+
+		if(locUsedNeutralShowers.find(locNeutralShower) != locUsedNeutralShowers.end())
+			++locIterator;
+		else
+		   locIterator = locAllHypos.erase(locIterator); 
 	}
 
-	return locIndependentNeutralParticleHypotheses;
+	return locAllHypos;
 }
 
 ULong64_t DEventWriterROOT::Calc_ParticleMultiplexID(Particle_t locPID) const
@@ -1450,13 +1381,7 @@ void DEventWriterROOT::Group_ThrownParticles(const vector<const DMCThrown*>& loc
 		locThrownIndexMap[locMCThrownsToSave[loc_i]] = loc_i;
 }
 
-void DEventWriterROOT::Fill_ThrownInfo(DTreeFillData* locTreeFillData, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying) const
-{
-	map<string, map<oid_t, int> > locObjectToArrayIndexMap;
-	Fill_ThrownInfo(locTreeFillData, locMCReaction, locMCThrowns, locThrownIndexMap, locNumPIDThrown_FinalState, locPIDThrown_Decaying, NULL, locObjectToArrayIndexMap);
-}
-
-void DEventWriterROOT::Fill_ThrownInfo(DTreeFillData* locTreeFillData, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying, const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const
+void DEventWriterROOT::Fill_ThrownInfo(DTreeFillData* locTreeFillData, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying, const DMCThrownMatching* locMCThrownMatching) const
 {
 	//THIS MUST BE CALLED FROM WITHIN A LOCK, SO DO NOT PASS IN JEVENTLOOP! //TOO TEMPTING TO DO SOMETHING BAD
 
@@ -1477,14 +1402,14 @@ void DEventWriterROOT::Fill_ThrownInfo(DTreeFillData* locTreeFillData, const DMC
 	//THROWN PRODUCTS
 	locTreeFillData->Fill_Single<UInt_t>("NumThrown", locMCThrowns.size());
 	for(size_t loc_i = 0; loc_i < locMCThrowns.size(); ++loc_i)
-		Fill_ThrownParticleData(locTreeFillData, loc_i, locMCThrowns[loc_i], locThrownIndexMap, locMCThrownMatching, locObjectToArrayIndexMap);
+		Fill_ThrownParticleData(locTreeFillData, loc_i, locMCThrowns[loc_i], locThrownIndexMap, locMCThrownMatching);
 
 	//PID INFO
 	locTreeFillData->Fill_Single<ULong64_t>("NumPIDThrown_FinalState", locNumPIDThrown_FinalState);
 	locTreeFillData->Fill_Single<ULong64_t>("PIDThrown_Decaying", locPIDThrown_Decaying);
 }
 
-void DEventWriterROOT::Fill_ThrownParticleData(DTreeFillData* locTreeFillData, unsigned int locArrayIndex, const DMCThrown* locMCThrown, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const
+void DEventWriterROOT::Fill_ThrownParticleData(DTreeFillData* locTreeFillData, unsigned int locArrayIndex, const DMCThrown* locMCThrown, const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DMCThrownMatching* locMCThrownMatching) const
 {
 	string locParticleBranchName = "Thrown";
 
@@ -1745,7 +1670,7 @@ void DEventWriterROOT::Fill_NeutralHypo(DTreeFillData* locTreeFillData, unsigned
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "PhotonRFDeltaTVar"), locPhotonRFDeltaTVar, locArrayIndex);
 }
 
-void DEventWriterROOT::Fill_ComboData(DTreeFillData* locTreeFillData, const DParticleCombo* locParticleCombo, unsigned int locComboIndex, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const
+void DEventWriterROOT::Fill_ComboData(DTreeFillData* locTreeFillData, const DParticleCombo* locParticleCombo, unsigned int locComboIndex, const map<pair<oid_t, Particle_t>, size_t>& locObjectToArrayIndexMap) const
 {
 	//MAIN CLASSES
 	const DReaction* locReaction = locParticleCombo->Get_Reaction();
@@ -1788,7 +1713,7 @@ void DEventWriterROOT::Fill_ComboData(DTreeFillData* locTreeFillData, const DPar
 		Fill_ComboStepData(locTreeFillData, locParticleCombo, loc_i, locComboIndex, locKinFitType, locObjectToArrayIndexMap);
 }
 
-void DEventWriterROOT::Fill_ComboStepData(DTreeFillData* locTreeFillData, const DParticleCombo* locParticleCombo, unsigned int locStepIndex, unsigned int locComboIndex, DKinFitType locKinFitType, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const
+void DEventWriterROOT::Fill_ComboStepData(DTreeFillData* locTreeFillData, const DParticleCombo* locParticleCombo, unsigned int locStepIndex, unsigned int locComboIndex, DKinFitType locKinFitType, const map<pair<oid_t, Particle_t>, size_t>& locObjectToArrayIndexMap) const
 {
 	const DReaction* locReaction = locParticleCombo->Get_Reaction();
 	const TList* locUserInfo = dTreeInterfaceMap.find(locReaction)->second->Get_UserInfo();
@@ -1806,7 +1731,11 @@ void DEventWriterROOT::Fill_ComboStepData(DTreeFillData* locTreeFillData, const 
 	{
 		const DKinematicData* locInitParticleMeasured = locParticleComboStep->Get_InitialParticle_Measured();
 		const DBeamPhoton* locMeasuredBeamPhoton = dynamic_cast<const DBeamPhoton*>(locInitParticleMeasured);
-		int locBeamIndex = locObjectToArrayIndexMap.find("DBeamPhoton")->second.find(locMeasuredBeamPhoton->id)->second;
+
+		//get array index
+		pair<oid_t, Particle_t> locBeamPair(locMeasuredBeamPhoton->id, locMeasuredBeamPhoton->PID())
+		size_t locBeamIndex = locObjectToArrayIndexMap.find(locBeamPair)->second;
+
 		Fill_ComboBeamData(locTreeFillData, locComboIndex, locBeamPhoton, locBeamIndex, locKinFitType);
 	}
 	else //decaying
@@ -1879,16 +1808,11 @@ void DEventWriterROOT::Fill_ComboStepData(DTreeFillData* locTreeFillData, const 
 			const DNeutralParticleHypothesis* locNeutralHypo = dynamic_cast<const DNeutralParticleHypothesis*>(locKinematicData);
 			const DNeutralParticleHypothesis* locMeasuredNeutralHypo = dynamic_cast<const DNeutralParticleHypothesis*>(locKinematicData_Measured);
 
-			//find "NeutralIndex" //map contains PreSelect object if exists, else combo object
-			const map<oid_t, int>& locObjectIDMap = locObjectToArrayIndexMap.find("DNeutralParticleHypothesis")->second;
-			map<oid_t, int>::const_iterator locIDMapIterator = locObjectIDMap.find(locMeasuredNeutralHypo->id); //check for Combo
-			if(locIDMapIterator == locObjectIDMap.end()) //not combo object: PreSelect
-			{
-				const DNeutralParticleHypothesis* locAssociatedNeutralHypo = NULL;
-				locMeasuredNeutralHypo->GetSingle(locAssociatedNeutralHypo);
-				locIDMapIterator = locObjectIDMap.find(locAssociatedNeutralHypo->id);
-			}
-			int locNeutralIndex = locIDMapIterator->second;
+			//get array index
+			const DNeutralShower* locNeutralShower = NULL;
+			locMeasuredNeutralHypo->GetSingle(locNeutralShower);
+			pair<oid_t, Particle_t> locNeutralPair(locNeutralShower->id, locMeasuredNeutralHypo->PID())
+			size_t locNeutralIndex = locObjectToArrayIndexMap.find(locNeutralPair)->second;
 
 			Fill_ComboNeutralData(locTreeFillData, locComboIndex, locParticleBranchName, locMeasuredNeutralHypo, locNeutralHypo, locNeutralIndex, locKinFitType);
 		}
@@ -1896,23 +1820,19 @@ void DEventWriterROOT::Fill_ComboStepData(DTreeFillData* locTreeFillData, const 
 		{
 			const DChargedTrackHypothesis* locChargedHypo = dynamic_cast<const DChargedTrackHypothesis*>(locKinematicData);
 			const DChargedTrackHypothesis* locMeasuredChargedHypo = dynamic_cast<const DChargedTrackHypothesis*>(locKinematicData_Measured);
-			//find "ChargedIndex" //map contains PreSelect object if exists, else combo object
-			const map<oid_t, int>& locObjectIDMap = locObjectToArrayIndexMap.find("DChargedTrackHypothesis")->second;
-			map<oid_t, int>::const_iterator locIDMapIterator = locObjectIDMap.find(locMeasuredChargedHypo->id); //check for Combo
-			if(locIDMapIterator == locObjectIDMap.end()) //not combo object: PreSelect
-			{
-				const DChargedTrackHypothesis* locAssociatedChargedHypo = NULL;
-				locMeasuredChargedHypo->GetSingle(locAssociatedChargedHypo);
-				locIDMapIterator = locObjectIDMap.find(locAssociatedChargedHypo->id);
-			}
-			int locChargedIndex = locIDMapIterator->second;
+
+			//get array index
+			const DTrackTimeBased* locTrackTimeBased = NULL;
+			locMeasuredChargedHypo->GetSingle(locTrackTimeBased);
+			pair<oid_t, Particle_t> locTrackPair(locTrackTimeBased->id, locMeasuredChargedHypo->PID())
+			size_t locChargedIndex = locObjectToArrayIndexMap.find(locMeasuredChargedHypo)->second;
 
 			Fill_ComboChargedData(locTreeFillData, locComboIndex, locParticleBranchName, locMeasuredChargedHypo, locChargedHypo, locChargedIndex, locKinFitType);
 		}
 	}
 }
 
-void DEventWriterROOT::Fill_ComboBeamData(DTreeFillData* locTreeFillData, unsigned int locComboIndex, const DBeamPhoton* locBeamPhoton, unsigned int locBeamIndex, DKinFitType locKinFitType) const
+void DEventWriterROOT::Fill_ComboBeamData(DTreeFillData* locTreeFillData, unsigned int locComboIndex, const DBeamPhoton* locBeamPhoton, size_t locBeamIndex, DKinFitType locKinFitType) const
 {
 	string locParticleBranchName = "ComboBeam";
 
@@ -1939,7 +1859,7 @@ void DEventWriterROOT::Fill_ComboBeamData(DTreeFillData* locTreeFillData, unsign
 	}
 }
 
-void DEventWriterROOT::Fill_ComboChargedData(DTreeFillData* locTreeFillData, unsigned int locComboIndex, string locParticleBranchName, const DChargedTrackHypothesis* locMeasuredChargedHypo, const DChargedTrackHypothesis* locChargedHypo, unsigned int locChargedIndex, DKinFitType locKinFitType) const
+void DEventWriterROOT::Fill_ComboChargedData(DTreeFillData* locTreeFillData, unsigned int locComboIndex, string locParticleBranchName, const DChargedTrackHypothesis* locMeasuredChargedHypo, const DChargedTrackHypothesis* locChargedHypo, size_t locChargedIndex, DKinFitType locKinFitType) const
 {
 	//IDENTIFIER
 	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ChargedIndex"), locChargedIndex, locComboIndex);
@@ -1973,7 +1893,7 @@ void DEventWriterROOT::Fill_ComboChargedData(DTreeFillData* locTreeFillData, uns
 	}
 }
 
-void DEventWriterROOT::Fill_ComboNeutralData(DTreeFillData* locTreeFillData, unsigned int locComboIndex, string locParticleBranchName, const DNeutralParticleHypothesis* locMeasuredNeutralHypo, const DNeutralParticleHypothesis* locNeutralHypo, unsigned int locNeutralIndex, DKinFitType locKinFitType) const
+void DEventWriterROOT::Fill_ComboNeutralData(DTreeFillData* locTreeFillData, unsigned int locComboIndex, string locParticleBranchName, const DNeutralParticleHypothesis* locMeasuredNeutralHypo, const DNeutralParticleHypothesis* locNeutralHypo, size_t locNeutralIndex, DKinFitType locKinFitType) const
 {
 	//IDENTIFIER
 	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "NeutralIndex"), locNeutralIndex, locComboIndex);
@@ -2017,4 +1937,4 @@ void DEventWriterROOT::Fill_ComboNeutralData(DTreeFillData* locTreeFillData, uns
 		locTreeFillData->Fill_Array<TLorentzVector>(Build_BranchName(locParticleBranchName, "P4_KinFit"), locP4_KinFit, locComboIndex);
 	}
 }
-
+(...)

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -746,16 +746,17 @@ void DEventWriterROOT::Create_Branches_ComboTrack(DTreeBranchRegister& locBranch
 	//IDENTIFIER
 	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ChargedIndex"), locArraySizeString, dInitNumComboArraySize);
 
+	//PID
+	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing"), locArraySizeString, dInitNumComboArraySize);
+	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing"), locArraySizeString, dInitNumComboArraySize);
+
 	//KINFIT INFO //at the production vertex
 	if(locKinFitType != d_NoFit)
 	{
+		//update p4 even if vertex-only fit, because charged momentum propagated through b-field
 		locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "P4_KinFit"), dInitNumComboArraySize);
 		if(locKinFitType != d_P4Fit)
-		{
 			locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "X4_KinFit"), dInitNumComboArraySize);
-			locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing_KinFit"), locArraySizeString, dInitNumComboArraySize);
-			locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing_KinFit"), locArraySizeString, dInitNumComboArraySize);
-		}
 	}
 }
 
@@ -1946,6 +1947,10 @@ void DEventWriterROOT::Fill_ComboChargedData(DTreeFillData* locTreeFillData, uns
 	//IDENTIFIER
 	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ChargedIndex"), locChargedIndex, locComboIndex);
 
+	//PID
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing"), locChargedHypo->measuredBeta(), locComboIndex);
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing"), locChargedHypo->dChiSq_Timing, locComboIndex);
+
 	//KINFIT
 	if(locKinFitType != d_NoFit)
 	{
@@ -1961,13 +1966,6 @@ void DEventWriterROOT::Fill_ComboChargedData(DTreeFillData* locTreeFillData, uns
 		DLorentzVector locDP4 = locChargedHypo->lorentzMomentum();
 		TLorentzVector locP4_KinFit(locDP4.Px(), locDP4.Py(), locDP4.Pz(), locDP4.E());
 		locTreeFillData->Fill_Array<TLorentzVector>(Build_BranchName(locParticleBranchName, "P4_KinFit"), locP4_KinFit, locComboIndex);
-
-		//PID INFO
-		if(locKinFitType != d_P4Fit)
-		{
-			locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing_KinFit"), locChargedHypo->measuredBeta(), locComboIndex);
-			locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing_KinFit"), locChargedHypo->dChiSq_Timing, locComboIndex);
-		}
 	}
 }
 

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -956,8 +956,8 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 	}
 	else
 	{
-		locChargedTrackHypotheses = Get_ChargedHypotheses_Used(locEventLoop, locParticleCombos);
-		locNeutralParticleHypotheses = Get_NeutralHypotheses_Used(locEventLoop, locParticleCombos);
+		locChargedTrackHypotheses = Get_ChargedHypotheses_Used(locEventLoop, locReactionPIDs, locParticleCombos);
+		locNeutralParticleHypotheses = Get_NeutralHypotheses_Used(locEventLoop, locReactionPIDs, locParticleCombos);
 	}
 
 	//GET BEAM PHOTONS
@@ -972,7 +972,7 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 	map<pair<oid_t, Particle_t>, size_t> locObjectToArrayIndexMap; //particle_t necessary for neutral showers!
 	for(size_t loc_i = 0; loc_i < locBeamPhotons.size(); ++loc_i)
 	{
-		pair<oid_t, Particle_t> locBeamPair(locBeamPhotons[loc_i]->id, locBeamPhotons[loc_i]->Get_PID());
+		pair<oid_t, Particle_t> locBeamPair(locBeamPhotons[loc_i]->id, locBeamPhotons[loc_i]->PID());
 		locObjectToArrayIndexMap[locBeamPair] = loc_i;
 	}
 
@@ -982,7 +982,7 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 		const DTrackTimeBased* locTrackTimeBased = NULL;
 		locChargedTrackHypotheses[loc_i]->GetSingle(locTrackTimeBased);
 
-		pair<oid_t, Particle_t> locTrackPair(locTrackTimeBased->id, locTrackTimeBased->Get_PID());
+		pair<oid_t, Particle_t> locTrackPair(locTrackTimeBased->id, locTrackTimeBased->PID());
 		locObjectToArrayIndexMap[locTrackPair] = loc_i;
 	}
 
@@ -992,7 +992,7 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 		const DNeutralShower* locNeutralShower = NULL;
 		locNeutralParticleHypotheses[loc_i]->GetSingle(locNeutralShower);
 
-		pair<oid_t, Particle_t> locShowerPair(locNeutralShower->id, locNeutralParticleHypotheses[loc_i]->Get_PID());
+		pair<oid_t, Particle_t> locShowerPair(locNeutralShower->id, locNeutralParticleHypotheses[loc_i]->PID());
 		locObjectToArrayIndexMap[locShowerPair] = loc_i;
 	}
 
@@ -1113,7 +1113,7 @@ vector<const DBeamPhoton*> DEventWriterROOT::Get_BeamPhotons(const deque<const D
 	return locBeamPhotons;
 }
 
-vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs) const
+vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses(JEventLoop* locEventLoop, const set<Particle_t>& locReactionPIDs) const
 {
 	//For default/preselect, save all
 	//For combo, of new PIDs ONLY, save one of each for each track
@@ -1133,7 +1133,7 @@ vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses(J
 	for(auto locChargedTrack : locChargedTracks)
 	{
 		for(auto locChargedHypo : locChargedTrack->dChargedTrackHypotheses)
-			locReconPIDs.insert(locChargedHypo->Get_PID());
+			locReconPIDs.insert(locChargedHypo->PID());
 	}
 
 	//comb through combo hypos for the ones we actually need: non-recon PIDs (with the right RF bunch)
@@ -1179,10 +1179,10 @@ vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses(J
 	return locChargedHyposToSave;
 }
 
-vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses_Used(JEventLoop* locEventLoop, const deque<const DParticleCombo*>& locParticleCombos) const
+vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses_Used(JEventLoop* locEventLoop, const set<Particle_t>& locReactionPIDs, const deque<const DParticleCombo*>& locParticleCombos) const
 {
 	//get all hypos
-	vector<const DChargedTrackHypothesis*> locAllHypos = Get_ChargedHypotheses(locEventLoop);
+	vector<const DChargedTrackHypothesis*> locAllHypos = Get_ChargedHypotheses(locEventLoop, locReactionPIDs);
 
 	//get used time-based tracks
 	set<const DTrackTimeBased*> locUsedTimeBasedTracks;
@@ -1214,7 +1214,7 @@ vector<const DChargedTrackHypothesis*> DEventWriterROOT::Get_ChargedHypotheses_U
 	return locAllHypos;
 }
 
-vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs) const
+vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypotheses(JEventLoop* locEventLoop, const set<Particle_t>& locReactionPIDs) const
 {
 	//For default/preselect, save all
 	//For combo, of new PIDs ONLY, save one of each for each shower
@@ -1234,7 +1234,7 @@ vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypothese
 	for(auto locNeutralParticle : locNeutralParticles)
 	{
 		for(auto locNeutralHypo : locNeutralParticle->dNeutralParticleHypotheses)
-			locReconPIDs.insert(locNeutralHypo->Get_PID());
+			locReconPIDs.insert(locNeutralHypo->PID());
 	}
 
 	//comb through combo hypos for the ones we actually need: non-recon PIDs (with the right RF bunch)
@@ -1280,10 +1280,10 @@ vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypothese
 	return locNeutralHyposToSave;
 }
 
-vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypotheses_Used(JEventLoop* locEventLoop, const deque<const DParticleCombo*>& locParticleCombos) const
+vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypotheses_Used(JEventLoop* locEventLoop, const set<Particle_t>& locReactionPIDs, const deque<const DParticleCombo*>& locParticleCombos) const
 {
 	//get all hypos
-	vector<const DNeutralParticleHypothesis*> locAllHypos = Get_NeutralHypotheses(locEventLoop);
+	vector<const DNeutralParticleHypothesis*> locAllHypos = Get_NeutralHypotheses(locEventLoop, locReactionPIDs);
 
 	//get used showers
 	set<const DNeutralShower*> locUsedNeutralShowers;
@@ -1733,7 +1733,7 @@ void DEventWriterROOT::Fill_ComboStepData(DTreeFillData* locTreeFillData, const 
 		const DBeamPhoton* locMeasuredBeamPhoton = dynamic_cast<const DBeamPhoton*>(locInitParticleMeasured);
 
 		//get array index
-		pair<oid_t, Particle_t> locBeamPair(locMeasuredBeamPhoton->id, locMeasuredBeamPhoton->PID())
+		pair<oid_t, Particle_t> locBeamPair(locMeasuredBeamPhoton->id, locMeasuredBeamPhoton->PID());
 		size_t locBeamIndex = locObjectToArrayIndexMap.find(locBeamPair)->second;
 
 		Fill_ComboBeamData(locTreeFillData, locComboIndex, locBeamPhoton, locBeamIndex, locKinFitType);
@@ -1811,7 +1811,7 @@ void DEventWriterROOT::Fill_ComboStepData(DTreeFillData* locTreeFillData, const 
 			//get array index
 			const DNeutralShower* locNeutralShower = NULL;
 			locMeasuredNeutralHypo->GetSingle(locNeutralShower);
-			pair<oid_t, Particle_t> locNeutralPair(locNeutralShower->id, locMeasuredNeutralHypo->PID())
+			pair<oid_t, Particle_t> locNeutralPair(locNeutralShower->id, locMeasuredNeutralHypo->PID());
 			size_t locNeutralIndex = locObjectToArrayIndexMap.find(locNeutralPair)->second;
 
 			Fill_ComboNeutralData(locTreeFillData, locComboIndex, locParticleBranchName, locMeasuredNeutralHypo, locNeutralHypo, locNeutralIndex, locKinFitType);
@@ -1824,7 +1824,7 @@ void DEventWriterROOT::Fill_ComboStepData(DTreeFillData* locTreeFillData, const 
 			//get array index
 			const DTrackTimeBased* locTrackTimeBased = NULL;
 			locMeasuredChargedHypo->GetSingle(locTrackTimeBased);
-			pair<oid_t, Particle_t> locTrackPair(locTrackTimeBased->id, locMeasuredChargedHypo->PID())
+			pair<oid_t, Particle_t> locTrackPair(locTrackTimeBased->id, locMeasuredChargedHypo->PID());
 			size_t locChargedIndex = locObjectToArrayIndexMap.find(locMeasuredChargedHypo)->second;
 
 			Fill_ComboChargedData(locTreeFillData, locComboIndex, locParticleBranchName, locMeasuredChargedHypo, locChargedHypo, locChargedIndex, locKinFitType);
@@ -1937,4 +1937,4 @@ void DEventWriterROOT::Fill_ComboNeutralData(DTreeFillData* locTreeFillData, uns
 		locTreeFillData->Fill_Array<TLorentzVector>(Build_BranchName(locParticleBranchName, "P4_KinFit"), locP4_KinFit, locComboIndex);
 	}
 }
-(...)
+

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -1286,7 +1286,7 @@ vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypothese
 	vector<const DNeutralParticleHypothesis*> locAllHypos = Get_NeutralHypotheses(locEventLoop, locReactionPIDs);
 
 	//get used showers
-	set<const DNeutralShower*> locUsedNeutralShowers;
+	set<pair<const DNeutralShower*, Particle_t> > locUsedNeutralShowers;
 	for(auto locCombo : locParticleCombos)
 	{
 		deque<const DKinematicData*> locNeutralParticles;
@@ -1296,7 +1296,9 @@ vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypothese
 		{
 			const DNeutralShower* locNeutralShower = NULL;
 			locParticle->GetSingle(locNeutralShower);
-			locUsedNeutralShowers.insert(locNeutralShower);
+
+			pair<const DNeutralShower*, Particle_t> locShowerPair(locNeutralShower, locParticle->PID());
+			locUsedNeutralShowers.insert(locShowerPair);
 		}
 	}
 
@@ -1305,11 +1307,12 @@ vector<const DNeutralParticleHypothesis*> DEventWriterROOT::Get_NeutralHypothese
 	{
 		const DNeutralShower* locNeutralShower = NULL;
 		(*locIterator)->GetSingle(locNeutralShower);
+		pair<const DNeutralShower*, Particle_t> locShowerPair(locNeutralShower, (*locIterator)->PID());
 
-		if(locUsedNeutralShowers.find(locNeutralShower) != locUsedNeutralShowers.end())
-			++locIterator;
+		if(locUsedNeutralShowers.find(locShowerPair) == locUsedNeutralShowers.end())
+		   locIterator = locAllHypos.erase(locIterator);
 		else
-		   locIterator = locAllHypos.erase(locIterator); 
+			++locIterator;
 	}
 
 	return locAllHypos;

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -746,9 +746,16 @@ void DEventWriterROOT::Create_Branches_ComboTrack(DTreeBranchRegister& locBranch
 	//IDENTIFIER
 	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ChargedIndex"), locArraySizeString, dInitNumComboArraySize);
 
-	//PID
-	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing"), locArraySizeString, dInitNumComboArraySize);
-	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing"), locArraySizeString, dInitNumComboArraySize);
+	//MEASURED PID
+	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing_Measured"), locArraySizeString, dInitNumComboArraySize);
+	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing_Measured"), locArraySizeString, dInitNumComboArraySize);
+
+	//KINFIT PID
+	if((locKinFitType != d_NoFit) && (locKinFitType != d_SpacetimeFit) && (locKinFitType != d_P4AndSpacetimeFit))
+	{
+		locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing_KinFit"), locArraySizeString, dInitNumComboArraySize);
+		locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing_KinFit"), locArraySizeString, dInitNumComboArraySize);
+	}
 
 	//KINFIT INFO //at the production vertex
 	if(locKinFitType != d_NoFit)
@@ -771,22 +778,25 @@ void DEventWriterROOT::Create_Branches_ComboNeutral(DTreeBranchRegister& locBran
 	locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "X4_Measured"), dInitNumComboArraySize);
 	locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "P4_Measured"), dInitNumComboArraySize);
 
-	//PID QUALITY
+	//MEASURED PID
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing_Measured"), locArraySizeString, dInitNumComboArraySize);
 	if(locParticleBranchName.substr(0, 6) == "Photon")
 		locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing_Measured"), locArraySizeString, dInitNumComboArraySize);
+
+	//KINFIT PID
+	if((locKinFitType != d_NoFit) && (locKinFitType != d_SpacetimeFit) && (locKinFitType != d_P4AndSpacetimeFit))
+	{
+		locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing_KinFit"), locArraySizeString, dInitNumComboArraySize);
+		if(locParticleBranchName.substr(0, 6) == "Photon")
+			locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing_KinFit"), locArraySizeString, dInitNumComboArraySize);
+	}
 
 	//KINFIT INFO //at the production vertex
 	if(locKinFitType != d_NoFit)
 	{
 		locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "P4_KinFit"), dInitNumComboArraySize);
 		if(locKinFitType != d_P4Fit)
-		{
 			locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "X4_KinFit"), dInitNumComboArraySize);
-			locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing_KinFit"), locArraySizeString, dInitNumComboArraySize);
-			if(locParticleBranchName.substr(0, 6) == "Photon")
-				locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing_KinFit"), locArraySizeString, dInitNumComboArraySize);
-		}
 	}
 }
 
@@ -1947,9 +1957,16 @@ void DEventWriterROOT::Fill_ComboChargedData(DTreeFillData* locTreeFillData, uns
 	//IDENTIFIER
 	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ChargedIndex"), locChargedIndex, locComboIndex);
 
-	//PID
-	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing"), locChargedHypo->measuredBeta(), locComboIndex);
-	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing"), locChargedHypo->dChiSq_Timing, locComboIndex);
+	//MEASURED PID
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing_Measured"), locMeasuredChargedHypo->measuredBeta(), locComboIndex);
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing_Measured"), locMeasuredChargedHypo->dChiSq_Timing, locComboIndex);
+
+	//KINFIT PID
+	if((locKinFitType != d_NoFit) && (locKinFitType != d_SpacetimeFit) && (locKinFitType != d_P4AndSpacetimeFit))
+	{
+		locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing_KinFit"), locChargedHypo->measuredBeta(), locComboIndex);
+		locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing_KinFit"), locChargedHypo->dChiSq_Timing, locComboIndex);
+	}
 
 	//KINFIT
 	if(locKinFitType != d_NoFit)
@@ -1988,6 +2005,14 @@ void DEventWriterROOT::Fill_ComboNeutralData(DTreeFillData* locTreeFillData, uns
 	if(locParticleBranchName.substr(0, 6) == "Photon")
 		locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing_Measured"), locMeasuredNeutralHypo->dChiSq, locComboIndex);
 
+	//KINFIT PID INFO
+	if((locKinFitType != d_NoFit) && (locKinFitType != d_SpacetimeFit) && (locKinFitType != d_P4AndSpacetimeFit))
+	{
+		locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing_KinFit"), locNeutralHypo->measuredBeta(), locComboIndex);
+		if(locParticleBranchName.substr(0, 6) == "Photon")
+			locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing_KinFit"), locNeutralHypo->dChiSq, locComboIndex);
+	}
+
 	//KINFIT
 	if(locKinFitType != d_NoFit)
 	{
@@ -2003,13 +2028,6 @@ void DEventWriterROOT::Fill_ComboNeutralData(DTreeFillData* locTreeFillData, uns
 		DLorentzVector locDP4 = locNeutralHypo->lorentzMomentum();
 		TLorentzVector locP4_KinFit(locDP4.Px(), locDP4.Py(), locDP4.Pz(), locDP4.E());
 		locTreeFillData->Fill_Array<TLorentzVector>(Build_BranchName(locParticleBranchName, "P4_KinFit"), locP4_KinFit, locComboIndex);
-
-		//PID INFO
-		if(locKinFitType != d_P4Fit)
-		{
-			locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing_KinFit"), locNeutralHypo->measuredBeta(), locComboIndex);
-			if(locParticleBranchName.substr(0, 6) == "Photon")
-				locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing_KinFit"), locNeutralHypo->dChiSq, locComboIndex);
-		}
 	}
 }
+

--- a/src/libraries/ANALYSIS/DEventWriterROOT.h
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.h
@@ -136,18 +136,17 @@ class DEventWriterROOT : public JObject
 		void Group_ThrownParticles(const vector<const DMCThrown*>& locMCThrowns_FinalState, const vector<const DMCThrown*>& locMCThrowns_Decaying,
 				vector<const DMCThrown*>& locMCThrownsToSave, map<const DMCThrown*, unsigned int>& locThrownIndexMap) const;
 		void Fill_ThrownInfo(DTreeFillData* locTreeFillData, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns,
-				const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying) const;
-		void Fill_ThrownInfo(DTreeFillData* locTreeFillData, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns,
 				const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying,
-				const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const;
+				const DMCThrownMatching* locMCThrownMatching = NULL) const;
 		void Fill_ThrownParticleData(DTreeFillData* locTreeFillData, unsigned int locArrayIndex, const DMCThrown* locMCThrown, const map<const DMCThrown*, unsigned int>& locThrownIndexMap,
-				const DMCThrownMatching* locMCThrownMatching, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const;
+				const DMCThrownMatching* locMCThrownMatching, const map<pair<oid_t, Particle_t>, size_t>& locObjectToArrayIndexMap) const;
 
-		//TREE FILLING: GET HYPOTHESES
-		vector<const DChargedTrackHypothesis*> Get_ChargedHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs, map<oid_t, int>& locObjectToArrayIndexMap) const;
-		vector<const DChargedTrackHypothesis*> Get_ChargedHypotheses_Used(JEventLoop* locEventLoop, deque<const DParticleCombo*>& locParticleCombos, map<oid_t, int>& locObjectToArrayIndexMap) const;
-		vector<const DNeutralParticleHypothesis*> Get_NeutralHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs, map<oid_t, int>& locObjectToArrayIndexMap) const;
-		vector<const DNeutralParticleHypothesis*> Get_NeutralHypotheses_Used(JEventLoop* locEventLoop, deque<const DParticleCombo*>& locParticleCombos, map<oid_t, int>& locObjectToArrayIndexMap) const;
+		//TREE FILLING: GET HYPOTHESES/BEAM
+		vector<const DBeamPhoton*> Get_BeamPhotons(const deque<const DParticleCombo*>& locParticleCombos) const;
+		vector<const DChargedTrackHypothesis*> Get_ChargedHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs) const;
+		vector<const DChargedTrackHypothesis*> Get_ChargedHypotheses_Used(JEventLoop* locEventLoop, const deque<const DParticleCombo*>& locParticleCombos) const;
+		vector<const DNeutralParticleHypothesis*> Get_NeutralHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs) const;
+		vector<const DNeutralParticleHypothesis*> Get_NeutralHypotheses_Used(JEventLoop* locEventLoop, const deque<const DParticleCombo*>& locParticleCombos) const;
 
 		//TREE FILLING: INDEPENDENT PARTICLES
 		void Fill_BeamData(DTreeFillData* locTreeFillData, unsigned int locArrayIndex, const DBeamPhoton* locBeamPhoton, const DVertex* locVertex, const DMCThrownMatching* locMCThrownMatching) const;
@@ -157,16 +156,16 @@ class DEventWriterROOT : public JObject
 				const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DDetectorMatches* locDetectorMatches) const;
 
 		//TREE FILLING: COMBO
-		void Fill_ComboData(DTreeFillData* locTreeFillData, const DParticleCombo* locParticleCombo, unsigned int locComboIndex, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const;
+		void Fill_ComboData(DTreeFillData* locTreeFillData, const DParticleCombo* locParticleCombo, unsigned int locComboIndex, const map<pair<oid_t, Particle_t>, size_t>& locObjectToArrayIndexMap) const;
 		void Fill_ComboStepData(DTreeFillData* locTreeFillData, const DParticleCombo* locParticleCombo, unsigned int locStepIndex, unsigned int locComboIndex,
-				DKinFitType locKinFitType, const map<string, map<oid_t, int> >& locObjectToArrayIndexMap) const;
+				DKinFitType locKinFitType, const map<pair<oid_t, Particle_t>, size_t>& locObjectToArrayIndexMap) const;
 
 		//TREE FILLING: COMBO PARTICLES
-		void Fill_ComboBeamData(DTreeFillData* locTreeFillData, unsigned int locComboIndex, const DBeamPhoton* locBeamPhoton, unsigned int locBeamIndex, DKinFitType locKinFitType) const;
+		void Fill_ComboBeamData(DTreeFillData* locTreeFillData, unsigned int locComboIndex, const DBeamPhoton* locBeamPhoton, size_t locBeamIndex, DKinFitType locKinFitType) const;
 		void Fill_ComboChargedData(DTreeFillData* locTreeFillData, unsigned int locComboIndex, string locParticleBranchName, const DChargedTrackHypothesis* locMeasuredChargedHypo,
-				const DChargedTrackHypothesis* locChargedHypo, unsigned int locChargedIndex, DKinFitType locKinFitType) const;
+				const DChargedTrackHypothesis* locChargedHypo, size_t locChargedIndex, DKinFitType locKinFitType) const;
 		void Fill_ComboNeutralData(DTreeFillData* locTreeFillData, unsigned int locComboIndex, string locParticleBranchName, const DNeutralParticleHypothesis* locMeasuredNeutralHypo,
-				const DNeutralParticleHypothesis* locNeutralHypo, unsigned int locNeutralIndex, DKinFitType locKinFitType) const;
+				const DNeutralParticleHypothesis* locNeutralHypo, size_t locNeutralIndex, DKinFitType locKinFitType) const;
 };
 
 inline string DEventWriterROOT::Convert_ToBranchName(string locInputName) const

--- a/src/libraries/ANALYSIS/DEventWriterROOT.h
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.h
@@ -138,15 +138,15 @@ class DEventWriterROOT : public JObject
 		void Fill_ThrownInfo(DTreeFillData* locTreeFillData, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns,
 				const map<const DMCThrown*, unsigned int>& locThrownIndexMap, ULong64_t locNumPIDThrown_FinalState, ULong64_t locPIDThrown_Decaying,
 				const DMCThrownMatching* locMCThrownMatching = NULL) const;
-		void Fill_ThrownParticleData(DTreeFillData* locTreeFillData, unsigned int locArrayIndex, const DMCThrown* locMCThrown, const map<const DMCThrown*, unsigned int>& locThrownIndexMap,
-				const DMCThrownMatching* locMCThrownMatching, const map<pair<oid_t, Particle_t>, size_t>& locObjectToArrayIndexMap) const;
+		void Fill_ThrownParticleData(DTreeFillData* locTreeFillData, unsigned int locArrayIndex, const DMCThrown* locMCThrown, 
+				const map<const DMCThrown*, unsigned int>& locThrownIndexMap, const DMCThrownMatching* locMCThrownMatching) const;
 
 		//TREE FILLING: GET HYPOTHESES/BEAM
 		vector<const DBeamPhoton*> Get_BeamPhotons(const deque<const DParticleCombo*>& locParticleCombos) const;
-		vector<const DChargedTrackHypothesis*> Get_ChargedHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs) const;
-		vector<const DChargedTrackHypothesis*> Get_ChargedHypotheses_Used(JEventLoop* locEventLoop, const deque<const DParticleCombo*>& locParticleCombos) const;
-		vector<const DNeutralParticleHypothesis*> Get_NeutralHypotheses(JEventLoop* locEventLoop, set<Particle_t> locReactionPIDs) const;
-		vector<const DNeutralParticleHypothesis*> Get_NeutralHypotheses_Used(JEventLoop* locEventLoop, const deque<const DParticleCombo*>& locParticleCombos) const;
+		vector<const DChargedTrackHypothesis*> Get_ChargedHypotheses(JEventLoop* locEventLoop, const set<Particle_t>& locReactionPIDs) const;
+		vector<const DChargedTrackHypothesis*> Get_ChargedHypotheses_Used(JEventLoop* locEventLoop, const set<Particle_t>& locReactionPIDs, const deque<const DParticleCombo*>& locParticleCombos) const;
+		vector<const DNeutralParticleHypothesis*> Get_NeutralHypotheses(JEventLoop* locEventLoop, const set<Particle_t>& locReactionPIDs) const;
+		vector<const DNeutralParticleHypothesis*> Get_NeutralHypotheses_Used(JEventLoop* locEventLoop, const set<Particle_t>& locReactionPIDs, const deque<const DParticleCombo*>& locParticleCombos) const;
 
 		//TREE FILLING: INDEPENDENT PARTICLES
 		void Fill_BeamData(DTreeFillData* locTreeFillData, unsigned int locArrayIndex, const DBeamPhoton* locBeamPhoton, const DVertex* locVertex, const DMCThrownMatching* locMCThrownMatching) const;

--- a/src/libraries/ANALYSIS/DKinFitUtils_GlueX.cc
+++ b/src/libraries/ANALYSIS/DKinFitUtils_GlueX.cc
@@ -1081,7 +1081,7 @@ deque<set<pair<int, int> > > DKinFitUtils_GlueX::Predict_VertexConstraints(const
 	for(size_t loc_i = 0; loc_i < locAllVertices.size(); ++loc_i)
 	{
 		set<pair<int, int> > locFullConstrainParticles, locDecayingParticles, locOnlyConstrainTimeParticles, locNoConstrainParticles;
-		Group_VertexParticles(locReaction, locAllVertices[loc_i], locFullConstrainParticles, locDecayingParticles, locOnlyConstrainTimeParticles, locNoConstrainParticles);
+		Group_VertexParticles(locReaction, locSpacetimeFitFlag, locAllVertices[loc_i], locFullConstrainParticles, locDecayingParticles, locOnlyConstrainTimeParticles, locNoConstrainParticles);
 		locAllFullConstrainParticles.push_back(locFullConstrainParticles);
 		locAllDecayingParticles.push_back(locDecayingParticles);
 		locAllOnlyConstrainTimeParticles.push_back(locOnlyConstrainTimeParticles);
@@ -1140,10 +1140,8 @@ deque<set<pair<int, int> > > DKinFitUtils_GlueX::Predict_VertexConstraints(const
 			locNumConstraints += locAllOnlyConstrainTimeParticles[locConstraintIndex].size();
 		}
 		else //vertex only
-		{
-			locAllNoConstrainParticles[locConstraintIndex].insert(locAllOnlyConstrainTimeParticles[locConstraintIndex].begin(), locAllOnlyConstrainTimeParticles[locConstraintIndex].end());
 			locNumConstraints += 2*locAllFullConstrainParticles[locConstraintIndex].size();
-		}
+
 		locVertexParticles.insert(locAllFullConstrainParticles[locConstraintIndex].begin(), locAllFullConstrainParticles[locConstraintIndex].end());
 		locVertexParticles.insert(locAllNoConstrainParticles[locConstraintIndex].begin(), locAllNoConstrainParticles[locConstraintIndex].end());
 		locAllVertexParticles.push_back(locVertexParticles);
@@ -1188,7 +1186,7 @@ deque<set<pair<int, int> > > DKinFitUtils_GlueX::Predict_VertexConstraints(const
 	return locAllVertexParticles;
 }
 
-void DKinFitUtils_GlueX::Group_VertexParticles(const DReaction* locReaction, const set<pair<int, int> >& locVertexParticles, set<pair<int, int> >& locFullConstrainParticles, set<pair<int, int> >& locDecayingParticles, set<pair<int, int> >& locOnlyConstrainTimeParticles, set<pair<int, int> >& locNoConstrainParticles) const
+void DKinFitUtils_GlueX::Group_VertexParticles(const DReaction* locReaction, bool locSpacetimeFitFlag, const set<pair<int, int> >& locVertexParticles, set<pair<int, int> >& locFullConstrainParticles, set<pair<int, int> >& locDecayingParticles, set<pair<int, int> >& locOnlyConstrainTimeParticles, set<pair<int, int> >& locNoConstrainParticles) const
 {
 	//Decaying: Only those that can conceivably be used to constrain: All unless dLinkVerticesFlag disabled (then none)
 	locFullConstrainParticles.clear();
@@ -1225,7 +1223,12 @@ void DKinFitUtils_GlueX::Group_VertexParticles(const DReaction* locReaction, con
 		else if(locParticleIndex == locReactionStep->Get_MissingParticleIndex()) //missing
 			locNoConstrainParticles.insert(*locIterator);
 		else if(ParticleCharge(locReactionStep->Get_FinalParticleID(locParticleIndex)) == 0) //detected neutral
-			locOnlyConstrainTimeParticles.insert(*locIterator);
+		{
+			if(locSpacetimeFitFlag)
+				locOnlyConstrainTimeParticles.insert(*locIterator);
+			else
+				locNoConstrainParticles.insert(*locIterator);
+		}
 		else //detected charged
 			locFullConstrainParticles.insert(*locIterator);
 	}

--- a/src/libraries/ANALYSIS/DKinFitUtils_GlueX.h
+++ b/src/libraries/ANALYSIS/DKinFitUtils_GlueX.h
@@ -132,7 +132,7 @@ class DKinFitUtils_GlueX : public DKinFitUtils
 		void Setup_VertexPrediction(const DReaction* locReaction, size_t locStepIndex, set<pair<int, int> >& locVertexParticles, const map<pair<int, int>, int>& locDecayMap_ParticleToDecayStep, set<size_t>& locIncludedStepIndices) const;
 
 		deque<set<pair<int, int> > > Predict_VertexConstraints(const DReaction* locReaction, deque<set<pair<int, int> > > locAllVertices, bool locSpacetimeFitFlag, size_t& locNumConstraints, string& locAllConstraintString) const;
-		void Group_VertexParticles(const DReaction* locReaction, const set<pair<int, int> >& locVertexParticles, set<pair<int, int> >& locFullConstrainParticles, set<pair<int, int> >& locDecayingParticles, set<pair<int, int> >& locOnlyConstrainTimeParticles, set<pair<int, int> >& locNoConstrainParticles) const;
+		void Group_VertexParticles(const DReaction* locReaction, bool locSpacetimeFitFlag, const set<pair<int, int> >& locVertexParticles, set<pair<int, int> >& locFullConstrainParticles, set<pair<int, int> >& locDecayingParticles, set<pair<int, int> >& locOnlyConstrainTimeParticles, set<pair<int, int> >& locNoConstrainParticles) const;
 
 		/*************************************************************** NESTED CLASS ***************************************************************/
 

--- a/src/libraries/ANALYSIS/DNeutralParticleHypothesis_factory_KinFit.cc
+++ b/src/libraries/ANALYSIS/DNeutralParticleHypothesis_factory_KinFit.cc
@@ -103,7 +103,11 @@ DNeutralParticleHypothesis* DNeutralParticleHypothesis_factory_KinFit::Build_Neu
  	vector<const JObject*> locObjects;
 	locNeutralParticleHypothesis->GetT(locObjects);
 	for(size_t loc_i = 0; loc_i < locObjects.size(); ++loc_i)
+	{
+		if(dynamic_cast<const DNeutralParticleHypothesis*>(locObjects[loc_i]) != NULL)
+			continue; //don't save: won't be able to keep track of which is which! (combo or default factory)
 		locNewNeutralParticleHypothesis->AddAssociatedObject(locObjects[loc_i]);
+	}
 
 	locNewNeutralParticleHypothesis->setMomentum(DVector3(locKinFitParticle->Get_Momentum().X(),locKinFitParticle->Get_Momentum().Y(),locKinFitParticle->Get_Momentum().Z()));
 	locNewNeutralParticleHypothesis->setPosition(DVector3(locKinFitParticle->Get_CommonVertex().X(),locKinFitParticle->Get_CommonVertex().Y(),locKinFitParticle->Get_CommonVertex().Z()));

--- a/src/libraries/ANALYSIS/DNeutralParticleHypothesis_factory_KinFit.cc
+++ b/src/libraries/ANALYSIS/DNeutralParticleHypothesis_factory_KinFit.cc
@@ -133,6 +133,7 @@ DNeutralParticleHypothesis* DNeutralParticleHypothesis_factory_KinFit::Build_Neu
 	if(locNewNeutralParticleHypothesis->PID() == Gamma)
 	{
 		double locTimePull = 0.0;
+		//for this calc: if rf time part of timing constraint, don't use locKinFitParticle->Get_CommonTime() for chisq calc!!!
 		locChiSq = dParticleID->Calc_TimingChiSq(locNewNeutralParticleHypothesis, locNDF, locTimePull);
 		locFOM = TMath::Prob(locChiSq, locNDF);
 	}

--- a/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.cc
+++ b/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.cc
@@ -79,30 +79,6 @@ jerror_t DTrackTimeBased_factory_Combo::init(void)
 	locPIDDeque[0] = Proton;  locPIDDeque[1] = KPlus;  locPIDDeque[2] = PiPlus;
 	dParticleIDsToTry[Deuteron] = locPIDDeque;
 
-	vector<int> hypotheses;
-	hypotheses.push_back(PiPlus);
-	hypotheses.push_back(KPlus);
-	hypotheses.push_back(Proton);
-	hypotheses.push_back(PiMinus);
-	hypotheses.push_back(KMinus);
-
-	ostringstream locMassStream;
-	for(size_t loc_i = 0; loc_i < hypotheses.size(); ++loc_i)
-	{
-		locMassStream << hypotheses[loc_i];
-		if(loc_i != (hypotheses.size() - 1))
-			locMassStream << ",";
-	}
-
-	string HYPOTHESES = locMassStream.str();
-	gPARMS->SetDefaultParameter("TRKFIT:HYPOTHESES", HYPOTHESES);
-
-	// Parse MASS_HYPOTHESES strings to make list of masses to try
-	hypotheses.clear();
-	SplitString(HYPOTHESES, hypotheses, ",");
-	for(size_t loc_i = 0; loc_i < hypotheses.size(); ++loc_i)
-		dAvailablePIDs.insert(Particle_t(hypotheses[loc_i]));
-
 	return NOERROR;
 }
 
@@ -214,9 +190,6 @@ void DTrackTimeBased_factory_Combo::Create_PIDsAsNeeded(const DReaction* locReac
 		Particle_t locPID = *locIterator;
 		if(locChargedTrack->Get_Hypothesis(locPID) != NULL)
 			continue; //already exists
-
-		if(dAvailablePIDs.find(locPID) != dAvailablePIDs.end())
-			continue; //This PID was available: it must have been cut
 
 		const DChargedTrackHypothesis* locChargedTrackHypothesis = Get_ChargedHypothesisToUse(locChargedTrack, locPID);
 

--- a/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.h
+++ b/src/libraries/ANALYSIS/DTrackTimeBased_factory_Combo.h
@@ -62,7 +62,6 @@ class DTrackTimeBased_factory_Combo:public jana::JFactory<DTrackTimeBased>
 		map<const DReaction*, set<Particle_t> > dNegativelyChargedPIDs;
 
 		string dTrackSelectionTag;
-		set<Particle_t> dAvailablePIDs;
 
 		// PRE-DPARTICLECOMBO CUT VALUES
 			//(first) bool = true/false for cut enabled/disabled, double = cut value

--- a/src/libraries/PID/DChargedTrack_factory_PreSelect.cc
+++ b/src/libraries/PID/DChargedTrack_factory_PreSelect.cc
@@ -52,9 +52,9 @@ jerror_t DChargedTrack_factory_PreSelect::evnt(jana::JEventLoop *locEventLoop, u
 	{
 		for(auto locChargedHypo : locChargedTracks[loc_i]->dChargedTrackHypotheses)
 		{
-			if(Cut_TrackingFOM(locChargedHypo))
+			if(!Cut_TrackingFOM(locChargedHypo))
 				continue;
-			if(Cut_HasDetectorMatch(locChargedHypo, locDetectorMatches))
+			if(!Cut_HasDetectorMatch(locChargedHypo, locDetectorMatches))
 				continue;
 
 			_data.push_back(const_cast<DChargedTrack*>(locChargedTracks[loc_i])); //don't cut: copy it

--- a/src/libraries/PID/DChargedTrack_factory_PreSelect.cc
+++ b/src/libraries/PID/DChargedTrack_factory_PreSelect.cc
@@ -39,9 +39,6 @@ jerror_t DChargedTrack_factory_PreSelect::brun(jana::JEventLoop *locEventLoop, i
 jerror_t DChargedTrack_factory_PreSelect::evnt(jana::JEventLoop *locEventLoop, uint64_t eventnumber)
 {
 	//Clear objects from last event
-	for(size_t loc_i = 0; loc_i < dCreatedChargedTracks.size(); ++loc_i)
-		delete dCreatedChargedTracks[loc_i];
-	dCreatedChargedTracks.clear();
 	_data.clear();
 
 	vector<const DChargedTrack*> locChargedTracks;
@@ -53,32 +50,15 @@ jerror_t DChargedTrack_factory_PreSelect::evnt(jana::JEventLoop *locEventLoop, u
 	//cut on min-tracking-FOM and has-detector-match
 	for(size_t loc_i = 0; loc_i < locChargedTracks.size(); ++loc_i)
 	{
-		vector<const DChargedTrackHypothesis*> locHypotheses = locChargedTracks[loc_i]->dChargedTrackHypotheses;
-		vector<const DChargedTrackHypothesis*>::iterator locIterator = locHypotheses.begin();
-		while(locIterator != locHypotheses.end())
+		for(auto locChargedHypo : locChargedTracks[loc_i]->dChargedTrackHypotheses)
 		{
-			if(!Cut_TrackingFOM(*locIterator))
-			{
-				locIterator = locHypotheses.erase(locIterator);
+			if(Cut_TrackingFOM(locChargedHypo))
 				continue;
-			}
-			if(!Cut_HasDetectorMatch(*locIterator, locDetectorMatches))
-			{
-				locIterator = locHypotheses.erase(locIterator);
+			if(Cut_HasDetectorMatch(locChargedHypo, locDetectorMatches))
 				continue;
-			}
-			++locIterator;
-		}
 
-		//copy/create new objects as needed
-		if(locHypotheses.size() == locChargedTracks[loc_i]->dChargedTrackHypotheses.size())
-			_data.push_back(const_cast<DChargedTrack*>(locChargedTracks[loc_i])); //nothing was cut, just copy it
-		else if(!locHypotheses.empty())
-		{
-			DChargedTrack* locChargedTrack = new DChargedTrack();
-			locChargedTrack->dChargedTrackHypotheses = locHypotheses;
-			dCreatedChargedTracks.push_back(locChargedTrack);
-			_data.push_back(locChargedTrack);
+			_data.push_back(const_cast<DChargedTrack*>(locChargedTracks[loc_i])); //don't cut: copy it
+			break;
 		}
 	}
 
@@ -113,11 +93,6 @@ jerror_t DChargedTrack_factory_PreSelect::erun(void)
 //------------------
 jerror_t DChargedTrack_factory_PreSelect::fini(void)
 {
-	//Clear objects from last event
-	for(size_t loc_i = 0; loc_i < dCreatedChargedTracks.size(); ++loc_i)
-		delete dCreatedChargedTracks[loc_i];
 
 	return NOERROR;
 }
-
-

--- a/src/libraries/PID/DChargedTrack_factory_PreSelect.h
+++ b/src/libraries/PID/DChargedTrack_factory_PreSelect.h
@@ -33,8 +33,6 @@ class DChargedTrack_factory_PreSelect : public jana::JFactory<DChargedTrack>
 		bool Cut_HasDetectorMatch(const DChargedTrackHypothesis* locChargedTrackHypothesis, const DDetectorMatches* locDetectorMatches) const;
 		bool Cut_TrackingFOM(const DChargedTrackHypothesis* locChargedTrackHypothesis) const;
 
-		vector<const DChargedTrack*> dCreatedChargedTracks;
-
 		//Command-line values will override these
 		double dMinTrackingFOM; //PRESELECT:MIN_TRACKING_FOM 
 		bool dHasDetectorMatchFlag; //PRESELECT:HAS_DETECTOR_MATCH_FLAG: if true/false, do/don't require tracks to have a detector match

--- a/src/libraries/PID/DNeutralShower_factory_PreSelect.cc
+++ b/src/libraries/PID/DNeutralShower_factory_PreSelect.cc
@@ -29,7 +29,7 @@ jerror_t DNeutralShower_factory_PreSelect::init(void)
 jerror_t DNeutralShower_factory_PreSelect::brun(jana::JEventLoop *locEventLoop, int32_t runnumber)
 {
 	gPARMS->SetDefaultParameter("PRESELECT:MIN_FCAL_E", dMinFCALE);
-        gPARMS->SetDefaultParameter("PRESELECT:MIN_BCAL_E", dMinBCALE);
+	gPARMS->SetDefaultParameter("PRESELECT:MIN_BCAL_E", dMinBCALE);
 	gPARMS->SetDefaultParameter("PRESELECT:MIN_BCAL_NCELL", dMinBCALNcell);
 
 	return NOERROR;
@@ -47,19 +47,24 @@ jerror_t DNeutralShower_factory_PreSelect::evnt(jana::JEventLoop *locEventLoop, 
 	vector<const DNeutralShower*> locNeutralShowers;
 	locEventLoop->Get(locNeutralShowers);
 
-	//Just pass-through for now
-	for(size_t loc_i = 0; loc_i < locNeutralShowers.size(); ++loc_i) {
-		if(locNeutralShowers[loc_i]->dDetectorSystem == SYS_FCAL) {
+	//Cut on shower energy, BCAL cells
+	for(size_t loc_i = 0; loc_i < locNeutralShowers.size(); ++loc_i)
+	{
+		if(locNeutralShowers[loc_i]->dDetectorSystem == SYS_FCAL)
+		{
 			if(locNeutralShowers[loc_i]->dEnergy < dMinFCALE) 
 				continue;
 		}
-		else if(locNeutralShowers[loc_i]->dDetectorSystem == SYS_BCAL) {
-                        if(locNeutralShowers[loc_i]->dEnergy < dMinBCALE)
-                                continue;
+		else if(locNeutralShowers[loc_i]->dDetectorSystem == SYS_BCAL)
+		{
+			if(locNeutralShowers[loc_i]->dEnergy < dMinBCALE)
+				continue;
+
 			const DBCALShower* locBCALShower = NULL;
 			locNeutralShowers[loc_i]->GetSingleT(locBCALShower);
-			if(locBCALShower->N_cell < dMinBCALNcell) continue; 
-               }
+			if(locBCALShower->N_cell < dMinBCALNcell)
+				continue;
+		}
 
 		_data.push_back(const_cast<DNeutralShower*>(locNeutralShowers[loc_i]));
 	}
@@ -82,4 +87,3 @@ jerror_t DNeutralShower_factory_PreSelect::fini(void)
 {
 	return NOERROR;
 }
-

--- a/src/libraries/TRACKING/DTrackTimeBased_factory_THROWN.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory_THROWN.cc
@@ -102,7 +102,10 @@ jerror_t DTrackTimeBased_factory_THROWN::evnt(JEventLoop *loop, uint64_t eventnu
 		DTrackTimeBased *track = new DTrackTimeBased;
 		DKinematicData *kd_track = track;
 		*kd_track = *kd_thrown;
-		
+
+		// Set PID		
+      timebased_track->setPID(thrown->PID());
+
 		// Add DMCThrown as associated object
 		track->AddAssociatedObject(thrown);
 

--- a/src/libraries/TRACKING/DTrackTimeBased_factory_THROWN.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory_THROWN.cc
@@ -104,7 +104,7 @@ jerror_t DTrackTimeBased_factory_THROWN::evnt(JEventLoop *loop, uint64_t eventnu
 		*kd_track = *kd_thrown;
 
 		// Set PID		
-      timebased_track->setPID(thrown->PID());
+      track->setPID(thrown->PID());
 
 		// Add DMCThrown as associated object
 		track->AddAssociatedObject(thrown);


### PR DESCRIPTION
Before, if (e.g.) a given track with a given PID had 2 different RF beam bunches picked for it (in different combos), then BOTH of these hypos were saved separately to the "measured" hypo array. Now, only one is saved, and the PID info is in the combo-track section instead.  Same for neutrals.

Now, preselect track hypos are not rejected unless ALL hypos are rejected.

Fix time propagation calculation for kinfit.