### PR TITLE
* programs/Simulation/HDGeant/gustep.F [rtj]

### DIFF
--- a/src/programs/Simulation/HDGeant/gustep.F
+++ b/src/programs/Simulation/HDGeant/gustep.F
@@ -834,8 +834,14 @@ c
 
 * Optionally store particle trajectory
       if (storetraj.ne.0) then
-        call addtrajectorypoint(VECT,TOFG,DESTEP,GEKIN,ITRA,ISTAK
-     +         ,IPART, RADL, STEP, NMEC, LMEC, storetraj)
+        if (storetraj.eq.1.or.storetraj.eq.2.or.
+     +     (storetraj.eq.4.and.ISTAK.ne.0)) then
+          call addtrajectorypoint(VECT,TOFG,DESTEP,GEKIN,ITRA,ISTAK
+     +           ,IPART, RADL, SLENG, NMEC, LMEC, storetraj)
+        else
+          call addtrajectorypoint(VECT,TOFG,DESTEP,GEKIN,ITRA,ISTAK
+     +           ,IPART, RADL, STEP, NMEC, LMEC, storetraj)
+        endif
       endif
      
 


### PR DESCRIPTION
   - change the mctrajectory output behavior to save total track length
     in the step="" field of the mcTrajectoryPoint tag if only birth and
     death points are being recorded for this track. Otherwise, the
     length of the final step is of no use in evaluating trajectories
     for which all of the intermediate steps are not saved.