### PR TITLE
Davidl nsamples override

### DIFF
--- a/src/libraries/DAQ/Df250PulseData.h
+++ b/src/libraries/DAQ/Df250PulseData.h
@@ -142,9 +142,9 @@ class Df250PulseData:public DDAQAddress{
 			AddString(items, "fine_time"               , "%d", fine_time               );
 			AddString(items, "pulse_peak"              , "%d", pulse_peak              );
 			AddString(items, "pulse_number"            , "%d", pulse_number            );
-			//AddString(items, "nsamples_integral"       , "%d", nsamples_integral       );
-			//AddString(items, "nsamples_pedestal"       , "%d", nsamples_pedestal       );
-			//AddString(items, "nsamples_over_threshold" , "%d", nsamples_over_threshold );
+			AddString(items, "nsamples_integral"       , "%d", nsamples_integral       );
+			AddString(items, "nsamples_pedestal"       , "%d", nsamples_pedestal       );
+			AddString(items, "nsamples_over_threshold" , "%d", nsamples_over_threshold );
 			AddString(items, "QF"                      , "%x", QF                      );
 			AddString(items, "emulated"                , "%x", emulated_all            );
 

--- a/src/libraries/TTAB/DTranslationTable.cc
+++ b/src/libraries/TTAB/DTranslationTable.cc
@@ -128,6 +128,12 @@ DTranslationTable::DTranslationTable(JEventLoop *loop)
 			"plugin, but otherwise, it will just give a slight performance"
 			"hit.");
 
+	// Here we create a bunch of config. parameters to allow us to overwrite
+	// the nsamples_integral and nsamples_pedestal fields of each type of
+	// fADC digihit class. This is done using some special macros in
+	// DTranslationTable.h
+	InitNsamplesOverride();
+
 	// Initialize dedicated JStreamLog used for debugging messages
 	ttout.SetTag("--- TT ---: ");
 	ttout.SetTimestampFlag();
@@ -615,6 +621,10 @@ void DTranslationTable::ApplyTranslationTable(JEventLoop *loop) const
              break;
       }
    }
+	
+	// Optionally overwrite nsamples_integral and/or nsamples_pedestal if 
+	// user specified via config. parameters.
+	OverwriteNsamples();
 
 	// Sort object order (this makes it easier to browse with hd_dump)
 	sort(vDBCALDigiHit.begin(), vDBCALDigiHit.end(), SortBCALDigiHit);


### PR DESCRIPTION
This defines config. parameters for all fADC DigiHit types that allow the user to overwrite the nsamples_integral and nsamples_pedestal fields. Two parameters exist for each type so the different detector systems can be specified separately. The format of the parameters is:

TT:NSAMPLES_INTEGRAL_DBCALDigiHit
TT:NSAMPLES_PEDESTAL_DBCALDigiHit

0 is the default value and is interpreted as "don't overwrite"