### PR TITLE
Coupled hdgeant and hddm fixes rtj

### DIFF
--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -2700,8 +2700,8 @@ jerror_t DEventSourceHDDM::Extract_DDIRCHit(hddm_s::HDDM *record,
 
    vector<DDIRCHit*> data;
 
-   const hddm_s::DircHitList &hits = record->getDircHits();
-   hddm_s::DircHitList::iterator iter;
+   const hddm_s::DircTruthHitList &hits = record->getDircTruthHits();
+   hddm_s::DircTruthHitList::iterator iter;
    for (iter = hits.begin(); iter != hits.end(); ++iter) {
       DDIRCHit *hit = new DDIRCHit;
       hit->x = iter->getX();

--- a/src/libraries/HDDM/event.xml
+++ b/src/libraries/HDDM/event.xml
@@ -96,13 +96,13 @@
         </cereTruthPoint>
       </Cerenkov>
       <RICH minOccurs="0">
-        <richHit maxOccurs="unbounded" minOccurs="0" t="float" x="float" y="float" z="float"/>
+        <richTruthHit maxOccurs="unbounded" minOccurs="0" t="float" x="float" y="float" z="float"/>
         <richTruthPoint E="float" maxOccurs="unbounded" minOccurs="0" primary="boolean" ptype="int" px="float" py="float" pz="float" t="float" track="int" x="float" y="float" z="float">
           <trackID minOccurs="0" itrack="int"/>
         </richTruthPoint>
       </RICH>
       <DIRC minOccurs="0">
-        <dircHit maxOccurs="unbounded" minOccurs="0" t="float" x="float" y="float" z="float" E="float"/>
+        <dircTruthHit maxOccurs="unbounded" minOccurs="0" t="float" x="float" y="float" z="float" E="float"/>
         <dircTruthPoint E="float" maxOccurs="unbounded" minOccurs="0" primary="boolean" ptype="int" px="float" py="float" pz="float" t="float" track="int" x="float" y="float" z="float">
           <trackID minOccurs="0" itrack="int"/>
         </dircTruthPoint>
@@ -162,18 +162,18 @@
           <psHit dE="float" t="float" maxOccurs="unbounded"/>
           <psTruthHit dE="float" t="float" maxOccurs="unbounded" itrack="int" ptype="int"/>
         </psTile>
-	<psTruthPoint E="float" dEdx="float" maxOccurs="unbounded" minOccurs="0" phi="float" primary="boolean" ptype="int" px="float" py="float" pz="float" column="int" arm="int" t="float" track="int" x="float" y="float" z="float">
-	  <trackID minOccurs="0" itrack="int"/>
-	</psTruthPoint>
+	    <psTruthPoint E="float" dEdx="float" maxOccurs="unbounded" minOccurs="0" phi="float" primary="boolean" ptype="int" px="float" py="float" pz="float" column="int" arm="int" t="float" track="int" x="float" y="float" z="float">
+	      <trackID minOccurs="0" itrack="int"/>
+	    </psTruthPoint>
       </pairSpectrometerFine>
       <pairSpectrometerCoarse minOccurs="0">
         <pscPaddle maxOccurs="unbounded" minOccurs="0" module="int" arm="int">
           <pscHit dE="float" t="float" maxOccurs="unbounded"/>
           <pscTruthHit dE="float" t="float" maxOccurs="unbounded" itrack="int" ptype="int"/>
         </pscPaddle>
-	<pscTruthPoint E="float" dEdx="float" maxOccurs="unbounded" minOccurs="0" phi="float" primary="boolean" ptype="int" px="float" py="float" pz="float" module="int" t="float" arm="int" track="int" x="float" y="float" z="float">
-	  <trackID minOccurs="0" itrack="int"/>
-	</pscTruthPoint>
+	    <pscTruthPoint E="float" dEdx="float" maxOccurs="unbounded" minOccurs="0" phi="float" primary="boolean" ptype="int" px="float" py="float" pz="float" module="int" t="float" arm="int" track="int" x="float" y="float" z="float">
+	      <trackID minOccurs="0" itrack="int"/>
+	    </pscTruthPoint>
       </pairSpectrometerCoarse>
       <mcTrajectory minOccurs="0">
         <mcTrajectoryPoint E="float" dE="float" maxOccurs="unbounded" mech="int" minOccurs="0" part="int" primary_track="int" px="float" py="float" pz="float" radlen="float" step="float" t="float" track="int" x="float" y="float" z="float"/>
@@ -185,6 +185,9 @@
 		  <fmwpcTruthHit dE="float" dx="float" maxOccurs="unbounded" t="float"/>
 	      <fmwpcHit dE="float" maxOccurs="unbounded" t="float"/>
         </fmwpcChamber>
+        <fmwpcTruthPoint E="float" maxOccurs="unbounded" minOccurs="0" primary="boolean" ptype="int" px="float" py="float" pz="float" t="float" track="int" x="float" y="float" z="float">
+          <trackID minOccurs="0" itrack="int"/>
+        </fmwpcTruthPoint>
 	  </forwardMWPC>
 
     </hitView>

--- a/src/programs/Simulation/HDGeant/hitDIRC.c
+++ b/src/programs/Simulation/HDGeant/hitDIRC.c
@@ -66,8 +66,8 @@ void hitDIRC(float xin[4], float xout[4], float pin[5], float pout[5],
 		void** twig = getTwig(&dircTree, mark);
 		if (*twig == 0) {
 			s_DIRC_t* dirc = *twig = make_s_DIRC();
-			s_DircHits_t* dircHits = make_s_DircHits(1);
-			dirc->dircHits = dircHits;
+			s_DircTruthHits_t* dircHits = make_s_DircTruthHits(1);
+			dirc->dircTruthHits = dircHits;
 			dircHits->in[0].x = xin[0];
 			dircHits->in[0].y = xin[1];
 			dircHits->in[0].z = xin[2];
@@ -98,17 +98,17 @@ s_DIRC_t* pickDirc() {
 
 	box = make_s_DIRC();
 	// create DIRC hits
-	box->dircHits = make_s_DircHits(dircCount);
+	box->dircTruthHits = make_s_DircTruthHits(dircCount);
 	box->dircTruthPoints = make_s_DircTruthPoints(dircpointCount);
 
 	while ((item = pickTwig(&dircTree))) {
 
 		// pack DIRC hits
-		s_DircHits_t* dirchits = item->dircHits;
+		s_DircTruthHits_t* dirchits = item->dircTruthHits;
 		int dirchit;
 		for (dirchit = 0; dirchit < dirchits->mult; ++dirchit) {
-			int m = box->dircHits->mult++;
-			box->dircHits->in[m] = dirchits->in[dirchit];
+			int m = box->dircTruthHits->mult++;
+			box->dircTruthHits->in[m] = dirchits->in[dirchit];
 		}
 		if (dirchits != HDDM_NULL) {
 			FREE(dirchits);
@@ -128,16 +128,16 @@ s_DIRC_t* pickDirc() {
 
 	// clear DIRC hits and truth
 	dircCount = dircpointCount = 0;
-	if ((box->dircHits != HDDM_NULL ) && (box->dircHits->mult == 0)) {
-		FREE(box->dircHits);
-		box->dircHits = HDDM_NULL;
+	if ((box->dircTruthHits != HDDM_NULL ) && (box->dircTruthHits->mult == 0)) {
+		FREE(box->dircTruthHits);
+		box->dircTruthHits = HDDM_NULL;
 	}
 	if ((box->dircTruthPoints != HDDM_NULL )
 			&& (box->dircTruthPoints->mult == 0)) {
 		FREE(box->dircTruthPoints);
 		box->dircTruthPoints = HDDM_NULL;
 	}
-	if ((box->dircHits->mult == 0) && (box->dircTruthPoints->mult == 0)) {
+	if ((box->dircTruthHits->mult == 0) && (box->dircTruthPoints->mult == 0)) {
 		FREE(box);
 		box = HDDM_NULL;
 	}

--- a/src/programs/Simulation/HDGeant/hitStart.c
+++ b/src/programs/Simulation/HDGeant/hitStart.c
@@ -115,7 +115,7 @@ void hitStartCntr (float xin[4], float xout[4],
           ncounter++;
         }
         if (!strcmp(strings[i].str,"START_THRESH_MEV")) {
-          TWO_HIT_RESOL  = values[i];
+          THRESH_MEV  = values[i];
           ncounter++;
         }
         if (!strcmp(strings[i].str,"START_LIGHT_GUIDE")) {

--- a/src/programs/Simulation/HDGeant/settofg.F
+++ b/src/programs/Simulation/HDGeant/settofg.F
@@ -6,8 +6,8 @@
 * Sets the Geant variable TOFG which determines the start time of the
 * tracking for subsequent particles placed on the primary stack.  The
 * start time is determined assuming a beam photon is being generated.
-* It is set so that the photon will cross the reference time plane at
-* TOF=t0 if it makes it that far.
+* It is set so that the beam photon will cross the reference plane at
+* TOF=time0 if it makes it that far.
 *
 #include "geant321/gconst.inc"
 #include "geant321/gctrak.inc"
@@ -45,7 +45,7 @@ c smear the time0 value by the trigger time sigma
       call GRANOR(xnormal(1),xnormal(2))
       t0 = time0 + trigger_time_sigma_ns*xnormal(1)
 c discretize the time according to the beam microstructure
-      TOFG=beam_bucket_period_ns*int(t0/beam_bucket_period_ns+0.5)
+      TOFG=beam_bucket_period_ns*floor(t0/beam_bucket_period_ns+0.5)
 c synchronize the time to the accelerator clock, with the phase
 c set to zero when the bunch crosses the reference plane
       TOFG=TOFG*1e-9 + (vertex(3)-reference_time_plane_z)/CLIGHT


### PR DESCRIPTION
While writing hits code for hdgeant4, I found a few bugs in the original hdgeant code. These are fixed here. I also took this opportunity to rename any tags that contain "truth" information to include the string "Truth" in the tag name, consistent with GlueX policy for tag names in hddm_s. No behavioral changes are expected because of the latter renaming operation, until such time as DIRC simulation developers come along and implement real "hits" code for the DIRC. At that point, the structure of both the dircTruthHit and dirHit tag will need to be revised, as following the light reflection path through the DIRC optics will no doubt be needed in the Geant sim. NOTE: this should not generate a hddm conflict error message when trying to read an old simulation with DIRC hits using the new DEventSourceHDDM code.