### PR TITLE
Don't treat truncated EVIO files as errors

### DIFF
--- a/src/libraries/DAQ/JEventSource_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.h
@@ -199,6 +199,7 @@ class JEventSource_EVIOpp: public jana::JEventSource{
 		bool     LINK_BORCONFIG;
 		bool     LINK_CONFIG;
 		bool     IGNORE_EMPTY_BOR;
+		bool     TREAT_TRUNCATED_AS_ERROR;
 		
 		uint32_t jobtype;
 };


### PR DESCRIPTION
Change so that truncated EVIO file doesn't propagate to JANA return code by default so that it indicates an error condition. Added EVIO:TREAT_TRUNCATED_AS_ERROR so user can specify what was previous default where truncated files are treated  as error conditions.