### PR TITLE
Davidl l1trigger

### DIFF
--- a/src/libraries/DAQ/HDEVIO.cc
+++ b/src/libraries/DAQ/HDEVIO.cc
@@ -1163,6 +1163,8 @@ void HDEVIO::PrintFileSummary(void)
 	uint32_t Nepics    = 0;
 	uint32_t Nbor      = 0;
 	uint32_t Nphysics  = 0;
+	uint32_t Nunknown  = 0;
+	uint32_t Nblockunknown = 0;
 
 	uint64_t first_event = 0;
 	uint64_t last_event  = 0;
@@ -1178,11 +1180,13 @@ void HDEVIO::PrintFileSummary(void)
 		events_in_block.insert(br.evio_events.size());
 		map_size += br.evio_events.size()*sizeof(EVIOEventRecord);
 
+		uint32_t Nunknown_prev = Nunknown;
 		for(uint32_t j=0; j<br.evio_events.size(); j++){
 			EVIOEventRecord &er = br.evio_events[j];
 			
 			uint32_t block_level;
 			switch(er.event_type){
+				case kBT_UNKNOWN:    Nunknown++;     break;
 				case kBT_SYNC:       Nsync++;        break;
 				case kBT_PRESTART:   Nprestart++;    break;
 				case kBT_GO:         Ngo++;          break;
@@ -1203,6 +1207,8 @@ void HDEVIO::PrintFileSummary(void)
 			
 			//_DBG_ << "Block " << i << "  event " << j << "  " << er.last_event <<" - " << er.first_event << " = " << block_level << endl;
 		}
+		
+		if( (Nunknown-Nunknown_prev) > 0 ) Nblockunknown++;
 	}
 	
 	// form succint string of block levels
@@ -1236,24 +1242,25 @@ void HDEVIO::PrintFileSummary(void)
 	string sevents_in_block = ss.str();
 	
 	// Print results
-	cout << endl;
+	PrintStats();
 	cout << "EVIO file size: " << (total_size_bytes>>20) << " MB" <<endl;
 	cout << "EVIO block map size: " << (map_size>>10) << " kB" <<endl;
 	cout << "first event: " << first_event << endl;
 	cout << "last event: " << last_event << endl;
 
 	cout << endl;
-	cout << "         Nblocks = " << evio_blocks.size() << endl;
-	cout << "    block levels = " << sblock_levels << endl;
-	cout << "events per block = " << sevents_in_block << endl;
-	cout << "           Nsync = " << Nsync << endl;
-	cout << "       Nprestart = " << Nprestart << endl;
-	cout << "             Ngo = " << Ngo << endl;
-	cout << "          Npause = " << Npause << endl;
-	cout << "            Nend = " << Nend << endl;
-	cout << "          Nepics = " << Nepics << endl;
-	cout << "            Nbor = " << Nbor << endl;
-	cout << "        Nphysics = " << Nphysics << endl;
+	cout << "             block levels = " << sblock_levels << endl;
+	cout << "         events per block = " << sevents_in_block << endl;
+	cout << "                    Nsync = " << Nsync << endl;
+	cout << "                Nprestart = " << Nprestart << endl;
+	cout << "                      Ngo = " << Ngo << endl;
+	cout << "                   Npause = " << Npause << endl;
+	cout << "                     Nend = " << Nend << endl;
+	cout << "                   Nepics = " << Nepics << endl;
+	cout << "                     Nbor = " << Nbor << endl;
+	cout << "                 Nphysics = " << Nphysics << endl;
+	cout << "                 Nunknown = " << Nunknown << endl;
+	cout << " blocks with unknown tags = " << Nblockunknown << endl;
 	cout << endl;
 }
 

--- a/src/libraries/TRIGGER/DL1Trigger.h
+++ b/src/libraries/TRIGGER/DL1Trigger.h
@@ -8,11 +8,10 @@ class DL1Trigger:public jana::JObject{
  public:
   JOBJECT_PUBLIC(DL1Trigger);
   
-  //  DL1Trigger():timestamp(0),trig_mask(0),fp_trig_mask(0),livetime(0),busytime(0),sync_evt(0){}
+  DL1Trigger():event_type(0),timestamp(0),trig_mask(0),fp_trig_mask(0),nsync(0),trig_number(0),live(0),busy(0),live_inst(0),unix_time(0){}
 
   
-  int event_type;  /* 1 - trigger
-		      2 - SYNC and trig */
+  int event_type;  // 0 - unknown , 1 - trigger   2 - SYNC and trig
   
   
   uint64_t timestamp; 
@@ -51,8 +50,8 @@ class DL1Trigger:public jana::JObject{
   void toStrings(vector<pair<string,string> > &items)const{
     AddString(items,  "timestamp",     "%ld",  timestamp );     
     AddString(items,  "event_type",    "%d",   event_type );
-    AddString(items,  "trig_mask",     "%d",   trig_mask );
-    AddString(items,  "fp_trig_mask",  "%d",   fp_trig_mask );    
+    AddString(items,  "trig_mask",     "0x%08x",   trig_mask );
+    AddString(items,  "fp_trig_mask",  "0x%08x",   fp_trig_mask );    
 
     AddString(items,  "nsync"       , "%d" , nsync); 
     AddString(items,  "trig_number" , "%d" , trig_number); 

--- a/src/libraries/TRIGGER/DL1Trigger_factory.cc
+++ b/src/libraries/TRIGGER/DL1Trigger_factory.cc
@@ -49,7 +49,7 @@ jerror_t DL1Trigger_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 
 	DL1Trigger *l1trigger = new DL1Trigger;
 
-
+	// Physics and possibly SYNC event
 	for(uint32_t i = 0; i < codarocinfos.size(); i++){
 		const DCODAROCInfo *cri = codarocinfos[i];
 		
@@ -65,6 +65,7 @@ jerror_t DL1Trigger_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 			// e-mail sent by Bryan Moffit Dec. 15, 2015).
 			l1trigger->trig_mask     = cri->misc[0]; // Global Trigger Processor latch word
 			l1trigger->fp_trig_mask  = cri->misc[1]; // Front Panel latch word
+			l1trigger->event_type = 1;
 			l1_found++;
 		}
 
@@ -75,8 +76,10 @@ jerror_t DL1Trigger_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 		break; // Should only be 1 with rocid=1
 	}
 
+	// SYNC event
 	if(l1_info.size() == 1){
 	  const DL1Info *l1_sc   = l1_info[0];
+	  l1trigger->event_type  = 2;
 	  l1trigger->nsync       = l1_sc->nsync;
 	  l1trigger->trig_number = l1_sc->trig_number;
 	  l1trigger->live        = l1_sc->live_time;
@@ -95,6 +98,8 @@ jerror_t DL1Trigger_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 
 	if(l1_found){
 	  _data.push_back(l1trigger);	 
+	}else{
+	  delete l1trigger; // prevent memory leak
 	}
 
 


### PR DESCRIPTION
 - Initialize all values so those not filled in by regular events are zeros rather than random
 - Set the event_type field so we know whether this was a sync event or not and therefore
   , whether to trust the values that are only set during a sync event
 - Plug small memory leak for events with no L1 info (e.g. EPICS and BOR events)