### PR TITLE
* control.in [rtj]

### DIFF
--- a/src/programs/Simulation/HDGeant/beamgen.F
+++ b/src/programs/Simulation/HDGeant/beamgen.F
@@ -20,6 +20,7 @@
 #include "geant321/gcscan.inc"
 #include "geant321/gcomis.inc"
 #include "geant321/gctrak.inc"
+#include "controlparams.inc"
 #include "cobrems.inc"
  
       real vertex(4),plab(5),pbeam
@@ -212,5 +213,7 @@ c  freq > freqMaximum is generated; a few ppm of these is no problem.
       call GSVERT(vertex,0,0,ubuf,nubuf,nvert)
       call GSKINE(plab,1,nvert,0,0,nt) ! push the beam photon on the stack
       vertex(4) = TOFG
-      call hitTagger(vertex,vertex,plab,plab,0.,1,0,0)
+      if (genbeam_mode(1).eq.0) then
+         call hitTagger(vertex,vertex,plab,plab,0.,1,0,0)
+      endif
       end

--- a/src/programs/Simulation/HDGeant/control.in
+++ b/src/programs/Simulation/HDGeant/control.in
@@ -40,6 +40,31 @@ c      radthick - dimaond radiator thickneess in m
 c Omitting the final parameter Emin results in the default value being used.
 cBEAM 10. 9.999 0.0012 76.00 0.005 10.e-9 20.e-6
 
+c The GENBEAM card configures the simulation program to act purely as a
+c Monte Carlo event generator, and not to actually track any of the particles
+c that it generates. The events are written to the output file with only the
+c MC section filled out (reactions tag). This file can be fed back later to
+c HDGeant using the INFILE card above to carry out the actual simulation.
+c This provides access to the built-in photon beam generator of HDGeant to
+c someone who wants to study the properties of the beam apart from its
+c interactions in the target. Three keywords are currently supported.
+c    'precol'   - single-photon events starting upstream of the primary
+c                 collimator, with correlated spatial and momentum 
+c                 distributions for the well-tuned GlueX beamline.
+c    'postcol'  - single-photon events starting downstream of the secondary
+c                 collimator. Beam photons have been tracked through the 
+c                 system of collimators and sweep magnets but then stopped
+c                 before entry into the pair spectrometer.
+c    'postconv' - e+e- pair and e+e-/e-recoil events generated in the
+c                 TPOL target. Beam photons have been tracked through
+c                 the system of collimators and then pair-converted in
+c                 the TPOL coverter using a custom polarization-sensitive
+c                 pair/triplet production generator. They are saved as
+c                 a single vertex within the PTAR target.
+c The first two modes are supported by both HDGeant and HDGeant4, while
+c postconv is only supported at present by HDGeant4.
+cGENBEAM 'postconv'
+
 c Commenting out the following line will disable simulated hits output.
 OUTFILE 'bgtest.hddm'
 

--- a/src/programs/Simulation/HDGeant/controlparams.inc
+++ b/src/programs/Simulation/HDGeant/controlparams.inc
@@ -8,3 +8,9 @@
      +                       ,tgtwidth(2),runtime_geom,get_next_evt
      +                       ,trigger_time_sigma_ns
      +                       ,event_count,override_run_number
+
+      integer genbeam_precol
+      integer genbeam_postcol
+      integer genbeam_mode
+      common /genbeam_pars/ genbeam_precol, genbeam_postcol,
+     +                      genbeam_mode(20)

--- a/src/programs/Simulation/HDGeant/gustep.F
+++ b/src/programs/Simulation/HDGeant/gustep.F
@@ -353,6 +353,21 @@ c
       integer enterbcal
       save enterbcal
 
+      if (genbeam_precol.ne.0) then
+         call storeBeam(vect, tofg)
+         writenohits = 1
+         ISTOP = 99
+         return
+      else if (genbeam_postcol.ne.0) then
+         if (vect(3).gt.-1520) then
+            call storeBeam(vect, tofg)
+            writenohits = 1
+            ISTOP = 99
+         else
+            writenohits = 0
+         endif
+      endif
+
 #ifdef BACKGROUND_PROFILING
 ********************************************************************************
 *   The following defines an ntuple containing information on particle type  

--- a/src/programs/Simulation/HDGeant/hddmOutput.c
+++ b/src/programs/Simulation/HDGeant/hddmOutput.c
@@ -151,6 +151,10 @@ int loadOutput (int runNo)
    if ((hitView->mcTrajectory = pickMCTrajectory()) != HDDM_NULL) {
       ++packages_hit;
    }
+   if (packages_hit == 0) {
+      thisOutputEvent->physicsEvents->in[0].hitView = HDDM_NULL;
+      free(hitView);
+   }
    return packages_hit;
 }
 

--- a/src/programs/Simulation/HDGeant/settofg.F
+++ b/src/programs/Simulation/HDGeant/settofg.F
@@ -15,18 +15,19 @@
 
       real reference_time_plane_z
       parameter (reference_time_plane_z=65.0)
+      real t0
       real xnormal(2)
       real beam_period_ns
       beam_period_ns = get_beam_period()
       if (time0 .eq. 0) then
 c smear the time0 value by the trigger time sigma
         call GRANOR(xnormal(1),xnormal(2))
-        time0 = trigger_time_sigma_ns*xnormal(1)
+        t0=trigger_time_sigma_ns*xnormal(1)
 c discretize the time according to the beam microstructure
-        time0=beam_bucket_period_ns*floor(time0/beam_period_ns+0.5)
+        t0=beam_period_ns*floor(t0/beam_period_ns+0.5)
 c synchronize the time to the accelerator clock, with the phase
 c set to zero when the bunch crosses the reference plane
-        TOFG=time0*1e-9 + (vertex(3)-reference_time_plane_z)/CLIGHT
+        TOFG=t0*1e-9 + (vertex(3)-reference_time_plane_z)/CLIGHT
       else
         TOFG=time0*1e-9
       endif

--- a/src/programs/Simulation/HDGeant/uginit.F
+++ b/src/programs/Simulation/HDGeant/uginit.F
@@ -198,6 +198,11 @@ c The following parameters are declared in controlparams.inc above.
       data trigger_time_sigma_ns/10./
       data event_count/0/
       data override_run_number/0/
+      data genbeam_precol/0/
+      data genbeam_postcol/0/
+      data genbeam_mode/20*0/
+      character*10 genbeam_modes
+      equivalence (genbeam_mode(1), genbeam_modes)
 
 C  Use this parameter to set up a minimum photon energy 
 C  for the coherent bremsstrahlung beam generator - see beamgen.F
@@ -263,6 +268,7 @@ C..geant..
       call ffkey('mcsmearopts',mcsmearopts,64,'MIXED')
       call ffkey('deleteunsmeared',deleteunsmeared,1,'INTEGER')
       call ffkey('beam',beamE0,7,'REAL')
+      call ffkey('genbeam',genbeam_mode,20,'MIXED')
       call ffkey('bfieldmap', bfield_map,20,'MIXED')
       call ffkey('bfieldtype', bfield_type,20,'MIXED')
       call ffkey('psbfieldmap', PS_bfield_map,20,'MIXED')
@@ -344,6 +350,22 @@ c        endif
      +        ' beamEmin is larger than a default value of 0.12 GeV,',
      +        ' cannot continue.'
          stop
+      endif
+
+      if (genbeam_mode(1) .ne. 0) then
+         call CUTOL(genbeam_modes)
+         if (genbeam_modes(1:6).eq.'precol') then
+            genbeam_precol = 1
+         elseif (genbeam_modes(1:7).eq.'postcol') then
+            genbeam_postcol = 1
+         else
+            print *, 'uginit.F: GENBEAM option ', genbeam_modes,
+     +               ' is not supported in this release of hdgeant,',
+     +               ' cannot continue.'
+            stop
+         endif
+
+
       endif
 
       if(showersincol.ne.0) then


### PR DESCRIPTION
   - added a new control card GENBEAM that can be used to run
     hdgeant as a pure Monte Carlo event generator to generate
     beam photons using the internal cobrems generator, but
     not to track them through the detector. Three modes are
     foreseen, two of which are supported in this code update.
     'precol' - generate a pre-collimated photon beam
     'postcol' - generate a post-collimator photon beam
     'postconv' - generate pair/triplet conversions in the
                  TPOL converter but do not track them.

* controlparams.inc, uginit.F [rtj]
   - add initialization code to support the new GENBEAM card

* beamgen.F [rtj]
   - when running in GENBEAM mode, do not simulate tagger hits

* hddmOutput.c [rtj]
   - when running in GENBEAM mode, do not create a hitView tag
     in the output event record.

* hddmInput.c [rtj]
   - add new function storeBeam to write out Monte Carlo info
     from the geneated beam photon wherever it was stopped.

* gustep.F [rtj]
   - add code to intercept beam photons when running in GENBEAM
     mode and not allow them to propagate down the beamline
     to the spectrometer.