### PR TITLE
 Fix how neutral particles are handled for kinfit

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisUtilities.cc
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.cc
@@ -1023,12 +1023,6 @@ double DAnalysisUtilities::Calc_DOCA(const DKinematicData* locKinematicData1, co
 	return Calc_DOCA(locKinematicData1, locKinematicData2, locPOCA1, locPOCA2);
 }
 
-double DAnalysisUtilities::Calc_DOCA(const DVector3 &locUnitDir1, const DVector3 &locUnitDir2, const DVector3 &locVertex1, const DVector3 &locVertex2) const
-{
-	DVector3 locPOCA1, locPOCA2;
-	return Calc_DOCA(locUnitDir1, locUnitDir2, locVertex1, locVertex2, locPOCA1, locPOCA2);
-}
-
 double DAnalysisUtilities::Calc_DOCA(const DKinFitParticle* locKinFitParticle1, const DKinFitParticle* locKinFitParticle2, DVector3 &locPOCA1, DVector3 &locPOCA2) const
 {
 	DVector3 locUnitDir1(locKinFitParticle1->Get_Momentum().Unit().X(),locKinFitParticle1->Get_Momentum().Unit().Y(),locKinFitParticle1->Get_Momentum().Unit().Z());
@@ -1047,26 +1041,36 @@ double DAnalysisUtilities::Calc_DOCA(const DKinematicData* locKinematicData1, co
 	return Calc_DOCA(locUnitDir1, locUnitDir2, locVertex1, locVertex2, locPOCA1, locPOCA2);
 }
 
+double DAnalysisUtilities::Calc_DOCA(const DVector3 &locUnitDir1, const DVector3 &locUnitDir2, const DVector3 &locVertex1, const DVector3 &locVertex2) const
+{
+	DVector3 locPOCA1, locPOCA2;
+	return Calc_DOCA(locUnitDir1, locUnitDir2, locVertex1, locVertex2, locPOCA1, locPOCA2);
+}
+
 double DAnalysisUtilities::Calc_DOCA(const DVector3 &locUnitDir1, const DVector3 &locUnitDir2, const DVector3 &locVertex1, const DVector3 &locVertex2, DVector3 &locPOCA1, DVector3 &locPOCA2) const
 {
-  //originated from code by Jörn Langheinrich
-  //you can use this function to find the DOCA to a fixed point by calling this function with locUnitDir1 and 2 parallel, and the fixed vertex as locVertex2
-  double locUnitDot = locUnitDir1.Dot(locUnitDir2);
-  double locDenominator = locUnitDot*locUnitDot - 1.0; /// scalar product of directions
-  double locDistVertToInterDOCA1 = 0.0, locDistVertToInterDOCA2 = 0.0; //distance from vertex to DOCA point
+	//originated from code by Jorn Langheinrich
+	//you can use this function to find the DOCA to a fixed point by calling this function with locUnitDir1 and 2 parallel, and the fixed vertex as locVertex2
+	double locUnitDot = locUnitDir1.Dot(locUnitDir2);
+	double locDenominator = locUnitDot*locUnitDot - 1.0; // scalar product of directions
+	double locDistVertToInterDOCA1 = 0.0, locDistVertToInterDOCA2 = 0.0; //distance from vertex to DOCA point
 
-  if(fabs(locDenominator) < 1.0e-15) //parallel
-    locDistVertToInterDOCA1 = (locVertex2 - locVertex1).Dot(locUnitDir2)/locUnitDot; //the opposite
-  else{
-    double locA = (locVertex1 - locVertex2).Dot(locUnitDir1);
-    double locB = (locVertex1 - locVertex2).Dot(locUnitDir2);
-    locDistVertToInterDOCA1 = (locA - locUnitDot*locB)/locDenominator;
-    locDistVertToInterDOCA2 = (locUnitDot*locA - locB)/locDenominator;
-  }
+	if(fabs(locDenominator) < 1.0e-15) //parallel
+	{
+		locDistVertToInterDOCA1 = (locVertex2 - locVertex1).Dot(locUnitDir2)/locUnitDot; //the opposite
+		locDistVertToInterDOCA2 = (locVertex1 - locVertex2).Dot(locUnitDir1)/locUnitDot;
+	}
+	else
+	{
+		double locA = (locVertex1 - locVertex2).Dot(locUnitDir1);
+		double locB = (locVertex1 - locVertex2).Dot(locUnitDir2);
+		locDistVertToInterDOCA1 = (locA - locUnitDot*locB)/locDenominator;
+		locDistVertToInterDOCA2 = (locUnitDot*locA - locB)/locDenominator;
+	}
 
-  locPOCA1 = locVertex1 + locDistVertToInterDOCA1*locUnitDir1; //intersection point of DOCA line and track 1
-  locPOCA2 = locVertex2 + locDistVertToInterDOCA2*locUnitDir2; //intersection point of DOCA line and track 2
-  return (locPOCA1 - locPOCA2).Mag();
+	locPOCA1 = locVertex1 + locDistVertToInterDOCA1*locUnitDir1; //intersection point of DOCA line and track 1
+	locPOCA2 = locVertex2 + locDistVertToInterDOCA2*locUnitDir2; //intersection point of DOCA line and track 2
+	return (locPOCA1 - locPOCA2).Mag();
 }
 
 double DAnalysisUtilities::Calc_CrudeTime(const deque<const DKinematicData*>& locParticles, const DVector3& locCommonVertex) const

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -122,7 +122,7 @@ void DEventWriterROOT::Create_DataTree(const DReaction* locReaction, JEventLoop*
 	DTreeBranchRegister locBranchRegister;
 
 	//fill maps
-	TMap* locPositionToNameMap = Create_UserInfoMaps(locBranchRegister, locReaction);
+	TMap* locPositionToNameMap = Create_UserInfoMaps(locBranchRegister, locEventLoop, locReaction);
 
 /******************************************************************** Create Branches ********************************************************************/
 
@@ -159,7 +159,7 @@ void DEventWriterROOT::Create_DataTree(const DReaction* locReaction, JEventLoop*
 	locTreeInterface->Create_Branches(locBranchRegister);
 }
 
-TMap* DEventWriterROOT::Create_UserInfoMaps(DTreeBranchRegister& locBranchRegister, const DReaction* locReaction) const
+TMap* DEventWriterROOT::Create_UserInfoMaps(DTreeBranchRegister& locBranchRegister, JEventLoop* locEventLoop, const DReaction* locReaction) const
 {
 	//kinfit type
 	DKinFitType locKinFitType = locReaction->Get_KinFitType();
@@ -213,6 +213,14 @@ TMap* DEventWriterROOT::Create_UserInfoMaps(DTreeBranchRegister& locBranchRegist
 		gPARMS->GetParameter("JANA_CALIB_CONTEXT", REST_JANA_CALIB_CONTEXT);
 	if(REST_JANA_CALIB_CONTEXT != "")
 		locMiscInfoMap->Add(new TObjString("REST:JANACALIBCONTEXT"), new TObjString(REST_JANA_CALIB_CONTEXT.c_str()));
+
+	if(locKinFitType != d_NoFit)
+	{
+		DKinFitUtils_GlueX locKinFitUtils(locEventLoop);
+		size_t locNumConstraints = 0, locNumUnknowns = 0;
+		string locConstraintString = dKinFitUtils.Get_ConstraintInfo(locReaction, locKinFitType, locNumConstraints, locNumUnknowns);
+		locMiscInfoMap->Add(new TObjString("KinFitConstraints"), new TObjString(locConstraintString.c_str()));
+	}
 
 	//find the # particles of each pid
 	map<Particle_t, unsigned int> locParticleNumberMap;

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -220,6 +220,14 @@ TMap* DEventWriterROOT::Create_UserInfoMaps(DTreeBranchRegister& locBranchRegist
 		size_t locNumConstraints = 0, locNumUnknowns = 0;
 		string locConstraintString = dKinFitUtils.Get_ConstraintInfo(locReaction, locKinFitType, locNumConstraints, locNumUnknowns);
 		locMiscInfoMap->Add(new TObjString("KinFitConstraints"), new TObjString(locConstraintString.c_str()));
+
+		ostringstream locKinFitInfoStream;
+		locKinFitInfoStream << locNumConstraints;
+		locMiscInfoMap->Add(new TObjString("NumKinFitConstraints"), new TObjString(locKinFitInfoStream.str().c_str()));
+
+		locKinFitInfoStream.str("");
+		locKinFitInfoStream << locNumUnknowns;
+		locMiscInfoMap->Add(new TObjString("NumKinFitUnknowns"), new TObjString(locKinFitInfoStream.str().c_str()));
 	}
 
 	//find the # particles of each pid

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -218,7 +218,7 @@ TMap* DEventWriterROOT::Create_UserInfoMaps(DTreeBranchRegister& locBranchRegist
 	{
 		DKinFitUtils_GlueX locKinFitUtils(locEventLoop);
 		size_t locNumConstraints = 0, locNumUnknowns = 0;
-		string locConstraintString = dKinFitUtils.Get_ConstraintInfo(locReaction, locKinFitType, locNumConstraints, locNumUnknowns);
+		string locConstraintString = locKinFitUtils.Get_ConstraintInfo(locReaction, locKinFitType, locNumConstraints, locNumUnknowns);
 		locMiscInfoMap->Add(new TObjString("KinFitConstraints"), new TObjString(locConstraintString.c_str()));
 
 		ostringstream locKinFitInfoStream;

--- a/src/libraries/ANALYSIS/DEventWriterROOT.h
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.h
@@ -107,7 +107,7 @@ class DEventWriterROOT : public JObject
 
 		//TREE CREATION:
 		void Create_DataTree(const DReaction* locReaction, JEventLoop* locEventLoop, bool locIsMCDataFlag);
-		TMap* Create_UserInfoMaps(DTreeBranchRegister& locTreeBranchRegister, const DReaction* locReaction) const;
+		TMap* Create_UserInfoMaps(DTreeBranchRegister& locTreeBranchRegister, JEventLoop* locEventLoop, const DReaction* locReaction) const;
 		void Create_UserTargetInfo(DTreeBranchRegister& locTreeBranchRegister, Particle_t locTargetPID) const;
 		void Create_Branches_Thrown(DTreeBranchRegister& locTreeBranchRegister, bool locIsOnlyThrownFlag) const;
 

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -2838,80 +2838,80 @@ void DHistogramAction_TrackShowerErrors::Initialize(JEventLoop* locEventLoop)
 
 			// Px
 			locHistName = "PxErrorVsP";
-			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{p_{x}}");
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{p_{x}} (GeV/c)");
 			dHistMap_TrackPxErrorVsP[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DPxyErrorBins, 0.0, dMaxPxyError);
 
 			locHistName = "PxErrorVsTheta";
-			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{p_{x}}");
+			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{p_{x}} (GeV/c)");
 			dHistMap_TrackPxErrorVsTheta[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, dMaxTheta, dNum2DPxyErrorBins, 0.0, dMaxPxyError);
 
 			locHistName = "PxErrorVsPhi";
-			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{p_{x}}");
+			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{p_{x}} (GeV/c)");
 			dHistMap_TrackPxErrorVsPhi[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPhiBins, dMinPhi, dMaxPhi, dNum2DPxyErrorBins, 0.0, dMaxPxyError);
 
 			// Py
 			locHistName = "PyErrorVsP";
-			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{p_{y}}");
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{p_{y}} (GeV/c)");
 			dHistMap_TrackPyErrorVsP[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DPxyErrorBins, 0.0, dMaxPxyError);
 
 			locHistName = "PyErrorVsTheta";
-			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{p_{y}}");
+			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{p_{y}} (GeV/c)");
 			dHistMap_TrackPyErrorVsTheta[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, dMaxTheta, dNum2DPxyErrorBins, 0.0, dMaxPxyError);
 
 			locHistName = "PyErrorVsPhi";
-			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{p_{y}}");
+			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{p_{y}} (GeV/c)");
 			dHistMap_TrackPyErrorVsPhi[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPhiBins, dMinPhi, dMaxPhi, dNum2DPxyErrorBins, 0.0, dMaxPxyError);
 
 			// Pz
 			locHistName = "PzErrorVsP";
-			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{p_{z}}");
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{p_{z}} (GeV/c)");
 			dHistMap_TrackPzErrorVsP[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DPzErrorBins, 0.0, dMaxPzError);
 
 			locHistName = "PzErrorVsTheta";
-			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{p_{z}}");
+			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{p_{z}} (GeV/c)");
 			dHistMap_TrackPzErrorVsTheta[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, dMaxTheta, dNum2DPzErrorBins, 0.0, dMaxPzError);
 
 			locHistName = "PzErrorVsPhi";
-			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{p_{z}}");
+			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{p_{z}} (GeV/c)");
 			dHistMap_TrackPzErrorVsPhi[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPhiBins, dMinPhi, dMaxPhi, dNum2DPzErrorBins, 0.0, dMaxPzError);
 
 			// X
 			locHistName = "XErrorVsP";
-			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{x}");
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{x} (cm)");
 			dHistMap_TrackXErrorVsP[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DXYErrorBins, 0.0, dMaxXYError);
 
 			locHistName = "XErrorVsTheta";
-			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{x}");
+			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{x} (cm)");
 			dHistMap_TrackXErrorVsTheta[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, dMaxTheta, dNum2DXYErrorBins, 0.0, dMaxXYError);
 
 			locHistName = "XErrorVsPhi";
-			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{x}");
+			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{x} (cm)");
 			dHistMap_TrackXErrorVsPhi[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPhiBins, dMinPhi, dMaxPhi, dNum2DXYErrorBins, 0.0, dMaxXYError);
 
 			// Y
 			locHistName = "YErrorVsP";
-			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{y}");
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{y} (cm)");
 			dHistMap_TrackYErrorVsP[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DXYErrorBins, 0.0, dMaxXYError);
 
 			locHistName = "YErrorVsTheta";
-			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{y}");
+			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{y} (cm)");
 			dHistMap_TrackYErrorVsTheta[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, dMaxTheta, dNum2DXYErrorBins, 0.0, dMaxXYError);
 
 			locHistName = "YErrorVsPhi";
-			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{y}");
+			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{y} (cm)");
 			dHistMap_TrackYErrorVsPhi[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPhiBins, dMinPhi, dMaxPhi, dNum2DXYErrorBins, 0.0, dMaxXYError);
 
 			// Z
 			locHistName = "ZErrorVsP";
-			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{z}");
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{z} (cm)");
 			dHistMap_TrackZErrorVsP[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DZErrorBins, 0.0, dMaxZError);
 
 			locHistName = "ZErrorVsTheta";
-			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{z}");
+			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{z} (cm)");
 			dHistMap_TrackZErrorVsTheta[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, dMaxTheta, dNum2DZErrorBins, 0.0, dMaxZError);
 
 			locHistName = "ZErrorVsPhi";
-			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{z}");
+			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{z} (cm)");
 			dHistMap_TrackZErrorVsPhi[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPhiBins, dMinPhi, dMaxPhi, dNum2DZErrorBins, 0.0, dMaxZError);
 
 			gDirectory->cd("..");
@@ -2930,67 +2930,67 @@ void DHistogramAction_TrackShowerErrors::Initialize(JEventLoop* locEventLoop)
 
 			// E
 			locHistName = "EErrorVsP";
-			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{E}");
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{E} (GeV)");
 			dHistMap_ShowerEErrorVsP[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, locMaxP, dNum2DEErrorBins, 0.0, dMaxEError);
 
 			locHistName = "EErrorVsTheta";
-			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{E}");
+			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{E} (GeV)");
 			dHistMap_ShowerEErrorVsTheta[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, locMinTheta, locMaxTheta, dNum2DEErrorBins, 0.0, dMaxEError);
 
 			locHistName = "EErrorVsPhi";
-			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{E}");
+			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{E} (GeV)");
 			dHistMap_ShowerEErrorVsPhi[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPhiBins, dMinPhi, dMaxPhi, dNum2DEErrorBins, 0.0, dMaxEError);
 
 			// X
 			locHistName = "XErrorVsP";
-			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{x}");
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{x} (cm)");
 			dHistMap_ShowerXErrorVsP[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, locMaxP, dNum2DXYErrorBins, 0.0, dMaxXYError);
 
 			locHistName = "XErrorVsTheta";
-			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{x}");
+			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{x} (cm)");
 			dHistMap_ShowerXErrorVsTheta[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, locMinTheta, locMaxTheta, dNum2DXYErrorBins, 0.0, dMaxXYError);
 
 			locHistName = "XErrorVsPhi";
-			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{x}");
+			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{x} (cm)");
 			dHistMap_ShowerXErrorVsPhi[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPhiBins, dMinPhi, dMaxPhi, dNum2DXYErrorBins, 0.0, dMaxXYError);
 
 			// Y
 			locHistName = "YErrorVsP";
-			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{y}");
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{y} (cm)");
 			dHistMap_ShowerYErrorVsP[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, locMaxP, dNum2DXYErrorBins, 0.0, dMaxXYError);
 
 			locHistName = "YErrorVsTheta";
-			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{y}");
+			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{y} (cm)");
 			dHistMap_ShowerYErrorVsTheta[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, locMinTheta, locMaxTheta, dNum2DXYErrorBins, 0.0, dMaxXYError);
 
 			locHistName = "YErrorVsPhi";
-			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{y}");
+			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{y} (cm)");
 			dHistMap_ShowerYErrorVsPhi[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPhiBins, dMinPhi, dMaxPhi, dNum2DXYErrorBins, 0.0, dMaxXYError);
 
 			// Z
 			locHistName = "ZErrorVsP";
-			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{z}");
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{z} (cm)");
 			dHistMap_ShowerZErrorVsP[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, locMaxP, dNum2DZErrorBins, 0.0, dMaxZError);
 
 			locHistName = "ZErrorVsTheta";
-			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{z}");
+			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{z} (cm)");
 			dHistMap_ShowerZErrorVsTheta[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, locMinTheta, locMaxTheta, dNum2DZErrorBins, 0.0, dMaxZError);
 
 			locHistName = "ZErrorVsPhi";
-			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{z}");
+			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{z} (cm)");
 			dHistMap_ShowerZErrorVsPhi[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPhiBins, dMinPhi, dMaxPhi, dNum2DZErrorBins, 0.0, dMaxZError);
 
-			// E
+			// T
 			locHistName = "TErrorVsP";
-			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{E}");
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);#sigma_{t} (ns)");
 			dHistMap_ShowerTErrorVsP[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, locMaxP, dNum2DTErrorBins, 0.0, dMaxTError);
 
 			locHistName = "TErrorVsTheta";
-			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{E}");
+			locHistTitle = locParticleROOTName + string(";#theta#circ;#sigma_{t} (ns)");
 			dHistMap_ShowerTErrorVsTheta[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, locMinTheta, locMaxTheta, dNum2DTErrorBins, 0.0, dMaxTError);
 
 			locHistName = "TErrorVsPhi";
-			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{E}");
+			locHistTitle = locParticleROOTName + string(";#phi#circ;#sigma_{t} (ns)");
 			dHistMap_ShowerTErrorVsPhi[locIsBCALFlag] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPhiBins, dMinPhi, dMaxPhi, dNum2DTErrorBins, 0.0, dMaxTError);
 
 			gDirectory->cd("..");

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -476,7 +476,7 @@ class DHistogramAction_KinFitResults : public DAnalysisAction
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 
-		void Create_ParticlePulls(string locFullROOTName, bool locIsInVertexFitFlag, bool locIsNeutralShowerFlag, map<DKinFitPullType, TH1I*>& locParticlePulls, map<DKinFitPullType, TH2I*>& locParticlePullsVsP, map<DKinFitPullType, TH2I*>& locParticlePullsVsTheta, map<DKinFitPullType, TH2I*>& locParticlePullsVsPhi);
+		void Create_ParticlePulls(string locFullROOTName, bool locIsChargedFlag, bool locIsInVertexFitFlag, bool locIsNeutralShowerFlag, map<DKinFitPullType, TH1I*>& locParticlePulls, map<DKinFitPullType, TH2I*>& locParticlePullsVsP, map<DKinFitPullType, TH2I*>& locParticlePullsVsTheta, map<DKinFitPullType, TH2I*>& locParticlePullsVsPhi);
 
 		double dPullHistConfidenceLevelCut;
 		const DAnalysisUtilities* dAnalysisUtilities;

--- a/src/libraries/ANALYSIS/DKinFitUtils_GlueX.cc
+++ b/src/libraries/ANALYSIS/DKinFitUtils_GlueX.cc
@@ -826,39 +826,6 @@ set<pair<int, int> > DKinFitUtils_GlueX::Get_KinFitVertexParticles(const DReacti
 	return locVertexParticles;
 }
 
-set<pair<int, int> > DKinFitUtils_GlueX::Get_KinFitNeutralShowers(const DReaction* locReaction, const deque<set<pair<int, int> > >& locVertices) const
-{
-	//the indices of the particles that can be used as neutral showers are returned. else must be used as neutral particles
-		//neutral shower: if position is defined by a vertex constraint
-
-	set<pair<int, int> > locNeutralShowers;
-	for(size_t loc_i = 0; loc_i < locVertices.size(); ++loc_i)
-	{
-		const set<pair<int, int> >& locVertexParticles = locVertices[loc_i];
-		set<pair<int, int> >::const_iterator locIterator = locVertexParticles.begin();
-		for(; locIterator != locVertexParticles.end(); ++locIterator)
-		{
-			int locStepIndex = (*locIterator).first;
-			int locParticleIndex = (*locIterator).second;
-			if(locParticleIndex < 0)
-				continue; //initial state particle
-
-			const DReactionStep* locReactionStep = locReaction->Get_ReactionStep(locStepIndex);
-			if(locParticleIndex == locReactionStep->Get_MissingParticleIndex())
-				continue; //missing particle
-			int locDecayStepIndex = locReaction->Get_DecayStepIndex(locStepIndex, locParticleIndex);
-			if(locDecayStepIndex >= 0)
-				continue; //decaying particle
-
-			Particle_t locPID = locReactionStep->Get_FinalParticleID(locParticleIndex);
-			if(ParticleCharge(locPID) == 0)
-				locNeutralShowers.insert(*locIterator);
-		}
-	}
-
-	return locNeutralShowers;
-}
-
 string DKinFitUtils_GlueX::Get_ConstraintInfo(const DReaction* locReaction, DKinFitType locKinFitType, size_t& locNumConstraints, size_t& locNumUnknowns) const
 {
 	//returns constraint string, sets # constraints & unknowns

--- a/src/libraries/ANALYSIS/DKinFitUtils_GlueX.h
+++ b/src/libraries/ANALYSIS/DKinFitUtils_GlueX.h
@@ -124,8 +124,6 @@ class DKinFitUtils_GlueX : public DKinFitUtils
 
 		/************************************************************ CONSTRAINT PREDICTORS *********************************************************/
 
-		set<pair<int, int> > Get_KinFitNeutralShowers(const DReaction* locReaction, const deque<set<pair<int, int> > >& locVertices) const;
-
 		string Build_VertexConstraintString(const DReaction* locReaction, const set<pair<int, int> >& locAllVertexParticles, set<pair<int, int> >& locFullConstrainParticles, set<pair<int, int> >& locOnlyConstrainTimeParticles, set<pair<int, int> >& locNoConstrainParticles, bool locSpacetimeFitFlag) const;
 
 		deque<set<pair<int, int> > > Setup_VertexPredictions(const DReaction* locReaction) const;

--- a/src/libraries/KINFITTER/DKinFitConstraint_Spacetime.h
+++ b/src/libraries/KINFITTER/DKinFitConstraint_Spacetime.h
@@ -30,7 +30,7 @@ class DKinFitConstraint_Spacetime : public DKinFitConstraint_Vertex
 		int Get_CommonTParamIndex(void) const;
 
 		set<DKinFitParticle*> Get_OnlyConstrainTimeParticles(void) const{return dOnlyConstrainTimeParticles;}
-		set<DKinFitParticle*> Get_AllConstrainedParticles(void) const;
+		set<DKinFitParticle*> Get_AllConstrainingParticles(void) const;
 		set<DKinFitParticle*> Get_AllParticles(void) const;
 
 		void Print_ConstraintInfo(void) const;
@@ -74,7 +74,7 @@ inline set<DKinFitParticle*> DKinFitConstraint_Spacetime::Get_AllParticles(void)
 	return locAllParticles;
 }
 
-inline set<DKinFitParticle*> DKinFitConstraint_Spacetime::Get_AllConstrainedParticles(void) const
+inline set<DKinFitParticle*> DKinFitConstraint_Spacetime::Get_AllConstrainingParticles(void) const
 {
 	set<DKinFitParticle*> locAllConstrainedParticles;
 	set_union(dFullConstrainParticles.begin(), dFullConstrainParticles.end(), dOnlyConstrainTimeParticles.begin(), 

--- a/src/libraries/KINFITTER/DKinFitConstraint_Vertex.h
+++ b/src/libraries/KINFITTER/DKinFitConstraint_Vertex.h
@@ -28,7 +28,7 @@ class DKinFitConstraint_Vertex : public DKinFitConstraint
 		int Get_CommonVxParamIndex(void) const;
 		int Get_FIndex(DKinFitParticle* locKinFitParticle) const;
 
-		virtual set<DKinFitParticle*> Get_AllConstrainedParticles(void) const{return dFullConstrainParticles;}
+		virtual set<DKinFitParticle*> Get_AllConstrainingParticles(void) const{return dFullConstrainParticles;}
 		set<DKinFitParticle*> Get_FullConstrainParticles(void) const{return dFullConstrainParticles;}
 		set<DKinFitParticle*> Get_NoConstrainParticles(void) const{return dNoConstrainParticles;}
 		virtual set<DKinFitParticle*> Get_AllParticles(void) const;

--- a/src/libraries/KINFITTER/DKinFitter.cc
+++ b/src/libraries/KINFITTER/DKinFitter.cc
@@ -37,7 +37,7 @@
 		//This is necessary if you want the neutral particle momentum (from an input shower) to change with the reconstructed vertex
 	//decaying particles should only be used to constrain a fit if the position is defined in another vertex constraint
 	//Massive neutral showers (e.g. neutron) cannot be used in vertex constraints: only spacetime constraints. However, photons can. 
-		//This is because their momentum is defined by the vertex time
+		//This is because their momentum is defined by the vertex time, which is not defined
 
 //SPACETIME CONSTRAINTS:
 	//THESE ARE CURRENTLY DISABLED
@@ -117,14 +117,14 @@ void DKinFitter::Print_Matrix(const TMatrixD& locMatrix) const
 	}
 }
 
-bool DKinFitter::Get_IsVertexConstrained(DKinFitParticle* locKinFitParticle) const
+bool DKinFitter::Get_IsConstrainingVertex(DKinFitParticle* locKinFitParticle) const
 {
 	set<DKinFitConstraint_Vertex*> locConstraints = Get_Constraints<DKinFitConstraint_Vertex>(locKinFitParticle);
 	set<DKinFitConstraint_Vertex*>::iterator locSetIterator = locConstraints.begin();
 	for(; locSetIterator != locConstraints.end(); ++locSetIterator)
 	{
-		set<DKinFitParticle*> locConstrainedParticles = (*locSetIterator)->Get_AllConstrainedParticles();
-		if(locConstrainedParticles.find(locKinFitParticle) != locConstrainedParticles.end())
+		set<DKinFitParticle*> locConstrainingParticles = (*locSetIterator)->Get_AllConstrainingParticles();
+		if(locConstrainingParticles.find(locKinFitParticle) != locConstrainingParticles.end())
 			return true;
 	}
 	return false;
@@ -136,7 +136,7 @@ bool DKinFitter::Get_IsTimeConstrained(DKinFitParticle* locKinFitParticle) const
 	set<DKinFitConstraint_Spacetime*>::iterator locSetIterator = locConstraints.begin();
 	for(; locSetIterator != locConstraints.end(); ++locSetIterator)
 	{
-		set<DKinFitParticle*> locConstrainedParticles = (*locSetIterator)->Get_AllConstrainedParticles();
+		set<DKinFitParticle*> locConstrainedParticles = (*locSetIterator)->Get_AllConstrainingParticles();
 		if(locConstrainedParticles.find(locKinFitParticle) != locConstrainedParticles.end())
 			return true;
 	}
@@ -332,9 +332,9 @@ void DKinFitter::Set_MatrixSizes(void)
 			cout << "PID, pointer, is in p4/mass/vert/indirectv, accel = " << locKinFitParticle->Get_PID() << ", " << locKinFitParticle << ", " << locIsInP4Constraint << ", " << locIsInMassConstraint << ", " << locIsInVertexConstraint << ", " << locIsIndirectlyInVertexConstraint << ", " << locChargedBFieldFlag << endl;
 		if(!locKinFitParticle->Get_IsNeutralShowerFlag())
 		{
-			if(locIsInP4Constraint || locIsInMassConstraint || Get_IsVertexConstrained(locKinFitParticle) || locIsIndirectlyInVertexConstraint)
+			if(locIsInP4Constraint || locIsInMassConstraint || Get_IsConstrainingVertex(locKinFitParticle) || locIsIndirectlyInVertexConstraint)
 				dNumEta += 3; //p3
-			if(Get_IsVertexConstrained(locKinFitParticle) || (locIsIndirectlyInVertexConstraint && locChargedBFieldFlag))
+			if(Get_IsConstrainingVertex(locKinFitParticle) || (locIsIndirectlyInVertexConstraint && locChargedBFieldFlag))
 				dNumEta += 3; //v3 //directly (first condition) or indirectly AND accelerating (second condition)
 		}
 		else //neutral shower
@@ -489,7 +489,7 @@ void DKinFitter::Fill_InputMatrices(void)
 
 		if(!locKinFitParticle->Get_IsNeutralShowerFlag()) //non-neutral-shower
 		{
-			if(locIsInP4Constraint || locIsInMassConstraint || Get_IsVertexConstrained(locKinFitParticle) || locIsIndirectlyInVertexConstraint)
+			if(locIsInP4Constraint || locIsInMassConstraint || Get_IsConstrainingVertex(locKinFitParticle) || locIsIndirectlyInVertexConstraint)
 			{
 				locKinFitParticle->Set_PxParamIndex(locParamIndex);
 				dY(locParamIndex, 0) = locMomentum.Px();
@@ -497,7 +497,7 @@ void DKinFitter::Fill_InputMatrices(void)
 				dY(locParamIndex + 2, 0) = locMomentum.Pz();
 				locParamIndex += 3;
 			}
-			if(Get_IsVertexConstrained(locKinFitParticle) || (locIsIndirectlyInVertexConstraint && locChargedBFieldFlag))
+			if(Get_IsConstrainingVertex(locKinFitParticle) || (locIsIndirectlyInVertexConstraint && locChargedBFieldFlag))
 			{
 				locKinFitParticle->Set_VxParamIndex(locParamIndex);
 				dY(locParamIndex, 0) = locPosition.Px();

--- a/src/libraries/KINFITTER/DKinFitter.h
+++ b/src/libraries/KINFITTER/DKinFitter.h
@@ -114,7 +114,7 @@ class DKinFitter //purely virtual: cannot directly instantiate class, can only i
 		template <typename DType> bool Get_IsInConstraint(DKinFitParticle* locKinFitParticle, bool locOnlyDirectFlag = false) const;
 		template <typename DType> bool Get_IsIndirectlyInConstraint(DKinFitParticle* locKinFitParticle) const;
 
-		bool Get_IsVertexConstrained(DKinFitParticle* locKinFitParticle) const;
+		bool Get_IsConstrainingVertex(DKinFitParticle* locKinFitParticle) const;
 		bool Get_IsTimeConstrained(DKinFitParticle* locKinFitParticle) const;
 
 		/*********************************************************** FIT INITIALIZATION *************************************************************/

--- a/src/libraries/PID/DNeutralParticleHypothesis_factory.cc
+++ b/src/libraries/PID/DNeutralParticleHypothesis_factory.cc
@@ -161,7 +161,11 @@ void DNeutralParticleHypothesis_factory::Calc_ParticleCovariance_Photon(const DN
 			locShowerPlusVertCovariance(5 + loc_l, 5 + loc_m) = locVertex->dCovarianceMatrix(loc_l, loc_m);
 	}
 
-	DVector3 locDeltaX = -1.0*locPathVector; //defined oppositely in document! //delta_x defined here as common_vertex - hit_point
+	//the input delta X is defined as "hit - start"
+	//however, the documentation and derivations define delta x as "start - hit"
+	//so, reverse the sign of the inputs to match the documentation
+	//and then the rest will follow the documentation
+	DVector3 locDeltaX = -1.0*locPathVector;
 	DVector3 locDeltaXOverDeltaXSq = (1.0/locDeltaX.Mag2())*locDeltaX;
 	DVector3 locUnitP = (1.0/locNeutralShower->dEnergy)*locMomentum;
 	DVector3 locUnitDeltaXOverC = (1.0/(29.9792458*locDeltaX.Mag()))*locDeltaX;

--- a/src/libraries/PID/DNeutralParticleHypothesis_factory.h
+++ b/src/libraries/PID/DNeutralParticleHypothesis_factory.h
@@ -23,7 +23,7 @@
 #include <DMatrix.h>
 #include <TMath.h>
 
-class DNeutralParticleHypothesis_factory:public jana::JFactory<DNeutralParticleHypothesis>
+class DNeutralParticleHypothesis_factory : public jana::JFactory<DNeutralParticleHypothesis>
 {
 	public:
 		DNeutralParticleHypothesis_factory(){};
@@ -31,20 +31,16 @@ class DNeutralParticleHypothesis_factory:public jana::JFactory<DNeutralParticleH
 
 		DNeutralParticleHypothesis* Create_DNeutralParticleHypothesis(const DNeutralShower* locNeutralShower, Particle_t locPID, const DEventRFBunch* locEventRFBunch, const DVertex* locVertex) const;
 
-		void Calc_ParticleCovariance_Photon(const DNeutralShower* locNeutralShower, const DVector3& locMomentum, const DVector3& locPathVector, DMatrixDSym& locParticleCovariance) const;
-		void Calc_ParticleCovariance_Massive(const DNeutralShower* locNeutralShower, double locMass, double locDeltaT, double locStartTimeVariance, const DVector3& locMomentum, const DVector3& locPathVector, DMatrixDSym& locParticleCovariance) const;
+		void Calc_ParticleCovariance_Photon(const DNeutralShower* locNeutralShower, const DVertex* locVertex, const DVector3& locMomentum, const DVector3& locPathVector, DMatrixDSym& locParticleCovariance) const;
+		void Calc_ParticleCovariance_Massive(const DNeutralShower* locNeutralShower, const DVertex* locVertex, double locMass, double locDeltaT, const DVector3& locMomentum, const DVector3& locPathVector, DMatrixDSym& locParticleCovariance) const;
 
 	private:
-		double dTargetLength;
-		double dTargetRadius;
-		DVector3 dTargetCenter;
+		double dTargetCenterZ;
 		const DParticleID* dParticleID;
 
 		jerror_t init(void);						///< Called once at program start.
 		jerror_t brun(jana::JEventLoop *locEventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
 		jerror_t evnt(jana::JEventLoop *locEventLoop, uint64_t eventnumber);	///< Called every event.
-		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
-		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 };
 
 #endif // _DNeutralParticleHypothesis_factory_

--- a/src/libraries/PID/DVertex.h
+++ b/src/libraries/PID/DVertex.h
@@ -26,6 +26,7 @@ class DVertex: public jana::JObject
 		JOBJECT_PUBLIC(DVertex);
 
 		DLorentzVector dSpacetimeVertex; // vertex position in cm + vertex time in ns
+		DMatrixDSym dCovarianceMatrix; //xyzt order
 
 		unsigned int dKinFitNDF;
 		double dKinFitChiSq;

--- a/src/libraries/PID/DVertex_factory.cc
+++ b/src/libraries/PID/DVertex_factory.cc
@@ -28,9 +28,12 @@ jerror_t DVertex_factory::brun(jana::JEventLoop* locEventLoop, int32_t runnumber
 
 	// Get Target parameters from XML
 	dTargetZCenter = 65.0;
+	dTargetLength = 30.0;
+	dTargetRadius = 1.5; //FIX: grab from database!!!
 	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
 	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
 	locGeometry->GetTargetZ(dTargetZCenter);
+	locGeometry->GetTargetLength(dTargetLength);
 
 	gPARMS->SetDefaultParameter("VERTEX:NO_KINFIT_FLAG", dNoKinematicFitFlag);
 	gPARMS->SetDefaultParameter("KINFIT:DEBUGLEVEL", dKinFitDebugLevel);
@@ -87,16 +90,16 @@ jerror_t DVertex_factory::evnt(JEventLoop* locEventLoop, uint64_t eventnumber)
 
 	//handle cases of no/one track
 	if(locTrackTimeBasedVectorToUse.empty())
-		return Create_Vertex(DVector3(0.0, 0.0, dTargetZCenter), locEventRFBunch->dTime);
+		return Create_Vertex_NoTracks(locEventRFBunch);
 	if(locTrackTimeBasedVectorToUse.size() == 1)
-		return Create_Vertex(locTrackTimeBasedVectorToUse[0]->position(), locEventRFBunch->dTime);
+		return Create_Vertex_OneTrack(locTrackTimeBasedVectorToUse[0], locEventRFBunch);
 
 	// first calculate a rough vertex
 	DVector3 locRoughPosition = dAnalysisUtilities->Calc_CrudeVertex(locTrackTimeBasedVectorToUse);
 
 	// if only want rough guess, save it and exit
 	if(dNoKinematicFitFlag)
-		return Create_Vertex(locRoughPosition, locEventRFBunch->dTime);
+		return Create_Vertex_Rough(locRoughPosition, locEventRFBunch);
 
 	//prepare for kinematic fit
 	dKinFitter->Reset_NewEvent();
@@ -110,25 +113,110 @@ jerror_t DVertex_factory::evnt(JEventLoop* locEventLoop, uint64_t eventnumber)
 	// create vertex constraint
 	set<DKinFitParticle*> locNoConstrainParticles;
 	DKinFitConstraint_Vertex* locVertexConstraint = dKinFitUtils->Make_VertexConstraint(locKinFitParticles, locNoConstrainParticles, locTRoughPosition);
-
 	dKinFitter->Add_Constraint(locVertexConstraint);
 
+	// fit, save, and return
 	if(!dKinFitter->Fit_Reaction()) //if fit fails to converge: use rough results
-		return Create_Vertex(locRoughPosition, locEventRFBunch->dTime);
-
-	DKinFitConstraint_Vertex* locResultVertexConstraint = dynamic_cast<DKinFitConstraint_Vertex*>(*dKinFitter->Get_KinFitConstraints().begin());
+		return Create_Vertex_Rough(locRoughPosition, locEventRFBunch);
 
 	//save kinfit results
+	return Create_Vertex_KinFit(locEventRFBunch);
+}
+
+jerror_t DVertex_factory::Create_Vertex_NoTracks(const DEventRFBunch* locEventRFBunch)
+{
+	DVertex* locVertex = new DVertex();
+	locVertex->dSpacetimeVertex = DLorentzVector(DVector3(0.0, 0.0, dTargetZCenter), locEventRFBunch->dTime);
+	locVertex->dKinFitNDF = 0;
+	locVertex->dKinFitChiSq = 0.0;
+
+	//error matrix
+	locVertex->dCovarianceMatrix.ResizeTo(4, 4);
+	locVertex->dCovarianceMatrix.Zero();
+	locVertex->dCovarianceMatrix(0, 0) = dTargetRadius*dTargetRadius/12.0; //x variance //should instead use beam spot size
+	locVertex->dCovarianceMatrix(1, 1) = dTargetRadius*dTargetRadius/12.0; //y variance //should instead use beam spot size
+	locVertex->dCovarianceMatrix(2, 2) = dTargetLength*dTargetLength/12.0; //z variance
+	locVertex->dCovarianceMatrix(3, 3) = locEventRFBunch->dTimeVariance; //t variance
+
+	_data.push_back(locVertex);
+	return NOERROR;
+}
+
+jerror_t DVertex_factory::Create_Vertex_OneTrack(const DTrackTimeBased* locTrackTimeBased, const DEventRFBunch* locEventRFBunch)
+{
+	DVector3 locPosition = locTrackTimeBased->position();
+	double locTime = locEventRFBunch->dTime + (locPosition.Z() - dTargetZCenter)/29.9792458;
+
+	DVertex* locVertex = new DVertex();
+	locVertex->dSpacetimeVertex = DLorentzVector(locPosition, locTime);
+	locVertex->dKinFitNDF = 0;
+	locVertex->dKinFitChiSq = 0.0;
+
+	//error matrix
+    const DMatrixDSym& locTrackErrorMatrix = locTrackTimeBased->errorMatrix();
+	locVertex->dCovarianceMatrix.ResizeTo(4, 4);
+	locVertex->dCovarianceMatrix.Zero();
+	for(size_t loc_i = 0; loc_i < 3; ++loc_i)
+	{
+		for(size_t loc_j = 0; loc_j < 3; ++loc_j)
+			locVertex->dCovarianceMatrix(loc_i, loc_j) = locTrackErrorMatrix(loc_i + 3, loc_j + 3);
+	}
+	locVertex->dCovarianceMatrix(3, 3) = locEventRFBunch->dTimeVariance; //t variance
+
+	_data.push_back(locVertex);
+	return NOERROR;
+}
+
+jerror_t DVertex_factory::Create_Vertex_Rough(DVector3 locPosition, const DEventRFBunch* locEventRFBunch)
+{
+	double locTime = locEventRFBunch->dTime + (locPosition.Z() - dTargetZCenter)/29.9792458;
+
+	DVertex* locVertex = new DVertex();
+	locVertex->dSpacetimeVertex = DLorentzVector(locPosition, locTime);
+	locVertex->dKinFitNDF = 0;
+	locVertex->dKinFitChiSq = 0.0;
+
+	//error matrix //too lazy to compute properly right now ... need to hack DAnalysisUtilities::Calc_DOCA()
+	locVertex->dCovarianceMatrix.ResizeTo(4, 4);
+	locVertex->dCovarianceMatrix.Zero();
+	locVertex->dCovarianceMatrix(0, 0) = 0.65; //x variance //from monitoring plots of vertex
+	locVertex->dCovarianceMatrix(1, 1) = 0.65; //y variance //from monitoring plots of vertex
+	locVertex->dCovarianceMatrix(2, 2) = 1.5; //z variance //a guess, semi-guarding against the worst case scenario //ugh
+	locVertex->dCovarianceMatrix(3, 3) = locEventRFBunch->dTimeVariance; //t variance
+
+	_data.push_back(locVertex);
+	return NOERROR;
+}
+
+jerror_t DVertex_factory::Create_Vertex_KinFit(const DEventRFBunch* locEventRFBunch)
+{
+	DKinFitConstraint_Vertex* locResultVertexConstraint = dynamic_cast<DKinFitConstraint_Vertex*>(*dKinFitter->Get_KinFitConstraints().begin());
+
 	TVector3 locFitVertex = locResultVertexConstraint->Get_CommonVertex();
-	DVector3 locTFitVertex(locFitVertex.X(), locFitVertex.Y(), locFitVertex.Z());
-	unsigned int locKinFitNDF = dKinFitter->Get_NDF();
-	double locKinFitChiSq = dKinFitter->Get_ChiSq();
-	Create_Vertex(locTFitVertex, locEventRFBunch->dTime, locKinFitNDF, locKinFitChiSq);
+	DVector3 locDFitVertex(locFitVertex.X(), locFitVertex.Y(), locFitVertex.Z());
+	double locTime = locEventRFBunch->dTime + (locDFitVertex.Z() - dTargetZCenter)/29.9792458;
+
+	DVertex* locVertex = new DVertex();
+	locVertex->dSpacetimeVertex = DLorentzVector(locDFitVertex, locTime);
+	locVertex->dKinFitNDF = dKinFitter->Get_NDF();
+	locVertex->dKinFitChiSq = dKinFitter->Get_ChiSq();
+
+	//error matrix
+	const TMatrixDSym* locMatrixDSym = dKinFitter->Get_VXi();
+	locVertex->dCovarianceMatrix.ResizeTo(4, 4);
+	locVertex->dCovarianceMatrix.Zero();
+	for(size_t loc_i = 0; loc_i < 3; ++loc_i)
+	{
+		for(size_t loc_j = 0; loc_j < 3; ++loc_j)
+			locVertex->dCovarianceMatrix(loc_i, loc_j) = (*locMatrixDSym)(loc_i, loc_j);
+	}
+	locVertex->dCovarianceMatrix(3, 3) = locEventRFBunch->dTimeVariance; //t variance
 
 	//Particle Maps & Pulls
 	//Build pulls from this:
 	map<DKinFitParticle*, map<DKinFitPullType, double> > locPulls_KinFitParticle;
 	dKinFitter->Get_Pulls(locPulls_KinFitParticle);
+
 	//By looping over the pulls:
 	map<DKinFitParticle*, map<DKinFitPullType, double> >::iterator locMapIterator = locPulls_KinFitParticle.begin();
 	for(; locMapIterator != locPulls_KinFitParticle.end(); ++locMapIterator)
@@ -137,38 +225,10 @@ jerror_t DVertex_factory::evnt(JEventLoop* locEventLoop, uint64_t eventnumber)
 		DKinFitParticle* locInputKinFitParticle = dKinFitUtils->Get_InputKinFitParticle(locOutputKinFitParticle);
 
 		const JObject* locSourceJObject = dKinFitUtils->Get_SourceJObject(locInputKinFitParticle);
-		_data.back()->dKinFitPulls[locSourceJObject] = locMapIterator->second;
+		locVertex->dKinFitPulls[locSourceJObject] = locMapIterator->second;
 	}
 
-	return NOERROR;
-}
-
-jerror_t DVertex_factory::Create_Vertex(DVector3 locPosition, double locRFTime, unsigned int locKinFitNDF, double locKinFitChiSq)
-{
-	double locTime = locRFTime + (locPosition.Z() - dTargetZCenter)/29.9792458;
-
-	DVertex* locVertex = new DVertex();
-	locVertex->dSpacetimeVertex = DLorentzVector(locPosition, locTime);
-	locVertex->dKinFitNDF = locKinFitNDF;
-	locVertex->dKinFitChiSq = locKinFitChiSq;
-
 	_data.push_back(locVertex);
+
 	return NOERROR;
 }
-
-//------------------
-// erun
-//------------------
-jerror_t DVertex_factory::erun(void)
-{
-	return NOERROR;
-}
-
-//------------------
-// fini
-//------------------
-jerror_t DVertex_factory::fini(void)
-{
-	return NOERROR;
-}
-

--- a/src/libraries/PID/DVertex_factory.h
+++ b/src/libraries/PID/DVertex_factory.h
@@ -31,16 +31,15 @@ using namespace jana;
 
 class DVertex_factory : public jana::JFactory<DVertex>
 {
-	public:
-
 	private:
 		jerror_t init(void);						///< Called once at program start.
 		jerror_t brun(jana::JEventLoop *locEventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
 		jerror_t evnt(jana::JEventLoop *locEventLoop, uint64_t eventnumber);	///< Called every event.
-		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
-		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
-		jerror_t Create_Vertex(DVector3 locPosition, double locRFTime, unsigned int locKinFitNDF = 0, double locKinFitChiSq = 0.0);
+		jerror_t Create_Vertex_NoTracks(const DEventRFBunch* locEventRFBunch);
+		jerror_t Create_Vertex_OneTrack(const DTrackTimeBased* locTrackTimeBased, const DEventRFBunch* locEventRFBunch);
+		jerror_t Create_Vertex_Rough(DVector3 locPosition, const DEventRFBunch* locEventRFBunch);
+		jerror_t Create_Vertex_KinFit(const DEventRFBunch* locEventRFBunch);
 
 		const DAnalysisUtilities* dAnalysisUtilities;
 		DKinFitter* dKinFitter;
@@ -49,6 +48,8 @@ class DVertex_factory : public jana::JFactory<DVertex>
 		int dKinFitDebugLevel;
 		bool dNoKinematicFitFlag;
 		double dTargetZCenter;
+		double dTargetLength;
+		double dTargetRadius;
 		double dMinTrackingFOM;
 };
 

--- a/src/plugins/Analysis/p3pi_hists/DReaction_factory_p3pi_hists.cc
+++ b/src/plugins/Analysis/p3pi_hists/DReaction_factory_p3pi_hists.cc
@@ -33,10 +33,6 @@ jerror_t DReaction_factory_p3pi_hists::evnt(JEventLoop* locEventLoop, uint64_t l
 	DReactionStep* locReactionStep = NULL;
 	DReaction* locReaction;
 
-	double minPi0FCAL = 0.115;
-	double maxPi0FCAL = 0.145;
-	double minPi0BCAL = 0.11;
-	double maxPi0BCAL = 0.16;
 	double minPi0FCAL_BCAL = 0.11;
 	double maxPi0FCAL_BCAL = 0.16;
 


### PR DESCRIPTION
1) Fix crash in histing kinfitresults for neutron pulls.

2) Compute error matrix for DVertex. Use this when building
DNeutralParticleHypothesis instead of target volume.  This gives a more
accurate momentum error matrix.

3) Fix sign error in massive neutral particle covariance calculation.

4) Save more kinfit metadata to the TTree.

5) Rename vertex constraint particles so more clear.

6) Add units to uncertainty histograms.