### PR TITLE
* hitXXX.c, hitBCal.cc [rtj]

### DIFF
--- a/src/programs/Simulation/HDGeant/hitBCal.cc
+++ b/src/programs/Simulation/HDGeant/hitBCal.cc
@@ -465,7 +465,7 @@ void hitBarrelEMcal (float xin[4], float xout[4],
          *twig = bcal;
          bcal->bcalTruthShowers = showers = make_s_BcalTruthShowers(1);
          int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
-         showers->in[0].primary = (track <= a);
+         showers->in[0].primary = (track <= a && stack == 0);
          showers->in[0].track = track;
          showers->in[0].z = xin[2];
          showers->in[0].r = r;

--- a/src/programs/Simulation/HDGeant/hitCCal.c
+++ b/src/programs/Simulation/HDGeant/hitCCal.c
@@ -62,8 +62,8 @@ void hitComptonEMcal (float xin[4], float xout[4],
       {
          s_ComptonEMcal_t* cal = *twig = make_s_ComptonEMcal();
          cal->ccalTruthShowers = showers = make_s_CcalTruthShowers(1);
-        int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
-         showers->in[0].primary = (stack <= a);
+         int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
+         showers->in[0].primary = (track <= a && stack == 0);
          showers->in[0].track = track;
          showers->in[0].t = xin[3]*1e9;
          showers->in[0].x = xin[0];

--- a/src/programs/Simulation/HDGeant/hitCDC.c
+++ b/src/programs/Simulation/HDGeant/hitCDC.c
@@ -355,6 +355,7 @@ void hitCentralDC (float xin[4], float xout[4],
   trackdir[2] =-xinlocal[2] + xoutlocal[2];
   alpha=-(xinlocal[0]*trackdir[0]+xinlocal[1]*trackdir[1])
     /(trackdir[0]*trackdir[0]+trackdir[1]*trackdir[1]);
+  alpha = (alpha < 0)? 0 : (alpha > 1)? 1 : alpha;
   xlocal[0]=xinlocal[0]+trackdir[0]*alpha;  
   xlocal[1]=xinlocal[1]+trackdir[1]*alpha;
   xlocal[2]=xinlocal[2]+trackdir[2]*alpha;  
@@ -446,8 +447,8 @@ void hitCentralDC (float xin[4], float xout[4],
       {
          s_CentralDC_t* cdc = *twig = make_s_CentralDC();
          s_CdcTruthPoints_t* points = make_s_CdcTruthPoints(1);
-        int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
-         points->in[0].primary = (stack <= a);
+         int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
+         points->in[0].primary = (track <= a && stack == 0);
          points->in[0].track = track;
          points->in[0].t = t;
          points->in[0].z = x[2];

--- a/src/programs/Simulation/HDGeant/hitCerenkov.c
+++ b/src/programs/Simulation/HDGeant/hitCerenkov.c
@@ -57,8 +57,8 @@ void hitCerenkov (float xin[4], float xout[4],
          s_Cerenkov_t* cere = *twig = make_s_Cerenkov();
          s_CereTruthPoints_t* points = make_s_CereTruthPoints(1);
          cere->cereTruthPoints = points;
-        int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
-         points->in[0].primary = (stack <= a);
+         int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
+         points->in[0].primary = (track <= a && stack == 0);
          points->in[0].track = track;
          points->in[0].x = xin[0];
          points->in[0].y = xin[1];

--- a/src/programs/Simulation/HDGeant/hitDIRC.c
+++ b/src/programs/Simulation/HDGeant/hitDIRC.c
@@ -40,9 +40,8 @@ void hitDIRC(float xin[4], float xout[4], float pin[5], float pout[5],
 			s_DIRC_t* dirc = *twig = make_s_DIRC();
 			s_DircTruthPoints_t* points = make_s_DircTruthPoints(1);
 			dirc->dircTruthPoints = points;
-			int a =
-					thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
-			points->in[0].primary = (stack <= a);
+			int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
+			points->in[0].primary = (track <= a && stack == 0);
 			points->in[0].track = track;
 			points->in[0].x = xin[0];
 			points->in[0].y = xin[1];

--- a/src/programs/Simulation/HDGeant/hitFCal.c
+++ b/src/programs/Simulation/HDGeant/hitFCal.c
@@ -143,8 +143,8 @@ void hitForwardEMcal (float xin[4], float xout[4],
       {
          s_ForwardEMcal_t* cal = *twig = make_s_ForwardEMcal();
          cal->fcalTruthShowers = showers = make_s_FcalTruthShowers(1);
-        int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
-         showers->in[0].primary = (stack <= a);
+         int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
+         showers->in[0].primary = (track <= a && stack == 0);
          showers->in[0].track = track;
          showers->in[0].t = xin[3]*1e9;
          showers->in[0].x = xin[0];

--- a/src/programs/Simulation/HDGeant/hitFDC.c
+++ b/src/programs/Simulation/HDGeant/hitFDC.c
@@ -691,8 +691,8 @@ void hitForwardDC (float xin[4], float xout[4],
       u[1] = xinlocal[0]-xwire;
       dradius = fabs(u[1]*cosalpha-u[0]*sinalpha);
       points->mult = 1;
-        int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
-      points->in[0].primary = (stack <= a);
+      int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
+      points->in[0].primary = (track <= a && stack == 0);
       points->in[0].track = track;
       points->in[0].x = x[0];
       points->in[0].y = x[1];

--- a/src/programs/Simulation/HDGeant/hitFTOF.c
+++ b/src/programs/Simulation/HDGeant/hitFTOF.c
@@ -41,6 +41,8 @@
 
 #include "calibDB.h"
 
+extern s_HDDM_t* thisInputEvent;
+
 // plastic scintillator specific constants
 static float ATTEN_LENGTH =   150;
 static float C_EFFECTIVE  =   15.0;
@@ -214,7 +216,8 @@ void hitForwardTOF (float xin[4], float xout[4],
       s_ForwardTOF_t* tof = *twig = make_s_ForwardTOF();
       s_FtofTruthPoints_t* points = make_s_FtofTruthPoints(1);
       tof->ftofTruthPoints = points;
-      points->in[0].primary = (stack == 0);
+      int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
+      points->in[0].primary = (track <= a && stack == 0);
       points->in[0].track = track;
       points->in[0].x = x[0];
       points->in[0].y = x[1];

--- a/src/programs/Simulation/HDGeant/hitGCal.c
+++ b/src/programs/Simulation/HDGeant/hitGCal.c
@@ -68,8 +68,8 @@ void hitGapEMcal (float xin[4], float xout[4],
       {
          s_GapEMcal_t* cal = *twig = make_s_GapEMcal();
          cal->gcalTruthShowers = showers = make_s_GcalTruthShowers(1);
-        int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
-         showers->in[0].primary = (stack <= a);
+         int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
+         showers->in[0].primary = (track <= a && stack == 0);
          showers->in[0].track = track;
          showers->in[0].z = xin[2];
          showers->in[0].r = r;

--- a/src/programs/Simulation/HDGeant/hitPS.c
+++ b/src/programs/Simulation/HDGeant/hitPS.c
@@ -85,7 +85,7 @@ void hitPS(float xin[4], float xout[4],float pin[5], float pout[5], float dEsum,
          s_PsTruthPoints_t* points = make_s_PsTruthPoints(1);
          ps->psTruthPoints = points;
          int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
-         points->in[0].primary = (stack <= a);
+         points->in[0].primary = (track <= a && stack == 0);
          points->in[0].track = track;
          points->in[0].t = t;
          points->in[0].z = x[2];

--- a/src/programs/Simulation/HDGeant/hitPSC.c
+++ b/src/programs/Simulation/HDGeant/hitPSC.c
@@ -84,8 +84,8 @@ void hitPSC(float xin[4], float xout[4],float pin[5], float pout[5], float dEsum
          s_PairSpectrometerCoarse_t* psc = *twig = make_s_PairSpectrometerCoarse();
          s_PscTruthPoints_t* points = make_s_PscTruthPoints(1);
          psc->pscTruthPoints = points;
-        int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
-         points->in[0].primary = (stack <= a);
+         int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
+         points->in[0].primary = (track <= a && stack == 0);
          points->in[0].track = track;
          points->in[0].t = t;
          points->in[0].z = x[2];

--- a/src/programs/Simulation/HDGeant/hitStart.c
+++ b/src/programs/Simulation/HDGeant/hitStart.c
@@ -1,10 +1,10 @@
 /*
  * hitStart - registers hits for Start counter
  *
- *	This is a part of the hits package for the
- *	HDGeant simulation program for Hall D.
+ *    This is a part of the hits package for the
+ *    HDGeant simulation program for Hall D.
  *
- *	version 1.0 	-Richard Jones July 16, 2001
+ *    version 1.0     -Richard Jones July 16, 2001
  *
  * changes: Wed Jun 20 13:19:56 EDT 2007 B. Zihlmann 
  *          add ipart to the function hitStartCntr
@@ -79,7 +79,7 @@ static int initialized = 0;
 
 void hitStartCntr (float xin[4], float xout[4],
                    float pin[5], float pout[5], float dEsum,
-                    int track, int stack, int history, int ipart)
+                   int track, int stack, int history, int ipart)
 {     
    float x[3], t;
    float dx[3], dr;
@@ -221,10 +221,10 @@ void hitStartCntr (float xin[4], float xout[4],
 
 
    //   printf("x_gl, z_gl, x_l, z_l %f %f %f\n",
-   //  	  xin[0],xin[1],xin[2]);
+   //        xin[0],xin[1],xin[2]);
 
    //   printf("x_gl, z_gl, x_l, z_l %f %f %f %f %f %f %f\n",
-   //  	  x[0],x[1],x[2], xlocal[0],xlocal[1],xlocal[2],dpath);
+   //        x[0],x[1],x[2], xlocal[0],xlocal[1],xlocal[2],dpath);
 
 
    /* post the hit to the truth tree */
@@ -238,8 +238,8 @@ void hitStartCntr (float xin[4], float xout[4],
          s_StartCntr_t* stc = *twig = make_s_StartCntr();
          s_StcTruthPoints_t* points = make_s_StcTruthPoints(1);
          stc->stcTruthPoints = points;
-	 int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
-         points->in[0].primary = (stack <= a);
+         int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
+         points->in[0].primary = (track <= a && stack == 0);
          points->in[0].track = track;
          points->in[0].t = t;
          points->in[0].z = x[2];
@@ -249,8 +249,8 @@ void hitStartCntr (float xin[4], float xout[4],
          points->in[0].py = pin[1]*pin[4];
          points->in[0].pz = pin[2]*pin[4];
          points->in[0].E = pin[3];
-	 points->in[0].dEdx = dEdx;
-	 points->in[0].ptype = ipart;
+         points->in[0].dEdx = dEdx;
+         points->in[0].ptype = ipart;
          points->in[0].sector = getsector_wrapper_();
          points->in[0].trackID = make_s_TrackID();
          points->in[0].trackID->itrack = gidGetId(track);
@@ -263,7 +263,7 @@ void hitStartCntr (float xin[4], float xout[4],
 
    //   if( (ipart==8) && (x[2]<90.)){
    //     printf("x_gl, z_gl, x_l, z_l %f %f %f %f %f %f\n",
-   //	    x[0],x[1],x[2], xlocal[0],xlocal[1],xlocal[2]);
+   //        x[0],x[1],x[2], xlocal[0],xlocal[1],xlocal[2]);
    //   }
 
 
@@ -279,52 +279,52 @@ void hitStartCntr (float xin[4], float xout[4],
       float dbent  = 0.0;
       float dpath  = 0.0;
       if(xlocal[2] >= BENT_REGION){
-      	dbent = ( xlocal[2] - BENT_REGION )*ANGLE_COR;
-      	dpath = BENT_REGION + dbent;
+          dbent = ( xlocal[2] - BENT_REGION )*ANGLE_COR;
+          dpath = BENT_REGION + dbent;
       } else {
-      	dpath  = xlocal[2];
+          dpath  = xlocal[2];
       }
 
       /* float dEcorr = dEsum * exp(-dpath/ATTEN_LENGTH); */
       /* float tcorr  = t + dpath/C_EFFECTIVE; */
 
       /* printf("\n Sector %d Fired \n t = %.5f \n dEsum = %.5f \n dpath = %.5f \n",  */
-      /* 	     sector, t, dEsum, dpath); */
+      /*          sector, t, dEsum, dpath); */
 
       int sector_index = sector - 1;
       float dEcorr = 9.9E+9;
       float tcorr  = 9.9E+9;
       
       if (xlocal[2] <= STRAIGHT_LENGTH)
-	{
-	  dEcorr = dEsum * exp(dpath*SC_STRAIGHT_ATTENUATION_B[sector_index]);
-	  tcorr  = t + dpath * SC_STRAIGHT_PROPAGATION_B[sector_index] + SC_STRAIGHT_PROPAGATION_A[sector_index];
+    {
+      dEcorr = dEsum * exp(dpath*SC_STRAIGHT_ATTENUATION_B[sector_index]);
+      tcorr  = t + dpath * SC_STRAIGHT_PROPAGATION_B[sector_index] + SC_STRAIGHT_PROPAGATION_A[sector_index];
 
-	  /* printf("HIT OCCURED IN STRAIGHT SECTION \n"); */
-	  /* printf("Attenuation Corrections: A = %.5f, B = %.5f, C = %.5f \n", SC_STRAIGHT_ATTENUATION_A[sector_index], SC_STRAIGHT_ATTENUATION_B[sector_index], SC_STRAIGHT_ATTENUATION_C[sector_index]); */
-	  /* printf("Time Corrections: B = %.5f, A = %.5f \n", SC_STRAIGHT_PROPAGATION_B[sector_index], SC_STRAIGHT_PROPAGATION_A[sector_index]);  */
-	}
+      /* printf("HIT OCCURED IN STRAIGHT SECTION \n"); */
+      /* printf("Attenuation Corrections: A = %.5f, B = %.5f, C = %.5f \n", SC_STRAIGHT_ATTENUATION_A[sector_index], SC_STRAIGHT_ATTENUATION_B[sector_index], SC_STRAIGHT_ATTENUATION_C[sector_index]); */
+      /* printf("Time Corrections: B = %.5f, A = %.5f \n", SC_STRAIGHT_PROPAGATION_B[sector_index], SC_STRAIGHT_PROPAGATION_A[sector_index]);  */
+    }
       else if (xlocal[2] > STRAIGHT_LENGTH && xlocal[2] <= (STRAIGHT_LENGTH + BEND_LENGTH))
-	{
-	  dEcorr = dEsum * ((SC_BENDNOSE_ATTENUATION_A[sector_index] * exp(dpath*SC_BENDNOSE_ATTENUATION_B[sector_index]) + SC_BENDNOSE_ATTENUATION_C[sector_index]) / 
-				  SC_STRAIGHT_ATTENUATION_A[sector_index]);
-	  tcorr  = t + dpath * SC_BEND_PROPAGATION_B[sector_index] + SC_BEND_PROPAGATION_A[sector_index];
+    {
+      dEcorr = dEsum * ((SC_BENDNOSE_ATTENUATION_A[sector_index] * exp(dpath*SC_BENDNOSE_ATTENUATION_B[sector_index]) + SC_BENDNOSE_ATTENUATION_C[sector_index]) / 
+                  SC_STRAIGHT_ATTENUATION_A[sector_index]);
+      tcorr  = t + dpath * SC_BEND_PROPAGATION_B[sector_index] + SC_BEND_PROPAGATION_A[sector_index];
 
-	  /* printf("HIT OCCURED IN BEND SECTION \n"); */
-	  /* printf("Attenuation Corrections: A = %.5f, B = %.5f, C = %.5f \n", SC_BENDNOSE_ATTENUATION_A[sector_index], SC_BENDNOSE_ATTENUATION_B[sector_index], SC_BENDNOSE_ATTENUATION_C[sector_index]); */
-	  /* printf("Time Corrections: B = %.5f,  A = %.5f \n", SC_BEND_PROPAGATION_B[sector_index], SC_BEND_PROPAGATION_A[sector_index]);  */
-	}
+      /* printf("HIT OCCURED IN BEND SECTION \n"); */
+      /* printf("Attenuation Corrections: A = %.5f, B = %.5f, C = %.5f \n", SC_BENDNOSE_ATTENUATION_A[sector_index], SC_BENDNOSE_ATTENUATION_B[sector_index], SC_BENDNOSE_ATTENUATION_C[sector_index]); */
+      /* printf("Time Corrections: B = %.5f,  A = %.5f \n", SC_BEND_PROPAGATION_B[sector_index], SC_BEND_PROPAGATION_A[sector_index]);  */
+    }
       else if (xlocal[2] > (STRAIGHT_LENGTH + BEND_LENGTH) && xlocal[2] <= (STRAIGHT_LENGTH + BEND_LENGTH + NOSE_LENGTH))
-	{
-	  dEcorr = dEsum * ((SC_BENDNOSE_ATTENUATION_A[sector_index] * exp(dpath*SC_BENDNOSE_ATTENUATION_B[sector_index]) + SC_BENDNOSE_ATTENUATION_C[sector_index]) / 
-				  SC_STRAIGHT_ATTENUATION_A[sector_index]);
-	  
-	  tcorr  = t + dpath * SC_NOSE_PROPAGATION_B[sector_index] + SC_NOSE_PROPAGATION_A[sector_index];
+    {
+      dEcorr = dEsum * ((SC_BENDNOSE_ATTENUATION_A[sector_index] * exp(dpath*SC_BENDNOSE_ATTENUATION_B[sector_index]) + SC_BENDNOSE_ATTENUATION_C[sector_index]) / 
+                  SC_STRAIGHT_ATTENUATION_A[sector_index]);
+      
+      tcorr  = t + dpath * SC_NOSE_PROPAGATION_B[sector_index] + SC_NOSE_PROPAGATION_A[sector_index];
 
-	  /* printf("HIT OCCURED IN NOSE SECTION \n"); */
-	  /* printf("Attenuation Corrections: A = %.5f, B = %.5f, C = %.5f \n", SC_BENDNOSE_ATTENUATION_A[sector_index], SC_BENDNOSE_ATTENUATION_B[sector_index], SC_BENDNOSE_ATTENUATION_C[sector_index]); */
-	  /* printf("Time Corrections: B = %.5f,  A = %.5f \n", SC_NOSE_PROPAGATION_B[sector_index], SC_NOSE_PROPAGATION_A[sector_index]); */ 
-	}
+      /* printf("HIT OCCURED IN NOSE SECTION \n"); */
+      /* printf("Attenuation Corrections: A = %.5f, B = %.5f, C = %.5f \n", SC_BENDNOSE_ATTENUATION_A[sector_index], SC_BENDNOSE_ATTENUATION_B[sector_index], SC_BENDNOSE_ATTENUATION_C[sector_index]); */
+      /* printf("Time Corrections: B = %.5f,  A = %.5f \n", SC_NOSE_PROPAGATION_B[sector_index], SC_NOSE_PROPAGATION_A[sector_index]); */ 
+    }
       else return;
 
       /* printf("tcorr = %.5f \n dEcorr = %.5f \n", tcorr, dEcorr); */
@@ -357,7 +357,7 @@ void hitStartCntr (float xin[4], float xout[4],
             break;
          }
       }
-      if (nhit < hits->mult)		/* merge with former hit */
+      if (nhit < hits->mult)        /* merge with former hit */
       {
          if (tcorr < hits->in[nhit].t)
          {
@@ -367,9 +367,9 @@ void hitStartCntr (float xin[4], float xout[4],
          hits->in[nhit].t = 
                  (hits->in[nhit].t * hits->in[nhit].dE + tcorr * dEcorr) /
                  (hits->in[nhit].dE + dEcorr);
-			hits->in[nhit].dE += dEcorr;
+            hits->in[nhit].dE += dEcorr;
       }
-      else if (nhit < MAX_HITS)		/* create new hit */
+      else if (nhit < MAX_HITS)        /* create new hit */
       {
          hits->in[nhit].t = tcorr ;
          hits->in[nhit].dE = dEcorr;

--- a/src/programs/Simulation/HDGeant/hitUPV.c
+++ b/src/programs/Simulation/HDGeant/hitUPV.c
@@ -100,8 +100,8 @@ void hitUpstreamEMveto (float xin[4], float xout[4],
     if (*twig == 0) {
       s_UpstreamEMveto_t* upv = *twig = make_s_UpstreamEMveto();
       s_UpvTruthShowers_t* showers = make_s_UpvTruthShowers(1);
-        int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
-      showers->in[0].primary = (stack <= a);
+      int a = thisInputEvent->physicsEvents->in[0].reactions->in[0].vertices->in[0].products->mult;
+      showers->in[0].primary = (track <= a && stack == 0);
       showers->in[0].track = track;
       showers->in[0].x = xin[0];
       showers->in[0].y = xin[1];


### PR DESCRIPTION
   - changed the way that the "primary" attribute of truth hits was
     being assigned, to correct a bug and make the output agree with
     HDGeant4. Prior to this, all of the tracks were being assigned
     primary="1", regardless of whether they were primary or secondary
     tracks, probably not a big deal but it should be fixed.