### PR TITLE
* programs/Simulation/HDGeant/hitCDC.c, hitCerenkov.c, hitDIRC.c, hit…

### DIFF
--- a/src/programs/Simulation/HDGeant/hitBCal.cc
+++ b/src/programs/Simulation/HDGeant/hitBCal.cc
@@ -429,7 +429,7 @@ void hitBarrelEMcal (float xin[4], float xout[4],
    float xlocal[3];
    float xbcal[3];
    float xHat[] = {1,0,0};
-  
+
    if (!initialized)
       initializeBarrelEMcal();
   
@@ -451,6 +451,8 @@ void hitBarrelEMcal (float xin[4], float xout[4],
      t = xin[3] * 1e9;
    }
   
+   int itrack = (stack == 0)? gidGetId(track) : -1;
+
    /* post the hit to the truth tree */
 
    if ((history == 0) && (pin[3] > THRESH_MEV/1e3)) {
@@ -476,8 +478,8 @@ void hitBarrelEMcal (float xin[4], float xout[4],
          showers->in[0].pz = pin[2]*pin[4];
          showers->in[0].E = pin[3];
          showers->in[0].ptype = ipart;
-	 showers->in[0].trackID = make_s_TrackID();
-	 showers->in[0].trackID->itrack = gidGetId(track);
+         showers->in[0].trackID = make_s_TrackID();
+         showers->in[0].trackID->itrack = itrack;
          showers->mult = 1;
          showerCount++;
       }

--- a/src/programs/Simulation/HDGeant/hitBCal.cc
+++ b/src/programs/Simulation/HDGeant/hitBCal.cc
@@ -620,7 +620,7 @@ s_BarrelEMcal_t* pickBarrelEMcal ()
          int i,iok;
          for (iok=i=0; i < (int)hits->mult; i++)
          {
-            if (hits->in[i].E >= THRESH_MEV/1e3)
+            if (hits->in[i].E > THRESH_MEV/1e3)
             {
 #if TESTING_CAL_CONTAINMENT
                Etotal += hits->in[i].E;

--- a/src/programs/Simulation/HDGeant/hitCCal.c
+++ b/src/programs/Simulation/HDGeant/hitCCal.c
@@ -53,6 +53,8 @@ void hitComptonEMcal (float xin[4], float xout[4],
 
    /* post the hit to the truth tree */
 
+   int itrack = (stack == 0)? gidGetId(track) : -1;
+
    if ((history == 0) && (pin[3] > THRESH_MEV/1e3))
    {
       s_CcalTruthShowers_t* showers;
@@ -75,7 +77,7 @@ void hitComptonEMcal (float xin[4], float xout[4],
          showers->in[0].E = pin[3];
          showers->in[0].ptype = ipart;
          showers->in[0].trackID = make_s_TrackID();
-         showers->in[0].trackID->itrack = gidGetId(track);
+         showers->in[0].trackID->itrack = itrack;
          showers->mult = 1;
          showerCount++;
       }

--- a/src/programs/Simulation/HDGeant/hitCCal.c
+++ b/src/programs/Simulation/HDGeant/hitCCal.c
@@ -193,7 +193,7 @@ s_ComptonEMcal_t* pickComptonEMcal ()
             int i,iok;
             for (iok=i=0; i < hits->mult; i++)
             {
-               if (hits->in[i].E >= THRESH_MEV/1e3)
+               if (hits->in[i].E > THRESH_MEV/1e3)
                {
                   if (iok < i)
                   {

--- a/src/programs/Simulation/HDGeant/hitCDC.c
+++ b/src/programs/Simulation/HDGeant/hitCDC.c
@@ -1,10 +1,10 @@
 /*
  * hitCDC - registers hits for Central Drift Chamber
  *
- *	This is a part of the hits package for the
- *	HDGeant simulation program for Hall D.
+ *    This is a part of the hits package for the
+ *    HDGeant simulation program for Hall D.
  *
- *	version 1.0 	-Richard Jones July 16, 2001
+ *    version 1.0     -Richard Jones July 16, 2001
  *
  * changes: Wed Jun 20 13:19:56 EDT 2007 B. Zihlmann 
  *          add ipart to the function call hitCentralDC
@@ -33,15 +33,15 @@ extern controlparams_t controlparams_;
 void gpoiss_(float*,int*,const int*); // avoid solaris compiler warnings
 
 // Drift speed 2.2cm/us is appropriate for a 90/10 Argon/Methane mixture
-static float DRIFT_SPEED     =   0.0055;
+static float DRIFT_SPEED     = 0.0055;
 static float TWO_HIT_RESOL   = 25.;
-static int   MAX_HITS 	     = 1000;
-static float THRESH_KEV	     =   1.;
-static float THRESH_MV = 1.;
-static float STRAW_RADIUS    =   0.776;
+static int   MAX_HITS        = 1000;
+static float THRESH_KEV      = 1.;
+static float THRESH_MV       = 1.;
+static float STRAW_RADIUS    = 0.776;
 static float CDC_TIME_WINDOW = 1000.0; //time window for accepting CDC hits, ns
-static float ELECTRON_CHARGE =1.6022e-4; /* fC */
-static float GAS_GAIN = 1e5;
+static float ELECTRON_CHARGE = 1.6022e-4; /* fC */
+static float GAS_GAIN        = 1e5;
 
 binTree_t* centralDCTree = 0;
 static int strawCount = 0;
@@ -74,7 +74,7 @@ int cdc_cluster_sort(const void *a,const void *b) {
 double asic_response(double t) {
   double func=0;
   double par[11]={-0.01986,0.01802,-0.001097,10.3,11.72,-0.03701,35.84,
-		  15.93,0.006141,80.95,24.77};
+          15.93,0.006141,80.95,24.77};
   if (t < par[3]) {
     func=par[0]*t+par[1]*t*t+par[2]*t*t*t;
   }
@@ -102,7 +102,7 @@ double cdc_wire_signal(double t,s_CdcStrawTruthHits_t* chits) {
 }
 
 void AddCDCCluster(s_CdcStrawTruthHits_t* hits, int ipart, int track, int n_p,
-		   float t, float xyzcluster[3])
+           float t, float xyzcluster[3])
 {
   // measured charge 
   float q=0.;
@@ -133,7 +133,7 @@ void AddCDCCluster(s_CdcStrawTruthHits_t* hits, int ipart, int track, int n_p,
     // Interpolate over the drift table to find an approximation for the drift 
     // time
     polint(&cdc_drift_distance[index],&cdc_drift_time[index],4,dradius,&my_t,
-	   &my_t_err);
+       &my_t_err);
   }
   float tdrift=my_t/(1.-BSCALE_PAR1-BSCALE_PAR2*Bmag);
 
@@ -247,31 +247,31 @@ void hitCentralDC (float xin[4], float xout[4],
       int ncounter = 0;
       int i;
       for ( i=0;i<(int)nvalues;i++) {
-	//printf("%d %s \n",i,strings[i].str);
-	if (!strcmp(strings[i].str,"CDC_DRIFT_SPEED")) {
-	  DRIFT_SPEED  = values[i];
-	  ncounter++;
-	}
-	if (!strcmp(strings[i].str,"CDC_TWO_HIT_RESOL")) {
-	  TWO_HIT_RESOL  = values[i];
-	  ncounter++;
-	}
-	if (!strcmp(strings[i].str,"CDC_MAX_HITS")) {
-	  MAX_HITS  = (int)values[i];
-	  ncounter++;
-	}
-	if (!strcmp(strings[i].str,"CDC_THRESH_KEV")) {
-	  THRESH_KEV  = values[i];
-	  ncounter++;
-	}
+    //printf("%d %s \n",i,strings[i].str);
+    if (!strcmp(strings[i].str,"CDC_DRIFT_SPEED")) {
+      DRIFT_SPEED  = values[i];
+      ncounter++;
+    }
+    if (!strcmp(strings[i].str,"CDC_TWO_HIT_RESOL")) {
+      TWO_HIT_RESOL  = values[i];
+      ncounter++;
+    }
+    if (!strcmp(strings[i].str,"CDC_MAX_HITS")) {
+      MAX_HITS  = (int)values[i];
+      ncounter++;
+    }
+    if (!strcmp(strings[i].str,"CDC_THRESH_KEV")) {
+      THRESH_KEV  = values[i];
+      ncounter++;
+    }
       }
       if (ncounter==4) {
-	printf("CDC: ALL parameters loaded from Data Base\n");
+    printf("CDC: ALL parameters loaded from Data Base\n");
       } else if (ncounter<5) {
-	printf("CDC: NOT ALL necessary parameters found in Data Base %d out of 5\n",ncounter);
+    printf("CDC: NOT ALL necessary parameters found in Data Base %d out of 5\n",ncounter);
       } else {
-	printf("CDC: SOME parameters found more than once in Data Base\n");
-      } 	
+    printf("CDC: SOME parameters found more than once in Data Base\n");
+      }     
     }
     //
     // Get drift table and scale factors from the database
@@ -284,38 +284,38 @@ void hitCentralDC (float xin[4], float xout[4],
       nvalues=78;
       status=GetColumn("CDC/cdc_drift_table",&nvalues,cdc_drift_time,"t");
       if (status != 0) {
-	printf("CDC: cdc_drift_time table corrupted in database!\n");
+    printf("CDC: cdc_drift_time table corrupted in database!\n");
       }
       int k;
       for (k=0;k<nvalues;k++){
-	cdc_drift_time[k]*=1000.; // Scale fron micro-secons to ns
-	cdc_drift_distance[k]=0.01*(float)k; // 100 micron increments;
+    cdc_drift_time[k]*=1000.; // Scale fron micro-secons to ns
+    cdc_drift_distance[k]=0.01*(float)k; // 100 micron increments;
       }
     
       nvalues=2;
       status = GetConstants("CDC/cdc_drift_parms", &nvalues, values, strings);
       if (status != 0) {
-	printf("CDC: cdc_drift_parms table corrupted in database!\n");
+    printf("CDC: cdc_drift_parms table corrupted in database!\n");
       }
       for ( k=0;k<(int)nvalues;k++) {
-	if (!strcmp(strings[k].str,"bscale_par1")) {
-	  BSCALE_PAR1 = values[k];
-	}
-	if (!strcmp(strings[k].str,"bscale_par2")) {
-	  BSCALE_PAR2 = values[k];
-	}
+    if (!strcmp(strings[k].str,"bscale_par1")) {
+      BSCALE_PAR1 = values[k];
+    }
+    if (!strcmp(strings[k].str,"bscale_par2")) {
+      BSCALE_PAR2 = values[k];
+    }
       }
     }
     else{
       nvalues=78;
       status=GetColumn("CDC/cdc_drift_table::NoBField",&nvalues,cdc_drift_time,"t");
       if (status != 0) {
-	printf("CDC: cdc_drift_table::NoBField corrupted in database!\n");
+    printf("CDC: cdc_drift_table::NoBField corrupted in database!\n");
       }
       int k;
       for (k=0;k<nvalues;k++){
-	cdc_drift_time[k]*=1000.; // Scale fron micro-secons to ns
-	cdc_drift_distance[k]=0.01*(float)k; // 100 micron increments;
+    cdc_drift_time[k]*=1000.; // Scale fron micro-secons to ns
+    cdc_drift_distance[k]=0.01*(float)k; // 100 micron increments;
       }
     }
 
@@ -346,7 +346,7 @@ void hitCentralDC (float xin[4], float xout[4],
    */
   if (xout[3] > 1.0)
     t = xin[3] * 1e9;
-	 
+     
   drin = sqrt(xinlocal[0]*xinlocal[0] + xinlocal[1]*xinlocal[1]);
   drout = sqrt(xoutlocal[0]*xoutlocal[0] + xoutlocal[1]*xoutlocal[1]);
   
@@ -389,12 +389,12 @@ void hitCentralDC (float xin[4], float xout[4],
    * it is because it is emerging from the wire volume and
    * automatically ignore those hits by returning immediately.
    */
-  if (drin < 0.0050)
-    return; /* entering straw within 50 microns of wire. ignore */
+   if (drin < 0.0050)
+      return; /* entering straw within 50 microns of wire. ignore */
  
-  if ((drin > (STRAW_RADIUS-0.0200) && drout<0.0050) ||
-      (drin < 0.274 && drin > 0.234 && drout<0.0050))
-  {
+   if ((drin > (STRAW_RADIUS-0.0200) && drout<0.0050) ||
+       (drin < 0.274 && drin > 0.234 && drout<0.0050))
+   {
     /* Either we entered within 200 microns of the straw tube and left
      * within 50 microns of the wire or we entered the stub region near the 
      * donuts at either end of the straw (the inner radius of the feedthrough 
@@ -402,28 +402,28 @@ void hitCentralDC (float xin[4], float xout[4],
      * through the wire volume.
      */
    
-    x[0] = xout[0];
-    x[1] = xout[1];
-    x[2] = xout[2];
-    t = xout[3] * 1e9;
-    xlocal[0] = xoutlocal[0];
-    xlocal[1] = xoutlocal[1];
-    xlocal[2] = xoutlocal[2];
-    
+      x[0] = xout[0];
+      x[1] = xout[1];
+      x[2] = xout[2];
+      t = xout[3] * 1e9;
+      xlocal[0] = xoutlocal[0];
+      xlocal[1] = xoutlocal[1];
+      xlocal[2] = xoutlocal[2];
+
     /* For dx, we will just assume it is twice the distance from
      * the straw to wire.
      */
-    dx[0] *= 2.0;
-    dx[1] *= 2.0;
-    dx[2] *= 2.0;
+      dx[0] *= 2.0;
+      dx[1] *= 2.0;
+      dx[2] *= 2.0;
 
     /* We will approximate the energy loss in the straw to be twice the 
        energy loss in the first half of the straw */
-    dEsum *= 2.0;
-  }
+      dEsum *= 2.0;
+   }
   
   /* Distance of hit from center of wire */
-  dradius = sqrt(xlocal[0]*xlocal[0] + xlocal[1]*xlocal[1]);
+   dradius = sqrt(xlocal[0]*xlocal[0] + xlocal[1]*xlocal[1]);
 
   /* Calculate dE/dx */
 
@@ -472,70 +472,69 @@ void hitCentralDC (float xin[4], float xout[4],
 
    if (dEsum > 0)
    {  
-     s_CdcStrawTruthHits_t* hits;
+      s_CdcStrawTruthHits_t* hits;
 
       int layer = getlayer_wrapper_();
       int ring = getring_wrapper_();
       int sector = getsector_wrapper_();
 
-      if (layer == 0)		/* in a straw */
-      {	
-	int mark = (ring<<20) + sector;
-	void** twig = getTwig(&centralDCTree, mark);
-	
-	if (*twig == 0)
-	  {
-	    s_CentralDC_t* cdc = *twig = make_s_CentralDC();
-	    s_CdcStraws_t* straws = make_s_CdcStraws(1);
-	    straws->mult = 1;
-	    straws->in[0].ring = ring;
-	    straws->in[0].straw = sector;
-	    straws->in[0].cdcStrawTruthHits = hits = make_s_CdcStrawTruthHits(MAX_HITS);
-	    cdc->cdcStraws = straws;
-	    strawCount++;
-	  }
-	else
-	  {
-	    s_CentralDC_t* cdc = (s_CentralDC_t*) *twig;
-	    hits = cdc->cdcStraws->in[0].cdcStrawTruthHits;
-	  }
-	
-	
-	/* Simulate number of primary ion pairs*/
-	/* The total number of ion pairs depends on the energy deposition 
-	   and the effective average energy to produce a pair, w_eff.
-	   On average for each primary ion pair produced there are n_s_per_p 
-	   secondary ion pairs produced. 
-	*/
-	int one=1;
-	// Average number of secondary ion pairs for 50/50 Ar/CO2 mixture
-	float n_s_per_p=1.94; 
-	//Average energy needed to produce an ion pair for 50/50 mixture
-	float w_eff=29.5e-9; // GeV
-	// Average number of primary ion pairs
-	float n_p_mean = dEsum/w_eff/(1.+n_s_per_p);
-	int n_p; // number of primary ion pairs
-	gpoiss_(&n_p_mean,&n_p,&one);
-	
-	if (controlparams_.driftclusters==0) {	  
-	  AddCDCCluster(hits,ipart,track,n_p,t,xlocal);
-	}
-	else{
-	  // Loop over the number of primary ion pairs
-	  int n;
-	  for (n=0; n < n_p; n++) {
-	    // Generate a cluster at a random position along the path within the 
-	    // straw
-	    int one=2;
-	    float rndno[1];
-	    grndm_(rndno,&one);
-	    xlocal[0]=xinlocal[0]+trackdir[0]*rndno[0];
-	    xlocal[1]=xinlocal[1]+trackdir[1]*rndno[0];
-	    xlocal[2]=xinlocal[2]+trackdir[2]*rndno[0];
-	    
-	    AddCDCCluster(hits,ipart,track,n_p,t,xlocal);
-	  }
-	}
+      if (layer == 0)        /* in a straw */
+      {    
+         int mark = (ring<<20) + sector;
+         void** twig = getTwig(&centralDCTree, mark);
+
+         if (*twig == 0)
+         {
+            s_CentralDC_t* cdc = *twig = make_s_CentralDC();
+            s_CdcStraws_t* straws = make_s_CdcStraws(1);
+            straws->mult = 1;
+            straws->in[0].ring = ring;
+            straws->in[0].straw = sector;
+            straws->in[0].cdcStrawTruthHits = hits = make_s_CdcStrawTruthHits(MAX_HITS);
+            cdc->cdcStraws = straws;
+            strawCount++;
+         }
+         else
+         {
+            s_CentralDC_t* cdc = (s_CentralDC_t*) *twig;
+            hits = cdc->cdcStraws->in[0].cdcStrawTruthHits;
+         }
+         
+         
+         /* Simulate number of primary ion pairs*/
+         /* The total number of ion pairs depends on the energy deposition 
+            and the effective average energy to produce a pair, w_eff.
+            On average for each primary ion pair produced there are n_s_per_p 
+            secondary ion pairs produced. 
+         */
+         int one=1;
+         // Average number of secondary ion pairs for 50/50 Ar/CO2 mixture
+         float n_s_per_p=1.94; 
+         //Average energy needed to produce an ion pair for 50/50 mixture
+         float w_eff=29.5e-9; // GeV
+         // Average number of primary ion pairs
+         float n_p_mean = dEsum/w_eff/(1.+n_s_per_p);
+         int n_p; // number of primary ion pairs
+         gpoiss_(&n_p_mean,&n_p,&one);
+         
+         if (controlparams_.driftclusters==0) {      
+            AddCDCCluster(hits,ipart,track,n_p,t,xlocal);
+         }
+         else {
+            // Loop over the number of primary ion pairs
+            int n;
+            for (n=0; n < n_p; n++) {
+               // Generate a cluster at a random position along the path within
+               // the straw
+               int one=2;
+               float rndno[1];
+               grndm_(rndno,&one);
+               xlocal[0]=xinlocal[0]+trackdir[0]*rndno[0];
+               xlocal[1]=xinlocal[1]+trackdir[1]*rndno[0];
+               xlocal[2]=xinlocal[2]+trackdir[2]*rndno[0];
+               AddCDCCluster(hits,ipart,track,n_p,t,xlocal);
+            }
+         }
       }
    }
 }
@@ -568,75 +567,76 @@ s_CentralDC_t* pickCentralDC ()
 
    while ((item = (s_CentralDC_t*) pickTwig(&centralDCTree)))
    {
-     s_CdcStraws_t* straws = item->cdcStraws;
-     int straw;
+      s_CdcStraws_t* straws = item->cdcStraws;
+      int straw;
 
-      s_CdcTruthPoints_t* points = item->cdcTruthPoints;
-      int point;
-      for (straw=0; straw < straws->mult; ++straw)
-	{
-	  int m = box->cdcStraws->mult;
-	  
-	  s_CdcStrawTruthHits_t* hits = straws->in[straw].cdcStrawTruthHits;
-	
-	  // Sort the clusters by time
-	  qsort(hits->in,hits->mult,sizeof(s_CdcStrawTruthHit_t),(compfn)cdc_cluster_sort);
-  
-	  /* compress out the hits below threshold */
-	  int i,iok=0;
-	  
-	  if (controlparams_.driftclusters == 0) {
-	    for (iok=i=0; i < hits->mult; i++)
-	      {
-	       if (hits->in[i].q >0.)
-		 {
-		   if (iok < i)
-		     {
-		       hits->in[iok] = hits->in[i];
-		     }
-		   ++iok;
-		 }
-	      }
-	  }
-	  else{
-  	    
-	    // Temporary histogram in 1 ns bins to store waveform data
-	    int num_samples=(int)CDC_TIME_WINDOW;
-	    float *samples=(float *)malloc(num_samples*sizeof(float));
-	    for (i=0;i<num_samples;i++) {
-	      samples[i]=cdc_wire_signal((float)i,hits);
-	      //printf("%f %f\n",(float)i,samples[i]);
-	    }
-	   
-	    int returned_to_baseline=0;
-	    float q=0.; 
-	    int FADC_BIN_SIZE=1;
-	    for (i=0; i<num_samples; i+=FADC_BIN_SIZE) {
-	      if (samples[i] >= THRESH_MV) {
-		if (returned_to_baseline == 0) {
-		  hits->in[iok].itrack = hits->in[0].itrack;
-		  hits->in[iok].ptype = hits->in[0].ptype;
-		  hits->in[iok].t=(float) i;
-		  returned_to_baseline = 1;
-		  iok++;
-		}
-		q += (float)FADC_BIN_SIZE*samples[i];
-	      }
-	      if (returned_to_baseline && (samples[i] < THRESH_MV)) {
-		returned_to_baseline = 0;   
-		if (iok > 0 && q > 0.) {
-		  hits->in[iok-1].q=q;
-		  q=0.;
-		}
-	     //break;
-	      }
-	    }
-	   if (q > 0) {
-	     hits->in[iok-1].q = q;
-	   }
-	   free(samples);
-	  }
-	 
+       s_CdcTruthPoints_t* points = item->cdcTruthPoints;
+       int point;
+       for (straw=0; straw < straws->mult; ++straw)
+       {
+          int m = box->cdcStraws->mult;
+
+          s_CdcStrawTruthHits_t* hits = straws->in[straw].cdcStrawTruthHits;
+
+         // Sort the clusters by time
+         qsort(hits->in,hits->mult,sizeof(s_CdcStrawTruthHit_t),(compfn)cdc_cluster_sort);
+
+         /* compress out the hits below threshold */
+         int i,iok=0;
+
+         if (controlparams_.driftclusters == 0)
+         {
+            for (iok=i=0; i < hits->mult; i++)
+            {
+               if (hits->in[i].q >0.)
+               {
+                  if (iok < i)
+                  {
+                     hits->in[iok] = hits->in[i];
+                  }
+                  ++iok;
+               }
+            }
+         }
+         else {
+           
+            // Temporary histogram in 1 ns bins to store waveform data
+            int num_samples=(int)CDC_TIME_WINDOW;
+            float *samples=(float *)malloc(num_samples*sizeof(float));
+            for (i=0;i<num_samples;i++) {
+               samples[i]=cdc_wire_signal((float)i,hits);
+               //printf("%f %f\n",(float)i,samples[i]);
+            }
+
+            int returned_to_baseline=0;
+            float q=0.; 
+            int FADC_BIN_SIZE=1;
+            for (i=0; i<num_samples; i+=FADC_BIN_SIZE) {
+               if (samples[i] >= THRESH_MV) {
+                  if (returned_to_baseline == 0) {
+                     hits->in[iok].itrack = hits->in[0].itrack;
+                     hits->in[iok].ptype = hits->in[0].ptype;
+                     hits->in[iok].t=(float) i;
+                     returned_to_baseline = 1;
+                     iok++;
+                  }
+                  q += (float)FADC_BIN_SIZE*samples[i];
+               }
+               if (returned_to_baseline && (samples[i] < THRESH_MV)) {
+                  returned_to_baseline = 0;   
+                  if (iok > 0 && q > 0.) {
+                     hits->in[iok-1].q=q;
+                     q=0.;
+                  }
+                  //break;
+               }
+            }
+            if (q > 0) {
+               hits->in[iok-1].q = q;
+            }
+            free(samples);
+         }
+     
          if (iok)
          {
             hits->mult = iok;
@@ -653,10 +653,19 @@ s_CentralDC_t* pickCentralDC ()
          FREE(straws);
       }
 
+      int last_track = -1;
+      double last_t = 1e9;
       for (point=0; point < points->mult; ++point)
       {
-         int m = box->cdcTruthPoints->mult++;
-         box->cdcTruthPoints->in[m] = points->in[point];
+         if (points->in[point].trackID->itrack > 0 &&
+            (points->in[point].track != last_track ||
+             fabs(points->in[point].t - last_t) > 0.05))
+         {
+            int m = box->cdcTruthPoints->mult++;
+            box->cdcTruthPoints->in[m] = points->in[point];
+            last_track = points->in[point].track;
+            last_t = points->in[point].t;
+         }
       }
       if (points != HDDM_NULL)
       {

--- a/src/programs/Simulation/HDGeant/hitCDC.c
+++ b/src/programs/Simulation/HDGeant/hitCDC.c
@@ -53,6 +53,8 @@ static float cdc_drift_distance[78];
 static float BSCALE_PAR1=0.;
 static float BSCALE_PAR2=0.;
 
+int itrack;
+
 /* void GetDOCA(int ipart, float x[3], float p[5], float doca[3]);  disabled 6/24/2009 */
 
 typedef int (*compfn)(const void*, const void*);
@@ -106,7 +108,7 @@ void AddCDCCluster(s_CdcStrawTruthHits_t* hits, int ipart, int track, int n_p,
 {
   // measured charge 
   float q=0.;
-  
+
   // drift radius 
   float dradius=sqrt(xyzcluster[0]*xyzcluster[0]+xyzcluster[1]*xyzcluster[1]);
 
@@ -197,7 +199,7 @@ void AddCDCCluster(s_CdcStrawTruthHits_t* hits, int ipart, int track, int n_p,
     if (hits->in[nhit].t > total_time) {
       hits->in[nhit].t = total_time;
       hits->in[nhit].d = dradius;
-      hits->in[nhit].itrack = gidGetId(track);
+      hits->in[nhit].itrack = itrack;
       hits->in[nhit].ptype = ipart;
     }
 
@@ -210,7 +212,7 @@ void AddCDCCluster(s_CdcStrawTruthHits_t* hits, int ipart, int track, int n_p,
     hits->in[nhit].t = total_time;
     hits->in[nhit].q = q;
     hits->in[nhit].d = dradius;
-    hits->in[nhit].itrack = gidGetId(track);
+    hits->in[nhit].itrack = itrack;
     hits->in[nhit].ptype = ipart;
 
     hits->mult++;
@@ -439,6 +441,8 @@ void hitCentralDC (float xin[4], float xout[4],
 
    /* post the hit to the truth tree */
 
+   itrack = (stack == 0)? gidGetId(track) : -1;
+
    if (history == 0)
    {
       int mark = (1<<30) + pointCount;
@@ -461,7 +465,7 @@ void hitCentralDC (float xin[4], float xout[4],
          points->in[0].dEdx = dEdx;
          points->in[0].ptype = ipart;
          points->in[0].trackID = make_s_TrackID();
-         points->in[0].trackID->itrack = gidGetId(track);
+         points->in[0].trackID->itrack = itrack;
          points->mult = 1;
          cdc->cdcTruthPoints = points;
          pointCount++;

--- a/src/programs/Simulation/HDGeant/hitCDC.c
+++ b/src/programs/Simulation/HDGeant/hitCDC.c
@@ -612,7 +612,7 @@ s_CentralDC_t* pickCentralDC ()
             float q=0.; 
             int FADC_BIN_SIZE=1;
             for (i=0; i<num_samples; i+=FADC_BIN_SIZE) {
-               if (samples[i] >= THRESH_MV) {
+               if (samples[i] > THRESH_MV) {
                   if (returned_to_baseline == 0) {
                      hits->in[iok].itrack = hits->in[0].itrack;
                      hits->in[iok].ptype = hits->in[0].ptype;

--- a/src/programs/Simulation/HDGeant/hitCerenkov.c
+++ b/src/programs/Simulation/HDGeant/hitCerenkov.c
@@ -169,7 +169,7 @@ s_Cerenkov_t* pickCerenkov ()
          int iok,i;
          for (iok=i=0; i < hits->mult; i++)
          {
-           if (hits->in[i].pe >= THRESH_PE)
+           if (hits->in[i].pe > THRESH_PE)
            {
              if (iok < i)
              {

--- a/src/programs/Simulation/HDGeant/hitCerenkov.c
+++ b/src/programs/Simulation/HDGeant/hitCerenkov.c
@@ -48,6 +48,8 @@ void hitCerenkov (float xin[4], float xout[4],
 
    /* post the hit to the truth tree */
 
+   int itrack = (stack == 0)? gidGetId(track) : -1;
+
    if ((history == 0) && (dEsum > 0))
    {
       int mark = (1<<30) + pointCount;
@@ -70,7 +72,7 @@ void hitCerenkov (float xin[4], float xout[4],
          points->in[0].E = pin[3];
          points->in[0].ptype = ipart;
          points->in[0].trackID = make_s_TrackID();
-         points->in[0].trackID->itrack = gidGetId(track);
+         points->in[0].trackID->itrack = itrack;
          points->mult = 1;
          pointCount++;
       }

--- a/src/programs/Simulation/HDGeant/hitCerenkov.c
+++ b/src/programs/Simulation/HDGeant/hitCerenkov.c
@@ -194,10 +194,19 @@ s_Cerenkov_t* pickCerenkov ()
          FREE(sections);
       }
 
+      int last_track = -1;
+      double last_t = 1e9;
       for (point=0; point < points->mult; ++point)
       {
-         int m = box->cereTruthPoints->mult++;
-         box->cereTruthPoints->in[m] = points->in[point];
+         if (points->in[point].trackID->itrack > 0 &&
+            (points->in[point].track != last_track ||
+             fabs(points->in[point].t - last_t) > 0.1))
+         {
+            int m = box->cereTruthPoints->mult++;
+            box->cereTruthPoints->in[m] = points->in[point];
+            last_track = points->in[point].track;
+            last_t = points->in[point].t;
+         }
       }
       if (points != HDDM_NULL)
       {

--- a/src/programs/Simulation/HDGeant/hitDIRC.c
+++ b/src/programs/Simulation/HDGeant/hitDIRC.c
@@ -25,12 +25,8 @@ static int dircpointCount = 0;
 /* register truth points during tracking (from gustep) */
 void hitDIRC(float xin[4], float xout[4], float pin[5], float pout[5],
 		float dEsum, int track, int stack, int history, int ipart) {
-	//float x[3], t;
 
-	//x[0] = (xin[0] + xout[0]) / 2;
-	//x[1] = (xin[1] + xout[1]) / 2;
-	//x[2] = (xin[2] + xout[2]) / 2;
-	//t = (xin[3] + xout[3]) / 2 * 1e9;
+    int itrack = (stack == 0)? gidGetId(track) : -1;
 
 	// post to truth tree
 	if ((history == 0) && (dEsum > 0)) {
@@ -53,7 +49,7 @@ void hitDIRC(float xin[4], float xout[4], float pin[5], float pout[5],
 			points->in[0].E = pin[3];
 			points->in[0].ptype = ipart;
 			points->in[0].trackID = make_s_TrackID();
-			points->in[0].trackID->itrack = gidGetId(track);
+			points->in[0].trackID->itrack = itrack;
 			points->mult = 1;
 			dircpointCount++;
 		}

--- a/src/programs/Simulation/HDGeant/hitDIRC.c
+++ b/src/programs/Simulation/HDGeant/hitDIRC.c
@@ -114,11 +114,20 @@ s_DIRC_t* pickDirc() {
 		}
 		// pack DIRC Truth points
 		s_DircTruthPoints_t* dircpoints = item->dircTruthPoints;
+        int last_track = -1;
+        double last_t = 1e9;
 		int dircpoint;
 		for (dircpoint = 0; dircpoint < dircpoints->mult; ++dircpoint) {
-			int m = box->dircTruthPoints->mult++;
-			box->dircTruthPoints->in[m] = dircpoints->in[dircpoint];
-		}
+            if (dircpoints->in[dircpoint].trackID->itrack > 0 &&
+               (dircpoints->in[dircpoint].track != last_track ||
+                fabs(dircpoints->in[dircpoint].t - last_t) > 0.1))
+            {
+               int m = box->dircTruthPoints->mult++;
+               box->dircTruthPoints->in[m] = dircpoints->in[dircpoint];
+               last_track = dircpoints->in[dircpoint].track;
+               last_t = dircpoints->in[dircpoint].t;
+            }
+        }
 		if (dircpoints != HDDM_NULL) {
 			FREE(dircpoints);
 		}

--- a/src/programs/Simulation/HDGeant/hitFCal.c
+++ b/src/programs/Simulation/HDGeant/hitFCal.c
@@ -134,6 +134,8 @@ void hitForwardEMcal (float xin[4], float xout[4],
 
    /* post the hit to the truth tree */
 
+   int itrack = (stack == 0)? gidGetId(track) : -1;
+
    if ((history == 0) && (pin[3] > THRESH_MEV/1e3))
    {
       s_FcalTruthShowers_t* showers;
@@ -156,7 +158,7 @@ void hitForwardEMcal (float xin[4], float xout[4],
          showers->in[0].E = pin[3];
          showers->in[0].ptype = ipart;
          showers->in[0].trackID = make_s_TrackID();
-         showers->in[0].trackID->itrack = gidGetId(track);
+         showers->in[0].trackID->itrack = itrack;
          showers->mult = 1;
          showerCount++;
       }

--- a/src/programs/Simulation/HDGeant/hitFCal.c
+++ b/src/programs/Simulation/HDGeant/hitFCal.c
@@ -278,7 +278,7 @@ s_ForwardEMcal_t* pickForwardEMcal ()
             int i,iok;
             for (iok=i=0; i < hits->mult; i++)
             {
-               if (hits->in[i].E >= THRESH_MEV/1e3)
+               if (hits->in[i].E > THRESH_MEV/1e3)
                {
 #if TESTING_CAL_CONTAINMENT
   Etotal += hits->in[i].E;

--- a/src/programs/Simulation/HDGeant/hitFDC.c
+++ b/src/programs/Simulation/HDGeant/hitFDC.c
@@ -1144,10 +1144,19 @@ s_ForwardDC_t* pickForwardDC ()
         {
            FREE(wires);
         }
+        int last_track = -1;
+        double last_t = 1e9;
         for (point=0; point < points->mult; ++point)
         {
-           int mm = box->fdcChambers->in[m].fdcTruthPoints->mult++;
-           box->fdcChambers->in[m].fdcTruthPoints->in[mm] = points->in[point];
+            if (points->in[point].trackID->itrack > 0 &&
+               (points->in[point].track != last_track ||
+               fabs(points->in[point].t - last_t) > 0.05))
+           {
+              int mm = box->fdcChambers->in[m].fdcTruthPoints->mult++;
+              box->fdcChambers->in[m].fdcTruthPoints->in[mm] = points->in[point];
+              last_track = points->in[point].track;
+              last_t = points->in[point].t;
+           }
         }
         if (points != HDDM_NULL)
         {

--- a/src/programs/Simulation/HDGeant/hitFDC.c
+++ b/src/programs/Simulation/HDGeant/hitFDC.c
@@ -935,7 +935,7 @@ s_ForwardDC_t* pickForwardDC ()
 	 if (controlparams_.driftclusters==0){
 	   for (iok=i=0; i < ahits->mult; i++)
 	     {
-	       if (ahits->in[i].dE >= THRESH_KEV/1e6)
+	       if (ahits->in[i].dE > THRESH_KEV/1e6)
 		 {
                if (iok < i)
 		 {
@@ -962,7 +962,7 @@ s_ForwardDC_t* pickForwardDC ()
 	   int returned_to_baseline=0;
 	   float q=0;
 	   for (i=0;i<num_samples;i++){
-	     if (samples[i]>=THRESH_ANODE){
+	     if (samples[i] > THRESH_ANODE){
 	       if (returned_to_baseline==0){
 		 ahits->in[iok].itrack = ahits->in[0].itrack;
 		 ahits->in[iok].ptype = ahits->in[0].ptype;
@@ -983,7 +983,7 @@ s_ForwardDC_t* pickForwardDC ()
 	       q+=samples[i];
 	     }
 	     if (returned_to_baseline 
-		 && (samples[i]<THRESH_ANODE)){
+		 && (samples[i] <= THRESH_ANODE)){
 	       returned_to_baseline=0;   
 	     }
 	   }
@@ -1046,7 +1046,7 @@ s_ForwardDC_t* pickForwardDC ()
 	    int istart=0;
 	    int FADC_BIN_SIZE=1;
 	    for (i=0;i<num_samples;i+=FADC_BIN_SIZE){
-	      if (samples[i]>=THRESH_STRIPS){
+	      if (samples[i] > THRESH_STRIPS){
 		if (threshold_toggle==0){
 		  chits->in[iok].itrack = chits->in[0].itrack;
 		  chits->in[iok].ptype = chits->in[0].ptype;
@@ -1059,7 +1059,7 @@ s_ForwardDC_t* pickForwardDC ()
 		}
 	      }
 	      if (threshold_toggle && 
-		  (samples[i]<THRESH_STRIPS)){
+		  (samples[i] <= THRESH_STRIPS)){
 		int j;
 		// Find the first peak
 		for (j=istart+1;j<i-1;j++){
@@ -1075,7 +1075,7 @@ s_ForwardDC_t* pickForwardDC ()
 	      }
 	    }
 	    i=num_samples-1;
-	    if (samples[i]>=THRESH_STRIPS&&threshold_toggle){
+	    if (samples[i] > THRESH_STRIPS&&threshold_toggle){
 	      int j;
 	      for (j=istart+1;j<i-1;j++){
 		if (samples[j]>samples[j-1] && samples[j]>samples[j+1]){

--- a/src/programs/Simulation/HDGeant/hitFDC.c
+++ b/src/programs/Simulation/HDGeant/hitFDC.c
@@ -32,6 +32,7 @@ typedef struct{
 
 extern controlparams_t controlparams_;
 
+int itrack;
 
 const float wire_dead_zone_radius[4]={3.0,3.0,3.9,3.9};
 const float strip_dead_zone_radius[4]={1.3,1.3,1.3,1.3};
@@ -48,7 +49,7 @@ static float WIRE_SPACING          =1.0;
 static float U_OF_WIRE_ZERO        =0;//(-((WIRES_PER_PLANE-1.)*WIRE_SPACING)/2)
 static float STRIPS_PER_PLANE      =192;
 static float STRIP_SPACING         =0.5;
-static float U_OF_STRIP_ZERO	   =0;//  (-((STRIPS_PER_PLANE-1.)*STRIP_SPACING)/2)
+static float U_OF_STRIP_ZERO       =0;//  (-((STRIPS_PER_PLANE-1.)*STRIP_SPACING)/2)
 static float STRIP_GAP             =0.1;
 static int   FDC_MAX_HITS          =1000;
 static float K2                  =1.15;
@@ -195,10 +196,10 @@ double cathode_signal(double t,s_FdcCathodeTruthHits_t* chits){
 
 // Generate hits in two cathode planes flanking the wire plane  
 void AddFDCCathodeHits(int PackNo,float xwire,float avalanche_y,float tdrift,
-		       int n_p,int track,int ipart,int chamber,int module,
-		       int layer, int global_wire_number){
+               int n_p,int track,int ipart,int chamber,int module,
+               int layer, int global_wire_number){
 
-  s_FdcCathodeTruthHits_t* chits;    	  
+  s_FdcCathodeTruthHits_t* chits;          
 
   // Anode charge
   float q_anode;
@@ -242,104 +243,97 @@ void AddFDCCathodeHits(int PackNo,float xwire,float avalanche_y,float tdrift,
 
 #if 0
     half_gap+=(plane==1)?+wire_dz_offset[global_wire_number]:
-	       -wire_dz_offset[global_wire_number];
+           -wire_dz_offset[global_wire_number];
 #endif
 
     for (node=-STRIP_NODES; node<=STRIP_NODES; node++){
       /* Induce charge on the strips according to the Mathieson 
-	 function tuned to results from FDC prototype
+     function tuned to results from FDC prototype
       */
       float lambda1=(((float)node-0.5)*STRIP_SPACING+STRIP_GAP/2.
-		     -delta)/half_gap;
+             -delta)/half_gap;
       float lambda2=(((float)node+0.5)*STRIP_SPACING-STRIP_GAP/2.
-		     -delta)/half_gap;
+             -delta)/half_gap;
       float factor=0.25*M_PI*K2;
       float q = 0.25*q_anode*(tanh(factor*lambda2)-tanh(factor*lambda1));
       
       int strip = strip1+node;
       /* Throw away hits on strips falling within a certain dead-zone
-	 radius */
+     radius */
       float strip_outer_u=cathode_u1
-	+(STRIP_SPACING+STRIP_GAP/2.)*(int)node;
+    +(STRIP_SPACING+STRIP_GAP/2.)*(int)node;
       float cathode_v=-xwire*sin(theta)+avalanche_y*cos(theta);
       float check_radius=sqrt(strip_outer_u*strip_outer_u
-			      +cathode_v*cathode_v);
+                  +cathode_v*cathode_v);
       
       if ((strip > 0) 
-	  && (check_radius>strip_dead_zone_radius[PackNo]) 
-	  && (strip <= STRIPS_PER_PLANE)){
-	int mark = (chamber<<20) + (plane<<10) + strip;
-	void** cathodeTwig = getTwig(&forwardDCTree, mark);
-	if (*cathodeTwig == 0){
-	  s_ForwardDC_t* fdc = *cathodeTwig = make_s_ForwardDC();
-	  s_FdcChambers_t* chambers = make_s_FdcChambers(1);
-	  s_FdcCathodeStrips_t* strips = make_s_FdcCathodeStrips(1);
-	  strips->mult = 1;
-	  strips->in[0].plane = plane;
-	  strips->in[0].strip = strip;
-	  strips->in[0].fdcCathodeTruthHits = chits
-	    = make_s_FdcCathodeTruthHits(MAX_HITS);
-	  chambers->mult = 1;
-	  chambers->in[0].module = module;
-	  chambers->in[0].layer = layer;
-	  chambers->in[0].fdcCathodeStrips = strips;
-	  fdc->fdcChambers = chambers;
-	  stripCount++;
-	}
-	else{
-	  s_ForwardDC_t* fdc = *cathodeTwig;
-	  chits = fdc->fdcChambers->in[0].fdcCathodeStrips
-	    ->in[0].fdcCathodeTruthHits;
-	}
-	
-	int nhit;
-	for (nhit = 0; nhit < chits->mult; nhit++){
-	  // To cut down on the number of output clusters, combine 
-	  // those that would be indistiguishable in time given the 
-	  // expected timing resolution
-	  if (fabs(chits->in[nhit].t - tdrift) <TWO_HIT_RESOL)
-	    {
-	      break;
-	    }
-	}
-	if (nhit < chits->mult)		/* merge with former hit */
-	  {
-	    /* Use the time from the earlier hit but add the charge */
-	    chits->in[nhit].q += q;
-	    if(chits->in[nhit].t>tdrift){
-	      chits->in[nhit].t = tdrift;
-	      chits->in[nhit].itrack = gidGetId(track);
-	      chits->in[nhit].ptype = ipart;
-	    }
-	  }
-	else if (nhit < MAX_HITS){        /* create new hit */
-	  chits->in[nhit].t = tdrift;
-	  chits->in[nhit].q = q;
-	  chits->in[nhit].itrack = gidGetId(track);
-	  chits->in[nhit].ptype = ipart;
-	  chits->mult++;
-	}
-	else{
-	  fprintf(stderr,"HDGeant error in hitForwardDC: ");
-	  fprintf(stderr,"max hit count %d exceeded, truncating!\n", MAX_HITS);
-	}
-	
+      && (check_radius>strip_dead_zone_radius[PackNo]) 
+      && (strip <= STRIPS_PER_PLANE)){
+    int mark = (chamber<<20) + (plane<<10) + strip;
+    void** cathodeTwig = getTwig(&forwardDCTree, mark);
+    if (*cathodeTwig == 0){
+      s_ForwardDC_t* fdc = *cathodeTwig = make_s_ForwardDC();
+      s_FdcChambers_t* chambers = make_s_FdcChambers(1);
+      s_FdcCathodeStrips_t* strips = make_s_FdcCathodeStrips(1);
+      strips->mult = 1;
+      strips->in[0].plane = plane;
+      strips->in[0].strip = strip;
+      strips->in[0].fdcCathodeTruthHits = chits
+        = make_s_FdcCathodeTruthHits(MAX_HITS);
+      chambers->mult = 1;
+      chambers->in[0].module = module;
+      chambers->in[0].layer = layer;
+      chambers->in[0].fdcCathodeStrips = strips;
+      fdc->fdcChambers = chambers;
+      stripCount++;
+    }
+    else{
+      s_ForwardDC_t* fdc = *cathodeTwig;
+      chits = fdc->fdcChambers->in[0].fdcCathodeStrips
+        ->in[0].fdcCathodeTruthHits;
+    }
+    
+    int nhit;
+    for (nhit = 0; nhit < chits->mult; nhit++){
+      // To cut down on the number of output clusters, combine 
+      // those that would be indistiguishable in time given the 
+      // expected timing resolution
+      if (fabs(chits->in[nhit].t - tdrift) <TWO_HIT_RESOL)
+        {
+          break;
+        }
+    }
+    if (nhit < chits->mult)        /* merge with former hit */
+      {
+        /* Use the time from the earlier hit but add the charge */
+        chits->in[nhit].q += q;
+        if(chits->in[nhit].t>tdrift){
+          chits->in[nhit].t = tdrift;
+          chits->in[nhit].itrack = itrack;
+          chits->in[nhit].ptype = ipart;
+        }
+      }
+    else if (nhit < MAX_HITS){        /* create new hit */
+      chits->in[nhit].t = tdrift;
+      chits->in[nhit].q = q;
+      chits->in[nhit].itrack = itrack;
+      chits->in[nhit].ptype = ipart;
+      chits->mult++;
+    }
+    else{
+      fprintf(stderr,"HDGeant error in hitForwardDC: ");
+      fprintf(stderr,"max hit count %d exceeded, truncating!\n", MAX_HITS);
+    }
+    
       }
     } // loop over cathode strips
   } // loop over cathode views
 }
 
 
-
-
-
-
-
-
-
 // Add wire information
 int AddFDCAnodeHit(s_FdcAnodeTruthHits_t* ahits,int layer,int ipart,int track,
-		   float xwire,float xyz[3],float dE,float t,float *tdrift){
+           float xwire,float xyz[3],float dE,float t,float *tdrift){
  
   // Generate 2 random numbers from a Gaussian distribution
   // 
@@ -348,7 +342,7 @@ int AddFDCAnodeHit(s_FdcAnodeTruthHits_t* ahits,int layer,int ipart,int track,
 
   // Only and always use the built-in Geant random generator,
   // otherwise debugging is a problem because sequences are not
-	  // reproducible from a given pair of random seeds. [rtj]
+      // reproducible from a given pair of random seeds. [rtj]
   
   /* rnorml_(rndno,&two); */ {
     float rho,phi1;
@@ -359,7 +353,7 @@ int AddFDCAnodeHit(s_FdcAnodeTruthHits_t* ahits,int layer,int ipart,int track,
     rndno[1] = rho*sin(phi1);
   }
 
-   // Get the magnetic field at this cluster position	    
+   // Get the magnetic field at this cluster position        
   float x[3],B[3];
   transformCoord(xyz,"local",x,"global");
   gufld_db_(x,B);
@@ -398,9 +392,9 @@ int AddFDCAnodeHit(s_FdcAnodeTruthHits_t* ahits,int layer,int ipart,int track,
     return 0;
 
   // Model the drift time and longitudinal diffusion as a function of 
-  // position of the cluster within the cell 	 	  
+  // position of the cluster within the cell            
   float tdrift_unsmeared=1086.0*(1.+0.039*Bmag)*dx2+( 1068.0 )*dz2
-    +dx4*(( -2.675 )/(dz2+0.001)+( 2.4e4 )*dz2);	
+    +dx4*(( -2.675 )/(dz2+0.001)+( 2.4e4 )*dz2);    
   float dt=(( 39.44   )*dx4/(0.5-dz2)+( 56.0  )*dz4/(0.5-dx2)
       +( 0.01566 )*dx4/(dz4+0.002)/(0.251-dx2))*rndno[1];
 
@@ -415,7 +409,7 @@ int AddFDCAnodeHit(s_FdcAnodeTruthHits_t* ahits,int layer,int ipart,int track,
 
   // Avalanche time
   *tdrift=t+tdrift_smeared;
-	  
+      
   // Skip cluster if the time would go beyond readout window
   if( *tdrift > FDC_TIME_WINDOW ) return 0;
 
@@ -425,21 +419,21 @@ int AddFDCAnodeHit(s_FdcAnodeTruthHits_t* ahits,int layer,int ipart,int track,
   for (nhit = 0; nhit < ahits->mult; nhit++)
     {
       if (fabs(ahits->in[nhit].t - *tdrift) < TWO_HIT_RESOL)
-	{
-	  break;
-	}
+    {
+      break;
+    }
     }
   if (nhit < ahits->mult)                 /* merge with former hit */
     {
       /* use the time from the earlier hit but add the energy */
       ahits->in[nhit].dE += dE;
       if(ahits->in[nhit].t>*tdrift){
-	ahits->in[nhit].t = *tdrift;
-	ahits->in[nhit].t_unsmeared=tdrift_unsmeared;
-	ahits->in[nhit].d = sqrt(dx2+dz2);
-	
-	ahits->in[nhit].itrack = gidGetId(track);
-	ahits->in[nhit].ptype = ipart;
+        ahits->in[nhit].t = *tdrift;
+        ahits->in[nhit].t_unsmeared=tdrift_unsmeared;
+        ahits->in[nhit].d = sqrt(dx2+dz2);
+
+        ahits->in[nhit].itrack = itrack;
+        ahits->in[nhit].ptype = ipart;
       }
     
 #ifdef FDC_AVERAGE_TIME_FOR_MERGED_HITS
@@ -448,8 +442,8 @@ int AddFDCAnodeHit(s_FdcAnodeTruthHits_t* ahits,int layer,int ipart,int track,
        * of just keeping the time of the first hit recorded.
        */
         ahits->in[nhit].t = 
-	(ahits->in[nhit].t * ahits->in[nhit].dE + tdrift * dE)
-	/ (ahits->in[nhit].dE += dE);
+            (ahits->in[nhit].t * ahits->in[nhit].dE + tdrift * dE)
+            / (ahits->in[nhit].dE += dE);
 #endif
 
     }
@@ -459,7 +453,7 @@ int AddFDCAnodeHit(s_FdcAnodeTruthHits_t* ahits,int layer,int ipart,int track,
       ahits->in[nhit].t_unsmeared=tdrift_unsmeared;
       ahits->in[nhit].dE = dE;
       ahits->in[nhit].d = sqrt(dx2+dz2);
-      ahits->in[nhit].itrack = gidGetId(track);
+      ahits->in[nhit].itrack = itrack;
       ahits->in[nhit].ptype = ipart;
       ahits->mult++;
     }
@@ -563,11 +557,11 @@ void hitForwardDC (float xin[4], float xout[4],
             DIFFUSION_COEFF  = values[i];
             ncounter++;
           }
-	}
-	U_OF_WIRE_ZERO     = (-((WIRES_PER_PLANE-1.)*WIRE_SPACING)/2);
-	U_OF_STRIP_ZERO	   = (-((STRIPS_PER_PLANE-1.)*STRIP_SPACING)/2);
+    }
+    U_OF_WIRE_ZERO     = (-((WIRES_PER_PLANE-1.)*WIRE_SPACING)/2);
+    U_OF_STRIP_ZERO       = (-((STRIPS_PER_PLANE-1.)*STRIP_SPACING)/2);
   
-	if (ncounter==16){
+    if (ncounter==16){
           printf("FDC: ALL parameters loaded from Data Base\n");
         } else if (ncounter<16){
           printf("FDC: NOT ALL necessary parameters found in Data Base %d out of 16\n",ncounter);
@@ -575,21 +569,21 @@ void hitForwardDC (float xin[4], float xout[4],
           printf("FDC: SOME parameters found more than once in Data Base\n");
         }       
 #if 0
-	{
-	  int num_values=2304*2;
-	  float my_values[2304*2]; 
-	  mystr_t my_strings[2304*2];
-	  status=GetArrayConstants("FDC/fdc_wire_offsets",&num_values,
-				   my_values,my_strings);
-	  if (!status){
-	    int i;
-	    for (i=0;i<num_values;i+=2){
-	      int j=i/2;
-	      wire_dx_offset[j]=my_values[i];
-	      wire_dz_offset[j]=my_values[i+1];
-	    }
-	  }
-	}
+    {
+      int num_values=2304*2;
+      float my_values[2304*2]; 
+      mystr_t my_strings[2304*2];
+      status=GetArrayConstants("FDC/fdc_wire_offsets",&num_values,
+                   my_values,my_strings);
+      if (!status){
+        int i;
+        for (i=0;i<num_values;i+=2){
+          int j=i/2;
+          wire_dx_offset[j]=my_values[i];
+          wire_dz_offset[j]=my_values[i+1];
+        }
+      }
+    }
 #endif
       }
       initializedx = 1 ;
@@ -675,6 +669,8 @@ void hitForwardDC (float xin[4], float xout[4],
   }
 
   /* post the hit to the truth tree */
+
+  int itrack = (stack == 0)? gidGetId(track) : -1;
  
   if (history == 0)
   {
@@ -706,7 +702,7 @@ void hitForwardDC (float xin[4], float xout[4],
       points->in[0].dEdx = dEdx;
       points->in[0].ptype = ipart;
       points->in[0].trackID = make_s_TrackID();
-      points->in[0].trackID->itrack = gidGetId(track);
+      points->in[0].trackID->itrack = itrack;
       chambers->mult = 1;
       chambers->in[0].module = module;
       chambers->in[0].layer = layer;
@@ -734,147 +730,147 @@ void hitForwardDC (float xin[4], float xout[4],
 #endif     
 
       if (wire1==wire2){
-	dE=dEsum; 
-	x0[0] = xinlocal[0];
-	x0[1] = xinlocal[1];
-	x0[2] = xinlocal[2]; 
-	x1[0] = xoutlocal[0];
-	x1[1] = xoutlocal[1];
-	x1[2] = xoutlocal[2];
+    dE=dEsum; 
+    x0[0] = xinlocal[0];
+    x0[1] = xinlocal[1];
+    x0[2] = xinlocal[2]; 
+    x1[0] = xoutlocal[0];
+    x1[1] = xoutlocal[1];
+    x1[2] = xoutlocal[2];
       }
       else{
-	x0[0] = xwire-0.5*dwire*WIRE_SPACING;
-	x0[1] = xinlocal[1] + (x0[0]-xinlocal[0]+1e-20)*
-	  (xoutlocal[1]-xinlocal[1])/(xoutlocal[0]-xinlocal[0]+1e-20);
-	x0[2] = xinlocal[2] + (x0[0]-xinlocal[0]+1e-20)*
-	  (xoutlocal[2]-xinlocal[2])/(xoutlocal[0]-xinlocal[0]+1e-20);
-	if (fabs(x0[2]-xoutlocal[2]) > fabs(xinlocal[2]-xoutlocal[2]))
-	  {
-	    x0[0] = xinlocal[0];
-	    x0[1] = xinlocal[1];
-	    x0[2] = xinlocal[2];
-	  }
-	x1[0] = xwire+0.5*dwire*WIRE_SPACING;
-	x1[1] = xinlocal[1] + (x1[0]-xinlocal[0]+1e-20)*
-	  (xoutlocal[1]-xinlocal[1])/(xoutlocal[0]-xinlocal[0]+1e-20);
-	x1[2] = xinlocal[2] + (x1[0]-xinlocal[0]+1e-20)*
-	  (xoutlocal[2]-xinlocal[2])/(xoutlocal[0]-xinlocal[0]+1e-20);
-	if (fabs(x1[2]-xinlocal[2]) > fabs(xoutlocal[2]-xinlocal[2]))
-	  {
-	    x1[0] = xoutlocal[0];
-	    x1[1] = xoutlocal[1];
-	    x1[2] = xoutlocal[2];
-	  }
-	dE = dEsum*(x1[2]-x0[2])/(xoutlocal[2]-xinlocal[2]);
+    x0[0] = xwire-0.5*dwire*WIRE_SPACING;
+    x0[1] = xinlocal[1] + (x0[0]-xinlocal[0]+1e-20)*
+      (xoutlocal[1]-xinlocal[1])/(xoutlocal[0]-xinlocal[0]+1e-20);
+    x0[2] = xinlocal[2] + (x0[0]-xinlocal[0]+1e-20)*
+      (xoutlocal[2]-xinlocal[2])/(xoutlocal[0]-xinlocal[0]+1e-20);
+    if (fabs(x0[2]-xoutlocal[2]) > fabs(xinlocal[2]-xoutlocal[2]))
+      {
+        x0[0] = xinlocal[0];
+        x0[1] = xinlocal[1];
+        x0[2] = xinlocal[2];
+      }
+    x1[0] = xwire+0.5*dwire*WIRE_SPACING;
+    x1[1] = xinlocal[1] + (x1[0]-xinlocal[0]+1e-20)*
+      (xoutlocal[1]-xinlocal[1])/(xoutlocal[0]-xinlocal[0]+1e-20);
+    x1[2] = xinlocal[2] + (x1[0]-xinlocal[0]+1e-20)*
+      (xoutlocal[2]-xinlocal[2])/(xoutlocal[0]-xinlocal[0]+1e-20);
+    if (fabs(x1[2]-xinlocal[2]) > fabs(xoutlocal[2]-xinlocal[2]))
+      {
+        x1[0] = xoutlocal[0];
+        x1[1] = xoutlocal[1];
+        x1[2] = xoutlocal[2];
+      }
+    dE = dEsum*(x1[2]-x0[2])/(xoutlocal[2]-xinlocal[2]);
       }
 
       if (dE > 0){
-	s_FdcAnodeTruthHits_t* ahits;    
+    s_FdcAnodeTruthHits_t* ahits;    
 
-	// Create (or grab) an entry in the tree for the anode wire
-	int mark = (chamber<<20) + (2<<10) + wire;
-	void** twig = getTwig(&forwardDCTree, mark);
-       	
-	if (*twig == 0)
-	  {
-	    s_ForwardDC_t* fdc = *twig = make_s_ForwardDC();
-	    s_FdcChambers_t* chambers = make_s_FdcChambers(1);
-	    s_FdcAnodeWires_t* wires = make_s_FdcAnodeWires(1);
-	    wires->mult = 1;
-	    wires->in[0].wire = wire;
-	    wires->in[0].fdcAnodeTruthHits = ahits = make_s_FdcAnodeTruthHits(MAX_HITS);
-	    chambers->mult = 1;
-	    chambers->in[0].module = module;
-	    chambers->in[0].layer = layer;
-	    chambers->in[0].fdcAnodeWires = wires;
-	    fdc->fdcChambers = chambers;
-	    wireCount++;          
-	  }
-	else
-	  {
-	    s_ForwardDC_t* fdc = *twig;
-	    ahits = fdc->fdcChambers->in[0].fdcAnodeWires->in[0].fdcAnodeTruthHits;
-	  }
-	
-	int two=2;
+    // Create (or grab) an entry in the tree for the anode wire
+    int mark = (chamber<<20) + (2<<10) + wire;
+    void** twig = getTwig(&forwardDCTree, mark);
+           
+    if (*twig == 0)
+      {
+        s_ForwardDC_t* fdc = *twig = make_s_ForwardDC();
+        s_FdcChambers_t* chambers = make_s_FdcChambers(1);
+        s_FdcAnodeWires_t* wires = make_s_FdcAnodeWires(1);
+        wires->mult = 1;
+        wires->in[0].wire = wire;
+        wires->in[0].fdcAnodeTruthHits = ahits = make_s_FdcAnodeTruthHits(MAX_HITS);
+        chambers->mult = 1;
+        chambers->in[0].module = module;
+        chambers->in[0].layer = layer;
+        chambers->in[0].fdcAnodeWires = wires;
+        fdc->fdcChambers = chambers;
+        wireCount++;          
+      }
+    else
+      {
+        s_ForwardDC_t* fdc = *twig;
+        ahits = fdc->fdcChambers->in[0].fdcAnodeWires->in[0].fdcAnodeTruthHits;
+      }
+    
+    int two=2;
       
-	// Find the number of primary ion pairs:
-	/* The total number of ion pairs depends on the energy deposition 
-	   and the effective average energy to produce a pair, w_eff.
-	   On average for each primary ion pair produced there are n_s_per_p 
-	   secondary ion pairs produced. 
-	*/
-	int one=1;
-	// Average number of secondary ion pairs for 40/60 Ar/CO2 mixture
-	float n_s_per_p=1.89; 
-	//Average energy needed to produce an ion pair for 50/50 mixture
-	float w_eff=30.2e-9; // GeV
-	// Average number of primary ion pairs
-	float n_p_mean = dE/w_eff/(1.+n_s_per_p);
-	int n_p; // number of primary ion pairs
-	gpoiss_(&n_p_mean,&n_p,&one);
+    // Find the number of primary ion pairs:
+    /* The total number of ion pairs depends on the energy deposition 
+       and the effective average energy to produce a pair, w_eff.
+       On average for each primary ion pair produced there are n_s_per_p 
+       secondary ion pairs produced. 
+    */
+    int one=1;
+    // Average number of secondary ion pairs for 40/60 Ar/CO2 mixture
+    float n_s_per_p=1.89; 
+    //Average energy needed to produce an ion pair for 50/50 mixture
+    float w_eff=30.2e-9; // GeV
+    // Average number of primary ion pairs
+    float n_p_mean = dE/w_eff/(1.+n_s_per_p);
+    int n_p; // number of primary ion pairs
+    gpoiss_(&n_p_mean,&n_p,&one);
    
-	// Drift time
-	float tdrift=0;
+    // Drift time
+    float tdrift=0;
 
-	if (controlparams_.driftclusters==0){
-	  float zrange=x1[2]-x0[2];
-	  float tany=(x1[1]-x0[1])/zrange;
-	  float tanx=(x1[0]-x0[0])/zrange;
-	  float dz=ANODE_CATHODE_SPACING-dradius*sign*sinalpha;
-#if 0	  
-	  dz+=wire_dz_offset[global_wire_number];
+    if (controlparams_.driftclusters==0){
+      float zrange=x1[2]-x0[2];
+      float tany=(x1[1]-x0[1])/zrange;
+      float tanx=(x1[0]-x0[0])/zrange;
+      float dz=ANODE_CATHODE_SPACING-dradius*sign*sinalpha;
+#if 0      
+      dz+=wire_dz_offset[global_wire_number];
 #endif
-	  xlocal[0]=x0[0]+tanx*dz;
-	  if (fabs(xlocal[0]-xwire)>0.5){
-	    xlocal[0]=x1[0];
-	    xlocal[1]=x1[1];
-	    xlocal[2]=x1[2];
-	  }
-	  else{
-	    xlocal[1]=x0[1]+tany*dz;
-	    xlocal[2]=x0[2]+dz;
-	  }
-	  
-	  /* If the cluster position is within the wire-deadened region of the 
-	     detector, skip this cluster 
-	  */
-	  if (sqrt(xlocal[0]*xlocal[0]+xlocal[1]*xlocal[1])
-	      >=wire_dead_zone_radius[PackNo]){	 
-	    if (AddFDCAnodeHit(ahits,layer,ipart,track,xwire,xlocal,dE,t,
-			       &tdrift)){
-	      AddFDCCathodeHits(PackNo,xwire,xlocal[1],tdrift,n_p,track,ipart,
-				chamber,module,layer,global_wire_number);
-	    }
-	  
-	  }
-	}
-	else{
-	  // Loop over the number of primary ion pairs
-	  int n;
-	  for (n=0;n<n_p;n++){
-	    // Generate a cluster at a random position along the path with cell
-	    float rndno[2];
-	    grndm_(rndno,&two);
-	    float dzrand=(x1[2]-x0[2])*rndno[0];
-	    // Position of the cluster
-	    xlocal[0]=x0[0]+(x1[0]-x0[0])*rndno[0];
-	    xlocal[1]=x0[1]+(x1[1]-x0[1])*rndno[0];
-	    xlocal[2]=x0[2]+dzrand;
-	    /* If the cluster position is within the wire-deadened region of the 
-	       detector, skip this cluster 
-	    */
-	    if (sqrt(xlocal[0]*xlocal[0]+xlocal[1]*xlocal[1])
-		>=wire_dead_zone_radius[PackNo]){	   
-	      if (AddFDCAnodeHit(ahits,layer,ipart,track,xwire,xlocal,dE,t,
-				 &tdrift)){
-		AddFDCCathodeHits(PackNo,xwire,xlocal[1],tdrift,n_p,track,ipart,
-				  chamber,module,layer,global_wire_number);
-	      }
-	    }
+      xlocal[0]=x0[0]+tanx*dz;
+      if (fabs(xlocal[0]-xwire)>0.5){
+        xlocal[0]=x1[0];
+        xlocal[1]=x1[1];
+        xlocal[2]=x1[2];
+      }
+      else{
+        xlocal[1]=x0[1]+tany*dz;
+        xlocal[2]=x0[2]+dz;
+      }
+      
+      /* If the cluster position is within the wire-deadened region of the 
+         detector, skip this cluster 
+      */
+      if (sqrt(xlocal[0]*xlocal[0]+xlocal[1]*xlocal[1])
+          >=wire_dead_zone_radius[PackNo]){     
+        if (AddFDCAnodeHit(ahits,layer,ipart,track,xwire,xlocal,dE,t,
+                   &tdrift)){
+          AddFDCCathodeHits(PackNo,xwire,xlocal[1],tdrift,n_p,track,ipart,
+                chamber,module,layer,global_wire_number);
+        }
+      
+      }
+    }
+    else{
+      // Loop over the number of primary ion pairs
+      int n;
+      for (n=0;n<n_p;n++){
+        // Generate a cluster at a random position along the path with cell
+        float rndno[2];
+        grndm_(rndno,&two);
+        float dzrand=(x1[2]-x0[2])*rndno[0];
+        // Position of the cluster
+        xlocal[0]=x0[0]+(x1[0]-x0[0])*rndno[0];
+        xlocal[1]=x0[1]+(x1[1]-x0[1])*rndno[0];
+        xlocal[2]=x0[2]+dzrand;
+        /* If the cluster position is within the wire-deadened region of the 
+           detector, skip this cluster 
+        */
+        if (sqrt(xlocal[0]*xlocal[0]+xlocal[1]*xlocal[1])
+            >=wire_dead_zone_radius[PackNo]){       
+          if (AddFDCAnodeHit(ahits,layer,ipart,track,xwire,xlocal,dE,t,
+                 &tdrift)){
+        AddFDCCathodeHits(PackNo,xwire,xlocal[1],tdrift,n_p,track,ipart,
+                  chamber,module,layer,global_wire_number);
+          }
+        }
 
-	  } // loop over primary ion pairs 
-	}
+      } // loop over primary ion pairs 
+    }
       } // Check for non-zero energy
 
       sign*=-1; // for dealing with the y-position for tracks crossing two cells
@@ -925,193 +921,193 @@ s_ForwardDC_t* pickForwardDC ()
       for (wire=0; wire < wires->mult; wire++)
       {
          s_FdcAnodeTruthHits_t* ahits = wires->in[wire].fdcAnodeTruthHits;
-	   
-	 // Sort the clusters by time
-	 qsort(ahits->in,ahits->mult,sizeof(s_FdcAnodeTruthHit_t),
-	       (compfn)fdc_anode_cluster_sort);
-	 
-	 int i,iok=0;
+       
+     // Sort the clusters by time
+     qsort(ahits->in,ahits->mult,sizeof(s_FdcAnodeTruthHit_t),
+           (compfn)fdc_anode_cluster_sort);
+     
+     int i,iok=0;
 
-	 if (controlparams_.driftclusters==0){
-	   for (iok=i=0; i < ahits->mult; i++)
-	     {
-	       if (ahits->in[i].dE > THRESH_KEV/1e6)
-		 {
+     if (controlparams_.driftclusters==0){
+       for (iok=i=0; i < ahits->mult; i++)
+         {
+           if (ahits->in[i].dE > THRESH_KEV/1e6)
+         {
                if (iok < i)
-		 {
-		   ahits->in[iok] = ahits->in[i];
-		 }
+         {
+           ahits->in[iok] = ahits->in[i];
+         }
                ++iok;
                ++mok;
-		 }
-	     }
-	 }
-	 else{  // Simulate clusters within the cell
-	
-	   // printf("-------------\n");
-	  
-	   
-	   // Temporary histogram in 1 ns bins to store waveform data
-	   int num_samples=(int)FDC_TIME_WINDOW;
-	   float *samples=(float *)malloc(num_samples*sizeof(float));
-	   for (i=0;i<num_samples;i++){
-	     samples[i]=wire_signal((float)i,ahits);
-	     //printf("%f %f\n",(float)i,samples[i]);
-	   }
-	   
-	   int returned_to_baseline=0;
-	   float q=0;
-	   for (i=0;i<num_samples;i++){
-	     if (samples[i] > THRESH_ANODE){
-	       if (returned_to_baseline==0){
-		 ahits->in[iok].itrack = ahits->in[0].itrack;
-		 ahits->in[iok].ptype = ahits->in[0].ptype;
-		 
-		 // Do an interpolation to find the time at which the threshold
-		 // was crossed.
-		 float t_array[4];
-		 int k;
-		 float my_t,my_terr;
-		 for (k=0;k<4;k++) t_array[k]=i-1+k;
-		 polint(&samples[i-1],t_array,4,THRESH_ANODE,&my_t,&my_terr);
-		 ahits->in[iok].t=my_t;
-		 
-		 returned_to_baseline=1;
-		 iok++;
-		 mok++;
-	       }
-	       q+=samples[i];
-	     }
-	     if (returned_to_baseline 
-		 && (samples[i] <= THRESH_ANODE)){
-	       returned_to_baseline=0;   
-	     }
-	   }
-	   free(samples);
-	 } // Simulation of clusters within cell
+         }
+         }
+     }
+     else{  // Simulate clusters within the cell
+    
+       // printf("-------------\n");
+      
+       
+       // Temporary histogram in 1 ns bins to store waveform data
+       int num_samples=(int)FDC_TIME_WINDOW;
+       float *samples=(float *)malloc(num_samples*sizeof(float));
+       for (i=0;i<num_samples;i++){
+         samples[i]=wire_signal((float)i,ahits);
+         //printf("%f %f\n",(float)i,samples[i]);
+       }
+       
+       int returned_to_baseline=0;
+       float q=0;
+       for (i=0;i<num_samples;i++){
+         if (samples[i] > THRESH_ANODE){
+           if (returned_to_baseline==0){
+         ahits->in[iok].itrack = ahits->in[0].itrack;
+         ahits->in[iok].ptype = ahits->in[0].ptype;
+         
+         // Do an interpolation to find the time at which the threshold
+         // was crossed.
+         float t_array[4];
+         int k;
+         float my_t,my_terr;
+         for (k=0;k<4;k++) t_array[k]=i-1+k;
+         polint(&samples[i-1],t_array,4,THRESH_ANODE,&my_t,&my_terr);
+         ahits->in[iok].t=my_t;
+         
+         returned_to_baseline=1;
+         iok++;
+         mok++;
+           }
+           q+=samples[i];
+         }
+         if (returned_to_baseline 
+         && (samples[i] <= THRESH_ANODE)){
+           returned_to_baseline=0;   
+         }
+       }
+       free(samples);
+     } // Simulation of clusters within cell
 
-	 if (iok)
-	   {
-	     ahits->mult = iok;
-	   }
-	 else if (ahits != HDDM_NULL)
-	   {
-	     FREE(ahits);
-	   }
+     if (iok)
+       {
+         ahits->mult = iok;
+       }
+     else if (ahits != HDDM_NULL)
+       {
+         FREE(ahits);
+       }
       } 
       if ((wires != HDDM_NULL) && (mok == 0))
-	{
-	  FREE(wires);
-	  wires = HDDM_NULL;
-	}
+    {
+      FREE(wires);
+      wires = HDDM_NULL;
+    }
       
       
       mok = 0;
       for (strip=0; strip < strips->mult; strip++)
-	{
-	  s_FdcCathodeTruthHits_t* chits = strips->in[strip].fdcCathodeTruthHits;
-	  
-	  // Sort the clusters by time
-	  qsort(chits->in,chits->mult,sizeof(s_FdcCathodeTruthHit_t),
-		  (compfn)fdc_cathode_cluster_sort);
-	  
-	  int i,iok=0;
-	  
-	  if (controlparams_.driftclusters==0){
-	    for (iok=i=0; i < chits->mult; i++)
-	      {
-		if (chits->in[i].q > 0.)
-		  {
-		    if (iok < i)
-		      {
-			chits->in[iok] = chits->in[i];
-		      }
-		    ++iok;
-		    ++mok;
-		  }
-	      }	    
-	    
-	  }
-	  else{
-	   
-	    // Temporary histogram in 1 ns bins to store waveform data
-	    int num_samples=(int)(FDC_TIME_WINDOW);
-	    float *samples=(float *)malloc(num_samples*sizeof(float));
-	    for (i=0;i<num_samples;i++){
-	      samples[i]=cathode_signal((float)i,chits);
-		 //printf("t %f V %f\n",(float)i,samples[i]);
-	    }	 
-	    
-	    int threshold_toggle=0;
-	    int istart=0;
-	    int FADC_BIN_SIZE=1;
-	    for (i=0;i<num_samples;i+=FADC_BIN_SIZE){
-	      if (samples[i] > THRESH_STRIPS){
-		if (threshold_toggle==0){
-		  chits->in[iok].itrack = chits->in[0].itrack;
-		  chits->in[iok].ptype = chits->in[0].ptype;
-		  chits->in[iok].t=(float) i;
-		  //chits->in[iok].q=samples[i];
-		  istart=(i > 0)? i-1 : 0;
-		  threshold_toggle=1;
-		  //iok++;
-		  //mok++;
-		}
-	      }
-	      if (threshold_toggle && 
-		  (samples[i] <= THRESH_STRIPS)){
-		int j;
-		// Find the first peak
-		for (j=istart+1;j<i-1;j++){
-		  if (samples[j]>samples[j-1] && samples[j]>samples[j+1]){
-		    chits->in[iok].q=samples[j];
-		    break;
-		  }
-		} 
-		threshold_toggle=0; 
-		iok++;
-		mok++;
-		//break;
-	      }
-	    }
-	    i=num_samples-1;
-	    if (samples[i] > THRESH_STRIPS&&threshold_toggle){
-	      int j;
-	      for (j=istart+1;j<i-1;j++){
-		if (samples[j]>samples[j-1] && samples[j]>samples[j+1]){
-		  chits->in[iok].q=samples[j];
-		  break;
-		}
-	      }
-	    }
-	    
-	    free(samples);
-	  }// Simulate clusters within cell
-	
-	  if (iok)
-	    {
-	      chits->mult = iok;
-	      //chits->mult=1;
-	    }
-	  else if (chits != HDDM_NULL)
-	    {
-	      FREE(chits);
-	    }
-	  
-	}
+    {
+      s_FdcCathodeTruthHits_t* chits = strips->in[strip].fdcCathodeTruthHits;
+      
+      // Sort the clusters by time
+      qsort(chits->in,chits->mult,sizeof(s_FdcCathodeTruthHit_t),
+          (compfn)fdc_cathode_cluster_sort);
+      
+      int i,iok=0;
+      
+      if (controlparams_.driftclusters==0){
+        for (iok=i=0; i < chits->mult; i++)
+          {
+        if (chits->in[i].q > 0.)
+          {
+            if (iok < i)
+              {
+            chits->in[iok] = chits->in[i];
+              }
+            ++iok;
+            ++mok;
+          }
+          }        
+        
+      }
+      else{
+       
+        // Temporary histogram in 1 ns bins to store waveform data
+        int num_samples=(int)(FDC_TIME_WINDOW);
+        float *samples=(float *)malloc(num_samples*sizeof(float));
+        for (i=0;i<num_samples;i++){
+          samples[i]=cathode_signal((float)i,chits);
+         //printf("t %f V %f\n",(float)i,samples[i]);
+        }     
+        
+        int threshold_toggle=0;
+        int istart=0;
+        int FADC_BIN_SIZE=1;
+        for (i=0;i<num_samples;i+=FADC_BIN_SIZE){
+          if (samples[i] > THRESH_STRIPS){
+        if (threshold_toggle==0){
+          chits->in[iok].itrack = chits->in[0].itrack;
+          chits->in[iok].ptype = chits->in[0].ptype;
+          chits->in[iok].t=(float) i;
+          //chits->in[iok].q=samples[i];
+          istart=(i > 0)? i-1 : 0;
+          threshold_toggle=1;
+          //iok++;
+          //mok++;
+        }
+          }
+          if (threshold_toggle && 
+          (samples[i] <= THRESH_STRIPS)){
+        int j;
+        // Find the first peak
+        for (j=istart+1;j<i-1;j++){
+          if (samples[j]>samples[j-1] && samples[j]>samples[j+1]){
+            chits->in[iok].q=samples[j];
+            break;
+          }
+        } 
+        threshold_toggle=0; 
+        iok++;
+        mok++;
+        //break;
+          }
+        }
+        i=num_samples-1;
+        if (samples[i] > THRESH_STRIPS&&threshold_toggle){
+          int j;
+          for (j=istart+1;j<i-1;j++){
+        if (samples[j]>samples[j-1] && samples[j]>samples[j+1]){
+          chits->in[iok].q=samples[j];
+          break;
+        }
+          }
+        }
+        
+        free(samples);
+      }// Simulate clusters within cell
+    
+      if (iok)
+        {
+          chits->mult = iok;
+          //chits->mult=1;
+        }
+      else if (chits != HDDM_NULL)
+        {
+          FREE(chits);
+        }
+      
+    }
       if ((strips != HDDM_NULL) && (mok == 0))
-	{
-	  FREE(strips);
-	  strips = HDDM_NULL;
-	}
+    {
+      FREE(strips);
+      strips = HDDM_NULL;
+    }
       
       if ((wires != HDDM_NULL) || 
           (strips != HDDM_NULL) ||
           (points != HDDM_NULL))
-	{
-	  if ((m == 0) || (module > box->fdcChambers->in[m-1].module)
+    {
+      if ((m == 0) || (module > box->fdcChambers->in[m-1].module)
                      || (layer  > box->fdcChambers->in[m-1].layer))
-	    {
+        {
           box->fdcChambers->in[m] = chambers->in[0];
 
           box->fdcChambers->in[m].fdcCathodeStrips = 

--- a/src/programs/Simulation/HDGeant/hitFTOF.c
+++ b/src/programs/Simulation/HDGeant/hitFTOF.c
@@ -147,6 +147,8 @@ void hitForwardTOF (float xin[4], float xout[4],
 
   }
 
+  int itrack = (stack == 0)? gidGetId(track) : -1;
+  
 
 
   // getplane is coded in
@@ -168,7 +170,7 @@ void hitForwardTOF (float xin[4], float xout[4],
   x[1] = (xin[1] + xout[1])/2;
   x[2] = (xin[2] + xout[2])/2;
   t    = (xin[3] + xout[3])/2 * 1e9;
-  
+
   // tranform the the global x coordinate into the local coordinate of the top_volume FTOF
   // defined in the geometry file src/programs/Simulation/hdds/ForwardTOF_HDDS.xml
   // the function transform Coord is defined in src/programs/Simulation/HDGeant/hitutil/hitutil.F
@@ -213,7 +215,7 @@ void hitForwardTOF (float xin[4], float xout[4],
       points->in[0].E = pin[3];
       points->in[0].ptype = ipart;
       points->in[0].trackID = make_s_TrackID();
-      points->in[0].trackID->itrack = gidGetId(track);
+      points->in[0].trackID->itrack = itrack;
       points->mult = 1;
       pointCount++;
     }
@@ -354,9 +356,12 @@ void hitForwardTOF (float xin[4], float xout[4],
           extras->in[nMChit].py = pin[1]*pin[4];
           extras->in[nMChit].pz = pin[2]*pin[4];
           extras->in[nMChit].ptype = ipart;
-          extras->in[nMChit].itrack = gidGetId(track);
+          extras->in[nMChit].itrack = itrack;
           extras->in[nMChit].dist = dist;
           extras->mult++;
+if (itrack > 0 && stack > 0) {
+printf("bang from the north %d,%f!\n", ipart, pin[3]);
+}
         }
         
       }  else if (nhit < MAX_HITS) {  // hit in new time window
@@ -377,10 +382,12 @@ void hitForwardTOF (float xin[4], float xout[4],
         extras->in[0].py = pin[1]*pin[4];
         extras->in[0].pz = pin[2]*pin[4];
         extras->in[0].ptype = ipart;
-        extras->in[0].itrack = gidGetId(track);
+        extras->in[0].itrack = itrack;
         extras->in[0].dist = dist;
         extras->mult = 1;
-        
+if (itrack > 0 && stack > 0) {
+printf("boom from the north %d,%f!\n", ipart, pin[3]);
+}
       } else {
         fprintf(stderr,"HDGeant error in hitForwardTOF (file hitFTOF.c): ");
         fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);
@@ -421,9 +428,12 @@ void hitForwardTOF (float xin[4], float xout[4],
           extras->in[nMChit].py = pin[1]*pin[4];
           extras->in[nMChit].pz = pin[2]*pin[4];
           extras->in[nMChit].ptype = ipart;
-          extras->in[nMChit].itrack = gidGetId(track);
+          extras->in[nMChit].itrack = itrack;
           extras->in[nMChit].dist = dist;
           extras->mult++;
+if (itrack > 0 && stack > 0) {
+printf("bang from the south %d,%f!\n", ipart, pin[3]);
+}
         }
         
       }  else if (nhit < MAX_HITS) {  // hit in new time window
@@ -443,10 +453,12 @@ void hitForwardTOF (float xin[4], float xout[4],
         extras->in[0].py = pin[1]*pin[4];
         extras->in[0].pz = pin[2]*pin[4];
         extras->in[0].ptype = ipart;
-        extras->in[0].itrack = gidGetId(track);
+        extras->in[0].itrack = itrack;
         extras->in[0].dist = dist;
         extras->mult = 1;
-        
+if (itrack > 0 && stack > 0) {
+printf("boom from the south %d,%f!\n", ipart, pin[3]);
+}
       } else {
         fprintf(stderr,"HDGeant error in hitForwardTOF (file hitFTOF.c): ");
         fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);

--- a/src/programs/Simulation/HDGeant/hitFTOF.c
+++ b/src/programs/Simulation/HDGeant/hitFTOF.c
@@ -318,7 +318,7 @@ void hitForwardTOF (float xin[4], float xout[4],
       hits = tof->ftofCounters->in[0].ftofTruthHits;
     }
     
-    if (hits != HDDM_NULL && column != 2) {
+    if (hits != HDDM_NULL && dEnorth > 0) {
       
       // loop over hits in this PM to find correct time slot, north end
       
@@ -387,7 +387,7 @@ void hitForwardTOF (float xin[4], float xout[4],
       }
     }
       
-    if (hits != HDDM_NULL && column != 1) {
+    if (hits != HDDM_NULL && dEsouth > 0) {
 
       // loop over hits in this PM to find correct time slot, south end
       

--- a/src/programs/Simulation/HDGeant/hitFTOF.c
+++ b/src/programs/Simulation/HDGeant/hitFTOF.c
@@ -359,9 +359,6 @@ void hitForwardTOF (float xin[4], float xout[4],
           extras->in[nMChit].itrack = itrack;
           extras->in[nMChit].dist = dist;
           extras->mult++;
-if (itrack > 0 && stack > 0) {
-printf("bang from the north %d,%f!\n", ipart, pin[3]);
-}
         }
         
       }  else if (nhit < MAX_HITS) {  // hit in new time window
@@ -385,9 +382,6 @@ printf("bang from the north %d,%f!\n", ipart, pin[3]);
         extras->in[0].itrack = itrack;
         extras->in[0].dist = dist;
         extras->mult = 1;
-if (itrack > 0 && stack > 0) {
-printf("boom from the north %d,%f!\n", ipart, pin[3]);
-}
       } else {
         fprintf(stderr,"HDGeant error in hitForwardTOF (file hitFTOF.c): ");
         fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);
@@ -431,9 +425,6 @@ printf("boom from the north %d,%f!\n", ipart, pin[3]);
           extras->in[nMChit].itrack = itrack;
           extras->in[nMChit].dist = dist;
           extras->mult++;
-if (itrack > 0 && stack > 0) {
-printf("bang from the south %d,%f!\n", ipart, pin[3]);
-}
         }
         
       }  else if (nhit < MAX_HITS) {  // hit in new time window
@@ -456,9 +447,6 @@ printf("bang from the south %d,%f!\n", ipart, pin[3]);
         extras->in[0].itrack = itrack;
         extras->in[0].dist = dist;
         extras->mult = 1;
-if (itrack > 0 && stack > 0) {
-printf("boom from the south %d,%f!\n", ipart, pin[3]);
-}
       } else {
         fprintf(stderr,"HDGeant error in hitForwardTOF (file hitFTOF.c): ");
         fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);

--- a/src/programs/Simulation/HDGeant/hitFTOF.c
+++ b/src/programs/Simulation/HDGeant/hitFTOF.c
@@ -51,7 +51,7 @@ static float BAR_LENGTH   =   252.0; // length of the bar
 // kinematic constants
 static float TWO_HIT_RESOL =  25.;// separation time between two different hits
 
-static float THRESH_MEV    =  0.;  // do not through away any hits, one can do that later
+static float THRESH_MEV    =  0.;  // do not throw away any hits, one can do that later
 
 // maximum particle tracks per counter
 static int TOF_MAX_HITS    = 25;  // was 100 changed to 25
@@ -194,7 +194,7 @@ void hitForwardTOF (float xin[4], float xout[4],
   /* post the hit to the truth tree */
   // in other words: store the GENERATED track information
   
-  if ((history == 0) && (plane == 0)) { 
+  if ((history == 0) && (plane == 0)) {
     
     // save all tracks from particles that hit the first plane of FTOF
     // save the generated "true" values
@@ -542,9 +542,18 @@ s_ForwardTOF_t* pickForwardTOF ()
     }
     
     // keep also the MC generated primary track particles
+    int last_track = -1;
+    double last_t = 1e9;
     for (point=0; point < points->mult; ++point) {
-      int m = box->ftofTruthPoints->mult++;
-      box->ftofTruthPoints->in[m] = points->in[point];
+       if (points->in[point].trackID->itrack > 0 &&
+          (points->in[point].track != last_track ||
+           fabs(points->in[point].t - last_t) > 0.1))
+       {
+          int m = box->ftofTruthPoints->mult++;
+          box->ftofTruthPoints->in[m] = points->in[point];
+          last_track = points->in[point].track;
+          last_t = points->in[point].t;
+       }
     }
     if (points != HDDM_NULL) {
       FREE(points);

--- a/src/programs/Simulation/HDGeant/hitFTOF.c
+++ b/src/programs/Simulation/HDGeant/hitFTOF.c
@@ -175,22 +175,6 @@ void hitForwardTOF (float xin[4], float xout[4],
   transformCoord(x,"global",xlocal,"FTOF");
   transformCoord(zeroHat,"local",xftof,"FTOF");
   
-  // track vector of this step
-  //dx[0] = xin[0] - xout[0];
-  //dx[1] = xin[1] - xout[1];
-  //dx[2] = xin[2] - xout[2];
-  // length of the track of this step
-  //dr = sqrt(dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2]);
-  // calculate dEdx only if track length is >0.001 cm
-  
-  // The following commented out to avoid compiler warnings 4/26/2015 DL
-//   if (dr > 1e-3) {
-//     dEdx = dEsum/dr;
-//   }
-//   else {
-//     dEdx = 0;
-//   }
-
   /* post the hit to the truth tree */
   // in other words: store the GENERATED track information
   
@@ -273,24 +257,24 @@ void hitForwardTOF (float xin[4], float xout[4],
     float dEnorth = dEsum * exp(-dxnorth/ATTEN_LENGTH);
     float dEsouth = dEsum * exp(-dxsouth/ATTEN_LENGTH);
 
-    if (plane==0){
-      if (column==1){
-	tnorth=0.;
-	dEnorth=0.;
+    if (plane==0) {
+      if (column==1) {
+        tnorth=0.;
+        dEnorth=0.;
       }
-      else if (column==2){	
-	tsouth=0.;
-	dEsouth=0.;
+      else if (column==2) {    
+        tsouth=0.;
+        dEsouth=0.;
       }
     }
-    else{
-      if (column==2){
-	tnorth=0.;
-	dEnorth=0.;
+    else {
+      if (column==2) {
+        tnorth=0.;
+        dEnorth=0.;
       }
-      else if (column==1){
-	tsouth=0.;
-	dEsouth=0.;
+      else if (column==1) {
+        tsouth=0.;
+        dEsouth=0.;
       }
     }
 
@@ -334,7 +318,7 @@ void hitForwardTOF (float xin[4], float xout[4],
       hits = tof->ftofCounters->in[0].ftofTruthHits;
     }
     
-    if (hits != HDDM_NULL) {
+    if (hits != HDDM_NULL && column != 2) {
       
       // loop over hits in this PM to find correct time slot, north end
       
@@ -351,10 +335,10 @@ void hitForwardTOF (float xin[4], float xout[4],
       // combine the times of this weighted by the energy of the hit
       
       if (nhit < hits->mult) {         /* merge with former hit */
-	float dEnew=hits->in[nhit].dE + dEnorth;
+        float dEnew=hits->in[nhit].dE + dEnorth;
         hits->in[nhit].t = 
           (hits->in[nhit].t * hits->in[nhit].dE + tnorth * dEnorth) /dEnew;
-	hits->in[nhit].dE=dEnew;
+        hits->in[nhit].dE=dEnew;
                 
         // now add MC tracking information 
         // first get MC pointer of this paddle
@@ -375,7 +359,7 @@ void hitForwardTOF (float xin[4], float xout[4],
           extras->mult++;
         }
         
-      }  else if (nhit < MAX_HITS){  // hit in new time window
+      }  else if (nhit < MAX_HITS) {  // hit in new time window
         hits->in[nhit].t = tnorth;
         hits->in[nhit].dE = dEnorth;
         hits->in[nhit].end = 0;
@@ -401,7 +385,10 @@ void hitForwardTOF (float xin[4], float xout[4],
         fprintf(stderr,"HDGeant error in hitForwardTOF (file hitFTOF.c): ");
         fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);
       }
+    }
       
+    if (hits != HDDM_NULL && column != 1) {
+
       // loop over hits in this PM to find correct time slot, south end
       
       for (nhit = 0; nhit < hits->mult; nhit++)
@@ -417,10 +404,10 @@ void hitForwardTOF (float xin[4], float xout[4],
       // combine the times of this weighted by the energy of the hit
       
       if (nhit < hits->mult) {         /* merge with former hit */
-	float dEnew=hits->in[nhit].dE + dEsouth;
+        float dEnew=hits->in[nhit].dE + dEsouth;
         hits->in[nhit].t = 
           (hits->in[nhit].t * hits->in[nhit].dE + tsouth * dEsouth) / dEnew;
-	hits->in[nhit].dE=dEnew;
+        hits->in[nhit].dE=dEnew;
         extras = hits->in[nhit].ftofTruthExtras;
 
         // now add MC tracking information 
@@ -513,7 +500,7 @@ s_ForwardTOF_t* pickForwardTOF ()
       for (iok=i=0; i < hits->mult; i++) {
         
         // check threshold
-        if (hits->in[i].dE >= THRESH_MEV/1e3) {
+        if (hits->in[i].dE > THRESH_MEV/1e3) {
           
           if (iok < i) {
             hits->in[iok] = hits->in[i];

--- a/src/programs/Simulation/HDGeant/hitGCal.c
+++ b/src/programs/Simulation/HDGeant/hitGCal.c
@@ -57,6 +57,8 @@ void hitGapEMcal (float xin[4], float xout[4],
 
    /* post the hit to the truth tree */
 
+   int itrack = (stack == 0)? gidGetId(track) : -1;
+
    if ((history == 0) && (pin[3] > THRESH_MEV/1e3))
    {
       s_GcalTruthShowers_t* showers;
@@ -81,7 +83,7 @@ void hitGapEMcal (float xin[4], float xout[4],
          showers->in[0].E = pin[3];
          showers->in[0].ptype = ipart;
          showers->in[0].trackID = make_s_TrackID();
-         showers->in[0].trackID->itrack = gidGetId(track);
+         showers->in[0].trackID->itrack = itrack;
          showers->mult = 1;
          showerCount++;
       }

--- a/src/programs/Simulation/HDGeant/hitGCal.c
+++ b/src/programs/Simulation/HDGeant/hitGCal.c
@@ -188,7 +188,7 @@ s_GapEMcal_t* pickGapEMcal ()
          int i,iok;
          for (iok=i=0; i < hits->mult; i++)
          {
-            if (hits->in[i].E >= THRESH_MEV/1e3)
+            if (hits->in[i].E > THRESH_MEV/1e3)
             {
 #if TESTING_CAL_CONTAINMENT
   Etotal += hits->in[i].E;

--- a/src/programs/Simulation/HDGeant/hitPS.c
+++ b/src/programs/Simulation/HDGeant/hitPS.c
@@ -211,7 +211,7 @@ s_PairSpectrometerFine_t* pickPs ()
          int i,iok;
          for (iok=i=0; i < hits->mult; i++)
          {
-            if (hits->in[i].dE >= THRESH_MEV/1e3)
+            if (hits->in[i].dE > THRESH_MEV/1e3)
             {
                if (iok < i)
                {

--- a/src/programs/Simulation/HDGeant/hitPS.c
+++ b/src/programs/Simulation/HDGeant/hitPS.c
@@ -236,10 +236,19 @@ s_PairSpectrometerFine_t* pickPs ()
          FREE(tiles);
       }
 
+      int last_track = -1;
+      double last_t = 1e9;
       for (point=0; point < points->mult; ++point)
       {
-         int m = box->psTruthPoints->mult++;
-         box->psTruthPoints->in[m] = item->psTruthPoints->in[point];
+         if (points->in[point].trackID->itrack > 0 &&
+            (points->in[point].track != last_track ||
+             fabs(points->in[point].t - last_t) > 0.1))
+         {
+            int m = box->psTruthPoints->mult++;
+            box->psTruthPoints->in[m] = item->psTruthPoints->in[point];
+            last_track = points->in[point].track;
+            last_t = points->in[point].t;
+         }
       }
       if (points != HDDM_NULL)
       {

--- a/src/programs/Simulation/HDGeant/hitPS.c
+++ b/src/programs/Simulation/HDGeant/hitPS.c
@@ -75,6 +75,8 @@ void hitPS(float xin[4], float xout[4],float pin[5], float pout[5], float dEsum,
       dEdx = 0;
    }
 
+   int itrack = (stack == 0)? gidGetId(track) : -1;
+
    if (history == 0)
    {
       int mark = (1<<30) + pointCount;
@@ -101,7 +103,7 @@ void hitPS(float xin[4], float xout[4],float pin[5], float pout[5], float dEsum,
          points->in[0].arm = getcolumn_wrapper_() / NUM_COLUMN_PER_ARM;
          points->in[0].column = getcolumn_wrapper_() % NUM_COLUMN_PER_ARM;
          points->in[0].trackID = make_s_TrackID();
-         points->in[0].trackID->itrack = gidGetId(track);
+         points->in[0].trackID->itrack = itrack;
          points->mult = 1;
          pointCount++;
       }
@@ -145,7 +147,7 @@ void hitPS(float xin[4], float xout[4],float pin[5], float pout[5], float dEsum,
          if (t < hits->in[nhit].t)
          {
             hits->in[nhit].ptype = ipart;
-            hits->in[nhit].itrack = gidGetId(track);
+            hits->in[nhit].itrack = itrack;
          }
          hits->in[nhit].t = 
                  (hits->in[nhit].t * hits->in[nhit].dE + t * dEsum) /
@@ -157,7 +159,7 @@ void hitPS(float xin[4], float xout[4],float pin[5], float pout[5], float dEsum,
          hits->in[nhit].t = t;
          hits->in[nhit].dE = dEsum;
          hits->in[nhit].ptype = ipart;
-         hits->in[nhit].itrack = gidGetId(track);
+         hits->in[nhit].itrack = itrack;
          hits->mult++;
       }
       else

--- a/src/programs/Simulation/HDGeant/hitPSC.c
+++ b/src/programs/Simulation/HDGeant/hitPSC.c
@@ -209,7 +209,7 @@ s_PairSpectrometerCoarse_t* pickPsc ()
          int i,iok;
          for (iok=i=0; i < hits->mult; i++)
          {
-            if (hits->in[i].dE >= THRESH_MEV/1e3)
+            if (hits->in[i].dE > THRESH_MEV/1e3)
             {
                if (iok < i)
                {

--- a/src/programs/Simulation/HDGeant/hitPSC.c
+++ b/src/programs/Simulation/HDGeant/hitPSC.c
@@ -75,6 +75,8 @@ void hitPSC(float xin[4], float xout[4],float pin[5], float pout[5], float dEsum
       dEdx = 0;
    }
 
+   int itrack = (stack == 0)? gidGetId(track) : -1;
+
    if (history == 0)
    {
       int mark = (1<<30) + pointCount;
@@ -100,7 +102,7 @@ void hitPSC(float xin[4], float xout[4],float pin[5], float pout[5], float dEsum
          points->in[0].arm = getmodule_wrapper_() / NUM_MODULES_PER_ARM;
          points->in[0].module = getmodule_wrapper_() % NUM_MODULES_PER_ARM;
          points->in[0].trackID = make_s_TrackID();
-         points->in[0].trackID->itrack = gidGetId(track);
+         points->in[0].trackID->itrack = itrack;
          points->mult = 1;
          pointCount++;
       }
@@ -143,7 +145,7 @@ void hitPSC(float xin[4], float xout[4],float pin[5], float pout[5], float dEsum
          if (t < hits->in[nhit].t)
          {
             hits->in[nhit].ptype = ipart;
-            hits->in[nhit].itrack = gidGetId(track);
+            hits->in[nhit].itrack = itrack;
          }
          hits->in[nhit].t = 
                  (hits->in[nhit].t * hits->in[nhit].dE + t * dEsum) /
@@ -155,7 +157,7 @@ void hitPSC(float xin[4], float xout[4],float pin[5], float pout[5], float dEsum
          hits->in[nhit].t = t;
          hits->in[nhit].dE = dEsum;
          hits->in[nhit].ptype = ipart;
-         hits->in[nhit].itrack = gidGetId(track);
+         hits->in[nhit].itrack = itrack;
          hits->mult++;
       }
       else

--- a/src/programs/Simulation/HDGeant/hitPSC.c
+++ b/src/programs/Simulation/HDGeant/hitPSC.c
@@ -234,10 +234,19 @@ s_PairSpectrometerCoarse_t* pickPsc ()
          FREE(paddles);
       }
 
+      int last_track = -1;
+      double last_t = 1e9;
       for (point=0; point < points->mult; ++point)
       {
-         int m = box->pscTruthPoints->mult++;
-         box->pscTruthPoints->in[m] = item->pscTruthPoints->in[point];
+         if (points->in[point].trackID->itrack > 0 &&
+            (points->in[point].track != last_track ||
+             fabs(points->in[point].t - last_t) > 0.1))
+         {
+            int m = box->pscTruthPoints->mult++;
+            box->pscTruthPoints->in[m] = item->pscTruthPoints->in[point];
+            last_track = points->in[point].track;
+            last_t = points->in[point].t;
+         }
       }
       if (points != HDDM_NULL)
       {

--- a/src/programs/Simulation/HDGeant/hitStart.c
+++ b/src/programs/Simulation/HDGeant/hitStart.c
@@ -428,7 +428,7 @@ s_StartCntr_t* pickStartCntr ()
          int i,iok;
          for (iok=i=0; i < hits->mult; i++)
          {
-            if (hits->in[i].dE >= THRESH_MEV/1e3)
+            if (hits->in[i].dE > THRESH_MEV/1e3)
             {
                if (iok < i)
                {

--- a/src/programs/Simulation/HDGeant/hitStart.c
+++ b/src/programs/Simulation/HDGeant/hitStart.c
@@ -453,10 +453,19 @@ s_StartCntr_t* pickStartCntr ()
          FREE(paddles);
       }
 
+      int last_track = -1;
+      double last_t = 1e9;
       for (point=0; point < points->mult; ++point)
       {
-         int m = box->stcTruthPoints->mult++;
-         box->stcTruthPoints->in[m] = item->stcTruthPoints->in[point];
+         if (points->in[point].trackID->itrack > 0 &&
+            (points->in[point].track != last_track ||
+             fabs(points->in[point].t - last_t) > 0.1))
+         {
+            int m = box->stcTruthPoints->mult++;
+            box->stcTruthPoints->in[m] = item->stcTruthPoints->in[point];
+            last_track = points->in[point].track;
+            last_t = points->in[point].t;
+         }
       }
       if (points != HDDM_NULL)
       {

--- a/src/programs/Simulation/HDGeant/hitStart.c
+++ b/src/programs/Simulation/HDGeant/hitStart.c
@@ -229,6 +229,8 @@ void hitStartCntr (float xin[4], float xout[4],
 
    /* post the hit to the truth tree */
 
+   int itrack = (stack == 0)? gidGetId(track) : -1;
+
    if (history == 0)
    {
       int mark = (1<<30) + pointCount;
@@ -253,7 +255,7 @@ void hitStartCntr (float xin[4], float xout[4],
          points->in[0].ptype = ipart;
          points->in[0].sector = getsector_wrapper_();
          points->in[0].trackID = make_s_TrackID();
-         points->in[0].trackID->itrack = gidGetId(track);
+         points->in[0].trackID->itrack = itrack;
          points->mult = 1;
          pointCount++;
       }
@@ -362,7 +364,7 @@ void hitStartCntr (float xin[4], float xout[4],
          if (tcorr < hits->in[nhit].t)
          {
             hits->in[nhit].ptype = ipart;
-            hits->in[nhit].itrack = gidGetId(track);
+            hits->in[nhit].itrack = itrack;
          }
          hits->in[nhit].t = 
                  (hits->in[nhit].t * hits->in[nhit].dE + tcorr * dEcorr) /
@@ -374,7 +376,7 @@ void hitStartCntr (float xin[4], float xout[4],
          hits->in[nhit].t = tcorr ;
          hits->in[nhit].dE = dEcorr;
          hits->in[nhit].ptype = ipart;
-         hits->in[nhit].itrack = gidGetId(track);
+         hits->in[nhit].itrack = itrack;
          hits->mult++;
       }
       else

--- a/src/programs/Simulation/HDGeant/hitUPV.c
+++ b/src/programs/Simulation/HDGeant/hitUPV.c
@@ -253,7 +253,7 @@ s_UpstreamEMveto_t* pickUpstreamEMveto ()
          int i,iok;
          for (iok=i=0; i < hits->mult; i++)
          {
-            if (hits->in[i].E >= THRESH_MEV/1e3)
+            if (hits->in[i].E > THRESH_MEV/1e3)
             {
                if (iok < i)
                {

--- a/src/programs/Simulation/HDGeant/hitUPV.c
+++ b/src/programs/Simulation/HDGeant/hitUPV.c
@@ -93,6 +93,8 @@ void hitUpstreamEMveto (float xin[4], float xout[4],
 
   /* post the hit to the truth tree */
 
+  int itrack = (stack == 0)? gidGetId(track) : -1;
+
   if ((history == 0) && (pin[3] > THRESH_MEV/1e3))
   {
     int mark = (1<<30) + showerCount;
@@ -113,7 +115,7 @@ void hitUpstreamEMveto (float xin[4], float xout[4],
       showers->in[0].E = pin[3];
       showers->in[0].ptype = ipart;
       showers->in[0].trackID = make_s_TrackID();
-      showers->in[0].trackID->itrack = gidGetId(track);
+      showers->in[0].trackID->itrack = itrack;
       showers->mult = 1;
       upv->upvTruthShowers = showers;
       showerCount++;

--- a/src/programs/Utilities/hddm2cMsg/.depends/Darwin/hddm2cMsg.d
+++ b/src/programs/Utilities/hddm2cMsg/.depends/Darwin/hddm2cMsg.d
@@ -1,5 +1,0 @@
-hddm2cMsg.o: hddm2cMsg.cc /usr/local/cMsg0.9/inc/cMsg.hxx \
-  /usr/local/cMsg0.9/inc/cMsgConstants.h \
-  /usr/local/cMsg0.9/inc/cMsgBase.hxx \
-  /Users/davidl/HallD/builds/latest/src/libraries/include/hddm_s.h \
-  /Users/davidl/HallD/builds/latest/src/include/particleType.h


### PR DESCRIPTION
…FDC.c,

                              hitFTOF.c, hitPS.c, hitPSC.c, hitStart.c [rtj]
   - add a cut to save xxxTruthPoint and xxxTruthShower objects only for
     primary tracks, not for every delta ray that they generate as they
     propagate. This cut was already in place for the calorimeter detectors
     (BCal, FCal, CCal, etc.) but the tracking detectors and scintillators
     tend to produce lots of TruthPoint/TruthShower objects for low-energy
     junk tracks. This gets MUCH worse in HDGeant4, so I had to add this
     cut there to prevent output hddm file size bloat, and now I push the
     mod back upstream to HDGeant to facilitate the direct comparison.