### PR TITLE
Attempt of fix of overcounting of same-mass opposite-charged particles

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisUtilities.cc
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.cc
@@ -794,10 +794,9 @@ DLorentzVector DAnalysisUtilities::Calc_MissingP4(const DParticleCombo* locParti
 		//target particle
 		locKinematicData = locParticleComboStep->Get_TargetParticle();
 		if(locKinematicData != NULL)
-		{
-		  locSourceObjects.insert(pair<const JObject*, unsigned int>(locKinematicData, abs(PDGtype(locKinematicData->PID()))));
+		 {
 			locMissingP4 += locKinematicData->lorentzMomentum();
-		}
+		 }
 	}
 
 	deque<const DKinematicData*> locParticles;

--- a/src/libraries/ANALYSIS/DAnalysisUtilities.cc
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.cc
@@ -785,8 +785,8 @@ DLorentzVector DAnalysisUtilities::Calc_MissingP4(const DParticleCombo* locParti
 	if(locStepIndex == 0)
 	{
 		//initial particle
-		locKinematicData = locParticleComboStep->Get_InitialParticle_Measured();
-		locSourceObjects.insert(pair<const JObject*, Particle_t>(locKinematicData, locKinematicData->PID())); //want to use source objects for comparing
+	        locKinematicData = locParticleComboStep->Get_InitialParticle_Measured();
+		locSourceObjects.insert(pair<const JObject*, unsigned int>(locKinematicData, abs(PDGtype(locKinematicData->PID())))); //want to use source objects for comparing
 		if(locUseKinFitDataFlag) //kinfit
 			locKinematicData = locParticleComboStep->Get_InitialParticle();
 		locMissingP4 += locKinematicData->lorentzMomentum();
@@ -795,7 +795,7 @@ DLorentzVector DAnalysisUtilities::Calc_MissingP4(const DParticleCombo* locParti
 		locKinematicData = locParticleComboStep->Get_TargetParticle();
 		if(locKinematicData != NULL)
 		{
-		  locSourceObjects.insert(pair<const JObject*, Particle_t>(locKinematicData, locKinematicData->PID()));
+		  locSourceObjects.insert(pair<const JObject*, unsigned int>(locKinematicData, abs(PDGtype(locKinematicData->PID()))));
 			locMissingP4 += locKinematicData->lorentzMomentum();
 		}
 	}

--- a/src/libraries/ANALYSIS/DAnalysisUtilities.cc
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.cc
@@ -756,22 +756,22 @@ bool DAnalysisUtilities::Are_ThrownPIDsSameAsDesired(JEventLoop* locEventLoop, c
 
 DLorentzVector DAnalysisUtilities::Calc_MissingP4(const DParticleCombo* locParticleCombo, bool locUseKinFitDataFlag) const
 {
-	set<pair<const JObject*, Particle_t> > locSourceObjects;
+	set<pair<const JObject*, unsigned int> > locSourceObjects;
 	return Calc_MissingP4(locParticleCombo, 0, -1, set<size_t>(), locSourceObjects, locUseKinFitDataFlag);
 }
 
-DLorentzVector DAnalysisUtilities::Calc_MissingP4(const DParticleCombo* locParticleCombo, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const
+DLorentzVector DAnalysisUtilities::Calc_MissingP4(const DParticleCombo* locParticleCombo, set<pair<const JObject*, unsigned int> >& locSourceObjects, bool locUseKinFitDataFlag) const
 {
 	return Calc_MissingP4(locParticleCombo, 0, -1, set<size_t>(), locSourceObjects, locUseKinFitDataFlag);
 }
 
 DLorentzVector DAnalysisUtilities::Calc_MissingP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, int locUpToStepIndex, set<size_t> locUpThroughIndices, bool locUseKinFitDataFlag) const
 {
-	set<pair<const JObject*, Particle_t> > locSourceObjects;
+	set<pair<const JObject*, unsigned int> > locSourceObjects;
 	return Calc_MissingP4(locParticleCombo, locStepIndex, locUpToStepIndex, locUpThroughIndices, locSourceObjects, locUseKinFitDataFlag);
 }
 
-DLorentzVector DAnalysisUtilities::Calc_MissingP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, int locUpToStepIndex, set<size_t> locUpThroughIndices, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const
+DLorentzVector DAnalysisUtilities::Calc_MissingP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, int locUpToStepIndex, set<size_t> locUpThroughIndices, set<pair<const JObject*, unsigned int> >& locSourceObjects, bool locUseKinFitDataFlag) const
 {
 	//NOTE: this routine assumes that the p4 of a charged decaying particle with a detached vertex is the same at both vertices!
 	//assumes missing particle is not the beam particle
@@ -795,7 +795,7 @@ DLorentzVector DAnalysisUtilities::Calc_MissingP4(const DParticleCombo* locParti
 		locKinematicData = locParticleComboStep->Get_TargetParticle();
 		if(locKinematicData != NULL)
 		{
-			locSourceObjects.insert(pair<const JObject*, Particle_t>(locKinematicData, locKinematicData->PID()));
+		  locSourceObjects.insert(pair<const JObject*, Particle_t>(locKinematicData, locKinematicData->PID()));
 			locMissingP4 += locKinematicData->lorentzMomentum();
 		}
 	}
@@ -820,7 +820,7 @@ DLorentzVector DAnalysisUtilities::Calc_MissingP4(const DParticleCombo* locParti
 		if(locDecayStepIndex == -2) //detected
 		{
 			locMissingP4 -= locParticles[loc_j]->lorentzMomentum();
-			locSourceObjects.insert(pair<const JObject*, Particle_t>(locParticleComboStep->Get_FinalParticle_SourceObject(loc_j), locPID));
+			locSourceObjects.insert(pair<const JObject*, unsigned int>(locParticleComboStep->Get_FinalParticle_SourceObject(loc_j), abs(PDGtype(locPID))));
 		}
 		else //decaying-particle
 			locMissingP4 += Calc_MissingP4(locParticleCombo, locDecayStepIndex, locUpToStepIndex, locUpThroughIndices, locSourceObjects, locUseKinFitDataFlag); //p4 returned is already < 0
@@ -886,22 +886,22 @@ DMatrixDSym DAnalysisUtilities::Calc_MissingP3Covariance(const DParticleCombo* l
 
 DLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, bool locUseKinFitDataFlag) const
 {
-	set<pair<const JObject*, Particle_t> > locSourceObjects;
+	set<pair<const JObject*, unsigned int> > locSourceObjects;
 	return Calc_FinalStateP4(locParticleCombo, locStepIndex, set<size_t>(), locSourceObjects, locUseKinFitDataFlag);
 }
 
-DLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const
+DLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<pair<const JObject*, unsigned int> >& locSourceObjects, bool locUseKinFitDataFlag) const
 {
 	return Calc_FinalStateP4(locParticleCombo, locStepIndex, set<size_t>(), locSourceObjects, locUseKinFitDataFlag);
 }
 
 DLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<size_t> locToIncludeIndices, bool locUseKinFitDataFlag) const
 {
-	set<pair<const JObject*, Particle_t> > locSourceObjects;
+	set<pair<const JObject*, unsigned int> > locSourceObjects;
 	return Calc_FinalStateP4(locParticleCombo, locStepIndex, locToIncludeIndices, locSourceObjects, locUseKinFitDataFlag);
 }
 
-DLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<size_t> locToIncludeIndices, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const
+DLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<size_t> locToIncludeIndices, set<pair<const JObject*, unsigned int> >& locSourceObjects, bool locUseKinFitDataFlag) const
 {
 	if(locUseKinFitDataFlag && (locParticleCombo->Get_KinFitResults() == NULL))
 		return Calc_FinalStateP4(locParticleCombo, locStepIndex, locToIncludeIndices, locSourceObjects, false); //kinematic fit failed
@@ -941,7 +941,7 @@ DLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DParticleCombo* locPa
 		else
 		{
 			locFinalStateP4 += locParticles[loc_i]->lorentzMomentum();
-			locSourceObjects.insert(pair<const JObject*, Particle_t>(locParticleComboStep->Get_FinalParticle_SourceObject(loc_i), locParticles[loc_i]->PID()));
+			locSourceObjects.insert(pair<const JObject*, unsigned int>(locParticleComboStep->Get_FinalParticle_SourceObject(loc_i), abs(PDGtype(locParticles[loc_i]->PID()))));
 		}
 	}
 	return locFinalStateP4;

--- a/src/libraries/ANALYSIS/DAnalysisUtilities.h
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.h
@@ -90,13 +90,13 @@ class DAnalysisUtilities : public JObject
 		double Calc_DOCAToVertex(const DKinematicData* locKinematicData, const DVector3& locVertex, DVector3& locPOCA) const;
 
 		DLorentzVector Calc_MissingP4(const DParticleCombo* locParticleCombo, bool locUseKinFitDataFlag) const;
-		DLorentzVector Calc_MissingP4(const DParticleCombo* locParticleCombo, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const;
+		DLorentzVector Calc_MissingP4(const DParticleCombo* locParticleCombo, set<pair<const JObject*, unsigned int> >& locSourceObjects, bool locUseKinFitDataFlag) const;
 		DLorentzVector Calc_MissingP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, int locUpToStepIndex, set<size_t> locUpThroughIndices, bool locUseKinFitDataFlag) const;
-		DLorentzVector Calc_MissingP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, int locUpToStepIndex, set<size_t> locUpThroughIndices, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const;
+		DLorentzVector Calc_MissingP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, int locUpToStepIndex, set<size_t> locUpThroughIndices, set<pair<const JObject*, unsigned int> >& locSourceObjects, bool locUseKinFitDataFlag) const;
 		DLorentzVector Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, bool locUseKinFitDataFlag) const;
-		DLorentzVector Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const;
+		DLorentzVector Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<pair<const JObject*, unsigned int> >& locSourceObjects, bool locUseKinFitDataFlag) const;
 		DLorentzVector Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<size_t> locToIncludeIndices, bool locUseKinFitDataFlag) const;
-		DLorentzVector Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<size_t> locToIncludeIndices, set<pair<const JObject*, Particle_t> >& locSourceObjects, bool locUseKinFitDataFlag) const;
+		DLorentzVector Calc_FinalStateP4(const DParticleCombo* locParticleCombo, size_t locStepIndex, set<size_t> locToIncludeIndices, set<pair<const JObject*, unsigned int> >& locSourceObjects, bool locUseKinFitDataFlag) const;
 
 		// These routines use the MEAURED particle data.  For the kinfit-data result, just use the error matrix from the missing particle
 		DMatrixDSym Calc_MissingP3Covariance(const DParticleCombo* locParticleCombo) const;

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -1218,7 +1218,7 @@ bool DHistogramAction_InvariantMass::Perform_Action(JEventLoop* locEventLoop, co
 		set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
 		for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
 		{
-			set<pair<const JObject*, Particle_t> > locSourceObjects;
+			set<pair<const JObject*, unsigned int> > locSourceObjects;
 			DLorentzVector locFinalStateP4 = dAnalysisUtilities->Calc_FinalStateP4(locParticleCombo, loc_i, *locComboIterator, locSourceObjects, Get_UseKinFitResultsFlag());
 
 			if(dPreviousSourceObjects.find(locSourceObjects) != dPreviousSourceObjects.end())
@@ -1296,8 +1296,8 @@ bool DHistogramAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, cons
 	vector<pair<double, double> > locMassesToFill; //first is missing mass, second is missing p
 	set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
 	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
-	{
-		set<pair<const JObject*, Particle_t> > locSourceObjects;
+	  {
+		set<pair<const JObject*, unsigned int> > locSourceObjects;
 		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, *locComboIterator, locSourceObjects, Get_UseKinFitResultsFlag());
 
 		if(dPreviousSourceObjects.find(locSourceObjects) != dPreviousSourceObjects.end())
@@ -1378,7 +1378,7 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoo
 	set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
 	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
 	{
-		set<pair<const JObject*, Particle_t> > locSourceObjects;
+		set<pair<const JObject*, unsigned int> > locSourceObjects;
 		DLorentzVector locMissingP4 = dAnalysisUtilities->Calc_MissingP4(locParticleCombo, 0, dMissingMassOffOfStepIndex, *locComboIterator, locSourceObjects, Get_UseKinFitResultsFlag());
 
 		if(dPreviousSourceObjects.find(locSourceObjects) != dPreviousSourceObjects.end())
@@ -1443,7 +1443,7 @@ bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, 
 
 	vector<pair<double, double> > locMassesToFill;
 	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
-	{
+	  {
 		const DReactionStep* locReactionStep = Get_Reaction()->Get_ReactionStep(loc_i);
 		if((dStepIndex != -1) && (int(loc_i) != dStepIndex))
 			continue;
@@ -1456,19 +1456,19 @@ bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, 
 		set<set<size_t> >::iterator locXComboIterator = locXIndexCombos.begin();
 		for(; locXComboIterator != locXIndexCombos.end(); ++locXComboIterator)
 		{
-			set<pair<const JObject*, Particle_t> > locXSourceObjects;
+		        set<pair<const JObject*, unsigned int> > locXSourceObjects;
 			DLorentzVector locXP4 = dAnalysisUtilities->Calc_FinalStateP4(locParticleCombo, loc_i, *locXComboIterator, locXSourceObjects, Get_UseKinFitResultsFlag());
 
 			set<set<size_t> >::iterator locYComboIterator = locYIndexCombos.begin();
 			for(; locYComboIterator != locYIndexCombos.end(); ++locYComboIterator)
 			{
-				set<pair<const JObject*, Particle_t> > locYSourceObjects;
+				set<pair<const JObject*, unsigned int> > locYSourceObjects;
 				DLorentzVector locYP4 = dAnalysisUtilities->Calc_FinalStateP4(locParticleCombo, loc_i, *locYComboIterator, locYSourceObjects, Get_UseKinFitResultsFlag());
 
 				if(locXSourceObjects == locYSourceObjects)
 					continue; //the same!
 
-				set<set<pair<const JObject*, Particle_t> > > locAllSourceObjects;
+				set<set<pair<const JObject*, unsigned int> > > locAllSourceObjects;
 				locAllSourceObjects.insert(locXSourceObjects);
 				locAllSourceObjects.insert(locYSourceObjects);
 				if(dPreviousSourceObjects.find(locAllSourceObjects) != dPreviousSourceObjects.end())
@@ -1544,19 +1544,19 @@ bool DHistogramAction_Dalitz::Perform_Action(JEventLoop* locEventLoop, const DPa
 		set<set<size_t> >::iterator locXComboIterator = locXIndexCombos.begin();
 		for(; locXComboIterator != locXIndexCombos.end(); ++locXComboIterator)
 		{
-			set<pair<const JObject*, Particle_t> > locXSourceObjects;
+			set<pair<const JObject*, unsigned int> > locXSourceObjects;
 			DLorentzVector locXP4 = dAnalysisUtilities->Calc_FinalStateP4(locParticleCombo, loc_i, *locXComboIterator, locXSourceObjects, Get_UseKinFitResultsFlag());
 
 			set<set<size_t> >::iterator locYComboIterator = locYIndexCombos.begin();
 			for(; locYComboIterator != locYIndexCombos.end(); ++locYComboIterator)
 			{
-				set<pair<const JObject*, Particle_t> > locYSourceObjects;
+				set<pair<const JObject*, unsigned int> > locYSourceObjects;
 				DLorentzVector locYP4 = dAnalysisUtilities->Calc_FinalStateP4(locParticleCombo, loc_i, *locYComboIterator, locYSourceObjects, Get_UseKinFitResultsFlag());
 
 				if(locXSourceObjects == locYSourceObjects)
 					continue; //the same!
 
-				set<set<pair<const JObject*, Particle_t> > > locAllSourceObjects;
+				set<set<pair<const JObject*, unsigned int> > > locAllSourceObjects;
 				locAllSourceObjects.insert(locXSourceObjects);
 				locAllSourceObjects.insert(locYSourceObjects);
 				if(dPreviousSourceObjects.find(locAllSourceObjects) != dPreviousSourceObjects.end())
@@ -1969,7 +1969,7 @@ bool DHistogramAction_MissingTransverseMomentum::Perform_Action(JEventLoop* locE
 	if(Get_NumPreviousParticleCombos() == 0)
 		dPreviousSourceObjects.clear();
 
-	set<pair<const JObject*, Particle_t> > locSourceObjects;
+	set<pair<const JObject*, unsigned int> > locSourceObjects;
 	DLorentzVector locFinalStateP4 = dAnalysisUtilities->Calc_FinalStateP4(locParticleCombo, 0, locSourceObjects, Get_UseKinFitResultsFlag()); // Use step '0'
 
 	if(dPreviousSourceObjects.find(locSourceObjects) != dPreviousSourceObjects.end())

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -275,7 +275,7 @@ class DHistogramAction_InvariantMass : public DAnalysisAction
 		const DAnalysisUtilities* dAnalysisUtilities;
 		TH1I* dHist_InvaraintMass;
 
-		set<set<pair<const JObject*, Particle_t> > > dPreviousSourceObjects;
+		set<set<pair<const JObject*, unsigned int> > > dPreviousSourceObjects;
 };
 
 class DHistogramAction_MissingMass : public DAnalysisAction
@@ -341,7 +341,7 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		TH2I* dHist_MissingMassVsMissingP;
 		const DAnalysisUtilities* dAnalysisUtilities;
 
-		set<set<pair<const JObject*, Particle_t> > > dPreviousSourceObjects;
+		set<set<pair<const JObject*, unsigned int> > > dPreviousSourceObjects;
 };
 
 class DHistogramAction_MissingMassSquared : public DAnalysisAction
@@ -407,7 +407,7 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		TH2I* dHist_MissingMassSquaredVsMissingP;
 		const DAnalysisUtilities* dAnalysisUtilities;
 
-		set<set<pair<const JObject*, Particle_t> > > dPreviousSourceObjects;
+		set<set<pair<const JObject*, unsigned int> > > dPreviousSourceObjects;
 };
 
 class DHistogramAction_2DInvariantMass : public DAnalysisAction
@@ -431,7 +431,7 @@ class DHistogramAction_2DInvariantMass : public DAnalysisAction
 		const DAnalysisUtilities* dAnalysisUtilities;
 		TH2I* dHist_2DInvaraintMass;
 
-		set<set<set<pair<const JObject*, Particle_t> > > > dPreviousSourceObjects;
+		set<set<set<pair<const JObject*, unsigned int> > > > dPreviousSourceObjects;
 };
 
 
@@ -456,7 +456,7 @@ class DHistogramAction_Dalitz : public DAnalysisAction
 		const DAnalysisUtilities* dAnalysisUtilities;
 		TH2I* dHist_DalitzPlot;
 
-		set<set<set<pair<const JObject*, Particle_t> > > > dPreviousSourceObjects;
+		set<set<set<pair<const JObject*, unsigned int> > > > dPreviousSourceObjects;
 };
 
 class DHistogramAction_KinFitResults : public DAnalysisAction
@@ -514,7 +514,7 @@ class DHistogramAction_MissingTransverseMomentum : public DAnalysisAction
 		const DAnalysisUtilities* dAnalysisUtilities;
 		TH1I* dHist_MissingTransverseMomentum;
 
-		set<set<pair<const JObject*, Particle_t> > > dPreviousSourceObjects;
+		set<set<pair<const JObject*, unsigned int> > > dPreviousSourceObjects;
 };
 
 #endif // _DHistogramActions_Reaction_


### PR DESCRIPTION
modified Histogram actions to avoid double counting in cases where there are two (or more) oppositely charged pair of particles of the same mass.