### PR TITLE
Don't recycle matrix memory unless it was allocated for this fit!

### DIFF
--- a/src/libraries/KINFITTER/DKinFitUtils.cc
+++ b/src/libraries/KINFITTER/DKinFitUtils.cc
@@ -909,7 +909,7 @@ void DKinFitUtils::Recycle_Particles(set<DKinFitParticle*>& locParticles)
 	for(; locParticleIterator != locParticles.end(); ++locParticleIterator)
 	{
 		const TMatrixFSym* locCovMatrix = (*locParticleIterator)->Get_CovarianceMatrix();
-		if(locCovMatrix != NULL)
+		if((locCovMatrix != NULL) && dUpdateCovarianceMatricesFlag)
 			locMatricesToRecycle.push_back(locCovMatrix);
 
 		map<DKinFitParticle*, DKinFitParticle*>::iterator locOIIterator = dParticleMap_OutputToInput.find(*locParticleIterator);

--- a/src/libraries/KINFITTER/DKinFitter.cc
+++ b/src/libraries/KINFITTER/DKinFitter.cc
@@ -2551,6 +2551,7 @@ void DKinFitter::Set_FinalTrackInfo(void)
 			continue; // no distance over which to propagate
 
 		//updating the covariance matrix: a unique cov matrix object was cloned on fit start, so can safely update it directly
+			//unless DKinFitUtils::Get_UpdateCovarianceMatricesFlag() is false. In which case, this matrix is not propagated (is unchanged)
 		TMatrixFSym* locCovarianceMatrix = const_cast<TMatrixFSym*>(locKinFitParticle->Get_CovarianceMatrix());
 
 		TVector3 locMomentum;


### PR DESCRIPTION
Was accidentally recycling memory that was allocated when reading in the
tracks!