### PR TITLE
Matching + Tracking Efficiencies + Pseudo-random DBeamPhotons

### DIFF
--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -830,7 +830,7 @@ void DHistogramAction_DetectorMatching::Initialize(JEventLoop* locEventLoop)
 	bool locIsRESTEvent = locEventLoop->GetJEvent().GetStatusBit(kSTATUS_REST);
 
 	map<string, double> tofparms;
- 	loop->GetCalib("TOF/tof_parms", tofparms);
+	locEventLoop->GetCalib("TOF/tof_parms", tofparms);
 
 	//CREATE THE HISTOGRAMS
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -924,6 +924,10 @@ void DHistogramAction_DetectorMatching::Initialize(JEventLoop* locEventLoop)
 			locHistName = "SCTrackDeltaPhiVsTheta";
 			locHistTitle = locTrackString + string(";#theta#circ;SC / Track #Delta#phi#circ");
 			dHistMap_SCTrackDeltaPhiVsTheta[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, dMaxTheta, dNum2DDeltaPhiBins, dSCMatchMinDeltaPhi, dSCMatchMaxDeltaPhi);
+
+			locHistName = "SCTrackDeltaPhiVsZ";
+			locHistTitle = locTrackString + string(";Projected SC Hit-Z (cm);SC / Track #Delta#phi#circ");
+			dHistMap_SCTrackDeltaPhiVsZ[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DSCZBins, 0.0, 120.0, dNum2DDeltaPhiBins, dSCMatchMinDeltaPhi, dSCMatchMaxDeltaPhi);
 			gDirectory->cd("..");
 
 			//TOFPaddle
@@ -1053,9 +1057,17 @@ void DHistogramAction_DetectorMatching::Initialize(JEventLoop* locEventLoop)
 			locHistTitle = locTrackString + string(";p (GeV/c);BCAL / Track #Delta#phi#circ");
 			dHistMap_BCALDeltaPhiVsP[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, 4.0, dNum2DDeltaPhiBins, dMinDeltaPhi, dMaxDeltaPhi);
 
+			locHistName = "BCALDeltaPhiVsZ";
+			locHistTitle = locTrackString + string(";Projected BCAL Hit-Z (cm);BCAL / Track #Delta#phi#circ");
+			dHistMap_BCALDeltaPhiVsZ[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DBCALZBins, 0.0, 450.0, dNum2DDeltaPhiBins, dMinDeltaPhi, dMaxDeltaPhi);
+
 			locHistName = "BCALDeltaZVsTheta";
 			locHistTitle = locTrackString + string(";#theta#circ;BCAL / Track #Deltaz (cm)");
 			dHistMap_BCALDeltaZVsTheta[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, dMaxTheta, dNum2DDeltaZBins, dMinDeltaZ, dMaxDeltaZ);
+
+			locHistName = "BCALDeltaZVsZ";
+			locHistTitle = locTrackString + string(";Projected BCAL Hit-Z (cm);BCAL / Track #Deltaz (cm)");
+			dHistMap_BCALDeltaZVsZ[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DBCALZBins, 0.0, 450.0, dNum2DDeltaZBins, dMinDeltaZ, dMaxDeltaZ);
 			gDirectory->cd("..");
 
 			//TRACKING
@@ -1168,33 +1180,59 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 	map<JObject::oid_t, const DKinematicData*>::iterator locTrackIterator;
 
 	//TRACK / BCAL CLOSEST MATCHES
-	map<const DKinematicData*, pair<double, double> > locBCALTrackDistanceMap; //first double is delta-phi, second delta-z
+	map<const DKinematicData*, pair<DBCALShowerMatchParams, double> > locBCALTrackDistanceMap; //double = z
 	for(locTrackIterator = locBestTrackMap.begin(); locTrackIterator != locBestTrackMap.end(); ++locTrackIterator)
 	{
-		double locBestMatchDeltaPhi = 0.0, locBestMatchDeltaZ = 0.0;
-		if(locParticleID->Get_ClosestToTrack_BCAL(locTrackIterator->second, locBCALShowers, locBestMatchDeltaPhi, locBestMatchDeltaZ) != NULL)
-			locBCALTrackDistanceMap[locTrackIterator->second] = pair<double, double>(locBestMatchDeltaPhi, locBestMatchDeltaZ);
+		DBCALShowerMatchParams locBestMatchParams;
+		const DReferenceTrajectory* rt = Get_ReferenceTrajectory(locTrackIterator->second);
+		if(rt == nullptr)
+			break; //e.g. REST data: no trajectory
+		double locStartTime = locTrackIterator->second->t0();
+		double locStartTimeVariance = 0.0;
+		DVector3 locProjPos, locProjMom;
+		if(locParticleID->Get_ClosestToTrack(rt, locBCALShowers, false, locStartTime, locBestMatchParams, &locStartTimeVariance, &locProjPos, &locProjMom))
+			locBCALTrackDistanceMap[locTrackIterator->second] = pair<DBCALShowerMatchParams, double>(locBestMatchParams, locProjPos.Z());
 	}
 
 	//TRACK / FCAL CLOSEST MATCHES
-	map<const DKinematicData*, double> locFCALTrackDistanceMap;
+	map<const DKinematicData*, DFCALShowerMatchParams> locFCALTrackDistanceMap;
 	for(locTrackIterator = locBestTrackMap.begin(); locTrackIterator != locBestTrackMap.end(); ++locTrackIterator)
 	{
-		double locBestDistance = 999.0;
-		if(locParticleID->Get_ClosestToTrack_FCAL(locTrackIterator->second, locFCALShowers, locBestDistance) != NULL)
-			locFCALTrackDistanceMap[locTrackIterator->second] = locBestDistance;
+		DFCALShowerMatchParams locBestMatchParams;
+		const DReferenceTrajectory* rt = Get_ReferenceTrajectory(locTrackIterator->second);
+		if(rt == nullptr)
+			break; //e.g. REST data: no trajectory
+		double locStartTime = locTrackIterator->second->t0();
+		if(locParticleID->Get_ClosestToTrack(rt, locFCALShowers, false, locStartTime, locBestMatchParams))
+			locFCALTrackDistanceMap[locTrackIterator->second] = locBestMatchParams;
+	}
+
+	//TRACK / SC CLOSEST MATCHES
+	map<const DKinematicData*, pair<DSCHitMatchParams, double> > locSCTrackDistanceMap; //double = z
+	for(locTrackIterator = locBestTrackMap.begin(); locTrackIterator != locBestTrackMap.end(); ++locTrackIterator)
+	{
+		DSCHitMatchParams locBestMatchParams;
+		const DReferenceTrajectory* rt = Get_ReferenceTrajectory(locTrackIterator->second);
+		if(rt == nullptr)
+			break; //e.g. REST data: no trajectory
+		double locStartTime = locTrackIterator->second->t0();
+		double locStartTimeVariance = 0.0;
+		DVector3 locProjPos, locProjMom;
+		if(locParticleID->Get_ClosestToTrack(rt, locSCHits, locIsTimeBased, false, locStartTime, locBestMatchParams, &locStartTimeVariance, &locProjPos, &locProjMom))
+			locSCTrackDistanceMap[locTrackIterator->second] = pair<DSCHitMatchParams, double>(locBestMatchParams, locProjPos.Z());
 	}
 
 	//TRACK / TOF POINT CLOSEST MATCHES
-	map<const DKinematicData*, pair<const DTOFPoint*, pair<double, double> > > locTOFPointTrackDistanceMap; //doubles: delta-x, delta-y
+	map<const DKinematicData*, DTOFHitMatchParams> locTOFPointTrackDistanceMap;
 	for(locTrackIterator = locBestTrackMap.begin(); locTrackIterator != locBestTrackMap.end(); ++locTrackIterator)
 	{
-		double locBestDeltaX, locBestDeltaY;
-		const DTOFPoint* locClosestTOFPoint = locParticleID->Get_ClosestToTrack_TOFPoint(locTrackIterator->second, locTOFPoints, locBestDeltaX, locBestDeltaY);
-		if(locClosestTOFPoint == NULL)
-			continue;
-		pair<double, double> locDeltas(locBestDeltaX, locBestDeltaY);
-		locTOFPointTrackDistanceMap[locTrackIterator->second] = pair<const DTOFPoint*, pair<double, double> >(locClosestTOFPoint, locDeltas);
+		DTOFHitMatchParams locBestMatchParams;
+		const DReferenceTrajectory* rt = Get_ReferenceTrajectory(locTrackIterator->second);
+		if(rt == nullptr)
+			break; //e.g. REST data: no trajectory
+		double locStartTime = locTrackIterator->second->t0();
+		if(locParticleID->Get_ClosestToTrack(rt, locTOFPoints, false, locStartTime, locBestMatchParams))
+			locTOFPointTrackDistanceMap[locTrackIterator->second] = locBestMatchParams;
 	}
 
 	//TRACK / TOF PADDLE CLOSEST MATCHES
@@ -1203,15 +1241,9 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 	for(locTrackIterator = locBestTrackMap.begin(); locTrackIterator != locBestTrackMap.end(); ++locTrackIterator)
 	{
 		const DKinematicData* locKinematicData = locTrackIterator->second;
-		const DTrackTimeBased* locTrackTimeBased = dynamic_cast<const DTrackTimeBased*>(locKinematicData);
-		const DTrackWireBased* locTrackWireBased = dynamic_cast<const DTrackWireBased*>(locKinematicData);
-		const DReferenceTrajectory* locReferenceTrajectory = nullptr;
-		if(locTrackTimeBased != nullptr)
-			locReferenceTrajectory = locTrackTimeBased->rt;
-		else if(locTrackWireBased != nullptr)
-			locReferenceTrajectory = locTrackWireBased->rt;
-		else
-			break;
+		const DReferenceTrajectory* locReferenceTrajectory = Get_ReferenceTrajectory(locKinematicData);
+		if(locReferenceTrajectory == nullptr)
+			break; //e.g. REST data: no trajectory
 
 		double locBestDeltaX = 999.9, locBestDeltaY = 999.9, locBestDistance_Vertical = 999.9, locBestDistance_Horizontal = 999.9;
 		double locStartTime = locParticleID->Calc_PropagatedRFTime(locKinematicData, locEventRFBunch);
@@ -1227,15 +1259,6 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 			locHorizontalTOFPaddleTrackDistanceMap[locTrackIterator->second] = pair<const DTOFPaddleHit*, pair<double, double> >(locClosestTOFPaddleHit_Horizontal, locDistancePair_Horizontal);
 	}
 
-	//TRACK / SC CLOSEST MATCHES
-	map<const DKinematicData*, double> locSCTrackDistanceMap;
-	for(locTrackIterator = locBestTrackMap.begin(); locTrackIterator != locBestTrackMap.end(); ++locTrackIterator)
-	{
-		double locBestDeltaPhi = 999.0;
-		if(locParticleID->Get_ClosestToTrack_SC(locTrackIterator->second, locSCHits, locBestDeltaPhi) != NULL)
-			locSCTrackDistanceMap[locTrackIterator->second] = locBestDeltaPhi;
-	}
-
 	//PROJECTED HIT POSITIONS
 	map<const DKinematicData*, pair<int, bool> > dProjectedSCPaddleMap; //pair: paddle, hit-barrel-flag (false if bend/nose)
 	map<const DKinematicData*, pair<int, int> > dProjectedTOF2DPaddlesMap; //pair: vertical, horizontal
@@ -1247,18 +1270,14 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 	for(locTrackIterator = locBestTrackMap.begin(); locTrackIterator != locBestTrackMap.end(); ++locTrackIterator)
 	{
 		const DKinematicData* locTrack = locTrackIterator->second;
-		const DReferenceTrajectory* locReferenceTrajectory = NULL;
-		if(locIsTimeBased)
-			locReferenceTrajectory = (static_cast<const DTrackTimeBased*>(locTrack))->rt;
-		else
-			locReferenceTrajectory = (static_cast<const DTrackWireBased*>(locTrack))->rt;
+		const DReferenceTrajectory* locReferenceTrajectory = Get_ReferenceTrajectory(locTrack);
 		if(locReferenceTrajectory == NULL)
 			break; //e.g. REST data: no trajectory
 
 		//SC
 		DVector3 locSCIntersection;
 		bool locProjBarrelFlag = false;
-		unsigned int locProjectedSCPaddle = locParticleID->PredictSCSector(locReferenceTrajectory, 999.9, &locSCIntersection, &locProjBarrelFlag);
+		unsigned int locProjectedSCPaddle = locParticleID->PredictSCSector(locReferenceTrajectory, &locSCIntersection, &locProjBarrelFlag);
 		if(locProjectedSCPaddle != 0)
 			dProjectedSCPaddleMap[locTrack] = pair<int, bool>(locProjectedSCPaddle, locProjBarrelFlag);
 
@@ -1298,21 +1317,25 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 		/********************************************************** MATCHING DISTANCE **********************************************************/
 
 		//BCAL
-		map<const DKinematicData*, pair<double, double> >::iterator locBCALIterator = locBCALTrackDistanceMap.begin();
-		for(; locBCALIterator != locBCALTrackDistanceMap.end(); ++locBCALIterator)
+		for(auto locMapPair : locBCALTrackDistanceMap)
 		{
-			const DKinematicData* locTrack = locBCALIterator->first;
-			dHistMap_BCALDeltaPhiVsP[locIsTimeBased]->Fill(locTrack->momentum().Mag(), locBCALIterator->second.first*180.0/TMath::Pi());
-			dHistMap_BCALDeltaZVsTheta[locIsTimeBased]->Fill(locTrack->momentum().Theta()*180.0/TMath::Pi(), locBCALIterator->second.second);
+			const DKinematicData* locTrack = locMapPair.first;
+			DBCALShowerMatchParams locMatchParams = locMapPair.second.first;
+			double locDeltaPhi = locMatchParams.dDeltaPhiToShower*180.0/TMath::Pi();
+			double locProjectedZ = locMapPair.second.second;
+			dHistMap_BCALDeltaPhiVsP[locIsTimeBased]->Fill(locTrack->momentum().Mag(), locDeltaPhi);
+			dHistMap_BCALDeltaZVsTheta[locIsTimeBased]->Fill(locTrack->momentum().Theta()*180.0/TMath::Pi(), locMatchParams.dDeltaZToShower);
+
+			dHistMap_BCALDeltaPhiVsZ[locIsTimeBased]->Fill(locProjectedZ, locDeltaPhi);
+			dHistMap_BCALDeltaZVsZ[locIsTimeBased]->Fill(locProjectedZ, locMatchParams.dDeltaZToShower);
 		}
 
 		//FCAL
-		map<const DKinematicData*, double>::iterator locFCALIterator = locFCALTrackDistanceMap.begin();
-		for(; locFCALIterator != locFCALTrackDistanceMap.end(); ++locFCALIterator)
+		for(auto locMapPair : locFCALTrackDistanceMap)
 		{
-			const DKinematicData* locTrack = locFCALIterator->first;
-			dHistMap_FCALTrackDistanceVsP[locIsTimeBased]->Fill(locTrack->momentum().Mag(), locFCALIterator->second);
-			dHistMap_FCALTrackDistanceVsTheta[locIsTimeBased]->Fill(locTrack->momentum().Theta()*180.0/TMath::Pi(), locFCALIterator->second);
+			const DKinematicData* locTrack = locMapPair.first;
+			dHistMap_FCALTrackDistanceVsP[locIsTimeBased]->Fill(locTrack->momentum().Mag(), locMapPair.second.dDOCAToShower);
+			dHistMap_FCALTrackDistanceVsTheta[locIsTimeBased]->Fill(locTrack->momentum().Theta()*180.0/TMath::Pi(), locMapPair.second.dDOCAToShower);
 		}
 
 		//TOF Paddle
@@ -1332,13 +1355,12 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 		}
 		
 		//TOF Point
-		map<const DKinematicData*, pair<const DTOFPoint*, pair<double, double> > >::iterator locTOFPointIterator = locTOFPointTrackDistanceMap.begin();
-		for(; locTOFPointIterator != locTOFPointTrackDistanceMap.end(); ++locTOFPointIterator)
+		for(auto locMapPair : locTOFPointTrackDistanceMap)
 		{
-			const DKinematicData* locTrack = locTOFPointIterator->first;
-			const DTOFPoint* locTOFPoint = locTOFPointIterator->second.first;
-			double locDeltaX = locTOFPointIterator->second.second.first;
-			double locDeltaY = locTOFPointIterator->second.second.second;
+			const DKinematicData* locTrack = locMapPair.first;
+			const DTOFPoint* locTOFPoint = locMapPair.second.dTOFPoint;
+			double locDeltaX = locMapPair.second.dDeltaXToHit;
+			double locDeltaY = locMapPair.second.dDeltaYToHit;
 
 			double locDistance = sqrt(locDeltaX*locDeltaX + locDeltaY*locDeltaY);
 			if((fabs(locDeltaX) < 500.0) && (fabs(locDeltaY) < 500.0)) //else position not well-defined
@@ -1359,24 +1381,26 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 		}
 
 		//SC
-		map<const DKinematicData*, double>::iterator locSCIterator = locSCTrackDistanceMap.begin();
 		if(locSCHits.size() <= 4) //don't fill if every paddle fired!
 		{
-			for(; locSCIterator != locSCTrackDistanceMap.end(); ++locSCIterator)
+			for(auto locMapPair : locSCTrackDistanceMap)
 			{
-				const DKinematicData* locTrack = locSCIterator->first;
-				double locDeltaPhi = locSCIterator->second*180.0/TMath::Pi();
+				const DKinematicData* locTrack = locMapPair.first;
+				DSCHitMatchParams locMatchParams = locMapPair.second.first;
+				double locDeltaPhi = locMatchParams.dDeltaPhiToHit*180.0/TMath::Pi();
+				double locProjectedZ = locMapPair.second.second;
 				dHistMap_SCTrackDeltaPhiVsP[locIsTimeBased]->Fill(locTrack->momentum().Mag(), locDeltaPhi);
 				dHistMap_SCTrackDeltaPhiVsTheta[locIsTimeBased]->Fill(locTrack->momentum().Theta()*180.0/TMath::Pi(), locDeltaPhi);
+				dHistMap_SCTrackDeltaPhiVsZ[locIsTimeBased]->Fill(locProjectedZ, locDeltaPhi);
 			}
 		}
 
 		/********************************************************* MATCHING EFFICINECY *********************************************************/
 
 		//Does-it-match, by detector
-		for(locTrackIterator = locBestTrackMap.begin(); locTrackIterator != locBestTrackMap.end(); ++locTrackIterator)
+		for(auto locMapPair : locBestTrackMap)
 		{
-			const DKinematicData* locTrack = locTrackIterator->second;
+			const DKinematicData* locTrack = locMapPair.second;
 			double locTheta = locTrack->momentum().Theta()*180.0/TMath::Pi();
 			double locPhi = locTrack->momentum().Phi()*180.0/TMath::Pi();
 			double locP = locTrack->momentum().Mag();
@@ -1411,89 +1435,95 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 			}
 
 			//FCAL
-			if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_FCAL))
+			if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_TOF))
 			{
-				dHistMap_PVsTheta_HasHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locP);
-				if(locP > 1.0)
-					dHistMap_PhiVsTheta_HasHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locPhi);
-				if((locP > 1.0) && (dProjectedFCALRowColumnMap.find(locTrack) != dProjectedFCALRowColumnMap.end()))
+				if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_FCAL))
 				{
-					pair<float, float>& locPositionPair = dProjectedFCALXYMap[locTrack];
-					dHistMap_TrackFCALYVsX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
-					pair<int, int>& locElementPair = dProjectedFCALRowColumnMap[locTrack];
-					dHistMap_TrackFCALRowVsColumn_HasHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
+					dHistMap_PVsTheta_HasHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locP);
+					if(locP > 1.0)
+						dHistMap_PhiVsTheta_HasHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locPhi);
+					if((locP > 1.0) && (dProjectedFCALRowColumnMap.find(locTrack) != dProjectedFCALRowColumnMap.end()))
+					{
+						pair<float, float>& locPositionPair = dProjectedFCALXYMap[locTrack];
+						dHistMap_TrackFCALYVsX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
+						pair<int, int>& locElementPair = dProjectedFCALRowColumnMap[locTrack];
+						dHistMap_TrackFCALRowVsColumn_HasHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
+					}
 				}
-			}
-			else
-			{
-				dHistMap_PVsTheta_NoHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locP);
-				if(locP > 1.0)
-					dHistMap_PhiVsTheta_NoHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locPhi);
-				if((locP > 1.0) && (dProjectedFCALRowColumnMap.find(locTrack) != dProjectedFCALRowColumnMap.end()))
+				else
 				{
-					pair<float, float>& locPositionPair = dProjectedFCALXYMap[locTrack];
-					dHistMap_TrackFCALYVsX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
-					pair<int, int>& locElementPair = dProjectedFCALRowColumnMap[locTrack];
-					dHistMap_TrackFCALRowVsColumn_NoHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
+					dHistMap_PVsTheta_NoHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locP);
+					if(locP > 1.0)
+						dHistMap_PhiVsTheta_NoHit[SYS_FCAL][locIsTimeBased]->Fill(locTheta, locPhi);
+					if((locP > 1.0) && (dProjectedFCALRowColumnMap.find(locTrack) != dProjectedFCALRowColumnMap.end()))
+					{
+						pair<float, float>& locPositionPair = dProjectedFCALXYMap[locTrack];
+						dHistMap_TrackFCALYVsX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
+						pair<int, int>& locElementPair = dProjectedFCALRowColumnMap[locTrack];
+						dHistMap_TrackFCALRowVsColumn_NoHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
+					}
 				}
 			}
 
 			//TOF Paddle
-			if((locP > 1.0) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
+			if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_FCAL))
 			{
-				pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
-				pair<int, int>& locPaddlePair = dProjectedTOF2DPaddlesMap[locTrack]; //vertical, horizontal
-
-				//Horizontal
-				if(locHorizontalTOFPaddleTrackDistanceMap.find(locTrack) != locHorizontalTOFPaddleTrackDistanceMap.end())
+				if((locP > 1.0) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
 				{
-					double locDistance = locHorizontalTOFPaddleTrackDistanceMap[locTrack].second.second;
-					if(locDistance <= dMinTOFPaddleMatchDistance) //match
-						dHistMap_TOFPaddleHorizontalPaddleVsTrackX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPaddlePair.second);
-					else //no match
+					pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
+					pair<int, int>& locPaddlePair = dProjectedTOF2DPaddlesMap[locTrack]; //vertical, horizontal
+
+					//Horizontal
+					if(locHorizontalTOFPaddleTrackDistanceMap.find(locTrack) != locHorizontalTOFPaddleTrackDistanceMap.end())
+					{
+						double locDistance = locHorizontalTOFPaddleTrackDistanceMap[locTrack].second.second;
+						if(locDistance <= dMinTOFPaddleMatchDistance) //match
+							dHistMap_TOFPaddleHorizontalPaddleVsTrackX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPaddlePair.second);
+						else //no match
+							dHistMap_TOFPaddleHorizontalPaddleVsTrackX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPaddlePair.second);
+					}
+					else // no match
 						dHistMap_TOFPaddleHorizontalPaddleVsTrackX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPaddlePair.second);
-				}
-				else // no match
-					dHistMap_TOFPaddleHorizontalPaddleVsTrackX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPaddlePair.second);
 
-				//Vertical
-				if(locVerticalTOFPaddleTrackDistanceMap.find(locTrack) != locVerticalTOFPaddleTrackDistanceMap.end())
-				{
-					double locDistance = locVerticalTOFPaddleTrackDistanceMap[locTrack].second.second;
-					if(locDistance <= dMinTOFPaddleMatchDistance) //match
-						dHistMap_TOFPaddleTrackYVsVerticalPaddle_HasHit[locIsTimeBased]->Fill(locPaddlePair.first, locPositionPair.second);
-					else //no match
+					//Vertical
+					if(locVerticalTOFPaddleTrackDistanceMap.find(locTrack) != locVerticalTOFPaddleTrackDistanceMap.end())
+					{
+						double locDistance = locVerticalTOFPaddleTrackDistanceMap[locTrack].second.second;
+						if(locDistance <= dMinTOFPaddleMatchDistance) //match
+							dHistMap_TOFPaddleTrackYVsVerticalPaddle_HasHit[locIsTimeBased]->Fill(locPaddlePair.first, locPositionPair.second);
+						else //no match
+							dHistMap_TOFPaddleTrackYVsVerticalPaddle_NoHit[locIsTimeBased]->Fill(locPaddlePair.first, locPositionPair.second);
+					}
+					else // no match
 						dHistMap_TOFPaddleTrackYVsVerticalPaddle_NoHit[locIsTimeBased]->Fill(locPaddlePair.first, locPositionPair.second);
 				}
-				else // no match
-					dHistMap_TOFPaddleTrackYVsVerticalPaddle_NoHit[locIsTimeBased]->Fill(locPaddlePair.first, locPositionPair.second);
-			}
 
-			//TOF Point
-			if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_TOF))
-			{
-				dHistMap_PVsTheta_HasHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locP);
-				if(locP > 1.0)
-					dHistMap_PhiVsTheta_HasHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locPhi);
-				if((locP > 1.0) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
+				//TOF Point
+				if(locDetectorMatches->Get_IsMatchedToDetector(locTrack, SYS_TOF))
 				{
-					pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
-					dHistMap_TrackTOFYVsX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
-					pair<int, int>& locElementPair = dProjectedTOF2DPaddlesMap[locTrack];
-					dHistMap_TrackTOF2DPaddles_HasHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
+					dHistMap_PVsTheta_HasHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locP);
+					if(locP > 1.0)
+						dHistMap_PhiVsTheta_HasHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locPhi);
+					if((locP > 1.0) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
+					{
+						pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
+						dHistMap_TrackTOFYVsX_HasHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
+						pair<int, int>& locElementPair = dProjectedTOF2DPaddlesMap[locTrack];
+						dHistMap_TrackTOF2DPaddles_HasHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
+					}
 				}
-			}
-			else
-			{
-				dHistMap_PVsTheta_NoHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locP);
-				if(locP > 1.0)
-					dHistMap_PhiVsTheta_NoHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locPhi);
-				if((locP > 1.0) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
+				else
 				{
-					pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
-					dHistMap_TrackTOFYVsX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
-					pair<int, int>& locElementPair = dProjectedTOF2DPaddlesMap[locTrack];
-					dHistMap_TrackTOF2DPaddles_NoHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
+					dHistMap_PVsTheta_NoHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locP);
+					if(locP > 1.0)
+						dHistMap_PhiVsTheta_NoHit[SYS_TOF][locIsTimeBased]->Fill(locTheta, locPhi);
+					if((locP > 1.0) && (dProjectedTOFXYMap.find(locTrack) != dProjectedTOFXYMap.end()))
+					{
+						pair<float, float>& locPositionPair = dProjectedTOFXYMap[locTrack];
+						dHistMap_TrackTOFYVsX_NoHit[locIsTimeBased]->Fill(locPositionPair.first, locPositionPair.second);
+						pair<int, int>& locElementPair = dProjectedTOF2DPaddlesMap[locTrack];
+						dHistMap_TrackTOF2DPaddles_NoHit[locIsTimeBased]->Fill(locElementPair.first, locElementPair.second);
+					}
 				}
 			}
 
@@ -1528,10 +1558,11 @@ void DHistogramAction_DetectorMatching::Fill_MatchingHists(JEventLoop* locEventL
 				}
 			}
 		}
+
 		//Is-Matched to Something
-		for(locTrackIterator = locBestTrackMap.begin(); locTrackIterator != locBestTrackMap.end(); ++locTrackIterator)
+		for(auto locMapPair : locBestTrackMap)
 		{
-			const DKinematicData* locTrack = locTrackIterator->second;
+			const DKinematicData* locTrack = locMapPair.second;
 			double locTheta = locTrack->momentum().Theta()*180.0/TMath::Pi();
 			double locP = locTrack->momentum().Mag();
 			if(locDetectorMatches->Get_IsMatchedToHit(locTrack))

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.h
@@ -610,9 +610,9 @@ class DHistogramAction_DetectedParticleKinematics : public DAnalysisAction
 	public:
 		DHistogramAction_DetectedParticleKinematics(const DReaction* locReaction, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Hist_DetectedParticleKinematics", false, locActionUniqueString), 
-		dMinPIDFOM(5.73303E-7), dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400),
-		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumBeamEBins(650),
-		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMaxBeamE(13.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
+		dMinPIDFOM(5.73303E-7), dNumPBins(600), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400),
+		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(300), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumBeamEBins(650),
+		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(12.0), dMaxBeamE(13.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
 		dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0),
 		dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
@@ -623,9 +623,9 @@ class DHistogramAction_DetectedParticleKinematics : public DAnalysisAction
 
 		DHistogramAction_DetectedParticleKinematics(string locActionUniqueString) : 
 		DAnalysisAction(NULL, "Hist_DetectedParticleKinematics", false, locActionUniqueString), 
-		dMinPIDFOM(5.73303E-7), dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400),
-		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumBeamEBins(650),
-		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMaxBeamE(13.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
+		dMinPIDFOM(5.73303E-7), dNumPBins(600), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400),
+		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(300), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumBeamEBins(650),
+		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(12.0), dMaxBeamE(13.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
 		dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0),
 		dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{
@@ -636,9 +636,9 @@ class DHistogramAction_DetectedParticleKinematics : public DAnalysisAction
 
 		DHistogramAction_DetectedParticleKinematics(void) : 
 		DAnalysisAction(NULL, "Hist_DetectedParticleKinematics", false, ""), 
-		dMinPIDFOM(5.73303E-7), dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400),
-		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumBeamEBins(650),
-		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMaxBeamE(13.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
+		dMinPIDFOM(5.73303E-7), dNumPBins(600), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400),
+		dNumVertexXYBins(400), dNumBetaBins(400), dNum2DDeltaBetaBins(400), dNum2DPBins(300), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumBeamEBins(650),
+		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(12.0), dMaxBeamE(13.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
 		dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0),
 		dTrackSelectionTag("NotATag"), dShowerSelectionTag("NotATag")
 		{

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.h
@@ -243,7 +243,7 @@ class DHistogramAction_DetectorMatching : public DAnalysisAction
 		DHistogramAction_DetectorMatching(const DReaction* locReaction, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_DetectorMatching", false, locActionUniqueString),
 		dNum2DThetaBins(280), dNum2DPBins(250), dNum2DPhiBins(360), dNum2DDeltaPhiBins(300), dNum2DDeltaZBins(300), dNum2DTrackDOCABins(200),
-		dNumTrackDOCABins(400), dNumFCALTOFXYBins(260), dNum2DBCALZBins(450), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
+		dNumTrackDOCABins(400), dNumFCALTOFXYBins(260), dNum2DBCALZBins(450), dNum2DSCZBins(240), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
 		dMinPhi(-180.0), dMaxPhi(180.0), dSCMatchMinDeltaPhi(-60.0), dSCMatchMaxDeltaPhi(60.0), dMinTrackDOCA(0.0), dMaxTrackMatchDOCA(20.0),
 		dMinDeltaPhi(-30.0), dMaxDeltaPhi(30.0), dMinDeltaZ(-30.0), dMaxDeltaZ(30.0),
 		dMinTrackingFOM(0.0027), dMinTOFPaddleMatchDistance(9.0), dMinHitRingsPerCDCSuperlayer(2), dMinHitPlanesPerFDCPackage(4) {}
@@ -251,7 +251,7 @@ class DHistogramAction_DetectorMatching : public DAnalysisAction
 		DHistogramAction_DetectorMatching(string locActionUniqueString) :
 		DAnalysisAction(NULL, "Hist_DetectorMatching", false, locActionUniqueString),
 		dNum2DThetaBins(280), dNum2DPBins(250), dNum2DPhiBins(360), dNum2DDeltaPhiBins(300), dNum2DDeltaZBins(300), dNum2DTrackDOCABins(200),
-		dNumTrackDOCABins(400), dNumFCALTOFXYBins(260), dNum2DBCALZBins(450), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
+		dNumTrackDOCABins(400), dNumFCALTOFXYBins(260), dNum2DBCALZBins(450), dNum2DSCZBins(240), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
 		dMinPhi(-180.0), dMaxPhi(180.0), dSCMatchMinDeltaPhi(-60.0), dSCMatchMaxDeltaPhi(60.0), dMinTrackDOCA(0.0), dMaxTrackMatchDOCA(20.0),
 		dMinDeltaPhi(-30.0), dMaxDeltaPhi(30.0), dMinDeltaZ(-30.0), dMaxDeltaZ(30.0),
 		dMinTrackingFOM(0.0027), dMinTOFPaddleMatchDistance(9.0), dMinHitRingsPerCDCSuperlayer(2), dMinHitPlanesPerFDCPackage(4) {}
@@ -259,7 +259,7 @@ class DHistogramAction_DetectorMatching : public DAnalysisAction
 		DHistogramAction_DetectorMatching(void) :
 		DAnalysisAction(NULL, "Hist_DetectorMatching", false, ""),
 		dNum2DThetaBins(280), dNum2DPBins(250), dNum2DPhiBins(360), dNum2DDeltaPhiBins(300), dNum2DDeltaZBins(300), dNum2DTrackDOCABins(200),
-		dNumTrackDOCABins(400), dNumFCALTOFXYBins(260), dNum2DBCALZBins(450), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
+		dNumTrackDOCABins(400), dNumFCALTOFXYBins(260), dNum2DBCALZBins(450), dNum2DSCZBins(240), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
 		dMinPhi(-180.0), dMaxPhi(180.0), dSCMatchMinDeltaPhi(-60.0), dSCMatchMaxDeltaPhi(60.0), dMinTrackDOCA(0.0), dMaxTrackMatchDOCA(20.0),
 		dMinDeltaPhi(-30.0), dMaxDeltaPhi(30.0), dMinDeltaZ(-30.0), dMaxDeltaZ(30.0),
 		dMinTrackingFOM(0.0027), dMinTOFPaddleMatchDistance(9.0), dMinHitRingsPerCDCSuperlayer(2), dMinHitPlanesPerFDCPackage(4) {}
@@ -267,7 +267,7 @@ class DHistogramAction_DetectorMatching : public DAnalysisAction
 		void Initialize(JEventLoop* locEventLoop);
 
 		unsigned int dNum2DThetaBins, dNum2DPBins, dNum2DPhiBins, dNum2DDeltaPhiBins, dNum2DDeltaZBins;
-		unsigned int dNum2DTrackDOCABins, dNumTrackDOCABins, dNumFCALTOFXYBins, dNum2DBCALZBins;
+		unsigned int dNum2DTrackDOCABins, dNumTrackDOCABins, dNumFCALTOFXYBins, dNum2DBCALZBins, dNum2DSCZBins;
 		double dMinP, dMaxP, dMinTheta, dMaxTheta, dMinPhi, dMaxPhi, dSCMatchMinDeltaPhi, dSCMatchMaxDeltaPhi, dMinTrackDOCA, dMaxTrackMatchDOCA;
 		double dMinDeltaPhi, dMaxDeltaPhi, dMinDeltaZ, dMaxDeltaZ;
 
@@ -277,6 +277,15 @@ class DHistogramAction_DetectorMatching : public DAnalysisAction
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo = NULL);
 		void Fill_MatchingHists(JEventLoop* locEventLoop, bool locIsTimeBased);
+
+		const DReferenceTrajectory* Get_ReferenceTrajectory(const DKinematicData* locTrack) const
+		{
+			const DTrackTimeBased* locTrackTimeBased = dynamic_cast<const DTrackTimeBased*>(locTrack);
+			const DTrackWireBased* locTrackWireBased = dynamic_cast<const DTrackWireBased*>(locTrack);
+			if((locTrackTimeBased == NULL) && (locTrackWireBased == NULL))
+				return NULL;
+			return (locTrackTimeBased != NULL) ? locTrackTimeBased->rt : locTrackWireBased->rt;
+		}
 
 		//bool is time/wire-based for true/false
 		map<DetectorSystem_t, map<bool, TH2I*> > dHistMap_PVsTheta_HasHit;
@@ -309,11 +318,14 @@ class DHistogramAction_DetectorMatching : public DAnalysisAction
 		map<bool, TH2I*> dHistMap_TrackPVsTheta_NoHitMatch;
 		map<bool, TH2I*> dHistMap_TrackPVsTheta_HitMatch;
 		map<bool, TH2I*> dHistMap_SCTrackDeltaPhiVsP;
+		map<bool, TH2I*> dHistMap_SCTrackDeltaPhiVsZ;
 		map<bool, TH2I*> dHistMap_SCTrackDeltaPhiVsTheta;
 		map<bool, TH2I*> dHistMap_FCALTrackDistanceVsP;
 		map<bool, TH2I*> dHistMap_FCALTrackDistanceVsTheta;
 		map<bool, TH2I*> dHistMap_BCALDeltaPhiVsP;
+		map<bool, TH2I*> dHistMap_BCALDeltaPhiVsZ;
 		map<bool, TH2I*> dHistMap_BCALDeltaZVsTheta;
+		map<bool, TH2I*> dHistMap_BCALDeltaZVsZ;
 
 		//DTOFPaddle Matching
 		map<bool, TH1I*> dHistMap_TOFPaddleTrackDeltaX;

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.h
@@ -287,6 +287,8 @@ class DHistogramAction_DetectorMatching : public DAnalysisAction
 			return (locTrackTimeBased != NULL) ? locTrackTimeBased->rt : locTrackWireBased->rt;
 		}
 
+		double TOF_E_THRESHOLD;
+
 		//bool is time/wire-based for true/false
 		map<DetectorSystem_t, map<bool, TH2I*> > dHistMap_PVsTheta_HasHit;
 		map<DetectorSystem_t, map<bool, TH2I*> > dHistMap_PVsTheta_NoHit;

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -179,9 +179,9 @@ class DHistogramAction_ParticleComboKinematics : public DAnalysisAction
 	public:
 		DHistogramAction_ParticleComboKinematics(const DReaction* locReaction, bool locUseKinFitResultsFlag, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Hist_ParticleComboKinematics", locUseKinFitResultsFlag, locActionUniqueString), 
-		dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumVertexXYBins(200), dNumBetaBins(400), dNumDeltaBetaBins(400),
-		dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumDeltaTRFBins(500), dNumPathLengthBins(750), dNumLifetimeBins(500),
-		dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
+		dNumPBins(600), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumVertexXYBins(200), dNumBetaBins(400), dNumDeltaBetaBins(400),
+		dNum2DPBins(300), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumDeltaTRFBins(500), dNumPathLengthBins(750), dNumLifetimeBins(500),
+		dMinP(0.0), dMaxP(12.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0),
 		dMinVertexXY(-5.0), dMaxVertexXY(5.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinDeltaBeta(-1.0), dMaxDeltaBeta(1.0), dMinDeltaTRF(-10.0), dMaxDeltaTRF(10.0),
 		dMaxPathLength(15), dMaxLifetime(5.0)
 		{

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -204,7 +204,7 @@ class DHistogramAction_ParticleComboKinematics : public DAnalysisAction
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 
-		void Fill_Hists(JEventLoop* locEventLoop, const DKinematicData* locKinematicData, const DEventRFBunch* locEventRFBunch, size_t locStepIndex);
+		void Fill_Hists(JEventLoop* locEventLoop, const DKinematicData* locKinematicData, bool locIsMissingFlag, const DEventRFBunch* locEventRFBunch, size_t locStepIndex);
 		void Fill_BeamHists(const DKinematicData* locKinematicData, const DEventRFBunch* locEventRFBunch);
 
 		const DParticleID* dParticleID;
@@ -221,15 +221,16 @@ class DHistogramAction_ParticleComboKinematics : public DAnalysisAction
 		TH1I* dBeamParticleHist_DeltaTRF;
 		TH2I* dBeamParticleHist_DeltaTRFVsBeamE;
 
-		deque<map<Particle_t, TH2I*> > dHistDeque_PVsTheta;
-		deque<map<Particle_t, TH2I*> > dHistDeque_BetaVsP;
-		deque<map<Particle_t, TH2I*> > dHistDeque_DeltaBetaVsP;
-		deque<map<Particle_t, TH2I*> > dHistDeque_PhiVsTheta;
-		deque<map<Particle_t, TH1I*> > dHistDeque_P;
-		deque<map<Particle_t, TH1I*> > dHistDeque_Theta;
-		deque<map<Particle_t, TH1I*> > dHistDeque_Phi;
-		deque<map<Particle_t, TH1I*> > dHistDeque_VertexZ;
-		deque<map<Particle_t, TH2I*> > dHistDeque_VertexYVsX;
+		//bool: true/false for missing/non-missing
+		deque<map<Particle_t, map<bool, TH2I*> > > dHistDeque_PVsTheta;
+		deque<map<Particle_t, map<bool, TH2I*> > > dHistDeque_BetaVsP;
+		deque<map<Particle_t, map<bool, TH2I*> > > dHistDeque_DeltaBetaVsP;
+		deque<map<Particle_t, map<bool, TH2I*> > > dHistDeque_PhiVsTheta;
+		deque<map<Particle_t, map<bool, TH1I*> > > dHistDeque_P;
+		deque<map<Particle_t, map<bool, TH1I*> > > dHistDeque_Theta;
+		deque<map<Particle_t, map<bool, TH1I*> > > dHistDeque_Phi;
+		deque<map<Particle_t, map<bool, TH1I*> > > dHistDeque_VertexZ;
+		deque<map<Particle_t, map<bool, TH2I*> > > dHistDeque_VertexYVsX;
 
 		deque<TH1I*> dHistDeque_MaxTrackDeltaZ;
 		deque<TH1I*> dHistDeque_MaxTrackDeltaT;

--- a/src/libraries/ANALYSIS/DParticleCombo_factory.h
+++ b/src/libraries/ANALYSIS/DParticleCombo_factory.h
@@ -58,7 +58,7 @@ class DParticleCombo_factory : public jana::JFactory<DParticleCombo>
 		void Set_SpacetimeVertex(const DParticleCombo* locNewParticleCombo, DParticleComboStep* locNewParticleComboStep, size_t locStepIndex, const DKinFitResults* locKinFitResults, const DKinFitChain* locKinFitChain) const;
 		void Reset_Data(void);
 
-		DKinematicData* Build_KinematicData(Particle_t locPID, DKinFitParticle* locKinFitParticle);
+		DKinematicData* Build_KinematicData(Particle_t locPID, DKinFitParticle* locKinFitParticle, DKinFitType locKinFitType, DVector3 locEventVertex);
 
 		DKinematicData* Get_KinematicDataResource(void);
 		DParticleComboStep* Get_ParticleComboStepResource(void);

--- a/src/libraries/ANALYSIS/DReaction.h
+++ b/src/libraries/ANALYSIS/DReaction.h
@@ -64,6 +64,7 @@ class DReaction : public JObject
 		// GET CONTROL INFO:
 		string Get_ReactionName(void) const{return dReactionName;}
 		int Get_DecayStepIndex(int locStepIndex, int locParticleIndex) const;
+		bool Check_IfMissingDecayProduct(size_t locStepIndex) const;
 		pair<int, int> Get_InitialParticleDecayFromIndices(int locStepIndex) const; //1st is step index, 2nd is particle index
 		int Get_DefinedParticleStepIndex(void) const; //-1 if none //defined: missing or open-ended-decaying
 		bool Get_IsInclusiveChannelFlag(void) const;
@@ -282,6 +283,23 @@ inline bool DReaction::Get_InvariantMassCut(Particle_t locStepInitialPID, double
 	locMinInvariantMass = locIterator->second.first;
 	locMaxInvariantMass = locIterator->second.second;
 	return true;
+}
+
+inline bool DReaction::Check_IfMissingDecayProduct(size_t locStepIndex) const
+{
+	const DReactionStep* locReactionStep = Get_ReactionStep(locStepIndex);
+	Particle_t locMissingPID;
+	if(locReactionStep->Get_MissingPID(locMissingPID))
+		return true;
+	for(size_t loc_j = 0; loc_j < locReactionStep->Get_NumFinalParticleIDs(); ++loc_j)
+	{
+		int locDecayStepIndex = Get_DecayStepIndex(locStepIndex, loc_j);
+		if(locDecayStepIndex <= 0)
+			continue; //doesn't decay
+		if(Check_IfMissingDecayProduct(locDecayStepIndex))
+			return true;
+	}
+	return false;
 }
 
 #endif // _DReaction_

--- a/src/libraries/ANALYSIS/DReactionStep.h
+++ b/src/libraries/ANALYSIS/DReactionStep.h
@@ -183,7 +183,7 @@ inline string DReactionStep::Get_StepName(void) const
 	string locStepName = ParticleType(dInitialParticleID);
 	if(dTargetParticleID != Unknown)
 		locStepName += string("_") + ParticleType(dTargetParticleID);
-	locStepName += "_->";
+	locStepName += "__";
 	for(size_t loc_i = 0; loc_i < dFinalParticleIDs.size(); ++loc_i)
 	{
 		if(int(loc_i) == dMissingParticleIndex)

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -1125,7 +1125,6 @@ jerror_t DEventSourceREST::Extract_DDetectorMatches(JEventLoop* locEventLoop, hd
          size_t locTrackIndex = bcalIter->getTrack();
 
          DBCALShowerMatchParams locShowerMatchParams;
-         locShowerMatchParams.dTrack = locTrackTimeBasedVector[locTrackIndex];
          locShowerMatchParams.dBCALShower = locBCALShowers[locShowerIndex];
          locShowerMatchParams.dx = bcalIter->getDx();
          locShowerMatchParams.dFlightTime = bcalIter->getTflight();
@@ -1145,9 +1144,7 @@ jerror_t DEventSourceREST::Extract_DDetectorMatches(JEventLoop* locEventLoop, hd
          size_t locTrackIndex = fcalIter->getTrack();
 
          DFCALShowerMatchParams locShowerMatchParams;
-         locShowerMatchParams.dTrack = locTrackTimeBasedVector[locTrackIndex];
          locShowerMatchParams.dFCALShower = locFCALShowers[locShowerIndex];
-
          locShowerMatchParams.dx = fcalIter->getDx();
          locShowerMatchParams.dFlightTime = fcalIter->getTflight();
          locShowerMatchParams.dFlightTimeVariance = fcalIter->getTflightvar();
@@ -1165,9 +1162,7 @@ jerror_t DEventSourceREST::Extract_DDetectorMatches(JEventLoop* locEventLoop, hd
          size_t locTrackIndex = scIter->getTrack();
 
          DSCHitMatchParams locSCHitMatchParams;
-         locSCHitMatchParams.dTrack = locTrackTimeBasedVector[locTrackIndex];
          locSCHitMatchParams.dSCHit = locSCHits[locHitIndex];
-
          locSCHitMatchParams.dEdx = scIter->getDEdx();
          locSCHitMatchParams.dHitTime = scIter->getThit();
          locSCHitMatchParams.dHitTimeVariance = scIter->getThitvar();
@@ -1188,7 +1183,6 @@ jerror_t DEventSourceREST::Extract_DDetectorMatches(JEventLoop* locEventLoop, hd
          size_t locTrackIndex = tofIter->getTrack();
 
          DTOFHitMatchParams locTOFHitMatchParams;
-         locTOFHitMatchParams.dTrack = locTrackTimeBasedVector[locTrackIndex];
          locTOFHitMatchParams.dTOFPoint = locTOFPoints[locHitIndex];
 
          locTOFHitMatchParams.dHitTime = tofIter->getThit();

--- a/src/libraries/HDGEOMETRY/DGeometry.cc
+++ b/src/libraries/HDGEOMETRY/DGeometry.cc
@@ -1738,6 +1738,7 @@ bool DGeometry::GetStartCounterGeom(vector<vector<DVector3> >&pos,
 	dir.SetMag(1.);
 	dirvec.push_back(dir);		
       }
+      posvec.push_back(DVector3(ray.X(),ray.Y(),ray.Z()+z0)); //SAVE THE ENDPOINT OF THE LAST PLANE
       pos.push_back(posvec);
       norm.push_back(dirvec);
 		  

--- a/src/libraries/PID/DBeamPhoton_factory.cc
+++ b/src/libraries/PID/DBeamPhoton_factory.cc
@@ -7,10 +7,26 @@
 
 #include <iostream>
 #include <iomanip>
+#include <cmath>
 using namespace std;
 
 #include "DBeamPhoton_factory.h"
 using namespace jana;
+
+inline bool DBeamPhoton_SortByTime(const DBeamPhoton* locBeamPhoton1, const DBeamPhoton* locBeamPhoton2)
+{
+	// pseudo-randomly sort beam photons by time, using only sub-picosecond digits
+	// do this by converting to picoseconds, then stripping all digits above the decimal place
+
+	//guard against NaN
+	if(std::isnan(locBeamPhoton1->time()))
+		return false;
+	if(std::isnan(locBeamPhoton2->time()))
+		return true;
+	double locT1_Picoseconds_Stripped = 1000.0*locBeamPhoton1->time() - floor(1000.0*locBeamPhoton1->time());
+	double locT2_Picoseconds_Stripped = 1000.0*locBeamPhoton2->time() - floor(1000.0*locBeamPhoton2->time());
+	return (locT1_Picoseconds_Stripped < locT2_Picoseconds_Stripped);
+}
 
 //------------------
 // init
@@ -85,6 +101,8 @@ jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t locE
             _data.push_back(gamma);
         }
     }
+
+	sort(_data.begin(), _data.end(), DBeamPhoton_SortByTime);
 
     return NOERROR;
 }

--- a/src/libraries/PID/DChargedTrackHypothesis.h
+++ b/src/libraries/PID/DChargedTrackHypothesis.h
@@ -67,22 +67,22 @@ class DChargedTrackHypothesis : public DKinematicData
 //THESE RETURN NULL IF NO MATCH TO THAT SYSTEM
 inline const DSCHitMatchParams* DChargedTrackHypothesis::Get_SCHitMatchParams(void) const
 {
-	return ((dSCHitMatchParams.dTrack == NULL) ? NULL : &dSCHitMatchParams);
+	return ((dSCHitMatchParams.dSCHit == NULL) ? NULL : &dSCHitMatchParams);
 }
 
 inline const DTOFHitMatchParams* DChargedTrackHypothesis::Get_TOFHitMatchParams(void) const
 {
-	return ((dTOFHitMatchParams.dTrack == NULL) ? NULL : &dTOFHitMatchParams);
+	return ((dTOFHitMatchParams.dTOFPoint == NULL) ? NULL : &dTOFHitMatchParams);
 }
 
 inline const DBCALShowerMatchParams* DChargedTrackHypothesis::Get_BCALShowerMatchParams(void) const
 {
-	return ((dBCALShowerMatchParams.dTrack == NULL) ? NULL : &dBCALShowerMatchParams);
+	return ((dBCALShowerMatchParams.dBCALShower == NULL) ? NULL : &dBCALShowerMatchParams);
 }
 
 inline const DFCALShowerMatchParams* DChargedTrackHypothesis::Get_FCALShowerMatchParams(void) const
 {
-	return ((dFCALShowerMatchParams.dTrack == NULL) ? NULL : &dFCALShowerMatchParams);
+	return ((dFCALShowerMatchParams.dFCALShower == NULL) ? NULL : &dFCALShowerMatchParams);
 }
 
 inline void DChargedTrackHypothesis::Set_SCHitMatchParams(const DSCHitMatchParams& locSCHitMatchParams)

--- a/src/libraries/PID/DDetectorMatches.h
+++ b/src/libraries/PID/DDetectorMatches.h
@@ -24,11 +24,9 @@ using namespace std;
 class DBCALShowerMatchParams
 {
 	public:
-		DBCALShowerMatchParams(void) : dTrack(NULL), dBCALShower(NULL),
+		DBCALShowerMatchParams(void) : dBCALShower(NULL),
 		dx(0.0), dFlightTime(0.0), dFlightTimeVariance(0.0), dPathLength(0.0), dDeltaPhiToShower(0.0), dDeltaZToShower(0.0){}
 
-		//dTrack is EITHER NULL (no match), DTrackTimeBased (default DDetectorMatches tag) or DTrackWireBased (DDetectorMatches tag = "WireBased")
-		const DKinematicData* dTrack;
 		const DBCALShower* dBCALShower;
 
 		double dx; //the distance the track traveled through the detector system up to the shower position
@@ -43,16 +41,24 @@ class DBCALShowerMatchParams
 			double locRSq = dBCALShower->x*dBCALShower->x + dBCALShower->y*dBCALShower->y;
 			return sqrt(dDeltaZToShower*dDeltaZToShower + dDeltaPhiToShower*dDeltaPhiToShower*locRSq);
 		}
+
+		bool operator != (const DBCALShowerMatchParams& locParams) const{return (!((*this) == locParams));}
+		bool operator == (const DBCALShowerMatchParams& locParams) const
+		{
+			if((dBCALShower != locParams.dBCALShower) || (dx != locParams.dx) || (dFlightTime != locParams.dFlightTime) || (dPathLength != locParams.dPathLength))
+				return false;
+			if((dFlightTimeVariance != locParams.dFlightTimeVariance) || (dDeltaZToShower != locParams.dDeltaZToShower) || (dDeltaPhiToShower != locParams.dDeltaPhiToShower))
+				return false;
+			return true;
+		}
 };
 
 class DFCALShowerMatchParams
 {
 	public:
-		DFCALShowerMatchParams(void) : dTrack(NULL), dFCALShower(NULL),
+		DFCALShowerMatchParams(void) : dFCALShower(NULL),
 		dx(0.0), dFlightTime(0.0), dFlightTimeVariance(0.0), dPathLength(0.0), dDOCAToShower(0.0){}
 
-		//dTrack is EITHER NULL (no match), DTrackTimeBased (default DDetectorMatches tag) or DTrackWireBased (DDetectorMatches tag = "WireBased")
-		const DKinematicData* dTrack;
 		const DFCALShower* dFCALShower;
 
 		double dx; //the distance the track traveled through the detector system up to the shower position
@@ -60,17 +66,25 @@ class DFCALShowerMatchParams
 		double dFlightTimeVariance;
 		double dPathLength; //path length from DKinematicData::position() to the shower
 		double dDOCAToShower; //DOCA of track to shower
+
+		bool operator != (const DFCALShowerMatchParams& locParams) const{return (!((*this) == locParams));}
+		bool operator == (const DFCALShowerMatchParams& locParams) const
+		{
+			if((dFCALShower != locParams.dFCALShower) || (dx != locParams.dx) || (dFlightTime != locParams.dFlightTime) || (dPathLength != locParams.dPathLength))
+				return false;
+			if((dFlightTimeVariance != locParams.dFlightTimeVariance) || (dDOCAToShower != locParams.dDOCAToShower))
+				return false;
+			return true;
+		}
 };
 
 class DTOFHitMatchParams
 {
 	public:
-		DTOFHitMatchParams(void) : dTrack(NULL), dTOFPoint(NULL),
+		DTOFHitMatchParams(void) : dTOFPoint(NULL),
 		dHitTime(0.0), dHitTimeVariance(0.0), dHitEnergy(0.0), dEdx(0.0), dFlightTime(0.0), dFlightTimeVariance(0.0), 
 		dPathLength(0.0), dDeltaXToHit(0.0), dDeltaYToHit(0.0){}
 
-		//dTrack is EITHER NULL (no match), DTrackTimeBased (default DDetectorMatches tag) or DTrackWireBased (DDetectorMatches tag = "WireBased")
-		const DKinematicData* dTrack;
 		const DTOFPoint* dTOFPoint;
 
 		double dHitTime; //This can be different from DTOFPoint::t, if the DTOFPoint was (e.g.) an unmatched, single-ended paddle
@@ -88,16 +102,26 @@ class DTOFHitMatchParams
 		{
 			return sqrt(dDeltaXToHit*dDeltaXToHit + dDeltaYToHit*dDeltaYToHit);
 		}
+
+		bool operator != (const DTOFHitMatchParams& locParams) const{return (!((*this) == locParams));}
+		bool operator == (const DTOFHitMatchParams& locParams) const
+		{
+			if((dTOFPoint != locParams.dTOFPoint) || (dHitTime != locParams.dHitTime) || (dHitTimeVariance != locParams.dHitTimeVariance))
+				return false;
+			if((dHitEnergy != locParams.dHitEnergy) || (dEdx != locParams.dEdx) || (dFlightTime != locParams.dFlightTime) || (dFlightTimeVariance != locParams.dFlightTimeVariance))
+				return false;
+			if((dPathLength != locParams.dPathLength) || (dDeltaXToHit != locParams.dDeltaXToHit) || (dDeltaYToHit != locParams.dDeltaYToHit))
+				return false;
+			return true;
+		}
 };
 
 class DSCHitMatchParams
 {
 	public:
-		DSCHitMatchParams(void) : dTrack(NULL), dSCHit(NULL), dHitTime(0.0), dHitTimeVariance(0.0),
+		DSCHitMatchParams(void) : dSCHit(NULL), dHitTime(0.0), dHitTimeVariance(0.0),
 		dHitEnergy(0.0), dEdx(0.0), dFlightTime(0.0), dFlightTimeVariance(0.0), dPathLength(0.0), dDeltaPhiToHit(0.0){}
 
-		//dTrack is EITHER NULL (no match), DTrackTimeBased (default DDetectorMatches tag) or DTrackWireBased (DDetectorMatches tag = "WireBased")
-		const DKinematicData* dTrack;
 		const DSCHit* dSCHit;
 
 		double dHitTime; //not the same as DSCHit time: corrected for propagation along scintillator
@@ -108,7 +132,19 @@ class DSCHitMatchParams
 		double dFlightTime; //flight time from DKinematicData::position() to the hit
 		double dFlightTimeVariance;
 		double dPathLength; //path length from DKinematicData::position() to the hit
-		double dDeltaPhiToHit; //difference in phi between track and hit
+		double dDeltaPhiToHit; //difference in phi between track and hit //units in radians
+
+		bool operator != (const DSCHitMatchParams& locParams) const{return (!((*this) == locParams));}
+		bool operator == (const DSCHitMatchParams& locParams) const
+		{
+			if((dSCHit != locParams.dSCHit) || (dHitTime != locParams.dHitTime) || (dHitTimeVariance != locParams.dHitTimeVariance))
+				return false;
+			if((dHitEnergy != locParams.dHitEnergy) || (dEdx != locParams.dEdx) || (dFlightTime != locParams.dFlightTime))
+				return false;
+			if((dPathLength != locParams.dPathLength) || (dDeltaPhiToHit != locParams.dDeltaPhiToHit) || (dFlightTimeVariance != locParams.dFlightTimeVariance))
+				return false;
+			return true;
+		}
 };
 
 class DDetectorMatches : public JObject

--- a/src/libraries/PID/DDetectorMatches_factory_WireBased.cc
+++ b/src/libraries/PID/DDetectorMatches_factory_WireBased.cc
@@ -102,9 +102,8 @@ void DDetectorMatches_factory_WireBased::MatchToBCAL(const DParticleID* locParti
 	for(size_t loc_i = 0; loc_i < locBCALShowers.size(); ++loc_i)
 	{
 		DBCALShowerMatchParams locShowerMatchParams;
-		if(!locParticleID->MatchToBCAL(locTrackWireBased, rt, locBCALShowers[loc_i], locInputStartTime, locShowerMatchParams))
-			continue;
-		locDetectorMatches->Add_Match(locTrackWireBased, locBCALShowers[loc_i], locShowerMatchParams);
+		if(locParticleID->Cut_MatchDistance(rt, locBCALShowers[loc_i], locInputStartTime, locShowerMatchParams))
+			locDetectorMatches->Add_Match(locTrackWireBased, locBCALShowers[loc_i], locShowerMatchParams);
 	}
 }
 
@@ -115,9 +114,8 @@ void DDetectorMatches_factory_WireBased::MatchToTOF(const DParticleID* locPartic
 	for(size_t loc_i = 0; loc_i < locTOFPoints.size(); ++loc_i)
 	{
 		DTOFHitMatchParams locTOFHitMatchParams;
-		if(!locParticleID->MatchToTOF(locTrackWireBased, rt, locTOFPoints[loc_i], locInputStartTime, locTOFHitMatchParams))
-			continue;
-		locDetectorMatches->Add_Match(locTrackWireBased, locTOFPoints[loc_i], locTOFHitMatchParams);
+		if(locParticleID->Cut_MatchDistance(rt, locTOFPoints[loc_i], locInputStartTime, locTOFHitMatchParams))
+			locDetectorMatches->Add_Match(locTrackWireBased, locTOFPoints[loc_i], locTOFHitMatchParams);
 	}
 }
 
@@ -128,9 +126,8 @@ void DDetectorMatches_factory_WireBased::MatchToFCAL(const DParticleID* locParti
 	for(size_t loc_i = 0; loc_i < locFCALShowers.size(); ++loc_i)
 	{
 		DFCALShowerMatchParams locShowerMatchParams;
-		if(!locParticleID->MatchToFCAL(locTrackWireBased, rt, locFCALShowers[loc_i], locInputStartTime, locShowerMatchParams))
-			continue;
-		locDetectorMatches->Add_Match(locTrackWireBased, locFCALShowers[loc_i], locShowerMatchParams);
+		if(locParticleID->Cut_MatchDistance(rt, locFCALShowers[loc_i], locInputStartTime, locShowerMatchParams))
+			locDetectorMatches->Add_Match(locTrackWireBased, locFCALShowers[loc_i], locShowerMatchParams);
 	}
 }
 
@@ -141,26 +138,27 @@ void DDetectorMatches_factory_WireBased::MatchToSC(const DParticleID* locParticl
 	for(size_t loc_i = 0; loc_i < locSCHits.size(); ++loc_i)
 	{
 		DSCHitMatchParams locSCHitMatchParams;
-		if(!locParticleID->MatchToSC(locTrackWireBased, rt, locSCHits[loc_i], locInputStartTime, locSCHitMatchParams))
-			continue;
-		locDetectorMatches->Add_Match(locTrackWireBased, locSCHits[loc_i], locSCHitMatchParams);
+		if(locParticleID->Cut_MatchDistance(rt, locSCHits[loc_i], locInputStartTime, locSCHitMatchParams, true))
+			locDetectorMatches->Add_Match(locTrackWireBased, locSCHits[loc_i], locSCHitMatchParams);
 	}
 }
 
 void DDetectorMatches_factory_WireBased::MatchToTrack(const DParticleID* locParticleID, const DBCALShower* locBCALShower, const vector<const DTrackWireBased*>& locTrackWireBasedVector, DDetectorMatches* locDetectorMatches) const
 {
-	double locDistance = 999.0, locMinDistance = 999.0;
+	double locMinDistance = 999.0;
 	double locFinalDeltaPhi = 999.0, locFinalDeltaZ = 999.0;
 	for(size_t loc_i = 0; loc_i < locTrackWireBasedVector.size(); ++loc_i)
 	{
+		DBCALShowerMatchParams locShowerMatchParams;
 		double locInputStartTime = locTrackWireBasedVector[loc_i]->t0();
 		const DReferenceTrajectory* rt = locTrackWireBasedVector[loc_i]->rt;
-		double locDeltaPhi = 0.0, locDeltaZ = 0.0;
-		if(!locParticleID->Distance_ToTrack(locBCALShower, rt, locInputStartTime, locDistance, locDeltaPhi, locDeltaZ))
+		if(!locParticleID->Distance_ToTrack(rt, locBCALShower, locInputStartTime, locShowerMatchParams))
 			continue;
 
 		double locRSq = locBCALShower->x*locBCALShower->x + locBCALShower->y*locBCALShower->y;
-		locDistance = sqrt(locDeltaZ*locDeltaZ + locDeltaPhi*locDeltaPhi*locRSq);
+		double locDeltaPhi = locShowerMatchParams.dDeltaPhiToShower;
+		double locDeltaZ = locShowerMatchParams.dDeltaZToShower;
+		double locDistance = sqrt(locDeltaZ*locDeltaZ + locDeltaPhi*locDeltaPhi*locRSq);
 		if(locDistance >= locMinDistance)
 			continue;
 
@@ -173,15 +171,16 @@ void DDetectorMatches_factory_WireBased::MatchToTrack(const DParticleID* locPart
 
 void DDetectorMatches_factory_WireBased::MatchToTrack(const DParticleID* locParticleID, const DFCALShower* locFCALShower, const vector<const DTrackWireBased*>& locTrackWireBasedVector, DDetectorMatches* locDetectorMatches) const
 {
-	double locDistance = 999.0, locMinDistance = 999.0;
+	double locMinDistance = 999.0;
 	for(size_t loc_i = 0; loc_i < locTrackWireBasedVector.size(); ++loc_i)
 	{
+		DFCALShowerMatchParams locShowerMatchParams;
 		double locInputStartTime = locTrackWireBasedVector[loc_i]->t0();
 		const DReferenceTrajectory* rt = locTrackWireBasedVector[loc_i]->rt;
-		if(!locParticleID->Distance_ToTrack(locFCALShower, rt, locInputStartTime, locDistance))
+		if(!locParticleID->Distance_ToTrack(rt, locFCALShower, locInputStartTime, locShowerMatchParams))
 			continue;
-		if(locDistance < locMinDistance)
-			locMinDistance = locDistance;
+		if(locShowerMatchParams.dDOCAToShower < locMinDistance)
+			locMinDistance = locShowerMatchParams.dDOCAToShower;
 	}
 	locDetectorMatches->Set_DistanceToNearestTrack(locFCALShower, locMinDistance);
 }

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -956,7 +956,7 @@ bool DParticleID::ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locS
 
 		// Check to see if the projections changed their mind, and put the hit in the straight section after all
 		if(locProjPos.Z() < sc_pos_eoss) // Assume hit at end of straight section
-			locProjPos.SetZ(sc_pos_eoss);
+			locProjPos.SetZ(sc_pos_eoss + 0.0001); //some tolerance
 	}
 
 	while(locDeltaPhi > TMath::Pi())

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -118,7 +118,7 @@ DParticleID::DParticleID(JEventLoop *loop)
 	TOF_CUT_PAR3 = 6.15;
 	gPARMS->SetDefaultParameter("TOF:CUT_PAR3",TOF_CUT_PAR3);
 
-	BCAL_Z_CUT=20.0;
+	BCAL_Z_CUT = 20.0;
 	gPARMS->SetDefaultParameter("BCAL:Z_CUT",BCAL_Z_CUT);
 
 	BCAL_PHI_CUT_PAR1=1.0;
@@ -624,12 +624,6 @@ bool DParticleID::Distance_ToTrack(const DReferenceTrajectory* rt, const DBCALSh
 	if(fabs(locDeltaT) > OUT_OF_TIME_CUT)
 		return false;
 
-	// Find intersection of track with inner radius of BCAL to get dx
-	DVector3 proj_pos_surface;
-	double locDx = 0.0;
-	if (rt->GetIntersectionWithRadius(65.0, proj_pos_surface) != NOERROR) //HARD-CODED RADIUS!!!
-		locDx = (bcal_pos - proj_pos_surface).Mag();
-
 	DVector3 locProjPos = rt->GetLastDOCAPoint();
 	DVector3 locProjMom = rt->swim_steps[0].mom;
 	if(locOutputProjMom != nullptr)
@@ -644,6 +638,12 @@ bool DParticleID::Distance_ToTrack(const DReferenceTrajectory* rt, const DBCALSh
 		locDeltaPhiMin -= M_TWO_PI;
 	while(locDeltaPhiMin < -M_PI)
 		locDeltaPhiMin += M_TWO_PI;
+
+	// Find intersection of track with inner radius of BCAL to get dx
+	DVector3 proj_pos_surface;
+	double locDx = 0.0;
+	if (rt->GetIntersectionWithRadius(65.0, proj_pos_surface) == NOERROR) //HARD-CODED RADIUS!!!
+		locDx = (locProjPos - proj_pos_surface).Mag();
 
 	// The next part of the code tries to take into account curvature
 	// of shower cluster distribution
@@ -1145,9 +1145,9 @@ DSCHitMatchParams DParticleID::Get_BestSCMatchParams(vector<DSCHitMatchParams>& 
 	DSCHitMatchParams locBestMatchParams;
 	for(size_t loc_i = 0; loc_i < locSCHitMatchParams.size(); ++loc_i)
 	{
-		if(locSCHitMatchParams[loc_i].dDeltaPhiToHit >= locMinDeltaPhi)
+		if(fabs(locSCHitMatchParams[loc_i].dDeltaPhiToHit) >= locMinDeltaPhi)
 			continue;
-		locMinDeltaPhi = locSCHitMatchParams[loc_i].dDeltaPhiToHit;
+		locMinDeltaPhi = fabs(locSCHitMatchParams[loc_i].dDeltaPhiToHit);
 		locBestMatchParams = locSCHitMatchParams[loc_i];
 	}
 	return locBestMatchParams;

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -118,7 +118,7 @@ DParticleID::DParticleID(JEventLoop *loop)
 	TOF_CUT_PAR3 = 6.15;
 	gPARMS->SetDefaultParameter("TOF:CUT_PAR3",TOF_CUT_PAR3);
 
-	BCAL_Z_CUT=10.0;
+	BCAL_Z_CUT=20.0;
 	gPARMS->SetDefaultParameter("BCAL:Z_CUT",BCAL_Z_CUT);
 
 	BCAL_PHI_CUT_PAR1=1.0;
@@ -952,7 +952,7 @@ bool DParticleID::ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locS
 		}
 
 		// Check to see if the projections changed their mind, and put the hit in the straight section after all
-		if(locProjPos.Z() < sc_pos_eoss) // Assume hit at end of straight section
+		if(locProjPos.Z() < sc_pos_eoss) // Assume hit just past the end of straight section
 		{
 			locProjPos.SetZ(sc_pos_eoss + 0.0001); //some tolerance
 			DVector3 sc_pos_at_projz = sc_pos[sc_index][0] + (locProjPos.Z() - sc_pos_soss)*sc_dir[sc_index][0];

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -922,7 +922,7 @@ bool DParticleID::ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locS
 	{
 		// Apply a user-specified matching cut in the leg region
 		DVector3 sc_pos_at_projz = sc_pos[sc_index][0] + (locProjPos.Z() - sc_pos_soss)*sc_dir[sc_index][0];
-		locDeltaPhi = sc_pos_at_projz.Phi() - locProjPos.Phi(); //phi could be 0 degrees & proj_phi could be 359 degrees
+		locDeltaPhi = sc_pos_at_projz.Phi() - locProjPos.Phi();
 	}
 	else //bend or nose
 	{
@@ -953,7 +953,11 @@ bool DParticleID::ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locS
 
 		// Check to see if the projections changed their mind, and put the hit in the straight section after all
 		if(locProjPos.Z() < sc_pos_eoss) // Assume hit at end of straight section
+		{
 			locProjPos.SetZ(sc_pos_eoss + 0.0001); //some tolerance
+			DVector3 sc_pos_at_projz = sc_pos[sc_index][0] + (locProjPos.Z() - sc_pos_soss)*sc_dir[sc_index][0];
+			locDeltaPhi = sc_pos_at_projz.Phi() - locProjPos.Phi();
+		}
 	}
 
 	while(locDeltaPhi > TMath::Pi())

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -130,9 +130,6 @@ DParticleID::DParticleID(JEventLoop *loop)
 	BCAL_PHI_CUT_PAR3=1.0;
 	gPARMS->SetDefaultParameter("BCAL:PHI_CUT_PAR3",BCAL_PHI_CUT_PAR3);
 
-	SC_DPHI_CUT=0.125;
-	gPARMS->SetDefaultParameter("SC:DPHI_CUT",SC_DPHI_CUT);
-
 	double locSCCutPar = 7.0;
 	gPARMS->SetDefaultParameter("SC:SC_CUT_PAR1",locSCCutPar);
 	dSCCutPars_TimeBased.push_back(locSCCutPar);
@@ -1064,7 +1061,7 @@ bool DParticleID::Cut_MatchDistance(const DReferenceTrajectory* rt, const DSCHit
 
 	// Look for a match in phi
 	auto& locSCCutPars = locIsTimeBased ? dSCCutPars_TimeBased : dSCCutPars_WireBased;
-	double sc_dphi_cut = locSCCutPars[0] + locSCCutPars[1]*exp(locSCCutPars[2]*(locProjPos.Z() - locSCCutPars[3]))
+	double sc_dphi_cut = locSCCutPars[0] + locSCCutPars[1]*exp(locSCCutPars[2]*(locProjPos.Z() - locSCCutPars[3]));
 	double locDeltaPhi = 180.0*locSCHitMatchParams.dDeltaPhiToHit/TMath::Pi();
 	return (fabs(locDeltaPhi) <= sc_dphi_cut);
 }
@@ -1086,10 +1083,7 @@ bool DParticleID::Cut_MatchDistance(const DReferenceTrajectory* rt, const DFCALS
 
 	double p=locProjMom.Mag();
 	double cut=FCAL_CUT_PAR1+FCAL_CUT_PAR2/p;
-	if(locShowerMatchParams.dDOCAToShower >= cut)
-		return false;
-
-	return true;
+	return (locShowerMatchParams.dDOCAToShower < cut);
 }
 
 /********************************************************** GET BEST MATCH **********************************************************/
@@ -1112,7 +1106,7 @@ DBCALShowerMatchParams DParticleID::Get_BestBCALMatchParams(DVector3 locMomentum
 	DBCALShowerMatchParams locBestMatchParams;
 	for(size_t loc_i = 0; loc_i < locShowerMatchParams.size(); ++loc_i)
 	{
-		double locPhiCut = BCAL_PHI_CUT_PAR1 + BCAL_PHI_CUT_PAR2*exp(-1.0*BCAL_PHI_CUT_PAR3*locP);
+		double locDeltaPhiCut = BCAL_PHI_CUT_PAR1 + BCAL_PHI_CUT_PAR2*exp(-1.0*BCAL_PHI_CUT_PAR3*locP);
 		double locDeltaPhiError = locDeltaPhiCut/3.0; //Cut is "3 sigma"
 		double locDeltaPhi = 180.0*locShowerMatchParams[loc_i].dDeltaPhiToShower/TMath::Pi();
 		double locMatchChiSq = locDeltaPhi*locDeltaPhi/(locDeltaPhiError*locDeltaPhiError);

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -63,25 +63,28 @@ DParticleID::DParticleID(JEventLoop *loop)
   // Get z position of face of FCAL
   locGeometry->GetFCALZ(dFCALz);
 
-  // Get start counter geometry;
-  if (locGeometry->GetStartCounterGeom(sc_pos,sc_norm)){
-    dSCphi0=sc_pos[0][0].Phi();
-    //sc_leg_tcor = -sc_pos[0][0].z()/C_EFFECTIVE;
-    double theta = sc_norm[0][sc_norm[0].size()-2].Theta();
-    sc_angle_cor = 1./cos(M_PI_2 - theta);
+	// Get start counter geometry;
+	if (locGeometry->GetStartCounterGeom(sc_pos, sc_norm))
+	{
+		dSCphi0=sc_pos[0][0].Phi();
+		//sc_leg_tcor = -sc_pos[0][0].z()/C_EFFECTIVE;
+		double theta = sc_norm[0][sc_norm[0].size() - 2].Theta();
+		sc_angle_cor = 1./cos(M_PI_2 - theta);
 
-    // Create vector of direction vectors in scintillator planes
-    for (int i=0;i<30;i++){
-      vector<DVector3>temp;
-      for (unsigned int j=0;j<sc_pos[i].size()-1;j++){
-	double dx=sc_pos[i][j+1].x()-sc_pos[i][j].x();
-	double dy=sc_pos[i][j+1].y()-sc_pos[i][j].y();
-	double dz=sc_pos[i][j+1].z()-sc_pos[i][j].z();
-	temp.push_back(DVector3(dx/dz,dy/dz,1.));
-      }
-      sc_dir.push_back(temp);
-    }
-  }
+		// Create vector of direction vectors in scintillator planes
+		for (int i=0;i<30;i++)
+		{
+			vector<DVector3> temp;
+			for (unsigned int j = 0; j < sc_pos[i].size() - 1; ++j)
+			{
+				double dx = sc_pos[i][j + 1].x() - sc_pos[i][j].x();
+				double dy = sc_pos[i][j + 1].y() - sc_pos[i][j].y();
+				double dz = sc_pos[i][j + 1].z() - sc_pos[i][j].z();
+				temp.push_back(DVector3(dx/dz,dy/dz,1.));
+			}
+			sc_dir.push_back(temp);
+		}
+	}
 
 
 	//Get calibration constants
@@ -515,153 +518,188 @@ double DParticleID::GetdEdxSigma_DC(double num_hits,double p,double mass,
   //return 0.41*mean_dedx*pow(double(num_hits),-0.5)*pow(mean_path_length,-0.32);
 }
 
-//------------------
-// MatchToBCAL
-//------------------
-// Loop over bcal clusters, looking for minimum distance of closest approach
-// of track to a cluster and using this to check for a match. 
-//
-// NOTE: an initial guess for start time is expected as input so that out-of-time 
-// hits can be skipped
+/****************************************************** DISTANCE TO TRACK ******************************************************/
 
-//to be called by track reconstruction
-bool DParticleID::MatchToBCAL(const DReferenceTrajectory* rt, const vector<const DBCALShower*>& locBCALShowers, double& locStartTime, double& locTimeVariance) const
+// NOTE: For these functions, an initial guess for start time is expected as input so that out-of-time tracks can be skipped
+
+bool DParticleID::Distance_ToTrack(const DReferenceTrajectory* rt, const DFCALShower* locFCALShower, double locInputStartTime, DFCALShowerMatchParams& locShowerMatchParams, DVector3* locOutputProjPos, DVector3* locOutputProjMom) const
 {
-	//Loop over bcal showers
-	vector<DBCALShowerMatchParams> locShowerMatchParamsVector;
-	for(size_t loc_i = 0; loc_i < locBCALShowers.size(); ++loc_i)
-	{
-		DBCALShowerMatchParams locShowerMatchParams;
-		if(MatchToBCAL(NULL, rt, locBCALShowers[loc_i], locStartTime, locShowerMatchParams))
-			locShowerMatchParamsVector.push_back(locShowerMatchParams);
-	}
-	if(locShowerMatchParamsVector.empty())
+	if(rt == nullptr)
 		return false;
 
-	DBCALShowerMatchParams locBestMatchParams;
-	Get_BestBCALMatchParams(rt->swim_steps[0].mom, locShowerMatchParamsVector, locBestMatchParams);
-	locStartTime = locBestMatchParams.dBCALShower->t - locBestMatchParams.dFlightTime;
-//	locTimeVariance = locBestMatchParams.dFlightTimeVariance + locBestMatchParams.dBCALShower->dCovarianceMatrix(4, 4); //uncomment when ready!!
-	locTimeVariance = 0.3*0.3+locBestMatchParams.dFlightTimeVariance;
+	// Find the distance of closest approach between the track trajectory
+	// and the cluster position, looking for the minimum
+	DVector3 fcal_pos = locFCALShower->getPosition();
+	DVector3 norm(0.0, 0.0, 1.0); //normal vector for the FCAL plane
+	double locPathLength = 9.9E9, locFlightTime = 9.9E9;
+	double locFlightTimeVariance=9.9E9;
+	DVector3 locProjPos, locProjMom;
+	if(rt->GetIntersectionWithPlane(fcal_pos, norm, locProjPos, locProjMom, &locPathLength, &locFlightTime, &locFlightTimeVariance,SYS_FCAL) != NOERROR)
+		return false;
 
-	return true;
-}
+	// Check that the hit is not out of time with respect to the track
+	double locDeltaT = locFCALShower->getTime() - locFlightTime - locInputStartTime;
+	if(fabs(locDeltaT) > OUT_OF_TIME_CUT)
+		return false;
 
+	// Find minimum distance between track projection and each of the hits
+	// associated with the shower.
+	double d2min=(fcal_pos - locProjPos).Mag();
+	double xproj=locProjPos.x();
+	double yproj=locProjPos.y();
+	vector<const DFCALCluster*>clusters;
+	locFCALShower->Get(clusters);
 
-bool DParticleID::MatchToBCAL(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DBCALShower* locBCALShower, double locInputStartTime, DBCALShowerMatchParams& locShowerMatchParams) const
-{
-  // NOTE: locTrack is NULL if calling from track reconstruction!!!
+	for (unsigned int k=0;k<clusters.size();k++)
+	{
+		vector<DFCALCluster::DFCALClusterHit_t>hits=clusters[k]->GetHits();
+		for (unsigned int m=0;m<hits.size();m++)
+		{
+			double dx=hits[m].x-xproj;
+			double dy=hits[m].y-yproj;
+			double d2=dx*dx+dy*dy;
+			if (d2<d2min)
+				d2min=d2;
+		}
+	}
 
-  double locFlightTime = 9.9E9, locPathLength = 9.9E9;
-  double locFlightTimeVariance=9.9E9,locProjectedZ=0.;
-  double locDeltaPhi=999.,locDeltaZ=999.,locDistance=999.;
-  if (Distance_ToTrack(locBCALShower,rt,locInputStartTime,locDistance,
-		       locDeltaPhi,locDeltaZ,locProjectedZ,locFlightTime,
-		       locFlightTimeVariance,locPathLength)){
+	if(locOutputProjMom != nullptr)
+	{
+		*locOutputProjPos = locProjPos;
+		*locOutputProjMom = locProjMom;
+	}
 
-    if (fabs(locDeltaPhi)>0.26) //0.13 radians = 7.5 degrees = one bcal module
-      return false;
+	double d = sqrt(d2min);
+	double p=locProjMom.Mag();
 
-    if (fabs(locDeltaZ)>BCAL_Z_CUT)
-      return false; 
-
-    // cut on shower phi
-    double p = rt->swim_steps[0].mom.Mag();
-    double phi_cut = (BCAL_PHI_CUT_PAR1 + BCAL_PHI_CUT_PAR2/(p*p))*(1.+BCAL_PHI_CUT_PAR3*pow(450.-locProjectedZ,-2));
-    if (fabs(locDeltaPhi)>phi_cut) return false;
-     
-  }
-  else return false;
-
-	//successful match
-	locShowerMatchParams.dTrack = locTrack;
-	locShowerMatchParams.dBCALShower = locBCALShower;
-	locShowerMatchParams.dx = 0.0; //SET ME!!!!
+	//SET MATCHING INFORMATION
+	locShowerMatchParams.dFCALShower = locFCALShower;
+	locShowerMatchParams.dx = 45.0*p/(locProjMom.Dot(norm));
 	locShowerMatchParams.dFlightTime = locFlightTime;
 	locShowerMatchParams.dFlightTimeVariance = locFlightTimeVariance;
 	locShowerMatchParams.dPathLength = locPathLength;
-	locShowerMatchParams.dDeltaPhiToShower = locDeltaPhi;
+	locShowerMatchParams.dDOCAToShower = d;
+	
+	return true;
+}
+
+bool DParticleID::Distance_ToTrack(const DReferenceTrajectory* rt, const DBCALShower* locBCALShower, double locInputStartTime, DBCALShowerMatchParams& locShowerMatchParams, DVector3* locOutputProjPos, DVector3* locOutputProjMom) const
+{
+	if(rt == nullptr)
+		return false;
+
+	// Get the BCAL cluster position and normal
+	DVector3 bcal_pos(locBCALShower->x, locBCALShower->y, locBCALShower->z);
+
+	double locFlightTime = 9.9E9, locPathLength = 9.9E9, locFlightTimeVariance = 9.9E9;
+	double locDistance = rt->DistToRTwithTime(bcal_pos, &locPathLength, &locFlightTime,&locFlightTimeVariance,SYS_BCAL);
+	if(!isfinite(locDistance))
+		return false;
+
+	// Check that the hit is not out of time with respect to the track
+	double locDeltaT = locBCALShower->t - locFlightTime - locInputStartTime;
+	if(fabs(locDeltaT) > OUT_OF_TIME_CUT)
+		return false;
+
+	// Find intersection of track with inner radius of BCAL to get dx
+	DVector3 proj_pos_surface;
+	double locDx = 0.0;
+	if (rt->GetIntersectionWithRadius(65.0, proj_pos_surface) != NOERROR) //HARD-CODED RADIUS!!!
+		locDx = (bcal_pos - proj_pos_surface).Mag();
+
+	DVector3 locProjPos = rt->GetLastDOCAPoint();
+	DVector3 locProjMom = rt->swim_steps[0].mom;
+	if(locOutputProjMom != nullptr)
+	{
+		*locOutputProjPos = locProjPos;
+		*locOutputProjMom = locProjMom;
+	}
+
+	double locDeltaZ = bcal_pos.z() - locProjPos.z();
+	double locDeltaPhiMin = bcal_pos.Phi() - locProjPos.Phi();
+	while(locDeltaPhiMin > M_PI)
+		locDeltaPhiMin -= M_TWO_PI;
+	while(locDeltaPhiMin < -M_PI)
+		locDeltaPhiMin += M_TWO_PI;
+
+	// The next part of the code tries to take into account curvature
+	// of shower cluster distribution
+
+	// Get clusters associated with this shower
+	vector<const DBCALCluster*>clusters;
+	locBCALShower->Get(clusters);
+
+	// make list of points associated with the shower
+	vector<const DBCALPoint*> points;
+	if(!clusters.empty())
+	{
+		// classic BCAL shower objects are built from the output of the clusterizer
+		// so the points need to be accessed as shower -> cluster -> points
+		for (unsigned int k=0;k<clusters.size();k++)
+		{
+			vector<const DBCALPoint*> cluster_points=clusters[k]->points();
+			points.insert(points.end(), cluster_points.begin(), cluster_points.end());
+		}
+	}
+	else
+	{
+		// other BCAL shower objects directly keep a list of the points associated with the shower
+		// (e.g. "CURVATURE" showers)
+		locBCALShower->Get(points);
+	}
+
+	// loop over points associated with this shower, finding
+	// the closest match between a point and the track
+	for (unsigned int m=0;m<points.size();m++)
+	{
+		double rpoint=points[m]->r();
+		double s, t;
+		DVector3 locPointProjPos, locPointProjMom;
+		if (rt->GetIntersectionWithRadius(rpoint, locPointProjPos, &s, &t, &locPointProjMom) != NOERROR)
+			continue;
+
+		double mydphi=points[m]->phi()-locPointProjPos.Phi();
+		while(mydphi > M_PI)
+			mydphi -= M_TWO_PI;
+		while(mydphi < -M_PI)
+			mydphi += M_TWO_PI;
+		if(fabs(mydphi) >= fabs(locDeltaPhiMin))
+			continue;
+
+		locDeltaPhiMin=mydphi;
+		if(locOutputProjMom != nullptr)
+		{
+			*locOutputProjPos = locPointProjPos;
+			*locOutputProjMom = locPointProjMom;
+		}
+	}
+
+	//SET MATCHING INFORMATION
+	locShowerMatchParams.dBCALShower = locBCALShower;
+	locShowerMatchParams.dx = locDx;
+	locShowerMatchParams.dFlightTime = locFlightTime;
+	locShowerMatchParams.dFlightTimeVariance = locFlightTimeVariance;
+	locShowerMatchParams.dPathLength = locPathLength;
+	locShowerMatchParams.dDeltaPhiToShower = locDeltaPhiMin;
 	locShowerMatchParams.dDeltaZToShower = locDeltaZ;
 
 	return true;
 }
 
-//------------------
-// MatchToTOF
-//------------------
-// Loop over TOF points, looking for minimum distance of closest approach
-// of track to a point in the TOF and using this to check for a match. 
-//
-// NOTE: an initial guess for start time is expected as input so that out-of-time 
-// hits can be skipped
-
-//to be called by track reconstruction
-bool DParticleID::MatchToTOF(const DReferenceTrajectory* rt, const vector<const DTOFPoint*>& locTOFPoints, double& locStartTime, double& locTimeVariance) const
+bool DParticleID::Distance_ToTrack(const DReferenceTrajectory* rt, const DTOFPoint* locTOFPoint, double locInputStartTime, DTOFHitMatchParams& locTOFHitMatchParams, DVector3* locOutputProjPos, DVector3* locOutputProjMom) const
 {
-	//Loop over tof points
-	vector<DTOFHitMatchParams> locTOFHitMatchParamsVector;
-	for(size_t loc_i = 0; loc_i < locTOFPoints.size(); ++loc_i)
-	{
-		DTOFHitMatchParams locTOFHitMatchParams;
-		if(MatchToTOF(NULL, rt, locTOFPoints[loc_i], locStartTime, locTOFHitMatchParams))
-			locTOFHitMatchParamsVector.push_back(locTOFHitMatchParams);
-	}
-	if(locTOFHitMatchParamsVector.empty())
+	if(rt == nullptr)
 		return false;
-
-	DTOFHitMatchParams locBestMatchParams;
-	Get_BestTOFMatchParams(locTOFHitMatchParamsVector, locBestMatchParams);
-	locStartTime = locBestMatchParams.dHitTime - locBestMatchParams.dFlightTime;
-//	locTimeVariance = locBestMatchParams.dFlightTimeVariance + locBestMatchParams.dHitTimeVariance; //uncomment when ready!
-	locTimeVariance = 0.1*0.1+locBestMatchParams.dFlightTimeVariance;
-
-	return true;
-}
-
-bool DParticleID::MatchToTOF(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DTOFPoint* locTOFPoint, double locInputStartTime, DTOFHitMatchParams& locTOFHitMatchParams) const
-{
-	// NOTE: locTrack is NULL if calling from track reconstruction!!!
 
 	// Find the distance of closest approach between the track trajectory
 	// and the tof cluster position, looking for the minimum
 	DVector3 tof_pos = locTOFPoint->pos;
 	DVector3 norm(0.0, 0.0, 1.0); //normal vector to TOF plane
-	DVector3 proj_pos, proj_mom;
+	DVector3 locProjPos, locProjMom;
 	double locPathLength = 9.9E9, locFlightTime = 9.9E9;
 	double locFlightTimeVariance=9.9E9;
-	if(rt->GetIntersectionWithPlane(tof_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime,&locFlightTimeVariance,SYS_TOF) != NOERROR)
+	if(rt->GetIntersectionWithPlane(tof_pos, norm, locProjPos, locProjMom, &locPathLength, &locFlightTime,&locFlightTimeVariance,SYS_TOF) != NOERROR)
 		return false;
-
-	//If the position in one dimension is not well-defined, compare distance only in the other direction
-	//Otherwise, cut in R
-	//y = e^(-A*x + B) + 6
-	double locP = proj_mom.Mag();
-	double locMatchCut_2D = exp(-1.0*TOF_CUT_PAR1*locP + TOF_CUT_PAR2) + TOF_CUT_PAR3;
-	double locMatchCut_1D = locMatchCut_2D;
-
-	double locDeltaX = locTOFPoint->Is_XPositionWellDefined() ? tof_pos.X() - proj_pos.X() : 999.0;
-	double locDeltaY = locTOFPoint->Is_YPositionWellDefined() ? tof_pos.Y() - proj_pos.Y() : 999.0;
-	if(!locTOFPoint->Is_XPositionWellDefined())
-	{
-		//Is unmatched horizontal paddle with only one hit above threshold: Only compare y-distance
-		if(fabs(locDeltaY) > locMatchCut_1D)
-			return false;
-	}
-	else if(!locTOFPoint->Is_YPositionWellDefined())
-	{
-		//Is unmatched vertical paddle with only one hit above threshold: Only compare x-distance
-		if(fabs(locDeltaX) > locMatchCut_1D)
-			return false;
-	}
-	else
-	{
-		//Both are good, cut on R
-		double locDistance = (tof_pos - proj_pos).Perp();
-		if(locDistance > locMatchCut_2D)
-			return false;
-	}
-
-	//GEOMETRIC MATCH
 
 	//If position was not well-defined, correct deposited energy due to attenuation, and time due to propagation along paddle
 		//These values were reported at the midpoint of the paddle
@@ -683,7 +721,7 @@ bool DParticleID::MatchToTOF(const DKinematicData* locTrack, const DReferenceTra
 		//delta_x = delta_x_actual - delta_x_mid
 			//if end.x > 0: delta_x = (end.x - track.x) - (end.x - mid.x) = mid.x - track.x //if track.x > mid.x, delta_x < 0: decrease energy & increase time
 			//if end.x < 0: delta_x = (track.x - end.x) - (mid.x - end.x) = track.x - mid.x //if track.x > mid.x, delta_x > 0: increase energy & decrease time
-		double locDistanceToMidPoint = locNorthIsGoodHit ? locPaddleMidPoint - proj_pos.X() : proj_pos.X() - locPaddleMidPoint;
+		double locDistanceToMidPoint = locNorthIsGoodHit ? locPaddleMidPoint - locProjPos.X() : locProjPos.X() - locPaddleMidPoint;
 
 		//Energy
 		locHitEnergy *= exp(locDistanceToMidPoint/TOF_ATTEN_LENGTH);
@@ -708,7 +746,7 @@ bool DParticleID::MatchToTOF(const DKinematicData* locTrack, const DReferenceTra
 		//delta_x = delta_x_actual - delta_x_mid
 			//if end.x > 0: delta_x = (end.x - track.x) - (end.x - mid.x) = mid.x - track.x //if track.x > mid.x, delta_x < 0: decrease energy & increase time
 			//if end.x < 0: delta_x = (track.x - end.x) - (mid.x - end.x) = track.x - mid.x //if track.x > mid.x, delta_x > 0: increase energy & decrease time
-		double locDistanceToMidPoint = locNorthIsGoodHit ? locPaddleMidPoint - proj_pos.Y() : proj_pos.Y() - locPaddleMidPoint;
+		double locDistanceToMidPoint = locNorthIsGoodHit ? locPaddleMidPoint - locProjPos.Y() : locProjPos.Y() - locPaddleMidPoint;
 
 		//Energy
 		locHitEnergy *= exp(locDistanceToMidPoint/TOF_ATTEN_LENGTH);
@@ -724,11 +762,17 @@ bool DParticleID::MatchToTOF(const DKinematicData* locTrack, const DReferenceTra
 	if(fabs(locDeltaT) > OUT_OF_TIME_CUT)
 		return false;
 
-	//SUCCESSFUL MATCH
+	if(locOutputProjMom != nullptr)
+	{
+		*locOutputProjPos = locProjPos;
+		*locOutputProjMom = locProjMom;
+	}
 
-	//Fill out match info
-	double dx = 2.54*proj_mom.Mag()/proj_mom.Dot(norm);
-	locTOFHitMatchParams.dTrack = locTrack;
+	double locDeltaX = locTOFPoint->Is_XPositionWellDefined() ? tof_pos.X() - locProjPos.X() : 999.0;
+	double locDeltaY = locTOFPoint->Is_YPositionWellDefined() ? tof_pos.Y() - locProjPos.Y() : 999.0;
+
+	//SET MATCHING INFORMATION
+	double dx = 2.54*locProjMom.Mag()/locProjMom.Dot(norm);
 	locTOFHitMatchParams.dTOFPoint = locTOFPoint;
 
 	locTOFHitMatchParams.dHitTime = locHitTime;
@@ -745,390 +789,74 @@ bool DParticleID::MatchToTOF(const DKinematicData* locTrack, const DReferenceTra
 	return true;
 }
 
-// Given a reference trajectory from a track, predict which FCAL block (if any)
-// should fire.
-bool DParticleID::PredictFCALHit(const DReferenceTrajectory *rt,
-				 unsigned int &row, unsigned int &col,
-				 DVector3 *intersection) const{
-   // Initialize output variables
-  row=0;
-  col=0;
-  if(rt == NULL)
-    return false;
-  // Find intersection with FCAL plane given by fcal_pos
-  DVector3 fcal_pos(0,0,dFCALz);
-  DVector3 norm(0.0, 0.0, 1.0); //normal vector to FCAL plane
-  DVector3 proj_mom,proj_pos;
-  if(rt->GetIntersectionWithPlane(fcal_pos, norm, proj_pos, proj_mom,
-				  NULL,NULL,NULL,SYS_FCAL) != NOERROR)
-    return false;
-
-  if (intersection) *intersection=proj_pos;
-
-  double x=proj_pos.x();
-  double y=proj_pos.y();
-  row=dFCALGeometry->row(float(y));
-  col=dFCALGeometry->column(float(x));
-  return (dFCALGeometry->isBlockActive(row,col));
-}
-
-// Given a reference trajectory from a track, predict which BCAL wedge should
-// have a hit
-bool DParticleID::PredictBCALWedge(const DReferenceTrajectory *rt,
-				   unsigned int &module,unsigned int &sector,
-				   DVector3 *intersection) const{
-  //initialize output variables 
-  sector=0;
-  module=0;
-  if(rt == NULL)
-    return false;
-  // Find intersection of track with inner radius of BCAL
-  DVector3 proj_pos;
-  if (rt->GetIntersectionWithRadius(65.0,proj_pos)==NOERROR){
-    double phi=180./M_PI*proj_pos.Phi();
-    if (phi<0)phi+=360.;
-    double slice=phi/7.5;
-    double mid_slice=round(slice);
-    module=int(mid_slice)+1;
-    sector=int(floor((phi-7.5*mid_slice+3.75)/1.875))+1;
-    
-    if (intersection) *intersection=proj_pos;
-    
-    return true;
-  }
-  
-  return false;
-}
-				   
-
-
-// Given a reference trajectory from a track, predict which TOF paddles should
-// fire due to the charged particle passing through the TOF planes.
-bool DParticleID::PredictTOFPaddles(const DReferenceTrajectory *rt,
-				    unsigned int &hbar,unsigned int &vbar,
-				    DVector3 *intersection) const{
-  // Initialize output variables
-  vbar=0;
-  hbar=0;
-  if(rt == NULL)
-    return false;
-  // Find intersection with TOF plane given by tof_pos
-  DVector3 tof_pos(0,0,dTOFGeometry->CenterMPlane);
-  DVector3 norm(0.0, 0.0, 1.0); //normal vector to TOF plane
-  DVector3 proj_mom,proj_pos;
-  if(rt->GetIntersectionWithPlane(tof_pos, norm, proj_pos, proj_mom, 
-				  NULL,NULL,NULL,SYS_TOF) != NOERROR)
-    return false;
-
-  double x=proj_pos.x();
-  double y=proj_pos.y();
-
-  vbar=dTOFGeometry->y2bar(x);
-  hbar=dTOFGeometry->y2bar(y);
-
-  if (intersection) *intersection=proj_pos;
-
-  return true;
-}
-
-
-
-//------------------
-// MatchToFCAL
-//------------------
-// Loop over fcal clusters, looking for minimum distance of closest approach
-// of track to a cluster and using this to check for a match. 
-//
-// NOTE: an initial guess for start time is expected as input so that out-of-time 
-// hits can be skipped
-
-//to be called by track reconstruction
-bool DParticleID::MatchToFCAL(const DReferenceTrajectory* rt, const vector<const DFCALShower*>& locFCALShowers, double& locStartTime, double& locTimeVariance) const
+bool DParticleID::Distance_ToTrack(const DReferenceTrajectory* rt, const DSCHit* locSCHit, double locInputStartTime, DSCHitMatchParams& locSCHitMatchParams, DVector3* locOutputProjPos, DVector3* locOutputProjMom) const
 {
-	//Loop over FCAL showers
-	vector<DFCALShowerMatchParams> locShowerMatchParamsVector;
-	for(size_t loc_i = 0; loc_i < locFCALShowers.size(); ++loc_i)
-	{
-		DFCALShowerMatchParams locShowerMatchParams;
-		if(MatchToFCAL(NULL, rt, locFCALShowers[loc_i], locStartTime, locShowerMatchParams))
-			locShowerMatchParamsVector.push_back(locShowerMatchParams);
-	}
-	if(locShowerMatchParamsVector.empty())
-		return false;
-
-	DFCALShowerMatchParams locBestMatchParams;
-	Get_BestFCALMatchParams(locShowerMatchParamsVector, locBestMatchParams);
-
-	locStartTime = locBestMatchParams.dFCALShower->getTime() - locBestMatchParams.dFlightTime;
-//	locTimeVariance = locBestMatchParams.dFlightTimeVariance + locBestMatchParams.dFCALShower->dCovarianceMatrix(4, 4); //uncomment when ready!
-	locTimeVariance = 0.5*0.5+locBestMatchParams.dFlightTimeVariance;
-
-	return true;
-}
-
-bool DParticleID::MatchToFCAL(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DFCALShower* locFCALShower, double locInputStartTime, DFCALShowerMatchParams& locShowerMatchParams) const
-{
-	// NOTE: locTrack is NULL if calling from track reconstruction!!!
-
-	// Find the distance of closest approach between the track trajectory
-	// and the cluster position, looking for the minimum
-	DVector3 fcal_pos = locFCALShower->getPosition();
-	DVector3 norm(0.0, 0.0, 1.0); //normal vector for the FCAL plane
-	DVector3 proj_pos, proj_mom;
-	double locPathLength = 9.9E9, locFlightTime = 9.9E9;
-	double locFlightTimeVariance=9.9E9;
-	if(rt->GetIntersectionWithPlane(fcal_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime, &locFlightTimeVariance,SYS_FCAL) != NOERROR)
-		return false;
-
-	// Check that the hit is not out of time with respect to the track
-	if(fabs(locFCALShower->getTime() - locFlightTime - locInputStartTime) > OUT_OF_TIME_CUT)
-		return false;
-
-	// Find minimum distance between track projection and each of the hits
-	// associated with the shower.
-	double d2min=100000.;
-	double xproj=proj_pos.x();
-	double yproj=proj_pos.y();
-	vector<const DFCALCluster*>clusters;
-	locFCALShower->Get(clusters);
-	for (unsigned int k=0;k<clusters.size();k++){
-	  vector<DFCALCluster::DFCALClusterHit_t>hits=clusters[k]->GetHits();
-	  for (unsigned int m=0;m<hits.size();m++){
-	    double dx=hits[m].x-xproj;
-	    double dy=hits[m].y-yproj;
-	    double d2=dx*dx+dy*dy;
-	    if (d2<d2min){
-	      d2min=d2;
-	    }
-	  }
-	}
-
-	double d = sqrt(d2min);
-	//double d = (fcal_pos - proj_pos).Mag();
-	double p=proj_mom.Mag();
-	double cut=FCAL_CUT_PAR1+FCAL_CUT_PAR2/p;
-	if(d >= cut)
-		return false;
-
-	locShowerMatchParams.dTrack = locTrack;
-	locShowerMatchParams.dFCALShower = locFCALShower;
-	locShowerMatchParams.dx = 45.0*p/(proj_mom.Dot(norm));
-	locShowerMatchParams.dFlightTime = locFlightTime;
-	locShowerMatchParams.dFlightTimeVariance = locFlightTimeVariance;
-	locShowerMatchParams.dPathLength = locPathLength;
-	locShowerMatchParams.dDOCAToShower = d;
-
-	return true;
-}
-
-//------------------
-// MatchToSC
-//------------------
-// Match track to the start counter paddles with hits.	If a match
-// is found, use the z-position of the track projection to the start counter 
-// planes to correct for the light propagation within the scintillator and 
-// estimate the "vertex" time.
-//
-// NOTE: an initial guess for start time is expected as input so that out-of-time 
-// hits can be skipped
-
-//to be called by track reconstruction
-bool DParticleID::MatchToSC(const DReferenceTrajectory* rt, const vector<const DSCHit*>& locSCHits, double& locStartTime, double& locTimeVariance, bool locIsTimeBased) const
-{
-	//Loop over SC points
-	vector<DSCHitMatchParams> locSCHitMatchParamsVector;
-	for(size_t loc_i = 0; loc_i < locSCHits.size(); ++loc_i)
-	{
-		DSCHitMatchParams locSCHitMatchParams;
-		if(MatchToSC(NULL, rt, locSCHits[loc_i], locStartTime, locSCHitMatchParams, locIsTimeBased))
-			locSCHitMatchParamsVector.push_back(locSCHitMatchParams);
-	}
-	if(locSCHitMatchParamsVector.empty())
-		return false;
-
-	DSCHitMatchParams locBestMatchParams;
-	Get_BestSCMatchParams(locSCHitMatchParamsVector, locBestMatchParams);
-
-	locStartTime = locBestMatchParams.dHitTime - locBestMatchParams.dFlightTime;
-	locTimeVariance = locBestMatchParams.dFlightTimeVariance + locBestMatchParams.dHitTimeVariance; 
-	//locTimeVariance = 0.3*0.3+locBestMatchParams.dFlightTimeVariance;
-
-	return true;
-}
-
-bool DParticleID::MatchToSC(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DSCHit* locSCHit, double locInputStartTime, DSCHitMatchParams& locSCHitMatchParams, bool locIsTimeBased, const float* locInputDeltaPhiCut, DVector3 *IntersectionPoint, DVector3 *IntersectionDir) const
-{
-	// NOTE: locTrack is NULL if calling from track reconstruction!!!
-	if(sc_pos.empty() || sc_norm.empty())
+	if(rt == nullptr)
 		return false;
 
 	// Find intersection with a "barrel" approximation for the start counter
-	DVector3 proj_pos(NaN,NaN,NaN), proj_mom(NaN,NaN,NaN);
-	double locPathLength = 9.9E9, locFlightTime = 9.9E9;
-	double locFlightTimeVariance = 9.9E9;
-	unsigned int sc_index=locSCHit->sector - 1;
-	if(rt->GetIntersectionWithPlane(sc_pos[sc_index][0], sc_norm[sc_index][0], proj_pos, proj_mom, &locPathLength, &locFlightTime, &locFlightTimeVariance) != NOERROR)
+	double locPathLength = 9.9E9, locFlightTime = 9.9E9, locFlightTimeVariance = 9.9E9, locDeltaPhi = 9.9E9;
+	DVector3 locProjPos, locProjMom, locPaddleNorm;
+	if(!ProjectTo_SC(rt, locSCHit->sector, locDeltaPhi, locProjPos, locProjMom, locPaddleNorm, locPathLength, locFlightTime, locFlightTimeVariance))
 		return false;
 
 	// Check that the hit is not out of time with respect to the track
 	if(fabs(locSCHit->t - locFlightTime - locInputStartTime) > OUT_OF_TIME_CUT)
 		return false;
 
-	// Check that the intersection isn't upstream of the paddle
-	double myz = proj_pos.z();
-	if (myz < sc_pos[sc_index][0].z() + 1e-4)
-		return false;
-	
-	// Look for a match in phi
-	//double phi = dSCphi0 + dSCdphi*(locSCHit->sector - 1);
-	double sc_dphi_cut = 0.0;
-	if(locInputDeltaPhiCut != NULL)
-		sc_dphi_cut = *locInputDeltaPhiCut;
-	else
-		sc_dphi_cut = (locIsTimeBased) ? SC_DPHI_CUT : SC_DPHI_CUT_WB;
-
-	double L = 0.; // Length along scintillator
-	double dphi = 0.;
-
-	// Initialize the normal vector for the SC paddle to the long, unbent region
-	DVector3 norm = sc_norm[sc_index][0];
-
-	// Now check to see if the intersection is in the nose region and find the
-	// start time
-	//double locCorrectedHitTime = locSCHit->t - sc_leg_tcor;
-	// double sc_pos0 = sc_pos[sc_index][0].z();	
-	// double sc_pos1 = sc_pos[sc_index][1].z();
-
-	// Start Counter geometry in hall coordinates, obtained from xml file 
+	// Start Counter geometry in hall coordinates, obtained from xml file
+	unsigned int sc_index = locSCHit->sector - 1;
 	double sc_pos_soss = sc_pos[sc_index][0].z();   // Start of straight section
 	double sc_pos_eoss = sc_pos[sc_index][1].z();   // End of straight section
-	double sc_pos_eobs = sc_pos[sc_index][11].z();  // End of bend section
-	double sc_pos_eons = sc_pos[sc_index][12].z();  // End of nose section
+	double sc_pos_eobs = sc_pos[sc_index][sc_pos[sc_index].size() - 2].z();  // End of bend section
+
 	// Grab the time-walk corrected start counter hit time, and the pulse integral
 	double locCorrectedHitTime   = locSCHit->t;
 	double locCorrectedHitEnergy = locSCHit->dE;
 
-	//if(myz <= sc_pos1)
-
 	// Check to see if hit occured in the straight section
-	if (myz <= sc_pos_eoss)
+	if (locProjPos.Z() <= sc_pos_eoss)
 	{
-		//L=myz;
-		//locCorrectedHitTime -= L/C_EFFECTIVE;
-
-		// Apply a user-specified matching cut in the leg region
-		DVector3 sc_pos_at_myz = sc_pos[sc_index][0] + (myz - sc_pos[sc_index][0].z())*sc_dir[sc_index][0];
-		dphi = sc_pos_at_myz.Phi() - proj_pos.Phi(); //phi could be 0 degrees & proj_phi could be 359 degrees
-		while(dphi > TMath::Pi())
-			dphi -= M_TWO_PI;
-		while(dphi < -1.0*TMath::Pi())
-			dphi += M_TWO_PI;
-		if(fabs(dphi) > sc_dphi_cut)
-			return false; //no match
-
 		// Calculate hit distance along scintillator relative to upstream end
-		L = myz - sc_pos_soss;
+		double L = locProjPos.Z() - sc_pos_soss;
 		// Apply propagation time correction
 		locCorrectedHitTime -= L*sc_pt_slope[SC_STRAIGHT][sc_index] + sc_pt_yint[SC_STRAIGHT][sc_index];
 		// Apply attenuation correction
 		locCorrectedHitEnergy *= 1.0/(exp(sc_attn_B[SC_STRAIGHT_ATTN][sc_index]*L));
 	}
-	else
+	else if(locProjPos.Z() > sc_pos_eoss && locProjPos.Z() <= sc_pos_eobs) //check if in bend section: if so, apply corrections
 	{
-		unsigned int num = sc_norm[sc_index].size() - 1;
-		for (unsigned int loc_i = 1; loc_i < num; ++loc_i)
-		{
-			locPathLength = 9.9E9;
-			locFlightTime = 9.9E9;
-			if(rt->GetIntersectionWithPlane(sc_pos[sc_index][loc_i], sc_norm[sc_index][loc_i], proj_pos, proj_mom, &locPathLength, &locFlightTime, &locFlightTimeVariance) != NOERROR)
-				continue;
-
-			myz = proj_pos.z();
-			norm = sc_norm[sc_index][loc_i];
-			if(myz > sc_pos[sc_index][loc_i + 1].z())
-				continue;
-
-			DVector3 sc_pos_at_myz = sc_pos[sc_index][loc_i] + (myz - sc_pos[sc_index][loc_i].z())*sc_dir[sc_index][loc_i];
-
-			dphi = sc_pos_at_myz.Phi() - proj_pos.Phi();
-			while(dphi > TMath::Pi())
-				dphi -= M_TWO_PI;
-			while(dphi < -1.0*TMath::Pi())
-				dphi += M_TWO_PI;
-
-			// Open up the phi cut in the nose region
-			if(locInputDeltaPhiCut == NULL)
-				sc_dphi_cut += SC_DPHI_CUT_SLOPE*(myz - sc_pos_eoss);
-
-			if (fabs(dphi) > sc_dphi_cut)
-				return false;
-			break;
-		}
-
-		// Check for intersection point beyond nose
-		if (myz > sc_pos[sc_index][num].z())
-			return false;
-	  
-		// Note: in the following code, L does not include a correction for where the start counter starts in z ...
-		// This is absorbed into locCorrectedHitTime, above.
-		// if(myz < sc_pos1)
-
-		// If location cannot be located in straight, bend, or nose section then
-		// force it to be located at the end/start of the straight/bend section
-		if(myz < sc_pos_eoss)  // Assume hit at end of straight section
-	    {
-			// L = sc_pos1;
-			// locCorrectedHitTime -= L/C_EFFECTIVE;
-
-			// Define the distance to be at the end of the end/start of the straight/bend section
-			L = sc_pos_eoss - sc_pos_soss;
-			// Apply propagation time correction
-			locCorrectedHitTime -= L*sc_pt_slope[SC_STRAIGHT][sc_index] + sc_pt_yint[SC_STRAIGHT][sc_index];
-			// Apply attenuation correction
-			locCorrectedHitEnergy *= 1.0/(exp(sc_attn_B[SC_STRAIGHT_ATTN][sc_index]*L));
-		}
-		//else
-		//{
-		//	L = (myz - sc_pos1)*sc_angle_cor + sc_pos1;
-		//	locCorrectedHitTime -= L/C_EFFECTIVE;
-		//}
-	  
-		// Check to see if hit occured in bend section and apply corrections
-		else if(myz > sc_pos_eoss && myz <= sc_pos_eobs)
-		{
-			//L = (myz - sc_pos_eoss)*sc_angle_corr);
-			//locCorrectedHitTime -= L/C_EFFECTIVE;
-
-			// Calculate the hit position relative to the upstream end
-			L = (myz - sc_pos_eoss)*sc_angle_cor + (sc_pos_eoss - sc_pos_soss);
-			// Apply propagation time correction
-			locCorrectedHitTime -= L*sc_pt_slope[SC_BEND][sc_index] + sc_pt_yint[SC_BEND][sc_index];
-			// Apply attenuation correction
-			locCorrectedHitEnergy *= (sc_attn_A[SC_STRAIGHT_ATTN][sc_index] / ((sc_attn_A[SC_BENDNOSE_ATTN][sc_index]*
-					exp(sc_attn_B[SC_BENDNOSE_ATTN][sc_index]*L)) + sc_attn_C[SC_BENDNOSE_ATTN][sc_index]));
-		}
-		// Check to see if hit occured in nose section and apply corrections
-		else if(myz > sc_pos_eobs && myz <= sc_pos_eons)
-		{
-			//L = (myz - sc_pos_eoss)*sc_angle_cor;
-
-			// Calculate the hit position relative to the upstream end
-			L = (myz - sc_pos_eoss)*sc_angle_cor + (sc_pos_eoss - sc_pos_soss);
-			// Apply propagation time correction
-			locCorrectedHitTime -= L*sc_pt_slope[SC_NOSE][sc_index] + sc_pt_yint[SC_NOSE][sc_index];
-			// Apply attenuation correction
-			locCorrectedHitEnergy *= (sc_attn_A[SC_STRAIGHT_ATTN][sc_index] / ((sc_attn_A[SC_BENDNOSE_ATTN][sc_index]*
-					exp(sc_attn_B[SC_BENDNOSE_ATTN][sc_index]*L)) + sc_attn_C[SC_BENDNOSE_ATTN][sc_index]));
-		}
+		// Calculate the hit position relative to the upstream end
+		double L = (locProjPos.Z() - sc_pos_eoss)*sc_angle_cor + (sc_pos_eoss - sc_pos_soss);
+		// Apply propagation time correction
+		locCorrectedHitTime -= L*sc_pt_slope[SC_BEND][sc_index] + sc_pt_yint[SC_BEND][sc_index];
+		// Apply attenuation correction
+		locCorrectedHitEnergy *= (sc_attn_A[SC_STRAIGHT_ATTN][sc_index] / ((sc_attn_A[SC_BENDNOSE_ATTN][sc_index]*
+				exp(sc_attn_B[SC_BENDNOSE_ATTN][sc_index]*L)) + sc_attn_C[SC_BENDNOSE_ATTN][sc_index]));
+	}
+	else // nose section: apply corrections
+	{
+		// Calculate the hit position relative to the upstream end
+		double L = (locProjPos.Z() - sc_pos_eoss)*sc_angle_cor + (sc_pos_eoss - sc_pos_soss);
+		// Apply propagation time correction
+		locCorrectedHitTime -= L*sc_pt_slope[SC_NOSE][sc_index] + sc_pt_yint[SC_NOSE][sc_index];
+		// Apply attenuation correction
+		locCorrectedHitEnergy *= (sc_attn_A[SC_STRAIGHT_ATTN][sc_index] / ((sc_attn_A[SC_BENDNOSE_ATTN][sc_index]*
+				exp(sc_attn_B[SC_BENDNOSE_ATTN][sc_index]*L)) + sc_attn_C[SC_BENDNOSE_ATTN][sc_index]));
 	}
 
-	double ds = 0.3*proj_mom.Mag()/fabs(proj_mom.Dot(norm));
+	if(locOutputProjMom != nullptr)
+	{
+		*locOutputProjPos = locProjPos;
+		*locOutputProjMom = locProjMom;
+	}
 
-	// For the dEdx measurement we now need to take into account that L does not 
+	// For the dEdx measurement we now need to take into account that L does not
 	// compensate for the position in z at which the start counter paddle starts
-	locSCHitMatchParams.dTrack = locTrack;
+	double ds = 0.3*locProjMom.Mag()/fabs(locProjMom.Dot(locPaddleNorm));
+
+	//SET MATCHING INFORMATION
 	locSCHitMatchParams.dSCHit = locSCHit;
-	//locSCHitMatchParams.dHitEnergy = (locSCHit->dE)*exp((L - sc_pos0)/ATTEN_LENGTH);
 	locSCHitMatchParams.dHitEnergy = locCorrectedHitEnergy;
 	locSCHitMatchParams.dEdx = locSCHitMatchParams.dHitEnergy/ds;
 	locSCHitMatchParams.dHitTime = locCorrectedHitTime;
@@ -1136,281 +864,74 @@ bool DParticleID::MatchToSC(const DKinematicData* locTrack, const DReferenceTraj
 	locSCHitMatchParams.dFlightTime = locFlightTime;
 	locSCHitMatchParams.dFlightTimeVariance = locFlightTimeVariance;
 	locSCHitMatchParams.dPathLength = locPathLength;
-	locSCHitMatchParams.dDeltaPhiToHit = dphi;
-
-	// Optionally output intersection position	
-	if (IntersectionPoint!=NULL)
-		*IntersectionPoint=proj_pos;
-	if (IntersectionDir!=NULL)
-	{
-		*IntersectionDir=proj_mom;
-		IntersectionDir->SetMag(1.);
-	}
+	locSCHitMatchParams.dDeltaPhiToHit = locDeltaPhi;
 
 	return true;
 }
 
-// Predict the start counter paddle that would match a track whose reference 
-// trajectory is given by rt.
-unsigned int DParticleID::PredictSCSector(const DReferenceTrajectory* rt, const double dphi_cut, DVector3* locProjPos, bool* locProjBarrelRegion, double* locMinDPhi) const
+bool DParticleID::ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locSCSector, double& locDeltaPhi, DVector3& locProjPos, DVector3& locProjMom, DVector3& locPaddleNorm, double& locPathLength, double& locFlightTime, double& locFlightTimeVariance) const
 {
-  if(sc_pos.empty() || sc_norm.empty())
-    return 0;
-
-  unsigned int best_sc_index=0;
-  double min_dphi=1e6;
-  // loop over geometry for all SC paddles looking for track intersections
-  for (unsigned int sc_index=0;sc_index<30;sc_index++){
-    // Find intersection with the leg region of the start counter
-    DVector3 proj_pos, proj_mom(NaN,NaN,NaN);
-    if(rt->GetIntersectionWithPlane(sc_pos[sc_index][0],sc_norm[sc_index][0], 
-				    proj_pos, proj_mom) != NOERROR)
-      continue;
-
-    // Check that the intersection isn't upstream of the paddle
-    double myz = proj_pos.z();
-    if (myz<sc_pos[sc_index][0].z()+1e-4) continue;
-
-    // Compute phi difference
-    double proj_phi = proj_pos.Phi();
-    DVector3 average_pos=0.5*(sc_pos[sc_index][0]+sc_pos[sc_index][1]);
-    double phi=average_pos.Phi();
-    double dphi = phi - proj_phi; //phi could be 0 degrees & proj_phi could be 359 degrees
-
-    while(dphi > TMath::Pi())
-      dphi -= M_TWO_PI;
-    while(dphi < -1.0*TMath::Pi())
-      dphi += M_TWO_PI;
-    if(fabs(dphi) >= SC_DPHI_CUT_WB)
-      continue;
-    
-    // Match in phi successful, refine match in nose region were applicable
-    // Initialize the normal vector for the SC paddle to the long, unbent region
-    DVector3 norm=sc_norm[sc_index][0];
-    double sc_pos1 = sc_pos[sc_index][1].z();
-    if(myz <= sc_pos1){
-      if (fabs(dphi)<fabs(min_dphi)){
-	best_sc_index=sc_index;
-   if(locProjBarrelRegion != NULL)
-     *locProjBarrelRegion = true;
-   if(locProjPos != NULL)
-     *locProjPos = proj_pos;
-	min_dphi=dphi;
-      }
-    }
-    else{
-      bool got_match=false;
-      unsigned int num = sc_norm[sc_index].size() - 1;
-      for (unsigned int loc_i = 1; loc_i < num; ++loc_i){
-	if(rt->GetIntersectionWithPlane(sc_pos[sc_index][loc_i],
-					sc_norm[sc_index][loc_i], 
-					proj_pos, proj_mom) != NOERROR)
-	  continue;
-	myz = proj_pos.z();
-	norm=sc_norm[sc_index][loc_i];
-	if(myz < sc_pos[sc_index][loc_i + 1].z()){
-	  average_pos
-	    =0.5*(sc_pos[sc_index][loc_i]+sc_pos[sc_index][loc_i+1]);
-	  dphi=average_pos.Phi()-proj_pos.Phi();
-	  while(dphi > TMath::Pi())
-	    dphi -= M_TWO_PI;
-	  while(dphi < -1.0*TMath::Pi())
-	    dphi += M_TWO_PI;
-	  if (fabs(dphi)<SC_DPHI_CUT_WB){
-	    got_match=true;
-	    break;
-	  }
-	}
-      }	
-      if (got_match==false) continue; //doesn't match well with nose region
-
-      // Check for intersection point beyond nose
-      if (myz> sc_pos[sc_index][num].z()) continue;
-
-      	
-
-      if (fabs(dphi)<fabs(min_dphi)){
-	best_sc_index=sc_index;
-   if(locProjBarrelRegion != NULL)
-     *locProjBarrelRegion = false;
-   if(locProjPos != NULL)
-     *locProjPos = proj_pos;
-	min_dphi=dphi;
-      }
-    }
-  }
-
-  if(locMinDPhi != NULL)
-    *locMinDPhi = min_dphi;
-
-  if (fabs(min_dphi)<dphi_cut) return best_sc_index+1;
-
-  return 0;
-}
-
-//------------------
-// Distance_ToTrack
-//-----------------
-bool DParticleID::Distance_ToTrack(const DBCALShower* locBCALShower, const DReferenceTrajectory* rt, double locInputStartTime, double& locDistance, double& locDeltaPhi, double& locDeltaZ) const
-{
-  double locFlightTime=0.,locFlightTimeVariance=0.,locProjectedZ=0.;
-  double locPathLength=0.;
-  return Distance_ToTrack(locBCALShower,rt,locInputStartTime,locDistance,
-			  locDeltaPhi,locDeltaZ,locProjectedZ,locFlightTime,
-			  locFlightTimeVariance,locPathLength);
-}
-
-//------------------
-// Distance_ToTrack
-//------------------
-// NOTE: an initial guess for start time is expected as input so that out-of-time 
-// tracks can be skipped
-    bool DParticleID::Distance_ToTrack(const DBCALShower* locBCALShower, const DReferenceTrajectory* rt, double locInputStartTime, double& locDistance, double& locDeltaPhi, double& locDeltaZ, double& locProjectedZ, double& locFlightTime, double& locFlightTimeVariance, double &locPathLength) const
-{
-	// Get the BCAL cluster position and normal
-	DVector3 bcal_pos(locBCALShower->x, locBCALShower->y, locBCALShower->z); 
-
-	locFlightTime = 9.9E9, locPathLength = 9.9E9;
-	locFlightTimeVariance = 9.9E9;
-	locDistance = rt->DistToRTwithTime(bcal_pos, &locPathLength, &locFlightTime,&locFlightTimeVariance,SYS_BCAL);
-	if(!isfinite(locDistance))
-		return false;
-
-	// Check that the hit is not out of time with respect to the track
-	double locDeltaT = locBCALShower->t - locFlightTime - locInputStartTime;
-	if(fabs(locDeltaT) > OUT_OF_TIME_CUT)
-		return false;
-
-	DVector3 proj_pos = rt->GetLastDOCAPoint();
-	//if(proj_pos.Perp() < 65.0)
-	//return false;  // not inside BCAL!
-
-	locDeltaZ = bcal_pos.z() - proj_pos.z();
-	locDeltaPhi = bcal_pos.Phi() - proj_pos.Phi();
-	while(locDeltaPhi > M_PI)
-		locDeltaPhi -= M_TWO_PI;
-	while(locDeltaPhi < -M_PI)
-		locDeltaPhi += M_TWO_PI;
-
-	// The next part of the code tries to take into account curvature
-	// of shower cluster distribution
-
-	// Get clusters associated with this shower
-	vector<const DBCALCluster*>clusters;
-	locBCALShower->Get(clusters);
-	
-	// make list of points associated with the shower
-	vector<const DBCALPoint*> points;
-	if(clusters.size() > 0) {
-	  // classic BCAL shower objects are built from the output of the clusterizer
-	  // so the points need to be accessed as shower -> cluster -> points
-	  for (unsigned int k=0;k<clusters.size();k++){
-	    vector<const DBCALPoint*> cluster_points=clusters[k]->points();
-	    points.insert(points.end(), cluster_points.begin(), cluster_points.end());
-	    }
-	} else {
-	  // other BCAL shower objects directly keep a list of the points associated with the shower
-	  // (e.g. "CURVATURE" showers)
-	  locBCALShower->Get(points);
-	}
-	
-	// loop over points associated with this shower, finding 
-	// the closest match between a point and the track
-	double locDeltaPhiMin = locDeltaPhi;
-	locProjectedZ=proj_pos.z();
-	for (unsigned int m=0;m<points.size();m++){
-	  double rpoint=points[m]->r();
-	  if (rt->GetIntersectionWithRadius(rpoint,proj_pos)==NOERROR){
-	    double mydphi=points[m]->phi()-proj_pos.Phi();
-	    while(mydphi > M_PI)
-	      mydphi -= M_TWO_PI;
-	    while(mydphi < -M_PI)
-		mydphi += M_TWO_PI;
-	    if (fabs(mydphi)<fabs(locDeltaPhiMin)){
-	      locDeltaPhiMin=mydphi;
-	      locProjectedZ=proj_pos.z();
-	    }
-	  }
-	}
-	locDeltaPhi=locDeltaPhiMin;
-
-	return true;
-}
-
-//------------------
-// Distance_ToTrack
-//------------------
-// NOTE: an initial guess for start time is expected as input so that out-of-time 
-// tracks can be skipped
-bool DParticleID::Distance_ToTrack(const DFCALShower* locFCALShower, const DReferenceTrajectory* rt, double locInputStartTime, double& locDistance) const
-{
-	DVector3 fcal_pos = locFCALShower->getPosition();
-	DVector3 norm(0.0, 0.0, 1.0); //normal vector for the FCAL plane
-	DVector3 proj_pos, proj_mom;
-	double locPathLength = 9.9E9, locFlightTime = 9.9E9;
-	if(rt->GetIntersectionWithPlane(fcal_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime,NULL,SYS_FCAL) != NOERROR)
-		return false;
-
-	// Check that the hit is not out of time with respect to the track
-	double locDeltaT = locFCALShower->getTime() - locFlightTime - locInputStartTime;
-	if(fabs(locDeltaT) > OUT_OF_TIME_CUT)
-		return false;
-
-	locDistance = (fcal_pos - proj_pos).Mag();
-	return true;
-}
-
-//------------------
-// Distance_ToTrack
-//------------------
-// NOTE: an initial guess for start time is expected as input so that out-of-time 
-// tracks can be skipped
-bool DParticleID::Distance_ToTrack(const DTOFPoint* locTOFPoint, const DReferenceTrajectory* rt, double locInputStartTime, double& locDeltaX, double& locDeltaY) const
-{
-	DVector3 tof_pos = locTOFPoint->pos;
-	DVector3 norm(0.0, 0.0, 1.0); //normal vector to TOF plane
-	DVector3 proj_pos, proj_mom;
-	double locPathLength = 9.9E9, locFlightTime = 9.9E9;
-	if(rt->GetIntersectionWithPlane(tof_pos, norm, proj_pos, proj_mom, &locPathLength, &locFlightTime, NULL, SYS_TOF) != NOERROR)
-		return false;
-
-	// Check that the hit is not out of time with respect to the track
-	double locDeltaT = locTOFPoint->t - locFlightTime - locInputStartTime;
-	if(fabs(locDeltaT) > OUT_OF_TIME_CUT)
-		return false;
-
-	locDeltaX = locTOFPoint->Is_XPositionWellDefined() ? tof_pos.X() - proj_pos.X() : 999.0;
-	locDeltaY = locTOFPoint->Is_YPositionWellDefined() ? tof_pos.Y() - proj_pos.Y() : 999.0;
-	return true;
-}
-
-//------------------
-// Distance_ToTrack
-//------------------
-// NOTE: an initial guess for start time is expected as input so that out-of-time 
-// tracks can be skipped
-bool DParticleID::Distance_ToTrack(const DSCHit* locSCHit, const DReferenceTrajectory* rt, double locInputStartTime, double& locDeltaPhi) const
-{
-	if(sc_pos.empty() || sc_norm.empty())
+	if(rt == nullptr)
 		return false;
 
 	// Find intersection with a "barrel" approximation for the start counter
-	DVector3 proj_pos(NaN,NaN,NaN), proj_mom(NaN,NaN,NaN);
-	double locPathLength = 9.9E9, locFlightTime = 9.9E9;
-	if(rt->GetIntersectionWithRadius(sc_pos[0][1].x(), proj_pos, &locPathLength, &locFlightTime, &proj_mom) != NOERROR)
+	unsigned int sc_index = locSCSector - 1;
+	if(rt->GetIntersectionWithPlane(sc_pos[sc_index][0], sc_norm[sc_index][0], locProjPos, locProjMom, &locPathLength, &locFlightTime, &locFlightTimeVariance) != NOERROR)
 		return false;
 
-	// Check that the hit is not out of time with respect to the track
-	double locDeltaT = locSCHit->t - locFlightTime - locInputStartTime;
-	if(fabs(locDeltaT) > OUT_OF_TIME_CUT)
+	// Start Counter geometry in hall coordinates, obtained from xml file
+	double sc_pos_soss = sc_pos[sc_index][0].z();   // Start of straight section
+	double sc_pos_eoss = sc_pos[sc_index][1].z();   // End of straight section
+	double sc_pos_eons = sc_pos[sc_index][sc_pos[sc_index].size() - 1].z();  // End of nose section
+
+	// Check that the intersection isn't upstream of the paddle
+	double locProjectionZTolerance = 5.0;
+	if (locProjPos.Z() < sc_pos_soss + locProjectionZTolerance)
 		return false;
+	if (locProjPos.Z() < sc_pos_soss) //unphysical, adjust: due to track projection uncertainty (or it really did miss)
+		locProjPos.SetZ(sc_pos_soss);
 
-	double proj_phi = proj_pos.Phi();
-	if(proj_phi < 0.0)
-		proj_phi += M_TWO_PI;
+	// Initialize the normal vector for the SC paddle to the long, unbent region
+	locPaddleNorm = sc_norm[sc_index][0];
 
-	double phi = dSCphi0 + dSCdphi*(locSCHit->sector - 1);
-	locDeltaPhi = phi - proj_phi; //phi could be 0 degrees & proj_phi could be 359 degrees
+	// Check to see if hit occured in the straight section
+	if (locProjPos.Z() <= sc_pos_eoss)
+	{
+		// Apply a user-specified matching cut in the leg region
+		DVector3 sc_pos_at_projz = sc_pos[sc_index][0] + (locProjPos.Z() - sc_pos_soss)*sc_dir[sc_index][0];
+		locDeltaPhi = sc_pos_at_projz.Phi() - locProjPos.Phi(); //phi could be 0 degrees & proj_phi could be 359 degrees
+	}
+	else //bend or nose
+	{
+		//loop through SC planes
+			//consider: 12 planes, labeled 1 -> 12
+			//but, the vectors are size 13
+			//sc_norm[sc_index][loc_i] are the normal vectors for plane loc_i //loc_i = 0 should be ignored
+			//sc_pos[sc_index][loc_i] are the end points for plane loc_i //for loc_i = 0, is begin point
+		for (unsigned int loc_i = 1; loc_i < sc_norm[sc_index].size(); ++loc_i)
+		{
+			if(rt->GetIntersectionWithPlane(sc_pos[sc_index][loc_i], sc_norm[sc_index][loc_i], locProjPos, locProjMom, &locPathLength, &locFlightTime, &locFlightTimeVariance) != NOERROR)
+				continue;
+
+			// If on final plane, check for intersection point well beyond nose
+			if(loc_i == (sc_norm[sc_index].size() - 1))
+			{
+				if (locProjPos.Z() > (sc_pos_eons + locProjectionZTolerance))
+					return false;
+			}
+			else if(locProjPos.Z() > sc_pos[sc_index][loc_i + 1].z())
+				continue; //past the end of this plane, go to next plane
+
+			DVector3 sc_pos_at_projz = sc_pos[sc_index][loc_i] + (locProjPos.Z() - sc_pos[sc_index][loc_i].z())*sc_dir[sc_index][loc_i];
+			locDeltaPhi = sc_pos_at_projz.Phi() - locProjPos.Phi();
+			locPaddleNorm = sc_norm[sc_index][loc_i];
+			break;
+		}
+
+		// Check to see if the projections changed their mind, and put the hit in the straight section after all
+		if(locProjPos.Z() < sc_pos_eoss) // Assume hit at end of straight section
+			locProjPos.SetZ(sc_pos_eoss);
+	}
 
 	while(locDeltaPhi > TMath::Pi())
 		locDeltaPhi -= M_TWO_PI;
@@ -1420,28 +941,141 @@ bool DParticleID::Distance_ToTrack(const DSCHit* locSCHit, const DReferenceTraje
 	return true;
 }
 
-bool DParticleID::Get_BestSCMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DSCHitMatchParams& locBestMatchParams) const
+/********************************************************** CUT MATCH DISTANCE **********************************************************/
+
+bool DParticleID::Cut_MatchDistance(const DReferenceTrajectory* rt, const DBCALShower* locBCALShower, double locInputStartTime, DBCALShowerMatchParams& locShowerMatchParams, DVector3 *locOutputProjPos, DVector3 *locOutputProjMom) const
 {
-	//choose the "best" detector hit to use for computing quantities
-	vector<DSCHitMatchParams> locSCHitMatchParams;
-	if(!locDetectorMatches->Get_SCMatchParams(locTrack, locSCHitMatchParams))
+	if(rt == nullptr)
 		return false;
 
-	Get_BestSCMatchParams(locSCHitMatchParams, locBestMatchParams);
+	DVector3 locProjPos, locProjMom;
+	if(!Distance_ToTrack(rt, locBCALShower, locInputStartTime, locShowerMatchParams, &locProjPos, &locProjMom))
+		return false;
+
+	if(locOutputProjMom != nullptr)
+	{
+		*locOutputProjPos = locProjPos;
+		*locOutputProjMom = locProjMom;
+	}
+
+	double locDeltaPhi = locShowerMatchParams.dDeltaPhiToShower;
+	if(fabs(locDeltaPhi) > 0.26) //0.13 radians = 7.5 degrees = one bcal module
+		return false;
+
+	if(fabs(locShowerMatchParams.dDeltaZToShower) > BCAL_Z_CUT)
+		return false;
+
+	// cut on shower phi
+	double p = locProjMom.Mag();
+	double phi_cut = (BCAL_PHI_CUT_PAR1 + BCAL_PHI_CUT_PAR2/(p*p))*(1.+BCAL_PHI_CUT_PAR3*pow(450.-1.0*locProjPos.Z(),-2));
+	if(fabs(locDeltaPhi) > phi_cut)
+		return false;
+
+	//successful match
 	return true;
 }
 
-void DParticleID::Get_BestSCMatchParams(vector<DSCHitMatchParams>& locSCHitMatchParams, DSCHitMatchParams& locBestMatchParams) const
+bool DParticleID::Cut_MatchDistance(const DReferenceTrajectory* rt, const DTOFPoint* locTOFPoint, double locInputStartTime, DTOFHitMatchParams& locTOFHitMatchParams, DVector3 *locOutputProjPos, DVector3 *locOutputProjMom) const
 {
-	double locMinDeltaPhi = 9.9E9;
-	for(size_t loc_i = 0; loc_i < locSCHitMatchParams.size(); ++loc_i)
+	if(rt == nullptr)
+		return false;
+
+	// Find the distance of closest approach between the track trajectory
+	// and the tof cluster position, looking for the minimum
+
+	DVector3 locProjPos, locProjMom;
+	if(!Distance_ToTrack(rt, locTOFPoint, locInputStartTime, locTOFHitMatchParams, &locProjPos, &locProjMom))
+		return false;
+
+	if(locOutputProjMom != nullptr)
 	{
-		if(locSCHitMatchParams[loc_i].dDeltaPhiToHit >= locMinDeltaPhi)
-			continue;
-		locMinDeltaPhi = locSCHitMatchParams[loc_i].dDeltaPhiToHit;
-		locBestMatchParams = locSCHitMatchParams[loc_i];
+		*locOutputProjPos = locProjPos;
+		*locOutputProjMom = locProjMom;
 	}
+
+	//If the position in one dimension is not well-defined, compare distance only in the other direction
+	//Otherwise, cut in R
+	double locMatchCut_2D = exp(-1.0*TOF_CUT_PAR1*locProjMom.Mag() + TOF_CUT_PAR2) + TOF_CUT_PAR3;
+	double locMatchCut_1D = locMatchCut_2D;
+
+	double locDeltaX = locTOFHitMatchParams.dDeltaXToHit;
+	double locDeltaY = locTOFHitMatchParams.dDeltaYToHit;
+	if(!locTOFPoint->Is_XPositionWellDefined())
+	{
+		//Is unmatched horizontal paddle with only one hit above threshold: Only compare y-distance
+		if(fabs(locDeltaY) > locMatchCut_1D)
+			return false;
+	}
+	else if(!locTOFPoint->Is_YPositionWellDefined())
+	{
+		//Is unmatched vertical paddle with only one hit above threshold: Only compare x-distance
+		if(fabs(locDeltaX) > locMatchCut_1D)
+			return false;
+	}
+	else
+	{
+		//Both are good, cut on R
+		double locDistance = sqrt(locDeltaX*locDeltaX + locDeltaY*locDeltaY);
+		if(locDistance > locMatchCut_2D)
+			return false;
+	}
+
+	return true;
 }
+
+bool DParticleID::Cut_MatchDistance(const DReferenceTrajectory* rt, const DSCHit* locSCHit, double locInputStartTime, DSCHitMatchParams& locSCHitMatchParams, bool locIsTimeBased, DVector3 *locOutputProjPos, DVector3 *locOutputProjMom) const
+{
+	if(rt == nullptr)
+		return false;
+
+	DVector3 locProjPos, locProjMom;
+	if(!Distance_ToTrack(rt, locSCHit, locInputStartTime, locSCHitMatchParams, &locProjPos, &locProjMom))
+		return false;
+
+	if(locOutputProjMom != nullptr)
+	{
+		*locOutputProjPos = locProjPos;
+		*locOutputProjMom = locProjMom;
+	}
+
+	// Look for a match in phi
+	double sc_dphi_cut = (locIsTimeBased) ? SC_DPHI_CUT : SC_DPHI_CUT_WB;
+
+	// Open up the phi cut in the nose region
+	double sc_pos_eoss = sc_pos[locSCHit->sector - 1][1].z();   // End of straight section
+	if(locProjPos.Z() > sc_pos_eoss)
+		sc_dphi_cut += SC_DPHI_CUT_SLOPE*(locProjPos.Z() - sc_pos_eoss);
+
+	if (fabs(locSCHitMatchParams.dDeltaPhiToHit) > sc_dphi_cut)
+		return false;
+
+	return true;
+}
+
+bool DParticleID::Cut_MatchDistance(const DReferenceTrajectory* rt, const DFCALShower* locFCALShower, double locInputStartTime, DFCALShowerMatchParams& locShowerMatchParams, DVector3 *locOutputProjPos, DVector3 *locOutputProjMom) const
+{
+	if(rt == nullptr)
+		return false;
+
+	DVector3 locProjPos, locProjMom;
+	if(!Distance_ToTrack(rt, locFCALShower, locInputStartTime, locShowerMatchParams, &locProjPos, &locProjMom))
+		return false;
+
+	if(locOutputProjMom != nullptr)
+	{
+		*locOutputProjPos = locProjPos;
+		*locOutputProjMom = locProjMom;
+	}
+
+	double p=locProjMom.Mag();
+	double cut=FCAL_CUT_PAR1+FCAL_CUT_PAR2/p;
+	if(locShowerMatchParams.dDOCAToShower >= cut)
+		return false;
+
+	return true;
+}
+
+/********************************************************** GET BEST MATCH **********************************************************/
 
 bool DParticleID::Get_BestBCALMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DBCALShowerMatchParams& locBestMatchParams) const
 {
@@ -1450,14 +1084,15 @@ bool DParticleID::Get_BestBCALMatchParams(const DKinematicData* locTrack, const 
 	if(!locDetectorMatches->Get_BCALMatchParams(locTrack, locShowerMatchParams))
 		return false;
 
-	Get_BestBCALMatchParams(locTrack->momentum(), locShowerMatchParams, locBestMatchParams);
+	locBestMatchParams = Get_BestBCALMatchParams(locTrack->momentum(), locShowerMatchParams);
 	return true;
 }
 
-void DParticleID::Get_BestBCALMatchParams(DVector3 locMomentum, vector<DBCALShowerMatchParams>& locShowerMatchParams, DBCALShowerMatchParams& locBestMatchParams) const
+DBCALShowerMatchParams DParticleID::Get_BestBCALMatchParams(DVector3 locMomentum, vector<DBCALShowerMatchParams>& locShowerMatchParams) const
 {
 	double locMinChiSq = 9.9E9;
 	double locP = locMomentum.Mag();
+	DBCALShowerMatchParams locBestMatchParams;
 	for(size_t loc_i = 0; loc_i < locShowerMatchParams.size(); ++loc_i)
 	{
 		double locDeltaPhiCut = BCAL_PHI_CUT_PAR1 + BCAL_PHI_CUT_PAR2/(locP*locP);
@@ -1473,6 +1108,33 @@ void DParticleID::Get_BestBCALMatchParams(DVector3 locMomentum, vector<DBCALShow
 		locMinChiSq = locMatchChiSq;
 		locBestMatchParams = locShowerMatchParams[loc_i];
 	}
+
+	return locBestMatchParams;
+}
+
+bool DParticleID::Get_BestSCMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DSCHitMatchParams& locBestMatchParams) const
+{
+	//choose the "best" detector hit to use for computing quantities
+	vector<DSCHitMatchParams> locSCHitMatchParams;
+	if(!locDetectorMatches->Get_SCMatchParams(locTrack, locSCHitMatchParams))
+		return false;
+
+	locBestMatchParams = Get_BestSCMatchParams(locSCHitMatchParams);
+	return true;
+}
+
+DSCHitMatchParams DParticleID::Get_BestSCMatchParams(vector<DSCHitMatchParams>& locSCHitMatchParams) const
+{
+	double locMinDeltaPhi = 9.9E9;
+	DSCHitMatchParams locBestMatchParams;
+	for(size_t loc_i = 0; loc_i < locSCHitMatchParams.size(); ++loc_i)
+	{
+		if(locSCHitMatchParams[loc_i].dDeltaPhiToHit >= locMinDeltaPhi)
+			continue;
+		locMinDeltaPhi = locSCHitMatchParams[loc_i].dDeltaPhiToHit;
+		locBestMatchParams = locSCHitMatchParams[loc_i];
+	}
+	return locBestMatchParams;
 }
 
 bool DParticleID::Get_BestTOFMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DTOFHitMatchParams& locBestMatchParams) const
@@ -1482,13 +1144,14 @@ bool DParticleID::Get_BestTOFMatchParams(const DKinematicData* locTrack, const D
 	if(!locDetectorMatches->Get_TOFMatchParams(locTrack, locTOFHitMatchParams))
 		return false;
 
-	Get_BestTOFMatchParams(locTOFHitMatchParams, locBestMatchParams);
+	locBestMatchParams = Get_BestTOFMatchParams(locTOFHitMatchParams);
 	return true;
 }
 
-void DParticleID::Get_BestTOFMatchParams(vector<DTOFHitMatchParams>& locTOFHitMatchParams, DTOFHitMatchParams& locBestMatchParams) const
+DTOFHitMatchParams DParticleID::Get_BestTOFMatchParams(vector<DTOFHitMatchParams>& locTOFHitMatchParams) const
 {
 	double locMinDistance = 9.9E9;
+	DTOFHitMatchParams locBestMatchParams;
 	for(size_t loc_i = 0; loc_i < locTOFHitMatchParams.size(); ++loc_i)
 	{
 		double locDeltaR = sqrt(locTOFHitMatchParams[loc_i].dDeltaXToHit*locTOFHitMatchParams[loc_i].dDeltaXToHit + locTOFHitMatchParams[loc_i].dDeltaYToHit*locTOFHitMatchParams[loc_i].dDeltaYToHit);
@@ -1497,6 +1160,7 @@ void DParticleID::Get_BestTOFMatchParams(vector<DTOFHitMatchParams>& locTOFHitMa
 		locMinDistance = locDeltaR;
 		locBestMatchParams = locTOFHitMatchParams[loc_i];
 	}
+	return locBestMatchParams;
 }
 
 bool DParticleID::Get_BestFCALMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DFCALShowerMatchParams& locBestMatchParams) const
@@ -1506,13 +1170,14 @@ bool DParticleID::Get_BestFCALMatchParams(const DKinematicData* locTrack, const 
 	if(!locDetectorMatches->Get_FCALMatchParams(locTrack, locShowerMatchParams))
 		return false;
 
-	Get_BestFCALMatchParams(locShowerMatchParams, locBestMatchParams);
+	locBestMatchParams = Get_BestFCALMatchParams(locShowerMatchParams);
 	return true;
 }
 
-void DParticleID::Get_BestFCALMatchParams(vector<DFCALShowerMatchParams>& locShowerMatchParams, DFCALShowerMatchParams& locBestMatchParams) const
+DFCALShowerMatchParams DParticleID::Get_BestFCALMatchParams(vector<DFCALShowerMatchParams>& locShowerMatchParams) const
 {
 	double locMinDistance = 9.9E9;
+	DFCALShowerMatchParams locBestMatchParams;
 	for(size_t loc_i = 0; loc_i < locShowerMatchParams.size(); ++loc_i)
 	{
 		if(locShowerMatchParams[loc_i].dDOCAToShower >= locMinDistance)
@@ -1520,90 +1185,226 @@ void DParticleID::Get_BestFCALMatchParams(vector<DFCALShowerMatchParams>& locSho
 		locMinDistance = locShowerMatchParams[loc_i].dDOCAToShower;
 		locBestMatchParams = locShowerMatchParams[loc_i];
 	}
+	return locBestMatchParams;
 }
 
-const DBCALShower* DParticleID::Get_ClosestToTrack_BCAL(const DKinematicData* locTrack, vector<const DBCALShower*>& locBCALShowers, double& locBestMatchDeltaPhi, double& locBestMatchDeltaZ) const
-{
-	const DTrackTimeBased* locTrackTimeBased = dynamic_cast<const DTrackTimeBased*>(locTrack);
-	const DTrackWireBased* locTrackWireBased = dynamic_cast<const DTrackWireBased*>(locTrack);
-	if((locTrackTimeBased == NULL) && (locTrackWireBased == NULL))
-		return NULL;
-	const DReferenceTrajectory* locReferenceTrajectory = (locTrackTimeBased != NULL) ? locTrackTimeBased->rt : locTrackWireBased->rt;
-	if(locReferenceTrajectory == NULL)
-		return NULL;
+/********************************************************** GET CLOSEST TO TRACK **********************************************************/
 
-	double locInputStartTime = locTrack->t0();
-	double locMinDistance = 999.0;
-	const DBCALShower* locBestBCALShower = NULL;
+// NOTE: an initial guess for start time is expected as input so that out-of-time hits can be skipped
+bool DParticleID::Get_ClosestToTrack(const DReferenceTrajectory* rt, const vector<const DBCALShower*>& locBCALShowers, bool locCutFlag, double& locStartTime, DBCALShowerMatchParams& locBestMatchParams, double* locStartTimeVariance, DVector3* locBestProjPos, DVector3* locBestProjMom) const
+{
+	if(rt == nullptr)
+		return false;
+
+	//Loop over bcal showers
+	vector<DBCALShowerMatchParams> locShowerMatchParamsVector;
+	vector<pair<DBCALShowerMatchParams, pair<DVector3, DVector3> > > locMatchProjectionPairs;
 	for(size_t loc_i = 0; loc_i < locBCALShowers.size(); ++loc_i)
 	{
-		double locDistance = 0.0, locDeltaPhi = 0.0, locDeltaZ = 0.0;
-		if(!Distance_ToTrack(locBCALShowers[loc_i], locReferenceTrajectory, locInputStartTime, locDistance, locDeltaPhi, locDeltaZ))
-			continue;
-		if(locDistance > locMinDistance)
-			continue;
-		locBestBCALShower = locBCALShowers[loc_i];
-		locMinDistance = locDistance;
-		locBestMatchDeltaPhi = locDeltaPhi;
-		locBestMatchDeltaZ = locDeltaZ;
+		DBCALShowerMatchParams locShowerMatchParams;
+		DVector3 locProjPos, locProjMom;
+		if(locCutFlag)
+		{
+			if(!Cut_MatchDistance(rt, locBCALShowers[loc_i], locStartTime, locShowerMatchParams, &locProjPos, &locProjMom))
+				continue;
+		}
+		else
+		{
+			if(!Distance_ToTrack(rt, locBCALShowers[loc_i], locStartTime, locShowerMatchParams, &locProjPos, &locProjMom))
+				continue;
+		}
+		locShowerMatchParamsVector.push_back(locShowerMatchParams);
+		pair<DBCALShowerMatchParams, pair<DVector3, DVector3> > locMatchProjectionPair(locShowerMatchParams, pair<DVector3, DVector3>(locProjPos, locProjMom));
+		locMatchProjectionPairs.push_back(locMatchProjectionPair);
 	}
-	return locBestBCALShower;
-}
+	if(locShowerMatchParamsVector.empty())
+		return false;
 
-const DFCALShower* DParticleID::Get_ClosestToTrack_FCAL(const DKinematicData* locTrack, vector<const DFCALShower*>& locFCALShowers, double& locBestDistance) const
-{
-	const DTrackTimeBased* locTrackTimeBased = dynamic_cast<const DTrackTimeBased*>(locTrack);
-	const DTrackWireBased* locTrackWireBased = dynamic_cast<const DTrackWireBased*>(locTrack);
-	if((locTrackTimeBased == NULL) && (locTrackWireBased == NULL))
-		return NULL;
-	const DReferenceTrajectory* locReferenceTrajectory = (locTrackTimeBased != NULL) ? locTrackTimeBased->rt : locTrackWireBased->rt;
-	if(locReferenceTrajectory == NULL)
-		return NULL;
+	locBestMatchParams = Get_BestBCALMatchParams(rt->swim_steps[0].mom, locShowerMatchParamsVector);
 
-	double locInputStartTime = locTrack->t0();
-	locBestDistance = 999.0;
-	const DFCALShower* locBestFCALShower = NULL;
-	for(size_t loc_i = 0; loc_i < locFCALShowers.size(); ++loc_i)
+	if(locStartTimeVariance != nullptr)
 	{
-		double locDistance = 0.0;
-		if(!Distance_ToTrack(locFCALShowers[loc_i], locReferenceTrajectory, locInputStartTime, locDistance))
-			continue;
-		if(locDistance > locBestDistance)
-			continue;
-		locBestDistance = locDistance;
-		locBestFCALShower = locFCALShowers[loc_i];
+		locStartTime = locBestMatchParams.dBCALShower->t - locBestMatchParams.dFlightTime;
+	//	locTimeVariance = locBestMatchParams.dFlightTimeVariance + locBestMatchParams.dBCALShower->dCovarianceMatrix(4, 4); //uncomment when ready!!
+		*locStartTimeVariance = 0.3*0.3+locBestMatchParams.dFlightTimeVariance;
 	}
-	return locBestFCALShower;
+
+	if(locBestProjMom != nullptr)
+	{
+		for(auto& locMatchProjectionPair : locMatchProjectionPairs)
+		{
+			DBCALShowerMatchParams locParams = locMatchProjectionPair.first;
+			if(locParams != locBestMatchParams)
+				continue;
+			*locBestProjPos = locMatchProjectionPair.second.first;
+			*locBestProjMom = locMatchProjectionPair.second.second;
+			break;
+		}
+	}
+
+	return true;
 }
 
-const DTOFPoint* DParticleID::Get_ClosestToTrack_TOFPoint(const DKinematicData* locTrack, vector<const DTOFPoint*>& locTOFPoints, double& locBestDeltaX, double& locBestDeltaY) const
+bool DParticleID::Get_ClosestToTrack(const DReferenceTrajectory* rt, const vector<const DTOFPoint*>& locTOFPoints, bool locCutFlag, double& locStartTime, DTOFHitMatchParams& locBestMatchParams, double* locStartTimeVariance, DVector3* locBestProjPos, DVector3* locBestProjMom) const
 {
-	const DTrackTimeBased* locTrackTimeBased = dynamic_cast<const DTrackTimeBased*>(locTrack);
-	const DTrackWireBased* locTrackWireBased = dynamic_cast<const DTrackWireBased*>(locTrack);
-	if((locTrackTimeBased == NULL) && (locTrackWireBased == NULL))
-		return NULL;
-	const DReferenceTrajectory* locReferenceTrajectory = (locTrackTimeBased != NULL) ? locTrackTimeBased->rt : locTrackWireBased->rt;
-	if(locReferenceTrajectory == NULL)
-		return NULL;
+	if(rt == nullptr)
+		return false;
 
-	double locMinDistance = 9.9E9;
-	const DTOFPoint* locClosestTOFPoint = NULL;
-	double locInputStartTime = locTrack->t0();
+	//Loop over tof points
+	vector<DTOFHitMatchParams> locTOFHitMatchParamsVector;
+	vector<pair<DTOFHitMatchParams, pair<DVector3, DVector3> > > locMatchProjectionPairs;
 	for(size_t loc_i = 0; loc_i < locTOFPoints.size(); ++loc_i)
 	{
-		double locDistance = 0.0, locDeltaX = 0.0, locDeltaY = 0.0;
-		if(!Distance_ToTrack(locTOFPoints[loc_i], locReferenceTrajectory, locInputStartTime, locDeltaX, locDeltaY))
-			continue;
-		locDistance = sqrt(locDeltaX*locDeltaX + locDeltaY*locDeltaY);
-		if(locDistance > locMinDistance)
-			continue;
-		locMinDistance = locDistance;
-		locBestDeltaX = locDeltaX;
-		locBestDeltaY = locDeltaY;
-		locClosestTOFPoint = locTOFPoints[loc_i];
+		DTOFHitMatchParams locTOFHitMatchParams;
+		DVector3 locProjPos, locProjMom;
+		if(locCutFlag)
+		{
+			if(!Cut_MatchDistance(rt, locTOFPoints[loc_i], locStartTime, locTOFHitMatchParams, &locProjPos, &locProjMom))
+				continue;
+		}
+		else
+		{
+			if(!Distance_ToTrack(rt, locTOFPoints[loc_i], locStartTime, locTOFHitMatchParams, &locProjPos, &locProjMom))
+				continue;
+		}
+		locTOFHitMatchParamsVector.push_back(locTOFHitMatchParams);
+		pair<DTOFHitMatchParams, pair<DVector3, DVector3> > locMatchProjectionPair(locTOFHitMatchParams, pair<DVector3, DVector3>(locProjPos, locProjMom));
+		locMatchProjectionPairs.push_back(locMatchProjectionPair);
+	}
+	if(locTOFHitMatchParamsVector.empty())
+		return false;
+
+	locBestMatchParams = Get_BestTOFMatchParams(locTOFHitMatchParamsVector);
+
+	if(locStartTimeVariance != nullptr)
+	{
+		locStartTime = locBestMatchParams.dHitTime - locBestMatchParams.dFlightTime;
+	//	locTimeVariance = locBestMatchParams.dFlightTimeVariance + locBestMatchParams.dHitTimeVariance; //uncomment when ready!
+		*locStartTimeVariance = 0.1*0.1+locBestMatchParams.dFlightTimeVariance;
 	}
 
-	return locClosestTOFPoint;
+	if(locBestProjMom != nullptr)
+	{
+		for(auto& locMatchProjectionPair : locMatchProjectionPairs)
+		{
+			DTOFHitMatchParams locParams = locMatchProjectionPair.first;
+			if(locParams != locBestMatchParams)
+				continue;
+			*locBestProjPos = locMatchProjectionPair.second.first;
+			*locBestProjMom = locMatchProjectionPair.second.second;
+			break;
+		}
+	}
+
+	return true;
+}
+
+bool DParticleID::Get_ClosestToTrack(const DReferenceTrajectory* rt, const vector<const DFCALShower*>& locFCALShowers, bool locCutFlag, double& locStartTime, DFCALShowerMatchParams& locBestMatchParams, double* locStartTimeVariance, DVector3* locBestProjPos, DVector3* locBestProjMom) const
+{
+	if(rt == nullptr)
+		return false;
+
+	//Loop over FCAL showers
+	vector<DFCALShowerMatchParams> locShowerMatchParamsVector;
+	vector<pair<DFCALShowerMatchParams, pair<DVector3, DVector3> > > locMatchProjectionPairs;
+	for(size_t loc_i = 0; loc_i < locFCALShowers.size(); ++loc_i)
+	{
+		DFCALShowerMatchParams locShowerMatchParams;
+		DVector3 locProjPos, locProjMom;
+		if(locCutFlag)
+		{
+			if(!Cut_MatchDistance(rt, locFCALShowers[loc_i], locStartTime, locShowerMatchParams, &locProjPos, &locProjMom))
+				continue;
+		}
+		else
+		{
+			if(!Distance_ToTrack(rt, locFCALShowers[loc_i], locStartTime, locShowerMatchParams, &locProjPos, &locProjMom))
+				continue;
+		}
+		locShowerMatchParamsVector.push_back(locShowerMatchParams);
+		pair<DFCALShowerMatchParams, pair<DVector3, DVector3> > locMatchProjectionPair(locShowerMatchParams, pair<DVector3, DVector3>(locProjPos, locProjMom));
+		locMatchProjectionPairs.push_back(locMatchProjectionPair);
+	}
+	if(locShowerMatchParamsVector.empty())
+		return false;
+
+	locBestMatchParams = Get_BestFCALMatchParams(locShowerMatchParamsVector);
+
+	if(locStartTimeVariance != nullptr)
+	{
+		locStartTime = locBestMatchParams.dFCALShower->getTime() - locBestMatchParams.dFlightTime;
+	//	locTimeVariance = locBestMatchParams.dFlightTimeVariance + locBestMatchParams.dFCALShower->dCovarianceMatrix(4, 4); //uncomment when ready!
+		*locStartTimeVariance = 0.5*0.5+locBestMatchParams.dFlightTimeVariance;
+	}
+
+	if(locBestProjMom != nullptr)
+	{
+		for(auto& locMatchProjectionPair : locMatchProjectionPairs)
+		{
+			DFCALShowerMatchParams locParams = locMatchProjectionPair.first;
+			if(locParams != locBestMatchParams)
+				continue;
+			*locBestProjPos = locMatchProjectionPair.second.first;
+			*locBestProjMom = locMatchProjectionPair.second.second;
+			break;
+		}
+	}
+
+	return true;
+}
+
+bool DParticleID::Get_ClosestToTrack(const DReferenceTrajectory* rt, const vector<const DSCHit*>& locSCHits, bool locIsTimeBased, bool locCutFlag, double& locStartTime, DSCHitMatchParams& locBestMatchParams, double* locStartTimeVariance, DVector3* locBestProjPos, DVector3* locBestProjMom) const
+{
+	if(rt == nullptr)
+		return false;
+
+	//Loop over SC points
+	vector<DSCHitMatchParams> locSCHitMatchParamsVector;
+	vector<pair<DSCHitMatchParams, pair<DVector3, DVector3> > > locMatchProjectionPairs;
+	for(size_t loc_i = 0; loc_i < locSCHits.size(); ++loc_i)
+	{
+		DSCHitMatchParams locSCHitMatchParams;
+		DVector3 locProjPos, locProjMom;
+		if(locCutFlag)
+		{
+			if(!Cut_MatchDistance(rt, locSCHits[loc_i], locStartTime, locSCHitMatchParams, locIsTimeBased, &locProjPos, &locProjMom))
+				continue;
+		}
+		else
+		{
+			if(!Distance_ToTrack(rt, locSCHits[loc_i], locStartTime, locSCHitMatchParams, &locProjPos, &locProjMom))
+				continue;
+		}
+		locSCHitMatchParamsVector.push_back(locSCHitMatchParams);
+		pair<DSCHitMatchParams, pair<DVector3, DVector3> > locMatchProjectionPair(locSCHitMatchParams, pair<DVector3, DVector3>(locProjPos, locProjMom));
+		locMatchProjectionPairs.push_back(locMatchProjectionPair);
+	}
+	if(locSCHitMatchParamsVector.empty())
+		return false;
+
+	locBestMatchParams = Get_BestSCMatchParams(locSCHitMatchParamsVector);
+
+	if(locStartTimeVariance != nullptr)
+	{
+		locStartTime = locBestMatchParams.dHitTime - locBestMatchParams.dFlightTime;
+		*locStartTimeVariance = locBestMatchParams.dFlightTimeVariance + locBestMatchParams.dHitTimeVariance;
+		//locTimeVariance = 0.3*0.3+locBestMatchParams.dFlightTimeVariance;
+	}
+
+	if(locBestProjMom != nullptr)
+	{
+		for(auto& locMatchProjectionPair : locMatchProjectionPairs)
+		{
+			DSCHitMatchParams locParams = locMatchProjectionPair.first;
+			if(locParams != locBestMatchParams)
+				continue;
+			*locBestProjPos = locMatchProjectionPair.second.first;
+			*locBestProjMom = locMatchProjectionPair.second.second;
+			break;
+		}
+	}
+
+	return true;
 }
 
 const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Horizontal(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaY, double& locBestDistance) const
@@ -1761,33 +1562,123 @@ const DTOFPaddleHit* DParticleID::Get_ClosestTOFPaddleHit_Vertical(const DRefere
 	return locClosestPaddleHit;
 }
 
-const DSCHit* DParticleID::Get_ClosestToTrack_SC(const DKinematicData* locTrack, vector<const DSCHit*>& locSCHits, double& locBestDeltaPhi) const
+/********************************************************** PREDICT HIT ELEMENT **********************************************************/
+
+bool DParticleID::PredictFCALHit(const DReferenceTrajectory *rt, unsigned int &row, unsigned int &col, DVector3 *intersection) const
 {
-	const DTrackTimeBased* locTrackTimeBased = dynamic_cast<const DTrackTimeBased*>(locTrack);
-	const DTrackWireBased* locTrackWireBased = dynamic_cast<const DTrackWireBased*>(locTrack);
-	if((locTrackTimeBased == NULL) && (locTrackWireBased == NULL))
-		return NULL;
-	const DReferenceTrajectory* locReferenceTrajectory = (locTrackTimeBased != NULL) ? locTrackTimeBased->rt : locTrackWireBased->rt;
-	if(locReferenceTrajectory == NULL)
-		return NULL;
+	// Initialize output variables
+	row=0;
+	col=0;
+	if(rt == nullptr)
+		return false;
 
-	double locInputStartTime = locTrack->t0();
-	const DSCHit* locBestSCHit = NULL;
+	// Find intersection with FCAL plane given by fcal_pos
+	DVector3 fcal_pos(0,0,dFCALz);
+	DVector3 norm(0.0, 0.0, 1.0); //normal vector to FCAL plane
+	DVector3 proj_mom,proj_pos;
+	if(rt->GetIntersectionWithPlane(fcal_pos, norm, proj_pos, proj_mom, NULL,NULL,NULL,SYS_FCAL) != NOERROR)
+		return false;
 
-	locBestDeltaPhi = TMath::Pi();
-	for(size_t loc_i = 0; loc_i < locSCHits.size(); ++loc_i)
+	if (intersection) *intersection=proj_pos;
+
+	double x=proj_pos.x();
+	double y=proj_pos.y();
+	row=dFCALGeometry->row(float(y));
+	col=dFCALGeometry->column(float(x));
+	return (dFCALGeometry->isBlockActive(row,col));
+}
+
+// Given a reference trajectory from a track, predict which BCAL wedge should
+// have a hit
+bool DParticleID::PredictBCALWedge(const DReferenceTrajectory *rt, unsigned int &module,unsigned int &sector, DVector3 *intersection) const
+{
+	//initialize output variables
+	sector=0;
+	module=0;
+	if(rt == nullptr)
+		return false;
+
+	// Find intersection of track with inner radius of BCAL
+	DVector3 proj_pos;
+	if (rt->GetIntersectionWithRadius(65.0, proj_pos) != NOERROR)
+		return false;
+
+	double phi=180./M_PI*proj_pos.Phi();
+	if (phi<0) phi+=360.;
+	double slice=phi/7.5;
+	double mid_slice=round(slice);
+	module=int(mid_slice)+1;
+	sector=int(floor((phi-7.5*mid_slice+3.75)/1.875))+1;
+
+	if (intersection) *intersection=proj_pos;
+
+	return true;
+}
+
+// Given a reference trajectory from a track, predict which TOF paddles should
+// fire due to the charged particle passing through the TOF planes.
+bool DParticleID::PredictTOFPaddles(const DReferenceTrajectory *rt, unsigned int &hbar,unsigned int &vbar, DVector3 *intersection) const
+{
+	// Initialize output variables
+	vbar=0;
+	hbar=0;
+	if(rt == nullptr)
+		return false;
+
+	// Find intersection with TOF plane given by tof_pos
+	DVector3 tof_pos(0,0,dTOFGeometry->CenterMPlane);
+	DVector3 norm(0.0, 0.0, 1.0); //normal vector to TOF plane
+	DVector3 proj_mom,proj_pos;
+	if(rt->GetIntersectionWithPlane(tof_pos, norm, proj_pos, proj_mom, NULL,NULL,NULL,SYS_TOF) != NOERROR)
+		return false;
+
+	double x=proj_pos.x();
+	double y=proj_pos.y();
+
+	vbar=dTOFGeometry->y2bar(x);
+	hbar=dTOFGeometry->y2bar(y);
+
+	if (intersection) *intersection=proj_pos;
+
+	return true;
+}
+
+// Predict the start counter paddle that would match a track whose reference
+// trajectory is given by rt.
+unsigned int DParticleID::PredictSCSector(const DReferenceTrajectory* rt, DVector3* locOutputProjPos, bool* locProjBarrelRegion, double* locMinDPhi) const
+{
+	if(rt == nullptr)
+		return 0;
+
+	unsigned int locBestSCSector = 0;
+	double min_dphi=1e6;
+	DVector3 locProjPos, locProjMom, locPaddleNorm;
+	// loop over geometry for all SC paddles looking for track intersections
+	for(unsigned int locSCSector = 1; locSCSector <= 30; ++locSCSector)
 	{
-		double locDeltaPhi = 0.0;
-		if(!Distance_ToTrack(locSCHits[loc_i], locReferenceTrajectory, locInputStartTime, locDeltaPhi))
+		double locPathLength = 9.9E9, locFlightTime = 9.9E9, locFlightTimeVariance = 9.9E9, locDeltaPhi = 9.9E9;
+		if(!ProjectTo_SC(rt, locSCSector, locDeltaPhi, locProjPos, locProjMom, locPaddleNorm, locPathLength, locFlightTime, locFlightTimeVariance))
+			return 0;
+
+		if(fabs(locDeltaPhi) >= fabs(min_dphi))
 			continue;
-		if(fabs(locDeltaPhi) > fabs(locBestDeltaPhi))
-			continue;
-		locBestDeltaPhi = locDeltaPhi;
-		locBestSCHit = locSCHits[loc_i];
+
+		min_dphi = locDeltaPhi;
+		locBestSCSector = locSCSector;
 	}
 
-	return locBestSCHit;
+	if(locProjBarrelRegion != NULL)
+		*locProjBarrelRegion = (locProjPos.Z() < sc_pos[locBestSCSector - 1][1].Z()); // End of straight section
+
+	if(locMinDPhi != NULL)
+		*locMinDPhi = min_dphi;
+
+	if(locOutputProjPos != NULL)
+		*locOutputProjPos = locProjPos;
+	return locBestSCSector;
 }
+
+/****************************************************** MISCELLANEOUS ******************************************************/
 
 double DParticleID::Calc_BCALFlightTimePCorrelation(const DKinematicData* locTrack, DDetectorMatches* locDetectorMatches) const
 {
@@ -1985,4 +1876,3 @@ Particle_t DParticleID::IDTrack(float locCharge, float locMass) const
 	}
 	return Unknown;
 }
-

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -159,10 +159,10 @@ class DParticleID:public jana::JObject
 		double dA_CDC;
 		double dA_FDC;
 
-		double BCAL_Z_CUT,BCAL_PHI_CUT_PAR1,BCAL_PHI_CUT_PAR2;
-		double BCAL_PHI_CUT_PAR3;
+		double BCAL_Z_CUT,BCAL_PHI_CUT_PAR1,BCAL_PHI_CUT_PAR2, BCAL_PHI_CUT_PAR3;
 		double FCAL_CUT_PAR1,FCAL_CUT_PAR2;
 		double TOF_CUT_PAR1, TOF_CUT_PAR2, TOF_CUT_PAR3;
+		vector<double> dSCCutPars_TimeBased, dSCCutPars_WireBased;
 
 		double DELTA_R_FCAL;
 		double C_EFFECTIVE; // start counter light propagation speed
@@ -219,7 +219,6 @@ class DParticleID:public jana::JObject
 		double ONESIDED_PADDLE_MIDPOINT_MAG; //+/- this number for North/South
 
 		double dTargetZCenter;
-		double SC_DPHI_CUT,SC_DPHI_CUT_WB,SC_DPHI_CUT_SLOPE;
 
 		const DTrackFinder *finder;
 		DTOFPoint_factory* dTOFPointFactory;

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -46,110 +46,110 @@
 
 class DTrackTimeBased;
 
-class DParticleID:public jana::JObject{
- public:
-  JOBJECT_PUBLIC(DParticleID);
- 
-  // Constructor and destructor
-  DParticleID(JEventLoop *loop); // require JEventLoop in constructor
-  virtual ~DParticleID(void){}
+class DParticleID:public jana::JObject
+{
+	public:
+		JOBJECT_PUBLIC(DParticleID);
 
-  class dedx_t{
-  public:
-  dedx_t(double dE,double dx, double p):dE(dE),dx(dx),p(p){dEdx = dE/dx;}
-      double dE; // energy loss in layer
-      double dx; // path length in layer
-      double dEdx; // ratio dE/dx
-      double p;  // momentum at this dE/dx measurement
-  };
+		// Constructor and destructor
+		DParticleID(JEventLoop *loop); // require JEventLoop in constructor
+		virtual ~DParticleID(void){}
 
-  virtual jerror_t CalcDCdEdxChiSq(DChargedTrackHypothesis *locChargedTrackHypothesis) const = 0;
+		class dedx_t
+		{
+			public:
+				dedx_t(double dE,double dx, double p):dE(dE),dx(dx),p(p){dEdx = dE/dx;}
+				double dE; // energy loss in layer
+				double dx; // path length in layer
+				double dEdx; // ratio dE/dx
+				double p;  // momentum at this dE/dx measurement
+		};
 
-  jerror_t GetDCdEdxHits(const DTrackTimeBased *track, vector<dedx_t>& dEdxHits_CDC, vector<dedx_t>& dEdxHits_FDC) const;
-  jerror_t CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const;
-  jerror_t CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, const vector<dedx_t>& locdEdxHits_CDC, const vector<dedx_t>& locdEdxHits_FDC, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const;
+		virtual jerror_t CalcDCdEdxChiSq(DChargedTrackHypothesis *locChargedTrackHypothesis) const = 0;
 
-  jerror_t CalcdEdxHit(const DVector3 &mom, const DVector3 &pos, const DCDCTrackHit *hit, pair <double,double> &dedx) const;
-  jerror_t GroupTracks(vector<const DTrackTimeBased *> &tracks, vector<vector<const DTrackTimeBased*> >&grouped_tracks) const;
+		jerror_t GetDCdEdxHits(const DTrackTimeBased *track, vector<dedx_t>& dEdxHits_CDC, vector<dedx_t>& dEdxHits_FDC) const;
+		jerror_t CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const;
+		jerror_t CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, const vector<dedx_t>& locdEdxHits_CDC, const vector<dedx_t>& locdEdxHits_FDC, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const;
 
-  void GetScintMPdEandSigma(double p,double M,double x,double &most_prob_dE, double &sigma_dE) const;
-  double GetMostProbabledEdx_DC(double p,double mass,double dx, bool locIsCDCFlag) const; //bool is false for FDC
-  double GetdEdxSigma_DC(double num_hits,double p,double mass, double mean_path_length, bool locIsCDCFlag) const; //bool is false for FDC
+		jerror_t CalcdEdxHit(const DVector3 &mom, const DVector3 &pos, const DCDCTrackHit *hit, pair <double,double> &dedx) const;
+		jerror_t GroupTracks(vector<const DTrackTimeBased *> &tracks, vector<vector<const DTrackTimeBased*> >&grouped_tracks) const;
 
-	//called by track reconstruction
-	bool MatchToTOF(const DReferenceTrajectory* rt, const vector<const DTOFPoint*>& locTOFPoints, double& locStartTime, double& locTimeVariance) const;
-	bool MatchToBCAL(const DReferenceTrajectory* rt, const vector<const DBCALShower*>& locBCALShowers, double& locStartTime, double& locTimeVariance) const;
-	bool MatchToFCAL(const DReferenceTrajectory* rt, const vector<const DFCALShower*>& locFCALShowers, double& locStartTime, double& locTimeVariance) const;
-	bool MatchToSC(const DReferenceTrajectory* rt, const vector<const DSCHit*>& locSCHits, double& locStartTime, double& locTimeVariance, bool locIsTimeBased=false) const;
+		void GetScintMPdEandSigma(double p,double M,double x,double &most_prob_dE, double &sigma_dE) const;
+		double GetMostProbabledEdx_DC(double p,double mass,double dx, bool locIsCDCFlag) const; //bool is false for FDC
+		double GetdEdxSigma_DC(double num_hits,double p,double mass, double mean_path_length, bool locIsCDCFlag) const; //bool is false for FDC
 
-	// Routines to predict which detector elements should fire given a track
-		//SC locProjBarrelRegion = true/false for barrel / (bend / nose) regions
-	unsigned int PredictSCSector(const DReferenceTrajectory* rt, const double dphi_cut, DVector3* locProjPos = NULL, bool* locProjBarrelRegion = NULL, double* locMinDPhi = NULL) const;
-	bool PredictTOFPaddles(const DReferenceTrajectory *rt,
-			       unsigned int &hbar,unsigned int &vbar,
-			       DVector3 *intersection=NULL) const;
-	bool PredictFCALHit(const DReferenceTrajectory *rt,
-			    unsigned int &row, unsigned int &col,
-			    DVector3 *intersection=NULL) const;
-	bool PredictBCALWedge(const DReferenceTrajectory *rt,
-			      unsigned int &module,unsigned int &sector,
-			      DVector3 *intersection=NULL) const;
+		/****************************************************** DISTANCE TO TRACK ******************************************************/
 
-	//matching tracks to hits/showers routines (can be called by DDetectorMatches factory)
-	bool MatchToBCAL(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DBCALShower* locBCALShower, double locInputStartTime, DBCALShowerMatchParams& locShowerMatchParams) const;
-	bool MatchToTOF(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DTOFPoint* locTOFPoint, double locInputStartTime, DTOFHitMatchParams& locTOFHitMatchParams) const;
-	bool MatchToFCAL(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DFCALShower* locFCALShower, double locInputStartTime, DFCALShowerMatchParams& locShowerMatchParams) const;
-	bool MatchToSC(const DKinematicData* locTrack, const DReferenceTrajectory* rt, const DSCHit* locSCHit, double locInputStartTime, DSCHitMatchParams& locSCHitMatchParams, bool locIsTimeBased=false, const float* locInputDeltaPhiCut=NULL, DVector3 *IntersectionPoint=NULL, DVector3 *IntersectionDir=NULL) const;
+		// NOTE: For these functions, an initial guess for start time is expected as input so that out-of-time tracks can be skipped
+		bool Distance_ToTrack(const DReferenceTrajectory* rt, const DFCALShower* locFCALShower, double locInputStartTime, DFCALShowerMatchParams& locShowerMatchParams, DVector3* locOutputProjPos = nullptr, DVector3* locOutputProjMom = nullptr) const;
+		bool Distance_ToTrack(const DReferenceTrajectory* rt, const DBCALShower* locBCALShower, double locInputStartTime, DBCALShowerMatchParams& locShowerMatchParams, DVector3* locOutputProjPos = nullptr, DVector3* locOutputProjMom = nullptr) const;
+		bool Distance_ToTrack(const DReferenceTrajectory* rt, const DTOFPoint* locTOFPoint, double locInputStartTime, DTOFHitMatchParams& locTOFHitMatchParams, DVector3* locOutputProjPos = nullptr, DVector3* locOutputProjMom = nullptr) const;
+		bool Distance_ToTrack(const DReferenceTrajectory* rt, const DSCHit* locSCHit, double locInputStartTime, DSCHitMatchParams& locSCHitMatchParams, DVector3* locOutputProjPos = nullptr, DVector3* locOutputProjMom = nullptr) const;
+		bool ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locSCSector, double& locDeltaPhi, DVector3& locProjPos, DVector3& locProjMom, DVector3& locPaddleNorm, double& locPathLength, double& locFlightTime, double& locFlightTimeVariance) const;
 
-	//select "best" matches //called by several factories
-	bool Get_BestSCMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DSCHitMatchParams& locBestMatchParams) const;
-	void Get_BestSCMatchParams(vector<DSCHitMatchParams>& locSCHitMatchParams, DSCHitMatchParams& locBestMatchParams) const;
-	bool Get_BestBCALMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DBCALShowerMatchParams& locBestMatchParams) const;
-	void Get_BestBCALMatchParams(DVector3 locMomentum, vector<DBCALShowerMatchParams>& locShowerMatchParams, DBCALShowerMatchParams& locBestMatchParams) const;
-	bool Get_BestTOFMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DTOFHitMatchParams& locBestMatchParams) const;
-	void Get_BestTOFMatchParams(vector<DTOFHitMatchParams>& locTOFHitMatchParams, DTOFHitMatchParams& locBestMatchParams) const;
-	bool Get_BestFCALMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DFCALShowerMatchParams& locBestMatchParams) const;
-	void Get_BestFCALMatchParams(vector<DFCALShowerMatchParams>& locShowerMatchParams, DFCALShowerMatchParams& locBestMatchParams) const;
+		/********************************************************** CUT MATCH DISTANCE **********************************************************/
 
-	//matching showers to tracks routines (mostly called by DDetectorMatches factory)
-	bool Distance_ToTrack(const DBCALShower* locBCALShower, const DReferenceTrajectory* rt, double locInputStartTime, double& locDistance, double& locDeltaPhi, double& locDeltaZ) const;
-	bool Distance_ToTrack(const DBCALShower* locBCALShower, const DReferenceTrajectory* rt, double locInputStartTime, double& locDistance, double& locDeltaPhi, double& locDeltaZ, double& locProjectedZ, double& locFlightTime, double& locFlightTimeVariance, double &locPathLength) const;
-	bool Distance_ToTrack(const DFCALShower* locFCALShower, const DReferenceTrajectory* rt, double locInputStartTime, double& locDistance) const;
-	bool Distance_ToTrack(const DTOFPoint* locTOFPoint, const DReferenceTrajectory* rt, double locInputStartTime, double& locDeltaX, double& locDeltaY) const;
-	bool Distance_ToTrack(const DSCHit* locSCHit, const DReferenceTrajectory* rt, double locInputStartTime, double& locDeltaPhi) const;
+		// NOTE: For these functions, an initial guess for start time is expected as input so that out-of-time tracks can be skipped
+		bool Cut_MatchDistance(const DReferenceTrajectory* rt, const DBCALShower* locBCALShower, double locInputStartTime, DBCALShowerMatchParams& locShowerMatchParams, DVector3 *locOutputProjPos = nullptr, DVector3 *locOutputProjMom = nullptr) const;
+		bool Cut_MatchDistance(const DReferenceTrajectory* rt, const DTOFPoint* locTOFPoint, double locInputStartTime, DTOFHitMatchParams& locTOFHitMatchParams, DVector3 *locOutputProjPos = nullptr, DVector3 *locOutputProjMom = nullptr) const;
+		bool Cut_MatchDistance(const DReferenceTrajectory* rt, const DSCHit* locSCHit, double locInputStartTime, DSCHitMatchParams& locSCHitMatchParams, bool locIsTimeBased, DVector3 *locOutputProjPos = nullptr, DVector3 *locOutputProjMom = nullptr) const;
+		bool Cut_MatchDistance(const DReferenceTrajectory* rt, const DFCALShower* locFCALShower, double locInputStartTime, DFCALShowerMatchParams& locShowerMatchParams, DVector3 *locOutputProjPos = nullptr, DVector3 *locOutputProjMom = nullptr) const;
 
-	//select closest shower/hit to track //track MUST be either DTrackTimeBased or DTrackWireBased //NULL if no possibly-valid matches
-	const DBCALShower* Get_ClosestToTrack_BCAL(const DKinematicData* locTrack, vector<const DBCALShower*>& locBCALShowers, double& locBestMatchDeltaPhi, double& locBestMatchDeltaZ) const;
-	const DFCALShower* Get_ClosestToTrack_FCAL(const DKinematicData* locTrack, vector<const DFCALShower*>& locFCALShowers, double& locBestDistance) const;
-	const DSCHit* Get_ClosestToTrack_SC(const DKinematicData* locTrack, vector<const DSCHit*>& locSCHits, double& locBestDeltaPhi) const;
-	const DTOFPoint* Get_ClosestToTrack_TOFPoint(const DKinematicData* locTrack, vector<const DTOFPoint*>& locTOFPoints, double& locBestDeltaX, double& locBestDeltaY) const;
+		/********************************************************** GET BEST MATCH **********************************************************/
 
-	//first in pair is vertical, second is horizontal // NULL If none / doesn't hit TOF
-	const DTOFPaddleHit* Get_ClosestTOFPaddleHit_Horizontal(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaY, double& locBestDistance) const;
-	const DTOFPaddleHit* Get_ClosestTOFPaddleHit_Vertical(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaX, double& locBestDistance) const;
+		// Wrappers
+		bool Get_BestBCALMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DBCALShowerMatchParams& locBestMatchParams) const;
+		bool Get_BestSCMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DSCHitMatchParams& locBestMatchParams) const;
+		bool Get_BestTOFMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DTOFHitMatchParams& locBestMatchParams) const;
+		bool Get_BestFCALMatchParams(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches, DFCALShowerMatchParams& locBestMatchParams) const;
 
-	double Calc_BCALFlightTimePCorrelation(const DKinematicData* locTrack, DDetectorMatches* locDetectorMatches) const;
-	double Calc_FCALFlightTimePCorrelation(const DKinematicData* locTrack, DDetectorMatches* locDetectorMatches) const;
-	double Calc_TOFFlightTimePCorrelation(const DKinematicData* locTrack, DDetectorMatches* locDetectorMatches) const;
-	double Calc_SCFlightTimePCorrelation(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches) const;
+		// Actual
+		DBCALShowerMatchParams Get_BestBCALMatchParams(DVector3 locMomentum, vector<DBCALShowerMatchParams>& locShowerMatchParams) const;
+		DSCHitMatchParams Get_BestSCMatchParams(vector<DSCHitMatchParams>& locSCHitMatchParams) const;
+		DTOFHitMatchParams Get_BestTOFMatchParams(vector<DTOFHitMatchParams>& locTOFHitMatchParams) const;
+		DFCALShowerMatchParams Get_BestFCALMatchParams(vector<DFCALShowerMatchParams>& locShowerMatchParams) const;
 
-	virtual Particle_t IDTrack(float locCharge, float locMass) const;
+		/********************************************************** GET CLOSEST TO TRACK **********************************************************/
 
-	double Calc_PropagatedRFTime(const DKinematicData* locKinematicData, const DEventRFBunch* locEventRFBunch) const;
-	double Calc_TimingChiSq(const DKinematicData* locKinematicData, unsigned int &locNDF, double& locTimingPull) const;
-	void Calc_ChargedPIDFOM(DChargedTrackHypothesis* locChargedTrackHypothesis, const DEventRFBunch* locEventRFBunch) const;
+		// NOTE: an initial guess for start time is expected as input so that out-of-time hits can be skipped
+		bool Get_ClosestToTrack(const DReferenceTrajectory* rt, const vector<const DBCALShower*>& locBCALShowers, bool locCutFlag, double& locStartTime, DBCALShowerMatchParams& locBestMatchParams, double* locStartTimeVariance = nullptr, DVector3* locBestProjPos = nullptr, DVector3* locBestProjMom = nullptr) const;
+		bool Get_ClosestToTrack(const DReferenceTrajectory* rt, const vector<const DTOFPoint*>& locTOFPoints, bool locCutFlag, double& locStartTime, DTOFHitMatchParams& locBestMatchParams, double* locStartTimeVariance = nullptr, DVector3* locBestProjPos = nullptr, DVector3* locBestProjMom = nullptr) const;
+		bool Get_ClosestToTrack(const DReferenceTrajectory* rt, const vector<const DFCALShower*>& locFCALShowers, bool locCutFlag, double& locStartTime, DFCALShowerMatchParams& locBestMatchParams, double* locStartTimeVariance = nullptr, DVector3* locBestProjPos = nullptr, DVector3* locBestProjMom = nullptr) const;
+		bool Get_ClosestToTrack(const DReferenceTrajectory* rt, const vector<const DSCHit*>& locSCHits, bool locIsTimeBased, bool locCutFlag, double& locStartTime, DSCHitMatchParams& locBestMatchParams, double* locStartTimeVariance = nullptr, DVector3* locBestProjPos = nullptr, DVector3* locBestProjMom = nullptr) const;
+		const DTOFPaddleHit* Get_ClosestTOFPaddleHit_Horizontal(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaY, double& locBestDistance) const;
+		const DTOFPaddleHit* Get_ClosestTOFPaddleHit_Vertical(const DReferenceTrajectory* locReferenceTrajectory, const vector<const DTOFPaddleHit*>& locTOFPaddleHits, double locInputStartTime, double& locBestDeltaX, double& locBestDistance) const;
 
-	unsigned int Get_CDCRingBitPattern(vector<const DCDCTrackHit*>& locCDCTrackHits) const;
-	unsigned int Get_FDCPlaneBitPattern(vector<const DFDCPseudo*>& locFDCPseudos) const;
-	void Get_CDCRings(int locBitPattern, set<int>& locCDCRings) const;
-	void Get_FDCPlanes(int locBitPattern, set<int>& locFDCPlanes) const;
+		/********************************************************** PREDICT HIT ELEMENT **********************************************************/
 
-	void Get_CDCNumHitRingsPerSuperlayer(int locBitPattern, map<int, int>& locNumHitRingsPerSuperlayer) const;
-	void Get_CDCNumHitRingsPerSuperlayer(const set<int>& locCDCRings, map<int, int>& locNumHitRingsPerSuperlayer) const;
-	void Get_FDCNumHitPlanesPerPackage(int locBitPattern, map<int, int>& locNumHitPlanesPerPackage) const;
-	void Get_FDCNumHitPlanesPerPackage(const set<int>& locFDCPlanes, map<int, int>& locNumHitPlanesPerPackage) const;
+		bool PredictFCALHit(const DReferenceTrajectory *rt, unsigned int &row, unsigned int &col, DVector3 *intersection = nullptr) const;
+		bool PredictBCALWedge(const DReferenceTrajectory *rt, unsigned int &module,unsigned int &sector, DVector3 *intersection = nullptr) const;
+		bool PredictTOFPaddles(const DReferenceTrajectory *rt, unsigned int &hbar,unsigned int &vbar, DVector3 *intersection = nullptr) const;
+		unsigned int PredictSCSector(const DReferenceTrajectory* rt, DVector3* locOutputProjPos = nullptr, bool* locProjBarrelRegion = nullptr, double* locMinDPhi = nullptr) const;
 
-  protected:
+		/********************************************************** MISCELLANEOUS **********************************************************/
+
+		double Calc_BCALFlightTimePCorrelation(const DKinematicData* locTrack, DDetectorMatches* locDetectorMatches) const;
+		double Calc_FCALFlightTimePCorrelation(const DKinematicData* locTrack, DDetectorMatches* locDetectorMatches) const;
+		double Calc_TOFFlightTimePCorrelation(const DKinematicData* locTrack, DDetectorMatches* locDetectorMatches) const;
+		double Calc_SCFlightTimePCorrelation(const DKinematicData* locTrack, const DDetectorMatches* locDetectorMatches) const;
+
+		virtual Particle_t IDTrack(float locCharge, float locMass) const;
+
+		double Calc_PropagatedRFTime(const DKinematicData* locKinematicData, const DEventRFBunch* locEventRFBunch) const;
+		double Calc_TimingChiSq(const DKinematicData* locKinematicData, unsigned int &locNDF, double& locTimingPull) const;
+		void Calc_ChargedPIDFOM(DChargedTrackHypothesis* locChargedTrackHypothesis, const DEventRFBunch* locEventRFBunch) const;
+
+		unsigned int Get_CDCRingBitPattern(vector<const DCDCTrackHit*>& locCDCTrackHits) const;
+		unsigned int Get_FDCPlaneBitPattern(vector<const DFDCPseudo*>& locFDCPseudos) const;
+		void Get_CDCRings(int locBitPattern, set<int>& locCDCRings) const;
+		void Get_FDCPlanes(int locBitPattern, set<int>& locFDCPlanes) const;
+
+		void Get_CDCNumHitRingsPerSuperlayer(int locBitPattern, map<int, int>& locNumHitRingsPerSuperlayer) const;
+		void Get_CDCNumHitRingsPerSuperlayer(const set<int>& locCDCRings, map<int, int>& locNumHitRingsPerSuperlayer) const;
+		void Get_FDCNumHitPlanesPerPackage(int locBitPattern, map<int, int>& locNumHitPlanesPerPackage) const;
+		void Get_FDCNumHitPlanesPerPackage(const set<int>& locFDCPlanes, map<int, int>& locNumHitPlanesPerPackage) const;
+
+	protected:
 		// gas material properties
 		double dKRhoZoverA_FDC, dRhoZoverA_FDC, dLnI_FDC;	
 		double dKRhoZoverA_Scint, dRhoZoverA_Scint, dLnI_Scint;
@@ -169,60 +169,60 @@ class DParticleID:public jana::JObject{
 		double ATTEN_LENGTH; // Start counter attenuation length
 		double OUT_OF_TIME_CUT; //for all matches
 
- private: 
- 
-  int DEBUG_LEVEL;
-  // Prohibit default constructor
-  DParticleID();
-  
-	// start counter geometry parameters
-	double sc_leg_tcor;
-	double sc_angle_cor;
-	vector<vector<DVector3> >sc_dir; // direction vector in plane of plastic
-	vector<vector<DVector3> >sc_pos;
-	vector<vector<DVector3> >sc_norm;
-	double dSCdphi;
-	double dSCphi0;
-	// start counter calibration parameters
-	// Propagation time (pt) parameters
-	enum sc_region_t{
-	  SC_STRAIGHT,
-	  SC_BEND,
-	  SC_NOSE,
-	};
-	vector<double>sc_veff[3];
-	vector<double>sc_pt_yint[3];
-	vector<double>sc_pt_slope[3];
-	// Attenuation (attn) calibration paramerters
-	enum sc_region_attn{
-	  SC_STRAIGHT_ATTN,
-	  SC_BENDNOSE_ATTN,
-	};
-	vector<double> sc_attn_A[2];
-	vector<double> sc_attn_B[2];
-	vector<double> sc_attn_C[2];
+	private:
 
-    vector<double> sc_paddle_resols;
+		int DEBUG_LEVEL;
+		// Prohibit default constructor
+		DParticleID();
 
-	// FCAL geometry
-	double dFCALz;
-	const DFCALGeometry *dFCALGeometry;
+		// start counter geometry parameters
+		double sc_leg_tcor;
+		double sc_angle_cor;
+		vector<vector<DVector3> >sc_dir; // direction vector in plane of plastic
+		vector<vector<DVector3> >sc_pos;
+		vector<vector<DVector3> >sc_norm;
+		double dSCdphi;
+		double dSCphi0;
+		// start counter calibration parameters
+		// Propagation time (pt) parameters
+		enum sc_region_t{
+			SC_STRAIGHT,
+			SC_BEND,
+			SC_NOSE,
+		};
+		vector<double>sc_veff[3];
+		vector<double>sc_pt_yint[3];
+		vector<double>sc_pt_slope[3];
+		// Attenuation (attn) calibration paramerters
+		enum sc_region_attn{
+			SC_STRAIGHT_ATTN,
+			SC_BENDNOSE_ATTN,
+		};
+		vector<double> sc_attn_A[2];
+		vector<double> sc_attn_B[2];
+		vector<double> sc_attn_C[2];
 
-	// TOF calibration constants
+		vector<double> sc_paddle_resols;
+
+		// FCAL geometry
+		double dFCALz;
+		const DFCALGeometry *dFCALGeometry;
+
+		// TOF calibration constants
 		// used to update hit energy & time when matching to un-matched, position-ill-defined bars
-	const DTOFGeometry* dTOFGeometry;
-	vector<double> propagation_speed;
-	double TOF_HALFPADDLE;
-	double dHalfPaddle_OneSided;
-	double TOF_ATTEN_LENGTH;
-	double TOF_E_THRESHOLD;
-	double ONESIDED_PADDLE_MIDPOINT_MAG; //+/- this number for North/South
+		const DTOFGeometry* dTOFGeometry;
+		vector<double> propagation_speed;
+		double TOF_HALFPADDLE;
+		double dHalfPaddle_OneSided;
+		double TOF_ATTEN_LENGTH;
+		double TOF_E_THRESHOLD;
+		double ONESIDED_PADDLE_MIDPOINT_MAG; //+/- this number for North/South
 
-  double dTargetZCenter;
-  double SC_DPHI_CUT,SC_DPHI_CUT_WB,SC_DPHI_CUT_SLOPE;
+		double dTargetZCenter;
+		double SC_DPHI_CUT,SC_DPHI_CUT_WB,SC_DPHI_CUT_SLOPE;
 
-  const DTrackFinder *finder;
-  DTOFPoint_factory* dTOFPointFactory;
+		const DTrackFinder *finder;
+		DTOFPoint_factory* dTOFPointFactory;
 };
 
 #endif // _DParticleID_

--- a/src/libraries/TRACKING/DReferenceTrajectory.cc
+++ b/src/libraries/TRACKING/DReferenceTrajectory.cc
@@ -467,9 +467,9 @@ void DReferenceTrajectory::FastSwim(const DVector3 &pos, const DVector3 &mom, do
     // Exit loop if we leave the tracking volume
     if (z>zmax){Nswim_steps++; break;} 
     if(Rsq>Rsqmax_exterior && z<407.0){Nswim_steps++; break;} // ran into BCAL
-    if (fabs(swim_step->origin.X())>129.  
-	|| fabs(swim_step->origin.Y())>129.)
-      {Nswim_steps++; break;} // left extent of TOF 
+    if (fabs(swim_step->origin.X())>160.0
+	|| fabs(swim_step->origin.Y())>160.0)
+      {Nswim_steps++; break;} // left extent of TOF + 31cm Buffer
     if(z>670.0){Nswim_steps++; break;} // ran into FCAL
     if(z<zmin){Nswim_steps++; break;} // exit upstream
     
@@ -746,9 +746,9 @@ void DReferenceTrajectory::Swim(const DVector3 &pos, const DVector3 &mom, double
 		
 		// Exit loop if we leave the tracking volume
 		if(Rsq>Rsqmax_exterior && z<407.0){Nswim_steps++; break;} // ran into BCAL
-		if (fabs(swim_step->origin.X())>129.  
-		    || fabs(swim_step->origin.Y())>129.)
-		  {Nswim_steps++; break;} // left extent of TOF 
+		if (fabs(swim_step->origin.X())>160.0
+		    || fabs(swim_step->origin.Y())>160.0)
+		  {Nswim_steps++; break;} // left extent of TOF + 31cm Buffer
 		if(z>zmax_track_boundary){Nswim_steps++; break;} // ran into FCAL
 		if(z<zmin_track_boundary){Nswim_steps++; break;} // exit upstream
 		if(wire && Nswim_steps>0){ // optionally check if we passed a wire we're supposed to be swimming to

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -757,43 +757,49 @@ void DTrackTimeBased_factory
   start_times.push_back(start_time);
 
   // Match to the start counter and the outer detectors
-  double locTimeVariance = 0.0, locStartTime = track->t0();  // initial guess from tracking
-  if(pid_algorithm->MatchToSC(track->rt, sc_hits, locStartTime, locTimeVariance))
+  double locStartTimeVariance = 0.0, locStartTime = track->t0();  // initial guess from tracking
+  DSCHitMatchParams locSCBestMatchParams;
+  if(pid_algorithm->Get_ClosestToTrack(track->rt, sc_hits, false, true, locStartTime, locSCBestMatchParams, &locStartTimeVariance))
   {
     // Fill in the start time vector
     start_time.t0=locStartTime;
 //    start_time.t0_sigma=sqrt(locTimeVariance); //uncomment when ready
-    start_time.t0_sigma=0.3;
+    start_time.t0_sigma=sqrt(locStartTimeVariance);
     start_time.system=SYS_START;
     start_times.push_back(start_time); 
   }
 
   locStartTime = track->t0();
-  if (pid_algorithm->MatchToTOF(track->rt, tof_points, locStartTime, locTimeVariance))
+  DTOFHitMatchParams locTOFBestMatchParams;
+  if(pid_algorithm->Get_ClosestToTrack(track->rt, tof_points, true, locStartTime, locTOFBestMatchParams, &locStartTimeVariance))
   {
     // Fill in the start time vector
     start_time.t0=locStartTime;
-    start_time.t0_sigma=0.1;
+    start_time.t0_sigma=sqrt(locStartTimeVariance);
 //    start_time.t0_sigma=sqrt(locTimeVariance); //uncomment when ready
     start_time.system=SYS_TOF;
     start_times.push_back(start_time); 
   }
+
   locStartTime = track->t0();
-  if (pid_algorithm->MatchToBCAL(track->rt, bcal_showers, locStartTime, locTimeVariance))
+  DBCALShowerMatchParams locBCALBestMatchParams;
+  if(pid_algorithm->Get_ClosestToTrack(track->rt, bcal_showers, true, locStartTime, locBCALBestMatchParams, &locStartTimeVariance))
   {
     // Fill in the start time vector
     start_time.t0=locStartTime;
-    start_time.t0_sigma=0.5;
+    start_time.t0_sigma=sqrt(locStartTimeVariance);
 //    start_time.t0_sigma=sqrt(locTimeVariance); //uncomment when ready
     start_time.system=SYS_BCAL;
     start_times.push_back(start_time);
   }
+
   locStartTime = track->t0();
-  if (pid_algorithm->MatchToFCAL(track->rt, fcal_showers, locStartTime, locTimeVariance))
+  DFCALShowerMatchParams locFCALBestMatchParams;
+  if(pid_algorithm->Get_ClosestToTrack(track->rt, fcal_showers, true, locStartTime, locFCALBestMatchParams, &locStartTimeVariance))
   {
     // Fill in the start time vector
     start_time.t0=locStartTime;
-    start_time.t0_sigma=0.5;
+    start_time.t0_sigma=sqrt(locStartTimeVariance);
 //    start_time.t0_sigma=sqrt(locTimeVariance); //uncomment when ready
     start_time.system=SYS_FCAL;
     start_times.push_back(start_time);

--- a/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.cc
+++ b/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.cc
@@ -279,18 +279,9 @@ void DReaction_factory_ReactionFilter::Define_LooseCuts(void)
 	dPIDTimingCuts[Electron][SYS_BCAL] = 1.0;
 	dPIDTimingCuts[Electron][SYS_FCAL] = 2.5;
 	dPIDTimingCuts[Electron][SYS_TOF] = 2.5;
-
-	dPIDTimingCuts[Positron][SYS_BCAL] = 1.0;
-	dPIDTimingCuts[Positron][SYS_FCAL] = 2.5;
-	dPIDTimingCuts[Positron][SYS_TOF] = 2.5;
-
-	dPIDTimingCuts[MuonMinus][SYS_BCAL] = 1.0;
-	dPIDTimingCuts[MuonMinus][SYS_FCAL] = 2.5;
-	dPIDTimingCuts[MuonMinus][SYS_TOF] = 2.5;
-
-	dPIDTimingCuts[MuonPlus][SYS_BCAL] = 1.0;
-	dPIDTimingCuts[MuonPlus][SYS_FCAL] = 2.5;
-	dPIDTimingCuts[MuonPlus][SYS_TOF] = 2.5;
+	dPIDTimingCuts[Positron] = dPIDTimingCuts[Electron];
+	dPIDTimingCuts[MuonMinus] = dPIDTimingCuts[Electron];
+	dPIDTimingCuts[MuonPlus] = dPIDTimingCuts[Electron];
 
 	// Timing Cuts: Mesons
 	dPIDTimingCuts[PiPlus][SYS_BCAL] = 2.0;
@@ -304,19 +295,14 @@ void DReaction_factory_ReactionFilter::Define_LooseCuts(void)
 	dPIDTimingCuts[KPlus][SYS_BCAL] = 0.75;
 	dPIDTimingCuts[KPlus][SYS_FCAL] = 2.5;
 	dPIDTimingCuts[KPlus][SYS_TOF] = 2.0;
-
-	dPIDTimingCuts[KMinus][SYS_BCAL] = 0.75;
-	dPIDTimingCuts[KMinus][SYS_FCAL] = 2.5;
-	dPIDTimingCuts[KMinus][SYS_TOF] = 2.0;
+	dPIDTimingCuts[KMinus] = dPIDTimingCuts[KPlus];
 
 	// Timing Cuts: Baryons
 	dPIDTimingCuts[Proton][SYS_BCAL] = 2.5;
 	dPIDTimingCuts[Proton][SYS_FCAL] = 2.5;
 	dPIDTimingCuts[Proton][SYS_TOF] = 2.5;
 
-	dPIDTimingCuts[AntiProton][SYS_BCAL] = 2.5;
-	dPIDTimingCuts[AntiProton][SYS_FCAL] = 2.5;
-	dPIDTimingCuts[AntiProton][SYS_TOF] = 2.5;
+	dPIDTimingCuts[AntiProton] = dPIDTimingCuts[Proton];
 }
 
 void DReaction_factory_ReactionFilter::Add_PreComboCuts(DReaction* locReaction, FSInfo* locFSInfo)

--- a/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.cc
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.cc
@@ -300,7 +300,8 @@ jerror_t JEventProcessor_BCAL_TDC_Timing::evnt(JEventLoop *loop, uint64_t eventn
       if (bcalMatch == NULL) continue; 
 
       // We also need the reference trajectory, which is buried deep in there
-      const DTrackTimeBased *timeBasedTrack = (const DTrackTimeBased *) bcalMatch->dTrack;
+      const DTrackTimeBased *timeBasedTrack = nullptr;
+      bestHypothesis->GetSingle(timeBasedTrack);
       const DReferenceTrajectory *rt = timeBasedTrack->rt;
 
 	  // Use CDC dEdx to help reject protons

--- a/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.cc
+++ b/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.cc
@@ -296,15 +296,8 @@ jerror_t JEventProcessor_ST_Propagation_Time::evnt(JEventLoop *loop, uint64_t ev
           bool sc_match = locDetectorMatches->Get_SCMatchParams(timeBasedTrack, st_params); 
           // If st_match = true, there is a match between this track and the ST
           if (!sc_match) continue;
-          DVector3 IntersectionPoint;
-          DVector3 IntersectionDir;
-          bool sc_match_pid = dParticleID->MatchToSC(timeBasedTrack, 
-                                                timeBasedTrack->rt, 
-                                                st_params[0].dSCHit, 
-                                                st_params[0].dSCHit->t, 
-                                                locSCHitMatchParams, 
-                                                true, NULL,
-                                                &IntersectionPoint, &IntersectionDir);      
+          DVector3 IntersectionPoint, IntersectionMomentum;
+          bool sc_match_pid = dParticleID->Cut_MatchDistance(timeBasedTrack->rt, st_params[0].dSCHit, st_params[0].dSCHit->t, locSCHitMatchParams, true, &IntersectionPoint, &IntersectionMomentum);
           if(!sc_match_pid) continue;
           // For each paddle calculate the hit time, flight time, intersection point (z), and t0 from TOF
           // For each hit we want to calculate thit - tflight - t0 from TOF

--- a/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.cc
+++ b/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.cc
@@ -216,15 +216,8 @@ jerror_t JEventProcessor_ST_Tresolution::evnt(JEventLoop *loop, uint64_t eventnu
       // If st_match = true, there is a match between this track and the ST
       if (!st_match) continue;
 
-      DVector3 IntersectionPoint;
-      DVector3 IntersectionDir;
-      bool sc_match_pid = dParticleID->MatchToSC(timeBasedTrack, 
-                                                 timeBasedTrack->rt, 
-                                                 st_params[0].dSCHit, 
-                                                 st_params[0].dSCHit->t, 
-                                                 locSCHitMatchParams, 
-                                                 true, NULL,
-                                                 &IntersectionPoint, &IntersectionDir); 
+      DVector3 IntersectionPoint, IntersectionMomentum;
+      bool sc_match_pid = dParticleID->Cut_MatchDistance(timeBasedTrack->rt, st_params[0].dSCHit, st_params[0].dSCHit->t, locSCHitMatchParams, true, &IntersectionPoint, &IntersectionMomentum);
       if(!sc_match_pid) continue; 
       // Cut on the number of particle votes to find the best RF time
       if (thisRFBunch->dNumParticleVotes < 2) continue;

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.cc
@@ -130,7 +130,6 @@ bool DCustomAction_CutNoDetectorHit::Perform_Action(JEventLoop* locEventLoop, co
 	double locBCALProjectedZ = locProjPos.Z();
 	double locBCALDeltaPhi = locBestBCALMatchParams.dDeltaPhiToShower*180.0/TMath::Pi();
 
-
 	// MATCHING: FCAL
 	DFCALShowerMatchParams locBestFCALMatchParams;
 	locStartTime = locParticleCombo->Get_ParticleComboStep(0)->Get_SpacetimeVertex().T();
@@ -143,7 +142,6 @@ bool DCustomAction_CutNoDetectorHit::Perform_Action(JEventLoop* locEventLoop, co
 	double locSCProjectedZ = locProjPos.Z();
 	double locSCDeltaPhi = locBestSCMatchParams.dDeltaPhiToHit*180.0/TMath::Pi();
 
-
 	// MATCHING: TOF
 	DTOFHitMatchParams locBestTOFMatchParams;
 	locStartTime = locParticleCombo->Get_ParticleComboStep(0)->Get_SpacetimeVertex().T();
@@ -151,7 +149,6 @@ bool DCustomAction_CutNoDetectorHit::Perform_Action(JEventLoop* locEventLoop, co
 	double locDeltaX = locBestTOFMatchParams.dDeltaXToHit;
 	double locDeltaY = locBestTOFMatchParams.dDeltaYToHit;
 	double locTOFDistance = sqrt(locDeltaX*locDeltaX + locDeltaY*locDeltaY);
-
 
 	//FILL HISTOGRAMS
 	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.cc
@@ -107,7 +107,7 @@ bool DCustomAction_CutNoDetectorHit::Perform_Action(JEventLoop* locEventLoop, co
 	DReferenceTrajectory rt(dMagneticFieldMap);
 	rt.SetMass(ParticleMass(dMissingPID));
 	rt.q = ParticleCharge(dMissingPID);
-	rt.FastSwim(locMissingParticle->position(), locMissingParticle->momentum(), rt.q);
+	rt.Swim(locMissingParticle->position(), locMissingParticle->momentum(), rt.q);
 
 	vector<const DBCALShower*> locBCALShowers;
 	locEventLoop->Get(locBCALShowers);

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.cc
@@ -1,0 +1,212 @@
+// $Id$
+//
+//    File: DCustomAction_CutNoDetectorHit.cc
+// Created: Mon Feb 20 16:01:16 EST 2017
+// Creator: pmatt (on Linux pmattdesktop.jlab.org 2.6.32-642.13.1.el6.x86_64 x86_64)
+//
+
+#include "DCustomAction_CutNoDetectorHit.h"
+
+void DCustomAction_CutNoDetectorHit::Initialize(JEventLoop* locEventLoop)
+{
+	//Optional: Create histograms and/or modify member variables.
+	//Create any histograms/trees/etc. within a ROOT lock. 
+		//This is so that when running multithreaded, only one thread is writing to the ROOT file at a time. 
+	//NEVER: Get anything from the JEventLoop while in a lock: May deadlock
+
+	const DReaction* locReaction = Get_Reaction();
+	if(!locReaction->Get_MissingPID(dMissingPID))
+		return; //invalid reaction setup
+
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	dMagneticFieldMap = locApplication->GetBfield(locEventLoop->GetJEvent().GetRunNumber());
+	locEventLoop->GetSingle(dParticleID);
+
+	string locHistName, locHistTitle;
+	string locTrackString = string("Missing ") + ParticleName_ROOT(dMissingPID);
+
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
+	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	{
+		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
+			//If another thread has already created the folder, it just changes to it. 
+		CreateAndChangeTo_ActionDirectory();
+
+		//SC MATCHING
+		locHistName = "SCTrackDeltaPhiVsP";
+		locHistTitle = locTrackString + string(";p (GeV/c);SC / Track #Delta#phi#circ");
+		dHist_SCTrackDeltaPhiVsP = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DDeltaPhiBins, dSCMatchMinDeltaPhi, dSCMatchMaxDeltaPhi);
+
+		locHistName = "SCTrackDeltaPhiVsTheta";
+		locHistTitle = locTrackString + string(";#theta#circ;SC / Track #Delta#phi#circ");
+		dHist_SCTrackDeltaPhiVsTheta = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, dMaxTheta, dNum2DDeltaPhiBins, dSCMatchMinDeltaPhi, dSCMatchMaxDeltaPhi);
+
+		locHistName = "SCTrackDeltaPhiVsZ";
+		locHistTitle = locTrackString + string(";Projected SC Hit-Z (cm);SC / Track #Delta#phi#circ");
+		dHistMap_SCTrackDeltaPhiVsZ = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DSCZBins, 0.0, 120.0, dNum2DDeltaPhiBins, dSCMatchMinDeltaPhi, dSCMatchMaxDeltaPhi);
+
+		//TOF MATCHING
+		locHistName = "TOFTrackDistanceVsP";
+		locHistTitle = locTrackString + string(";p (GeV/c);TOF / Track Distance (cm)");
+		dHist_TOFPointTrackDistanceVsP = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DTrackDOCABins, dMinTrackDOCA, dMaxTrackMatchDOCA);
+
+		locHistName = "TOFTrackDistanceVsTheta";
+		locHistTitle = locTrackString + string(";#theta#circ;TOF / Track Distance (cm)");
+		dHist_TOFPointTrackDistanceVsTheta = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, 20.0, dNum2DTrackDOCABins, dMinTrackDOCA, dMaxTrackMatchDOCA);
+
+		//FCAL MATCHING
+		locHistName = "FCALTrackDistanceVsP";
+		locHistTitle = locTrackString + string(";p (GeV/c);FCAL / Track Distance (cm)");
+		dHist_FCALTrackDistanceVsP = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DTrackDOCABins, dMinTrackDOCA, dMaxTrackMatchDOCA);
+
+		locHistName = "FCALTrackDistanceVsTheta";
+		locHistTitle = locTrackString + string(";#theta#circ;FCAL / Track Distance (cm)");
+		dHist_FCALTrackDistanceVsTheta = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, 20.0, dNum2DTrackDOCABins, dMinTrackDOCA, dMaxTrackMatchDOCA);
+
+		//BCAL MATCHING
+		locHistName = "BCALDeltaPhiVsP";
+		locHistTitle = locTrackString + string(";p (GeV/c);BCAL / Track #Delta#phi#circ");
+		dHist_BCALDeltaPhiVsP = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, 4.0, dNum2DDeltaPhiBins, dMinDeltaPhi, dMaxDeltaPhi);
+
+		locHistName = "BCALDeltaPhiVsZ";
+		locHistTitle = locTrackString + string(";Projected BCAL Hit-Z (cm);BCAL / Track #Delta#phi#circ");
+		dHistMap_BCALDeltaPhiVsZ = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DBCALZBins, 0.0, 450.0, dNum2DDeltaPhiBins, dMinDeltaPhi, dMaxDeltaPhi);
+
+		locHistName = "BCALDeltaZVsTheta";
+		locHistTitle = locTrackString + string(";#theta#circ;BCAL / Track #Deltaz (cm)");
+		dHist_BCALDeltaZVsTheta = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, dMaxTheta, dNum2DDeltaZBins, dMinDeltaZ, dMaxDeltaZ);
+
+		locHistName = "BCALDeltaZVsZ";
+		locHistTitle = locTrackString + string(";Projected BCAL Hit-Z (cm);BCAL / Track #Deltaz (cm)");
+		dHistMap_BCALDeltaZVsZ = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DBCALZBins, 0.0, 450.0, dNum2DDeltaZBins, dMinDeltaZ, dMaxDeltaZ);
+}
+	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+bool DCustomAction_CutNoDetectorHit::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+{
+	//Write custom code to perform an action on the INPUT DParticleCombo (DParticleCombo)
+	//NEVER: Grab DParticleCombo or DAnalysisResults objects (of any tag!) from the JEventLoop within this function
+	//NEVER: Grab objects that are created post-kinfit (e.g. DKinFitResults, etc.) from the JEventLoop if Get_UseKinFitResultsFlag() == false: CAN CAUSE INFINITE DEPENDENCY LOOP
+	//NEVER: Get anything from the JEventLoop while in a lock: May deadlock
+
+	if(dMissingPID == Unknown)
+		return false; //invalid reaction setup
+	if(ParticleCharge(dMissingPID) == 0)
+		return false; //NOT SUPPORTED
+
+	const DKinematicData* locMissingParticle = locParticleCombo->Get_MissingParticle(); //is NULL if no kinfit!!
+	if(locMissingParticle == nullptr)
+		return false;
+
+	double locP = locMissingParticle->momentum().Mag();
+	double locTheta = locMissingParticle->momentum().Theta()*180.0/TMath::Pi();
+
+	// Generate & swim reference trajectory for this
+	DReferenceTrajectory rt(dMagneticFieldMap);
+	rt.SetMass(ParticleMass(dMissingPID));
+	rt.q = ParticleCharge(dMissingPID);
+	rt.FastSwim(locMissingParticle->position(), locMissingParticle->momentum(), rt.q);
+
+	vector<const DBCALShower*> locBCALShowers;
+	locEventLoop->Get(locBCALShowers);
+
+	vector<const DFCALShower*> locFCALShowers;
+	locEventLoop->Get(locFCALShowers);
+
+	vector<const DTOFPoint*> locTOFPoints;
+	locEventLoop->Get(locTOFPoints);
+
+	vector<const DSCHit*> locSCHits;
+	locEventLoop->Get(locSCHits);
+
+	// MATCHING: BCAL
+	DBCALShowerMatchParams locBestBCALMatchParams;
+	double locStartTimeVariance = 0.0;
+	DVector3 locProjPos, locProjMom;
+	double locStartTime = locParticleCombo->Get_ParticleComboStep(0)->Get_SpacetimeVertex().T();
+	bool locBCALHitFoundFlag = dParticleID->Get_ClosestToTrack(&rt, locBCALShowers, false, locStartTime, locBestBCALMatchParams, &locStartTimeVariance, &locProjPos, &locProjMom);
+	double locBCALProjectedZ = locProjPos.Z();
+	double locBCALDeltaPhi = locBestBCALMatchParams.dDeltaPhiToShower*180.0/TMath::Pi();
+
+
+	// MATCHING: FCAL
+	DFCALShowerMatchParams locBestFCALMatchParams;
+	locStartTime = locParticleCombo->Get_ParticleComboStep(0)->Get_SpacetimeVertex().T();
+	bool locFCALHitFoundFlag = dParticleID->Get_ClosestToTrack(&rt, locFCALShowers, false, locStartTime, locBestFCALMatchParams);
+
+	// MATCHING: SC
+	DSCHitMatchParams locBestSCMatchParams;
+	locStartTime = locParticleCombo->Get_ParticleComboStep(0)->Get_SpacetimeVertex().T();
+	bool locSCHitFoundFlag = dParticleID->Get_ClosestToTrack(&rt, locSCHits, true, false, locStartTime, locBestSCMatchParams, &locStartTimeVariance, &locProjPos, &locProjMom);
+	double locSCProjectedZ = locProjPos.Z();
+	double locSCDeltaPhi = locBestSCMatchParams.dDeltaPhiToHit*180.0/TMath::Pi();
+
+
+	// MATCHING: TOF
+	DTOFHitMatchParams locBestTOFMatchParams;
+	locStartTime = locParticleCombo->Get_ParticleComboStep(0)->Get_SpacetimeVertex().T();
+	bool locTOFHitFoundFlag = dParticleID->Get_ClosestToTrack(&rt, locTOFPoints, false, locStartTime, locBestTOFMatchParams);
+	double locDeltaX = locBestTOFMatchParams.dDeltaXToHit;
+	double locDeltaY = locBestTOFMatchParams.dDeltaYToHit;
+	double locTOFDistance = sqrt(locDeltaX*locDeltaX + locDeltaY*locDeltaY);
+
+
+	//FILL HISTOGRAMS
+	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
+	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
+	{
+		/********************************************************** MATCHING DISTANCE **********************************************************/
+
+		//BCAL
+		if(locBCALHitFoundFlag)
+		{
+			dHist_BCALDeltaPhiVsP->Fill(locP, locBCALDeltaPhi);
+			dHist_BCALDeltaZVsTheta->Fill(locTheta, locBestBCALMatchParams.dDeltaZToShower);
+			dHistMap_BCALDeltaPhiVsZ->Fill(locBCALProjectedZ, locBCALDeltaPhi);
+			dHistMap_BCALDeltaZVsZ->Fill(locBCALProjectedZ, locBestBCALMatchParams.dDeltaZToShower);
+		}
+
+		//FCAL
+		if(locFCALHitFoundFlag)
+		{
+			dHist_FCALTrackDistanceVsP->Fill(locP, locBestFCALMatchParams.dDOCAToShower);
+			dHist_FCALTrackDistanceVsTheta->Fill(locTheta, locBestFCALMatchParams.dDOCAToShower);
+		}
+
+		//TOF Point
+		if(locTOFHitFoundFlag)
+		{
+			dHist_TOFPointTrackDistanceVsP->Fill(locP, locTOFDistance);
+			dHist_TOFPointTrackDistanceVsTheta->Fill(locTheta, locTOFDistance);
+		}
+
+		//SC
+		if(locSCHitFoundFlag)
+		{
+			dHist_SCTrackDeltaPhiVsP->Fill(locP, locSCDeltaPhi);
+			dHist_SCTrackDeltaPhiVsTheta->Fill(locTheta, locSCDeltaPhi);
+			dHistMap_SCTrackDeltaPhiVsZ->Fill(locSCProjectedZ, locSCDeltaPhi);
+		}
+	}
+	Unlock_Action(); //RELEASE ROOT LOCK!!
+
+	//REQUIRE: ST hit + EITHER BCAL hit OR TOF && FCAL hits
+	if(!locSCHitFoundFlag)
+		return false;
+	if((locSCProjectedZ < 76.5) && (fabs(locSCDeltaPhi) > 10.0))
+		return false; //HARD-CODED: BAD!
+	if((locSCProjectedZ >= 76.5) && (fabs(locSCDeltaPhi) > (10.0 + locSCProjectedZ - 76.5)))
+		return false;
+
+	//BCAL Hit
+	if(locBCALHitFoundFlag)
+		return ((fabs(locBestBCALMatchParams.dDeltaZToShower) < 7.0) && (fabs(locBCALDeltaPhi) < 10.0));
+
+	//MUST HAVE FCAL & TOF
+	if(!locTOFHitFoundFlag || !locFCALHitFoundFlag)
+		return false;
+	return ((locTOFDistance < 10.0) && (locBestFCALMatchParams.dDOCAToShower < 10.0));
+}

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.cc
@@ -200,11 +200,13 @@ bool DCustomAction_CutNoDetectorHit::Perform_Action(JEventLoop* locEventLoop, co
 	//REQUIRE: ST hit
 	if(!locSCHitFoundFlag)
 		return false;
-	if((locSCProjectedZ < 76.5) && (fabs(locSCDeltaPhi) > 10.0))
+	if(fabs(locSCDeltaPhi) > 30.0)
+		return false;
+/*	if((locSCProjectedZ < 76.5) && (fabs(locSCDeltaPhi) > 10.0))
 		return false; //HARD-CODED: BAD!
 	if((locSCProjectedZ >= 76.5) && (fabs(locSCDeltaPhi) > (10.0 + locSCProjectedZ - 76.5)))
 		return false;
-
+*/
 	//Check for slow protons stopping in the drift chambers: don't expect any further hits
 	if((locP < 0.4) && locMassiveParticleFlag)
 		return true;
@@ -213,14 +215,18 @@ bool DCustomAction_CutNoDetectorHit::Perform_Action(JEventLoop* locEventLoop, co
 
 	//BCAL Hit
 	if(locBCALHitFoundFlag)
-		return ((fabs(locBestBCALMatchParams.dDeltaZToShower) < 7.0) && (fabs(locBCALDeltaPhi) < 10.0));
+		return ((fabs(locBestBCALMatchParams.dDeltaZToShower) < 20.0) && (fabs(locBCALDeltaPhi) < 20.0));
 
-/*
+	//MUST HAVE FCAL & TOF
+	if(!locTOFHitFoundFlag || !locFCALHitFoundFlag)
+		return false;
+
+	/*
 	//MUST HAVE FCAL & TOF
 	if(!locTOFHitFoundFlag || !locFCALHitFoundFlag)
 		return false;
 	return ((locTOFDistance < 10.0) && (locBestFCALMatchParams.dDOCAToShower < 10.0));
 */
-	//extrapolation to FCAL/TOF is too poor to work
+	//extrapolation to FCAL/TOF is too poor to cut on
 	return (locTheta < 20.0);
 }

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.h
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.h
@@ -37,9 +37,9 @@ class DCustomAction_CutNoDetectorHit : public DAnalysisAction
 
 		DCustomAction_CutNoDetectorHit(const DReaction* locReaction, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Custom_CutDetectorHit", false, locActionUniqueString),
-		dNum2DPBins(250), dNum2DThetaBins(280), dNum2DDeltaPhiBins(300), dNum2DTrackDOCABins(200), dNum2DDeltaZBins(300), dNum2DSCZBins(240),
+		dNum2DPBins(250), dNum2DThetaBins(280), dNum2DDeltaPhiBins(300), dNum2DTrackDOCABins(500), dNum2DDeltaZBins(300), dNum2DSCZBins(240),
 		dNum2DBCALZBins(450), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinDeltaPhi(-30.0), dMaxDeltaPhi(30.0),
-		dSCMatchMinDeltaPhi(-60.0), dSCMatchMaxDeltaPhi(60.0), dMinTrackDOCA(0.0), dMaxTrackMatchDOCA(20.0), dMinDeltaZ(-30.0), dMaxDeltaZ(30.0) {}
+		dSCMatchMinDeltaPhi(-60.0), dSCMatchMaxDeltaPhi(60.0), dMinTrackDOCA(0.0), dMaxTrackMatchDOCA(50.0), dMinDeltaZ(-30.0), dMaxDeltaZ(30.0) {}
 
 		void Initialize(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void){}; //RESET HISTOGRAM DUPLICATE-CHECK TRACKING HERE!!

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.h
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.h
@@ -1,0 +1,81 @@
+// $Id$
+//
+//    File: DCustomAction_CutNoDetectorHit.h
+// Created: Mon Feb 20 16:01:16 EST 2017
+// Creator: pmatt (on Linux pmattdesktop.jlab.org 2.6.32-642.13.1.el6.x86_64 x86_64)
+//
+
+#ifndef _DCustomAction_CutNoDetectorHit_
+#define _DCustomAction_CutNoDetectorHit_
+
+#include <string>
+#include <iostream>
+
+#include "TH2I.h"
+
+#include "JANA/JEventLoop.h"
+#include "JANA/JApplication.h"
+
+#include "BCAL/DBCALShower.h"
+#include "FCAL/DFCALShower.h"
+#include "TOF/DTOFPoint.h"
+#include "START_COUNTER/DSCHit.h"
+#include "HDGEOMETRY/DMagneticFieldMap.h"
+#include "PID/DParticleID.h"
+
+#include "ANALYSIS/DAnalysisAction.h"
+#include "ANALYSIS/DReaction.h"
+#include "ANALYSIS/DParticleCombo.h"
+#include "ANALYSIS/DAnalysisUtilities.h"
+
+using namespace std;
+using namespace jana;
+
+class DCustomAction_CutNoDetectorHit : public DAnalysisAction
+{
+	public:
+
+		DCustomAction_CutNoDetectorHit(const DReaction* locReaction, string locActionUniqueString = "") :
+		DAnalysisAction(locReaction, "Custom_CutDetectorHit", false, locActionUniqueString),
+		dNum2DPBins(250), dNum2DThetaBins(280), dNum2DDeltaPhiBins(300), dNum2DTrackDOCABins(200), dNum2DDeltaZBins(300), dNum2DSCZBins(240),
+		dNum2DBCALZBins(450), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinDeltaPhi(-30.0), dMaxDeltaPhi(30.0),
+		dSCMatchMinDeltaPhi(-60.0), dSCMatchMaxDeltaPhi(60.0), dMinTrackDOCA(0.0), dMaxTrackMatchDOCA(20.0), dMinDeltaZ(-30.0), dMaxDeltaZ(30.0) {}
+
+		void Initialize(JEventLoop* locEventLoop);
+		void Reset_NewEvent(void){}; //RESET HISTOGRAM DUPLICATE-CHECK TRACKING HERE!!
+
+	private:
+
+		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
+
+		unsigned int dNum2DPBins, dNum2DThetaBins, dNum2DDeltaPhiBins, dNum2DTrackDOCABins, dNum2DDeltaZBins, dNum2DSCZBins, dNum2DBCALZBins;
+		float dMinP, dMaxP, dMinTheta, dMaxTheta, dMinDeltaPhi, dMaxDeltaPhi, dSCMatchMinDeltaPhi, dSCMatchMaxDeltaPhi;
+		float dMinTrackDOCA, dMaxTrackMatchDOCA, dMinDeltaZ, dMaxDeltaZ;
+
+		//Store any histograms as member variables here
+		const DMagneticFieldMap* dMagneticFieldMap;
+		const DParticleID* dParticleID;
+		Particle_t dMissingPID;
+
+		//SC MATCHING
+		TH2I* dHist_SCTrackDeltaPhiVsP;
+		TH2I* dHist_SCTrackDeltaPhiVsTheta;
+		TH2I* dHistMap_SCTrackDeltaPhiVsZ;
+
+		//TOF MATCHING
+		TH2I* dHist_TOFPointTrackDistanceVsP;
+		TH2I* dHist_TOFPointTrackDistanceVsTheta;
+
+		//FCAL MATCHING
+		TH2I* dHist_FCALTrackDistanceVsP;
+		TH2I* dHist_FCALTrackDistanceVsTheta;
+
+		//BCAL MATCHING
+		TH2I* dHist_BCALDeltaPhiVsP;
+		TH2I* dHistMap_BCALDeltaPhiVsZ;
+		TH2I* dHist_BCALDeltaZVsTheta;
+		TH2I* dHistMap_BCALDeltaZVsZ;
+};
+
+#endif // _DCustomAction_CutNoDetectorHit_
+

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.h
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.h
@@ -37,9 +37,9 @@ class DCustomAction_CutNoDetectorHit : public DAnalysisAction
 
 		DCustomAction_CutNoDetectorHit(const DReaction* locReaction, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Custom_CutDetectorHit", false, locActionUniqueString),
-		dNum2DPBins(250), dNum2DThetaBins(280), dNum2DDeltaPhiBins(300), dNum2DTrackDOCABins(500), dNum2DDeltaZBins(300), dNum2DSCZBins(240),
-		dNum2DBCALZBins(450), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinDeltaPhi(-30.0), dMaxDeltaPhi(30.0),
-		dSCMatchMinDeltaPhi(-60.0), dSCMatchMaxDeltaPhi(60.0), dMinTrackDOCA(0.0), dMaxTrackMatchDOCA(50.0), dMinDeltaZ(-30.0), dMaxDeltaZ(30.0) {}
+		dNum2DPBins(250), dNum2DThetaBins(280), dNum2DDeltaPhiBins(360), dNum2DTrackDOCABins(500), dNum2DDeltaZBins(300), dNum2DSCZBins(240),
+		dNum2DBCALZBins(450), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinDeltaPhi(-60.0), dMaxDeltaPhi(60.0),
+		dSCMatchMinDeltaPhi(-180.0), dSCMatchMaxDeltaPhi(180.0), dMinTrackDOCA(0.0), dMaxTrackMatchDOCA(50.0), dMinDeltaZ(-60.0), dMaxDeltaZ(60.0) {}
 
 		void Initialize(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void){}; //RESET HISTOGRAM DUPLICATE-CHECK TRACKING HERE!!
@@ -73,6 +73,7 @@ class DCustomAction_CutNoDetectorHit : public DAnalysisAction
 		//BCAL MATCHING
 		TH2I* dHist_BCALDeltaPhiVsP;
 		TH2I* dHistMap_BCALDeltaPhiVsZ;
+		TH2I* dHistMap_BCALDeltaPhiVsTheta;
 		TH2I* dHist_BCALDeltaZVsTheta;
 		TH2I* dHistMap_BCALDeltaZVsZ;
 };

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_dEdxCut_trackeff.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_dEdxCut_trackeff.cc
@@ -19,11 +19,11 @@ void DCustomAction_dEdxCut_trackeff::Initialize(JEventLoop* locEventLoop)
 	{
 		string locFuncName = "df_dEdxCut_SelectHeavy"; //e.g. proton
 		dFunc_dEdxCut_SelectHeavy = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-		dFunc_dEdxCut_SelectHeavy->SetParameters(3.93024, 3.0, 1.0);
+		dFunc_dEdxCut_SelectHeavy->SetParameters(2.0, 2.0, 1.0);
 
 		locFuncName = "df_dEdxCut_SelectLight"; //e.g. pions, kaons
 		dFunc_dEdxCut_SelectLight = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-		dFunc_dEdxCut_SelectLight->SetParameters(6.0, 2.80149, 2.55);
+		dFunc_dEdxCut_SelectLight->SetParameters(2.0, 0.8, 3.0);
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
+++ b/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
@@ -590,8 +590,8 @@ void DReaction_factory_trackeff_missing::Add_MassHistograms(DReaction* locReacti
 
 		//add the cut
 		if(locCutPair.first >= 0.0)
-			locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, locDecayFromStep, locMissingMassOffOfPIDs, locKinFitFlag, locNumBins, locCutPair.first, locCutPair.second));
+			locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, locDecayFromStep, locMissingMassOffOfPIDs, locKinFitFlag, locNumBins, locCutPair.first, locCutPair.second, locActionUniqueName));
 		else
-			locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, locDecayFromStep, locMissingMassOffOfPIDs, locKinFitFlag, locNumBins, locCutPair.first, locCutPair.second));
+			locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, locDecayFromStep, locMissingMassOffOfPIDs, locKinFitFlag, locNumBins, locCutPair.first, locCutPair.second, locActionUniqueName));
 	}
 }

--- a/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
+++ b/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
@@ -302,9 +302,13 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 			Add_MassHistograms(locReaction, false, "KinFitMassCut");
 
 		// DETECTOR HIT MATCHING MISSING TRACK TRAJECTORY
-		locReaction->Add_AnalysisAction(new DCustomAction_CutNoDetectorHit(locReaction));
-		Add_MassHistograms(locReaction, false, "HasDetectorHit");
-		Add_MassHistograms(locReaction, true, "HasDetectorHit_KinFit");
+		string locReactionName = locReaction->Get_ReactionName();
+		if((locReactionName != "TrackEff_MissingPiMinus_3pi") && (locReactionName != "TrackEff_MissingPiPlus_3pi"))
+		{
+			locReaction->Add_AnalysisAction(new DCustomAction_CutNoDetectorHit(locReaction));
+			Add_MassHistograms(locReaction, false, "HasDetectorHit");
+			Add_MassHistograms(locReaction, true, "HasDetectorHit_KinFit");
+		}
 
 		// KINEMATICS
 		locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true)); //true: fill histograms with kinematic-fit particle data

--- a/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
+++ b/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
@@ -500,7 +500,7 @@ void DReaction_factory_trackeff_missing::Add_MassCuts(DReaction* locReaction, bo
 		if(locCutPair.first >= 0.0)
 			locMassCut = new DCutAction_MissingMass(locReaction, locDecayFromStep, locMissingMassOffOfPIDs, locKinFitFlag, locCutPair.first, locCutPair.second);
 		else
-			locMassCut = new DCutAction_MissingMassSquared(locReaction, locDecayFromStep, locMissingMassOffOfPIDs, locKinFitFlag, locCutPair.first, locCutPair.second));
+			locMassCut = new DCutAction_MissingMassSquared(locReaction, locDecayFromStep, locMissingMassOffOfPIDs, locKinFitFlag, locCutPair.first, locCutPair.second);
 
 		//add the cut
 		if(locKinFitFlag)

--- a/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
+++ b/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
@@ -10,6 +10,16 @@
 #include "DCustomAction_CutExtraPi0.h"
 #include "DCustomAction_CutExtraShowers.h"
 #include "DCustomAction_dEdxCut_trackeff.h"
+#include "DCustomAction_CutNoDetectorHit.h"
+
+//------------------
+// init
+//------------------
+jerror_t DReaction_factory_trackeff_missing::init(void)
+{
+	Define_LooseCuts();
+	return NOERROR;
+}
 
 //------------------
 // brun
@@ -36,12 +46,15 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	// ANALYSIS library: https://halldweb1.jlab.org/wiki/index.php/GlueX_Analysis_Software
 	// DReaction factory: https://halldweb1.jlab.org/wiki/index.php/Analysis_DReaction
 
+	// DEFINE CHANNELS:
+	deque<DReaction*> locReactions;
+
+
 	/**************************************************** TrackEff_MissingProton Reaction Steps ****************************************************/
 
-	//Required: DReactionSteps to specify the channel and decay chain you want to study
-		//Particles are of type Particle_t, an enum defined in sim-recon/src/libraries/include/particleType.h
+	locReaction = new DReaction("TrackEff_MissingProton"); //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
 
-	//Example: g, p -> pi+, pi-, (p)
+	//g, p -> pi+, pi-, (p)
 	locReactionStep = new DReactionStep();
 	locReactionStep->Set_InitialParticleID(Gamma);
 	locReactionStep->Set_TargetParticleID(Proton);
@@ -50,89 +63,13 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReactionStep->Add_FinalParticleID(Proton, true); //true: proton missing
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
-
-	/**************************************************** TrackEff_MissingProton Control Settings ****************************************************/
-
-	// Recommended: Type of kinematic fit to perform (default is d_NoFit)
-		//fit types are of type DKinFitType, an enum defined in sim-recon/src/libraries/ANALYSIS/DKinFitResults.h
-	//locReaction->Set_KinFitType(d_P4Fit); //simultaneously constrain apply four-momentum conservation, invariant masses, and common-vertex constraints
-	locReaction->Set_KinFitType(d_P4Fit);
-	locReaction->Set_KinFitUpdateCovarianceMatricesFlag(true);
-
-	// Highly Recommended: When generating particle combinations, reject all photon candidates with a PID confidence level < 5.73303E-7 (+/- 5-sigma)
-	// locReaction->Set_MinPhotonPIDFOM(5.73303E-7);
-
-	// Highly Recommended: When generating particle combinations, reject all charged track candidates with a PID confidence level < 5.73303E-7 (+/- 5-sigma)
-	// locReaction->Set_MinChargedPIDFOM(5.73303E-7);
-
-	// Highly Recommended: When generating particle combinations, reject all beam photons that match to a different RF bunch (delta_t > 1.002 ns)
-	locReaction->Set_MaxPhotonRFDeltaT(1.5*dBeamBunchPeriod); //should be minimum cut value
-
-	// Highly Recommended: Cut on number of extra "good" tracks. "Good" tracks are ones that survive the "PreSelect" (or user custom) factory.
-		// Current (09/26/2014): "Good" tracks have a detector-hit match, and tracking FOM > 0.0027 (+/- 3 sigma). 
-		// Important: Keep cut large: Can have many ghost and accidental tracks that look "good"
-//	locReaction->Set_MaxExtraGoodTracks(1);
-
-	/************************************************** TrackEff_MissingProton Pre-Combo Custom Cuts *************************************************/
-
-	// Highly Recommended: Very loose DAnalysisAction cuts, applied just after creating the combination (before saving it)
-	// Example: Missing mass squared of proton
-	locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMass(locReaction, false, 0.5, 1.4));
-
-	/**************************************************** TrackEff_MissingProton Analysis Actions ****************************************************/
-
-	// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
-		//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination 
-		//Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
-
-	// Reject events with large unused shower energy
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));		
-
-	// Hist PID
-	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
-
-	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiPlus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiPlus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiPlus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiMinus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiMinus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiMinus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_TrackFCALShowerEOverP(locReaction, false, 0.5)); //false: measured data //value: cut e+/e- below this, tracks above this
-	locReaction->Add_AnalysisAction(new DCutAction_EachPIDFOM(locReaction, -9.9E9, true)); //cut particles with PID FOM = 0
-
-	// Kinematic Fit Results
-	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-
-	// Kinematic Fit: Vertex-Only Fit
-	//locReaction->Add_AnalysisAction(new DCutAction_OneVertexKinFit(locReaction, 5.73303E-7, 44.0, 85.0)); //cut +/- 5 sigma, vertex-z between 44 & 85
-
-	// Track DOCA, etc.
-	locReaction->Add_AnalysisAction(new DHistogramAction_TrackVertexComparison(locReaction));
-
-	// Missing Mass Squared
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, false, 900, 0.5, 1.4));
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraPi0(locReaction, 0.0775209, 0.188047));
-	locReaction->Add_AnalysisAction(new DCutAction_MinTrackHits(locReaction, 10));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, false, 900, 0.5, 1.4, "PostPi0"));
-
-	// Kinematics
-	locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true)); //true: fill histograms with kinematic-fit particle data
-
-	// Tracking Efficiency
-	locReaction->Add_AnalysisAction(new DCustomAction_TrackingEfficiency(locReaction, true));
-
-	//_data.push_back(locReaction); //Register the DReaction with the factory
+	locReactions.push_back(locReaction);
 
 	/**************************************************** TrackEff_MissingPiMinus Reaction Steps ****************************************************/
 
 	locReaction = new DReaction("TrackEff_MissingPiMinus"); //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
 
-	//Required: DReactionSteps to specify the channel and decay chain you want to study
-		//Particles are of type Particle_t, an enum defined in sim-recon/src/libraries/include/particleType.h
-
-	//Example: g, p -> pi+, p, (pi-)
+	//g, p -> pi+, p, (pi-)
 	locReactionStep = new DReactionStep();
 	locReactionStep->Set_InitialParticleID(Gamma);
 	locReactionStep->Set_TargetParticleID(Proton);
@@ -141,92 +78,13 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReactionStep->Add_FinalParticleID(PiMinus, true); //true: pi- missing
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
-
-	/**************************************************** TrackEff_MissingPiMinus Control Settings ****************************************************/
-
-	// Recommended: Type of kinematic fit to perform (default is d_NoFit)
-		//fit types are of type DKinFitType, an enum defined in sim-recon/src/libraries/ANALYSIS/DKinFitResults.h
-	//locReaction->Set_KinFitType(d_P4Fit); //simultaneously constrain apply four-momentum conservation, invariant masses, and common-vertex constraints
-	locReaction->Set_KinFitType(d_P4Fit);
-	locReaction->Set_KinFitUpdateCovarianceMatricesFlag(true);
-
-	// Highly Recommended: When generating particle combinations, reject all photon candidates with a PID confidence level < 5.73303E-7 (+/- 5-sigma)
-	// locReaction->Set_MinPhotonPIDFOM(5.73303E-7);
-
-	// Highly Recommended: When generating particle combinations, reject all charged track candidates with a PID confidence level < 5.73303E-7 (+/- 5-sigma)
-	// locReaction->Set_MinChargedPIDFOM(5.73303E-7);
-
-	// Highly Recommended: When generating particle combinations, reject all beam photons that match to a different RF bunch (delta_t > 1.002 ns)
-	locReaction->Set_MaxPhotonRFDeltaT(1.5*dBeamBunchPeriod); //should be minimum cut value
-
-	// Highly Recommended: Cut on number of extra "good" tracks. "Good" tracks are ones that survive the "PreSelect" (or user custom) factory.
-		// Current (09/26/2014): "Good" tracks have a detector-hit match, and tracking FOM > 0.0027 (+/- 3 sigma).
-		// Important: Keep cut large: Can have many ghost and accidental tracks that look "good"
-//	locReaction->Set_MaxExtraGoodTracks(1);
-
-	/************************************************** TrackEff_MissingPiMinus Pre-Combo Custom Cuts *************************************************/
-
-	// Highly Recommended: Very loose DAnalysisAction cuts, applied just after creating the combination (before saving it)
-	// Example: Missing mass squared of proton
-	locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, -0.5, 0.6));
-
-	/**************************************************** TrackEff_MissingPiMinus Analysis Actions ****************************************************/
-
-	// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
-		//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination
-		//Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
-
-	// Reject events with large unused shower energy
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));
-
-//	locReaction->Add_AnalysisAction(new DCutAction_BeamEnergy(locReaction, false, 3.0, 6.0));
-
-	// Hist PID
-	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
-
-	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, Proton, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.8, Proton, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Proton, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiPlus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiPlus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiPlus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_TrackFCALShowerEOverP(locReaction, false, 0.5)); //false: measured data //value: cut e+/e- below this, tracks above this
-	locReaction->Add_AnalysisAction(new DCutAction_EachPIDFOM(locReaction, -9.9E9, true)); //cut particles with PID FOM = 0
-
-	// Kinematic Fit Results
-	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-
-	// Kinematic Fit: Vertex-Only Fit
-	//locReaction->Add_AnalysisAction(new DCutAction_OneVertexKinFit(locReaction, 5.73303E-7, 44.0, 85.0)); //cut +/- 5 sigma, vertex-z between 44 & 85
-
-	// Track DOCA, etc.
-	locReaction->Add_AnalysisAction(new DHistogramAction_TrackVertexComparison(locReaction));
-
-	// Missing Mass Squared
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 1100, -0.5, 0.6));
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraPi0(locReaction, 0.0775209, 0.188047));
-	locReaction->Add_AnalysisAction(new DCutAction_MinTrackHits(locReaction, 10));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 1100, -0.5, 0.6, "PostPi0"));
-
-	// Kinematics
-	locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true)); //true: fill histograms with kinematic-fit particle data
-
-	// Tracking Efficiency
-	locReaction->Add_AnalysisAction(new DCustomAction_TrackingEfficiency(locReaction, true));
-
-	_data.push_back(locReaction); //Register the DReaction with the factory
-
+	locReactions.push_back(locReaction);
 
 	/**************************************************** TrackEff_MissingPiPlus Reaction Steps ****************************************************/
 
 	locReaction = new DReaction("TrackEff_MissingPiPlus"); //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
 
-	//Required: DReactionSteps to specify the channel and decay chain you want to study
-		//Particles are of type Particle_t, an enum defined in sim-recon/src/libraries/include/particleType.h
-
-	//Example: g, p -> pi-, p, (pi+)
+	//g, p -> pi-, p, (pi+)
 	locReactionStep = new DReactionStep();
 	locReactionStep->Set_InitialParticleID(Gamma);
 	locReactionStep->Set_TargetParticleID(Proton);
@@ -235,385 +93,11 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReactionStep->Add_FinalParticleID(PiPlus, true); //true: pi+ missing
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
-
-	/**************************************************** TrackEff_MissingPiPlus Control Settings ****************************************************/
-
-	// Recommended: Type of kinematic fit to perform (default is d_NoFit)
-		//fit types are of type DKinFitType, an enum defined in sim-recon/src/libraries/ANALYSIS/DKinFitResults.h
-	//locReaction->Set_KinFitType(d_P4Fit); //simultaneously constrain apply four-momentum conservation, invariant masses, and common-vertex constraints
-	locReaction->Set_KinFitType(d_P4Fit);
-	locReaction->Set_KinFitUpdateCovarianceMatricesFlag(true);
-
-	// Highly Recommended: When generating particle combinations, reject all photon candidates with a PID confidence level < 5.73303E-7 (+/- 5-sigma)
-	// locReaction->Set_MinPhotonPIDFOM(5.73303E-7);
-
-	// Highly Recommended: When generating particle combinations, reject all charged track candidates with a PID confidence level < 5.73303E-7 (+/- 5-sigma)
-	// locReaction->Set_MinChargedPIDFOM(5.73303E-7);
-
-	// Highly Recommended: When generating particle combinations, reject all beam photons that match to a different RF bunch (delta_t > 1.002 ns)
-	locReaction->Set_MaxPhotonRFDeltaT(1.5*dBeamBunchPeriod); //should be minimum cut value
-
-	// Highly Recommended: Cut on number of extra "good" tracks. "Good" tracks are ones that survive the "PreSelect" (or user custom) factory.
-		// Current (09/26/2014): "Good" tracks have a detector-hit match, and tracking FOM > 0.0027 (+/- 3 sigma).
-		// Important: Keep cut large: Can have many ghost and accidental tracks that look "good"
-//	locReaction->Set_MaxExtraGoodTracks(1);
-
-	/************************************************** TrackEff_MissingPiPlus Pre-Combo Custom Cuts *************************************************/
-
-	// Highly Recommended: Very loose DAnalysisAction cuts, applied just after creating the combination (before saving it)
-	// Example: Missing mass squared of proton
-	locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, -0.5, 0.6));
-
-	/**************************************************** TrackEff_MissingPiPlus Analysis Actions ****************************************************/
-
-	// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
-		//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination
-		//Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
-
-	// Reject events with large unused shower energy
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));
-
-//	locReaction->Add_AnalysisAction(new DCutAction_BeamEnergy(locReaction, false, 3.0, 6.0));
-
-	// Hist PID
-	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
-
-	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, Proton, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.8, Proton, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Proton, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiMinus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiMinus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiMinus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_TrackFCALShowerEOverP(locReaction, false, 0.5)); //false: measured data //value: cut e+/e- below this, tracks above this
-	locReaction->Add_AnalysisAction(new DCutAction_EachPIDFOM(locReaction, -9.9E9, true)); //cut particles with PID FOM = 0
-
-	// Kinematic Fit Results
-	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-
-	// Kinematic Fit: Vertex-Only Fit
-	//locReaction->Add_AnalysisAction(new DCutAction_OneVertexKinFit(locReaction, 5.73303E-7, 44.0, 85.0)); //cut +/- 5 sigma, vertex-z between 44 & 85
-
-	// Track DOCA, etc.
-	locReaction->Add_AnalysisAction(new DHistogramAction_TrackVertexComparison(locReaction));
-
-	// Missing Mass Squared
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 1100, -0.5, 0.6));
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraPi0(locReaction, 0.0775209, 0.188047));
-	locReaction->Add_AnalysisAction(new DCutAction_MinTrackHits(locReaction, 10));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 1100, -0.5, 0.6, "PostPi0"));
-
-	// Kinematics
-	locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true)); //true: fill histograms with kinematic-fit particle data
-
-	// Tracking Efficiency
-	locReaction->Add_AnalysisAction(new DCustomAction_TrackingEfficiency(locReaction, true));
-
-	_data.push_back(locReaction); //Register the DReaction with the factory
-
-	/*************************************************************************************************************/
-	/**************************************************** 3pi ****************************************************/
-	/*************************************************************************************************************/
-
-	/**************************************************** TrackEff_MissingProton_3pi Reaction Steps ****************************************************/
-
-	locReaction = new DReaction("TrackEff_MissingProton_3pi"); //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
-
-	deque<Particle_t> locToIncludePIDs;
-	locToIncludePIDs.push_back(PiPlus); locToIncludePIDs.push_back(PiMinus); locToIncludePIDs.push_back(Pi0); 
-
-	//Example: g, p -> pi+, pi-, pi0 , (p)
-	locReactionStep = new DReactionStep();
-	locReactionStep->Set_InitialParticleID(Gamma);
-	locReactionStep->Set_TargetParticleID(Proton);
-	locReactionStep->Add_FinalParticleID(PiPlus);
-	locReactionStep->Add_FinalParticleID(PiMinus);
-	locReactionStep->Add_FinalParticleID(Pi0);
-	locReactionStep->Add_FinalParticleID(Proton, true); //true: proton missing
-	locReaction->Add_ReactionStep(locReactionStep);
-	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
-
-	//pi0 -> g, g
-	locReactionStep = new DReactionStep();
-	locReactionStep->Set_InitialParticleID(Pi0);
-	locReactionStep->Add_FinalParticleID(Gamma);
-	locReactionStep->Add_FinalParticleID(Gamma);
-	locReaction->Add_ReactionStep(locReactionStep);
-	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
-
-	/**************************************************** TrackEff_MissingProton_3pi Control Settings ****************************************************/
-
-	locReaction->Set_KinFitType(d_P4Fit);
-	locReaction->Set_KinFitUpdateCovarianceMatricesFlag(true);
-	locReaction->Set_MaxPhotonRFDeltaT(1.5*dBeamBunchPeriod); //should be minimum cut value
-//	locReaction->Set_MaxExtraGoodTracks(1);
-
-	/************************************************** TrackEff_MissingProton_3pi Pre-Combo Custom Cuts *************************************************/
-
-	// Highly Recommended: Very loose invariant mass cuts, applied during DParticleComboBlueprint construction
-	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
-
-	// Highly Recommended: Very loose DAnalysisAction cuts, applied just after creating the combination (before saving it)
-	// Example: Missing mass squared of proton
-	locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMass(locReaction, false, 0.5, 1.4));
-
-	/**************************************************** TrackEff_MissingProton_3pi Analysis Actions ****************************************************/
-
-	// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
-		//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination 
-		//Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
-
-	// Reject events with large unused shower energy
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));
-
-//	locReaction->Add_AnalysisAction(new DCutAction_BeamEnergy(locReaction, false, 3.0, 6.0));
-
-	// Hist PID
-	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
-
-	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiPlus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiPlus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiPlus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiMinus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiMinus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiMinus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_TrackFCALShowerEOverP(locReaction, false, 0.5)); //false: measured data //value: cut e+/e- below this, tracks above this
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Gamma, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, Gamma, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_EachPIDFOM(locReaction, -9.9E9, true)); //cut particles with PID FOM = 0
-
-	// Kinematic Fit Results
-	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-
-	// Track DOCA, etc.
-	locReaction->Add_AnalysisAction(new DHistogramAction_TrackVertexComparison(locReaction));
-	
-	// Missing Mass
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 400, 0.05, 0.22, "Pi0"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, 0, locToIncludePIDs, true, 600, 0.5, 1.7, "3pi"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, false, 900, 0.5, 1.4));
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraPi0(locReaction, 0.0775209, 0.188047));
-	locReaction->Add_AnalysisAction(new DCutAction_MinTrackHits(locReaction, 10));
-
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 400, 0.05, 0.22, "Pi0_PostExtraPi0"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, 0, locToIncludePIDs, true, 600, 0.5, 1.7, "3pi_PostExtraPi0"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, false, 900, 0.5, 1.4, "PostExtraPi0"));
-	
-	locReaction->Add_AnalysisAction(new DCutAction_InvariantMass(locReaction, Pi0, false, 0.115, 0.155));
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, 0, locToIncludePIDs, true, 600, 0.5, 1.7, "3pi_PostPi0Mass"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, false, 900, 0.5, 1.4, "PostPi0Mass"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true, "PostPi0Mass")); //true: fill histograms with kinematic-fit particle data
-	
-	//locReaction->Add_AnalysisAction(new DCutAction_InvariantMass(locReaction, 0, locToIncludePIDs, true, 1.2, 1.7));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, false, 900, 0.5, 1.4, "Post3piMass"));
-
-	// Kinematics
-	locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true)); //true: fill histograms with kinematic-fit particle data
-
-	// Tracking Efficiency
-	locReaction->Add_AnalysisAction(new DCustomAction_TrackingEfficiency(locReaction, true));
-
-	//_data.push_back(locReaction); //Register the DReaction with the factory
-
-	/**************************************************** TrackEff_MissingPiPlus_3pi Reaction Steps ****************************************************/
-
-	locReaction = new DReaction("TrackEff_MissingPiPlus_3pi"); //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
-
-	//Example: g, p -> (pi+), pi-, pi0 , p
-	locReactionStep = new DReactionStep();
-	locReactionStep->Set_InitialParticleID(Gamma);
-	locReactionStep->Set_TargetParticleID(Proton);
-	locReactionStep->Add_FinalParticleID(PiPlus, true); // true: pi+ missing
-	locReactionStep->Add_FinalParticleID(PiMinus);
-	locReactionStep->Add_FinalParticleID(Pi0);
-	locReactionStep->Add_FinalParticleID(Proton); 
-	locReaction->Add_ReactionStep(locReactionStep);
-	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
-
-	//pi0 -> g, g
-	locReactionStep = new DReactionStep();
-	locReactionStep->Set_InitialParticleID(Pi0);
-	locReactionStep->Add_FinalParticleID(Gamma);
-	locReactionStep->Add_FinalParticleID(Gamma);
-	locReaction->Add_ReactionStep(locReactionStep);
-	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
-
-	/**************************************************** TrackEff_MissingPiPlus_3pi Control Settings ****************************************************/
-
-	locReaction->Set_KinFitType(d_P4Fit);
-	locReaction->Set_KinFitUpdateCovarianceMatricesFlag(true);
-	locReaction->Set_MaxPhotonRFDeltaT(1.5*dBeamBunchPeriod); //should be minimum cut value
-//	locReaction->Set_MaxExtraGoodTracks(1);
-
-	/************************************************** TrackEff_MissingPiPlus_3pi Pre-Combo Custom Cuts *************************************************/
-
-	// Highly Recommended: Very loose invariant mass cuts, applied during DParticleComboBlueprint construction
-	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
-
-	// Highly Recommended: Very loose DAnalysisAction cuts, applied just after creating the combination (before saving it)
-	// Example: Missing mass squared of proton
-	locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, -0.5, 0.6));
-
-	/**************************************************** TrackEff_MissingPiPlus_3pi Analysis Actions ****************************************************/
-
-	// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
-		//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination 
-		//Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
-
-	// Reject events with large unused shower energy
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));
-
-	// Hist PID
-	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
-
-	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, Proton, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.8, Proton, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Proton, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiMinus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiMinus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiMinus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_TrackFCALShowerEOverP(locReaction, false, 0.5)); //false: measured data //value: cut e+/e- below this, tracks above this
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Gamma, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, Gamma, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_EachPIDFOM(locReaction, -9.9E9, true)); //cut particles with PID FOM = 0
-
-	// Kinematic Fit Results
-	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-
-	// Track DOCA, etc.
-	locReaction->Add_AnalysisAction(new DHistogramAction_TrackVertexComparison(locReaction));
-	
-	// Missing Mass
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 400, 0.05, 0.22, "Pi0"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, 0, locToIncludePIDs, true, 300, 0.5, 1.1, "3pi"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 500, -0.3, 0.4));
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraPi0(locReaction, 0.0775209, 0.188047));
-	locReaction->Add_AnalysisAction(new DCutAction_MinTrackHits(locReaction, 10));
-
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 400, 0.05, 0.22, "Pi0_PostExtraPi0"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, 0, locToIncludePIDs, true, 300, 0.5, 1.1, "3pi_PostExtraPi0"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 500, -0.3, 0.4, "PostExtraPi0"));
-	
-	locReaction->Add_AnalysisAction(new DCutAction_InvariantMass(locReaction, Pi0, false, 0.115, 0.155));
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, 0, locToIncludePIDs, true, 300, 0.5, 1.1, "3pi_PostPi0Mass"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 500, -0.3, 0.4, "Post3piMass"));
-
-	// Kinematics
-	locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true)); //true: fill histograms with kinematic-fit particle data
-
-	// Tracking Efficiency
-	locReaction->Add_AnalysisAction(new DCustomAction_TrackingEfficiency(locReaction, true));
-
-	//_data.push_back(locReaction); //Register the DReaction with the factory
-
-	/**************************************************** TrackEff_MissingPiMinus_3pi Reaction Steps ****************************************************/
-
-	locReaction = new DReaction("TrackEff_MissingPiMinus_3pi"); //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
-
-	//Example: g, p -> pi+, (pi-), pi0 , p
-	locReactionStep = new DReactionStep();
-	locReactionStep->Set_InitialParticleID(Gamma);
-	locReactionStep->Set_TargetParticleID(Proton);
-	locReactionStep->Add_FinalParticleID(PiPlus);
-	locReactionStep->Add_FinalParticleID(PiMinus, true); // true: pi- missing
-	locReactionStep->Add_FinalParticleID(Pi0);
-	locReactionStep->Add_FinalParticleID(Proton);
-	locReaction->Add_ReactionStep(locReactionStep);
-	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
-
-	//pi0 -> g, g
-	locReactionStep = new DReactionStep();
-	locReactionStep->Set_InitialParticleID(Pi0);
-	locReactionStep->Add_FinalParticleID(Gamma);
-	locReactionStep->Add_FinalParticleID(Gamma);
-	locReaction->Add_ReactionStep(locReactionStep);
-	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
-
-	/**************************************************** TrackEff_MissingPiMinus_3pi Control Settings ****************************************************/
-
-	locReaction->Set_KinFitType(d_P4Fit);
-	locReaction->Set_KinFitUpdateCovarianceMatricesFlag(true);
-	locReaction->Set_MaxPhotonRFDeltaT(1.5*dBeamBunchPeriod); //should be minimum cut value
-//	locReaction->Set_MaxExtraGoodTracks(1);
-
-	/************************************************** TrackEff_MissingPiMinus_3pi Pre-Combo Custom Cuts *************************************************/
-
-	// Highly Recommended: Very loose invariant mass cuts, applied during DParticleComboBlueprint construction
-	locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
-
-	// Highly Recommended: Very loose DAnalysisAction cuts, applied just after creating the combination (before saving it)
-	// Example: Missing mass squared of proton
-	locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, -0.5, 0.6));
-
-	/**************************************************** TrackEff_MissingPiMinus_3pi Analysis Actions ****************************************************/
-
-	// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
-		//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination 
-		//Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
-
-	// Reject events with large unused shower energy
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));
-
-	// Hist PID
-	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
-
-	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, Proton, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.8, Proton, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Proton, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiPlus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiPlus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiPlus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_TrackFCALShowerEOverP(locReaction, false, 0.5)); //false: measured data //value: cut e+/e- below this, tracks above this
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Gamma, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, Gamma, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_EachPIDFOM(locReaction, -9.9E9, true)); //cut particles with PID FOM = 0
-
-	// Kinematic Fit Results
-	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-
-	// Track DOCA, etc.
-	locReaction->Add_AnalysisAction(new DHistogramAction_TrackVertexComparison(locReaction));
-	
-	// Missing Mass
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 400, 0.05, 0.22, "Pi0"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, 0, locToIncludePIDs, true, 300, 0.5, 1.1, "3pi"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 500, -0.3, 0.4));
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraPi0(locReaction, 0.0775209, 0.188047));
-	locReaction->Add_AnalysisAction(new DCutAction_MinTrackHits(locReaction, 10));
-
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 400, 0.05, 0.22, "Pi0_PostExtraPi0"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, 0, locToIncludePIDs, true, 300, 0.5, 1.1, "3pi_PostExtraPi0"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 500, -0.3, 0.4, "PostExtraPi0"));
-	
-	locReaction->Add_AnalysisAction(new DCutAction_InvariantMass(locReaction, Pi0, false, 0.115, 0.155));
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, 0, locToIncludePIDs, true, 300, 0.5, 1.1, "3pi_PostPi0Mass"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 500, -0.3, 0.4, "Post3piMass"));
-
-	// Kinematics
-	locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true)); //true: fill histograms with kinematic-fit particle data
-
-	// Tracking Efficiency
-	locReaction->Add_AnalysisAction(new DCustomAction_TrackingEfficiency(locReaction, true));
-
-	//_data.push_back(locReaction); //Register the DReaction with the factory
-
-	/*************************************************************************************************************/
-	/**************************************************** 4pi ****************************************************/
-	/*************************************************************************************************************/
+	locReactions.push_back(locReaction);
 
 	/**************************************************** TrackEff_MissingProton_4pi Reaction Steps ****************************************************/
 
 	locReaction = new DReaction("TrackEff_MissingProton_4pi"); //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
-
-	//Required: DReactionSteps to specify the channel and decay chain you want to study
-		//Particles are of type Particle_t, an enum defined in sim-recon/src/libraries/include/particleType.h
 
 	//Example: g, p -> 2pi+, 2pi-, (p)
 	locReactionStep = new DReactionStep();
@@ -626,69 +110,7 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReactionStep->Add_FinalParticleID(Proton, true); //true: proton missing
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
-
-	/**************************************************** TrackEff_MissingProton_4pi Control Settings ****************************************************/
-
-	locReaction->Set_KinFitType(d_P4Fit);
-	locReaction->Set_KinFitUpdateCovarianceMatricesFlag(true);
-	locReaction->Set_MaxPhotonRFDeltaT(1.5*dBeamBunchPeriod); //should be minimum cut value
-//	locReaction->Set_MaxExtraGoodTracks(1);
-
-	/************************************************** TrackEff_MissingProton_4pi Pre-Combo Custom Cuts *************************************************/
-
-	// Highly Recommended: Very loose DAnalysisAction cuts, applied just after creating the combination (before saving it)
-	// Example: Missing mass squared of proton
-	locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMass(locReaction, false, 0.5, 1.4));
-
-	/**************************************************** TrackEff_MissingProton_4pi Analysis Actions ****************************************************/
-
-	// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
-		//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination 
-		//Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
-
-	// Reject events with large unused shower energy
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));
-
-//	locReaction->Add_AnalysisAction(new DCutAction_BeamEnergy(locReaction, false, 3.0, 6.0));
-
-	// Hist PID
-	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
-
-	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiPlus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiPlus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiPlus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiMinus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiMinus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiMinus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_TrackFCALShowerEOverP(locReaction, false, 0.5)); //false: measured data //value: cut e+/e- below this, tracks above this
-	locReaction->Add_AnalysisAction(new DCutAction_EachPIDFOM(locReaction, -9.9E9, true)); //cut particles with PID FOM = 0
-
-	// Kinematic Fit Results
-	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-
-	// Kinematic Fit: Vertex-Only Fit
-	//locReaction->Add_AnalysisAction(new DCutAction_OneVertexKinFit(locReaction, 5.73303E-7, 44.0, 85.0)); //cut +/- 5 sigma, vertex-z between 44 & 85
-
-	// Track DOCA, etc.
-	locReaction->Add_AnalysisAction(new DHistogramAction_TrackVertexComparison(locReaction));
-
-	// Missing Mass Squared
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, false, 900, 0.5, 1.4));
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraPi0(locReaction, 0.0775209, 0.188047));
-	locReaction->Add_AnalysisAction(new DCutAction_MinTrackHits(locReaction, 10));
-
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, false, 900, 0.5, 1.4, "PostExtraPi0"));
-
-	// Kinematics
-	locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true)); //true: fill histograms with kinematic-fit particle data
-
-	// Tracking Efficiency
-	locReaction->Add_AnalysisAction(new DCustomAction_TrackingEfficiency(locReaction, true));
-
-	_data.push_back(locReaction); //Register the DReaction with the factory
-
+	locReactions.push_back(locReaction);
 
 	/**************************************************** TrackEff_MissingPiPlus_4pi Reaction Steps ****************************************************/
 
@@ -705,69 +127,10 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReactionStep->Add_FinalParticleID(PiMinus);
 	locReactionStep->Add_FinalParticleID(PiPlus);
 	locReactionStep->Add_FinalParticleID(PiMinus);
-	locReactionStep->Add_FinalParticleID(Proton); 
+	locReactionStep->Add_FinalParticleID(Proton);
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
-
-	/**************************************************** TrackEff_MissingPiPlus_4pi Control Settings ****************************************************/
-
-	locReaction->Set_KinFitType(d_P4Fit);
-	locReaction->Set_KinFitUpdateCovarianceMatricesFlag(true);
-	locReaction->Set_MaxPhotonRFDeltaT(1.5*dBeamBunchPeriod); //should be minimum cut value
-//	locReaction->Set_MaxExtraGoodTracks(1);
-
-	/************************************************** TrackEff_MissingPiPlus_4pi Pre-Combo Custom Cuts *************************************************/
-
-	// Highly Recommended: Very loose DAnalysisAction cuts, applied just after creating the combination (before saving it)
-	// Example: Missing mass squared of proton
-	locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, -0.5, 0.6));
-
-	/**************************************************** TrackEff_MissingPiPlus_4pi Analysis Actions ****************************************************/
-
-	// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
-		//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination 
-		//Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
-
-	// Reject events with large unused shower energy
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));
-
-	// Hist PID
-	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
-
-	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, Proton, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.8, Proton, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Proton, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiPlus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiPlus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiPlus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiMinus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiMinus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiMinus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_TrackFCALShowerEOverP(locReaction, false, 0.5)); //false: measured data //value: cut e+/e- below this, tracks above this
-	locReaction->Add_AnalysisAction(new DCutAction_EachPIDFOM(locReaction, -9.9E9, true)); //cut particles with PID FOM = 0
-
-	// Kinematic Fit Results
-	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-
-	// Track DOCA, etc.
-	locReaction->Add_AnalysisAction(new DHistogramAction_TrackVertexComparison(locReaction));
-
-	// Missing Mass Squared
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 1100, -0.5, 0.6));
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraPi0(locReaction, 0.0775209, 0.188047));
-	locReaction->Add_AnalysisAction(new DCutAction_MinTrackHits(locReaction, 10));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 1100, -0.5, 0.6, "PostExtraPi0"));
-
-	// Kinematics
-	locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true)); //true: fill histograms with kinematic-fit particle data
-
-	// Tracking Efficiency
-	locReaction->Add_AnalysisAction(new DCustomAction_TrackingEfficiency(locReaction, true));
-
-	_data.push_back(locReaction); //Register the DReaction with the factory
-
+	locReactions.push_back(locReaction);
 
 	/**************************************************** TrackEff_MissingPiMinus_4pi Reaction Steps ****************************************************/
 
@@ -780,82 +143,20 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReactionStep = new DReactionStep();
 	locReactionStep->Set_InitialParticleID(Gamma);
 	locReactionStep->Set_TargetParticleID(Proton);
-	locReactionStep->Add_FinalParticleID(PiPlus); 
+	locReactionStep->Add_FinalParticleID(PiPlus);
 	locReactionStep->Add_FinalParticleID(PiMinus, true); //true: piminus missing
 	locReactionStep->Add_FinalParticleID(PiPlus);
 	locReactionStep->Add_FinalParticleID(PiMinus);
-	locReactionStep->Add_FinalParticleID(Proton); 
+	locReactionStep->Add_FinalParticleID(Proton);
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+	locReactions.push_back(locReaction);
 
-	/**************************************************** TrackEff_MissingPiMinus_4pi Control Settings ****************************************************/
+	/**************************************************** TrackEff_MissingProton_3pi Reaction Steps ****************************************************/
 
-	locReaction->Set_KinFitType(d_P4Fit);
-	locReaction->Set_KinFitUpdateCovarianceMatricesFlag(true);
-	locReaction->Set_MaxPhotonRFDeltaT(1.5*dBeamBunchPeriod); //should be minimum cut value
-//	locReaction->Set_MaxExtraGoodTracks(1);
+	locReaction = new DReaction("TrackEff_MissingProton_3pi"); //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
 
-	/************************************************** TrackEff_MissingPiMinus_4pi Pre-Combo Custom Cuts *************************************************/
-
-	// Highly Recommended: Very loose DAnalysisAction cuts, applied just after creating the combination (before saving it)
-	// Example: Missing mass squared of proton
-	locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, -0.5, 0.6));
-
-	/**************************************************** TrackEff_MissingPiMinus_4pi Analysis Actions ****************************************************/
-
-	// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
-		//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination 
-		//Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
-
-	// Reject events with large unused shower energy
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));
-
-	// Hist PID
-	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
-
-	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, Proton, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.8, Proton, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, Proton, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiPlus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiPlus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiPlus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 0.5, PiMinus, SYS_TOF)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, PiMinus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.5, PiMinus, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_TrackFCALShowerEOverP(locReaction, false, 0.5)); //false: measured data //value: cut e+/e- below this, tracks above this
-	locReaction->Add_AnalysisAction(new DCutAction_EachPIDFOM(locReaction, -9.9E9, true)); //cut particles with PID FOM = 0
-
-	// Kinematic Fit Results
-	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-
-	// Track DOCA, etc.
-	locReaction->Add_AnalysisAction(new DHistogramAction_TrackVertexComparison(locReaction));
-
-	// Missing Mass Squared
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 1100, -0.5, 0.6));
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraPi0(locReaction, 0.0775209, 0.188047));
-	locReaction->Add_AnalysisAction(new DCutAction_MinTrackHits(locReaction, 10));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 1100, -0.5, 0.6, "PostExtraPi0"));
-
-	// Kinematics
-	locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true)); //true: fill histograms with kinematic-fit particle data
-
-	// Tracking Efficiency
-	locReaction->Add_AnalysisAction(new DCustomAction_TrackingEfficiency(locReaction, true));
-
-	_data.push_back(locReaction); //Register the DReaction with the factory
-
-	/*************************************************************************************************************/
-	/******************************************* omega -> pi0 gamma **********************************************/
-	/*************************************************************************************************************/
-
-	/**************************************************** TrackEff_MissingProton_Omega Reaction Steps ****************************************************/
-
-	locReaction = new DReaction("TrackEff_MissingProton_Omega"); //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
-
-	//Example: g, p -> omega, (p)
+	//g, p -> omega, (p)
 	locReactionStep = new DReactionStep();
 	locReactionStep->Set_InitialParticleID(Gamma);
 	locReactionStep->Set_TargetParticleID(Proton);
@@ -864,11 +165,12 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
 
-	//omega -> pi0, gamma
+	//omega -> pi+, pi-, pi0
 	locReactionStep = new DReactionStep();
 	locReactionStep->Set_InitialParticleID(omega);
+	locReactionStep->Add_FinalParticleID(PiPlus);
+	locReactionStep->Add_FinalParticleID(PiMinus);
 	locReactionStep->Add_FinalParticleID(Pi0);
-	locReactionStep->Add_FinalParticleID(Gamma);
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
 
@@ -879,63 +181,134 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 	locReactionStep->Add_FinalParticleID(Gamma);
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+	locReactions.push_back(locReaction);
 
-	/**************************************************** TrackEff_MissingProton_Omega Control Settings ****************************************************/
+	/**************************************************** TrackEff_MissingPiMinus_3pi Reaction Steps ****************************************************/
 
-	locReaction->Set_KinFitType(d_P4Fit);
-	locReaction->Set_KinFitUpdateCovarianceMatricesFlag(true);
-	locReaction->Set_MaxPhotonRFDeltaT(1.5*dBeamBunchPeriod); //should be minimum cut value
-//	locReaction->Set_MaxExtraGoodTracks(1);
+	locReaction = new DReaction("TrackEff_MissingPiMinus_3pi"); //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
 
-	/************************************************** TrackEff_MissingProton_Omega Pre-Combo Custom Cuts *************************************************/
+	//g, p -> omega, p
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(Gamma);
+	locReactionStep->Set_TargetParticleID(Proton);
+	locReactionStep->Add_FinalParticleID(omega);
+	locReactionStep->Add_FinalParticleID(Proton);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
 
-	// Highly Recommended: Very loose DAnalysisAction cuts, applied just after creating the combination (before saving it)
-	// Example: Missing mass squared of proton
-	locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMass(locReaction, false, 0.5, 1.4));
+	//omega -> pi+, (pi-), pi0
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(omega);
+	locReactionStep->Add_FinalParticleID(PiPlus);
+	locReactionStep->Add_FinalParticleID(PiMinus, true); //true: pi- missing
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
 
-	/**************************************************** TrackEff_MissingProton_Omega Analysis Actions ****************************************************/
+	//pi0 -> g, g
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(Pi0);
+	locReactionStep->Add_FinalParticleID(Gamma);
+	locReactionStep->Add_FinalParticleID(Gamma);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+	locReactions.push_back(locReaction);
 
-	// Reject events with large unused shower energy
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));
+	/**************************************************** TrackEff_MissingPiPlus_3pi Reaction Steps ****************************************************/
 
-//	locReaction->Add_AnalysisAction(new DCutAction_BeamEnergy(locReaction, false, 3.0, 6.0));		
+	locReaction = new DReaction("TrackEff_MissingPiPlus_3pi"); //needs to be a unique name for each DReaction object, CANNOT (!) be "Thrown"
 
-	// Hist PID
-	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
+	//g, p -> omega, p
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(Gamma);
+	locReactionStep->Set_TargetParticleID(Proton);
+	locReactionStep->Add_FinalParticleID(omega);
+	locReactionStep->Add_FinalParticleID(Proton);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
 
-	// PID Cuts
-	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 1.0, Gamma, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, Gamma, SYS_FCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_TrackFCALShowerEOverP(locReaction, false, 0.5)); //false: measured data //value: cut e+/e- below this, tracks above this
-	locReaction->Add_AnalysisAction(new DCutAction_EachPIDFOM(locReaction, -9.9E9, true)); //cut particles with PID FOM = 0
+	//omega -> (pi+), pi-, pi0
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(omega);
+	locReactionStep->Add_FinalParticleID(PiPlus, true); //true: pi+ missing
+	locReactionStep->Add_FinalParticleID(PiMinus);
+	locReactionStep->Add_FinalParticleID(Pi0);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
 
-	// Kinematic Fit Results
-	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+	//pi0 -> g, g
+	locReactionStep = new DReactionStep();
+	locReactionStep->Set_InitialParticleID(Pi0);
+	locReactionStep->Add_FinalParticleID(Gamma);
+	locReactionStep->Add_FinalParticleID(Gamma);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+	locReactions.push_back(locReaction);
 
-	// Missing Mass Squared
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 400, 0.05, 0.22, "Pi0"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, omega, true, 300, 0.5, 1.1, "Omega"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, false, 900, 0.5, 1.4));
 
-	locReaction->Add_AnalysisAction(new DCustomAction_CutExtraPi0(locReaction, 0.0775209, 0.188047));	
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 400, 0.05, 0.22, "Pi0_PostExtraPi0"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, omega, true, 300, 0.5, 1.1, "Omega_PostExtraPi0"));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, false, 900, 0.5, 1.4, "PostExtraPi0"));
 
-	locReaction->Add_AnalysisAction(new DCutAction_InvariantMass(locReaction, Pi0, false, 0.115, 0.155));
-	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, omega, true, 300, 0.5, 1.1, "Omega_PostPi0Mass"));
 
-	locReaction->Add_AnalysisAction(new DCutAction_InvariantMass(locReaction, omega, true, 0.757, 0.807));
-	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, false, 900, 0.5, 1.4, "PostOmegaMass"));
 
-	// Kinematics
-	locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true)); //true: fill histograms with kinematic-fit particle data
+	for(auto& locReaction : locReactions)
+	{
+		/**************************************************** Control Settings ****************************************************/
 
-	// Tracking Efficiency
-	locReaction->Add_AnalysisAction(new DCustomAction_TrackingEfficiency(locReaction, true));
+		// Recommended: Type of kinematic fit to perform (default is d_NoFit)
+			//fit types are of type DKinFitType, an enum defined in sim-recon/src/libraries/ANALYSIS/DReaction.h
+			//Options: d_NoFit (default), d_P4Fit, d_VertexFit, d_P4AndVertexFit
+			//P4 fits automatically constrain decaying particle masses, unless they are manually disabled
+		locReaction->Set_KinFitType(d_P4Fit); //d_P4AndVertexFit //No vertex: can't cut on kinfit conlev anyway, but could distort if alignment is bad
+		locReaction->Set_KinFitUpdateCovarianceMatricesFlag(true);
 
-	//_data.push_back(locReaction); //Register the DReaction with the factory
+		// Highly Recommended: When generating particle combinations, reject all beam photons that match to a different RF bunch
+		locReaction->Set_MaxPhotonRFDeltaT(1.5*dBeamBunchPeriod); // +/- 1 bunch for sideband subtraction
+
+		/************************************************** Pre-Combo Custom Cuts *************************************************/
+
+		Add_PreComboCuts(locReaction);
+
+		// PID
+		Add_PIDActions(locReaction);
+
+		/**************************************************** Analysis Actions ****************************************************/
+
+		// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
+			//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination
+			//Pre-defined actions can be found in ANALYSIS/DHistogramActions_*.h and ANALYSIS/DCutActions.h
+			//If a histogram action is repeated, it should be created with a unique name (string) to distinguish them
+
+		//FURTHER PID
+		locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_trackeff(locReaction, true)); //true: focus on rejecting background
+		locReaction->Add_AnalysisAction(new DCutAction_TrackFCALShowerEOverP(locReaction, false, 0.5)); //false: measured data //value: cut e+/e- below this, tracks above this
+		locReaction->Add_AnalysisAction(new DCutAction_EachPIDFOM(locReaction, -9.9E9, true)); //cut particles with PID FOM = 0
+
+		// SHOWER BACKGROUND
+		locReaction->Add_AnalysisAction(new DCustomAction_CutExtraPi0(locReaction, 0.0775209, 0.188047));
+		locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));
+
+		//TRACK PURITY
+		locReaction->Add_AnalysisAction(new DCutAction_MinTrackHits(locReaction, 10));
+
+		// HISTOGRAM MASSES //false/true: measured/kinfit data
+		Add_MassHistograms(locReaction, false, "PreKinFit");
+
+		// KINEMATIC FIT
+		locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+		locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, -1.0)); //require kinematic fit converges
+
+		// HISTOGRAM MASSES //false/true: measured/kinfit data
+		locReaction->Add_AnalysisAction(new DCustomAction_CutNoDetectorHit(locReaction));
+		Add_MassHistograms(locReaction, false, "PostKinFit");
+		Add_MassHistograms(locReaction, true, "PostKinFit_KinFit");
+
+		// KINEMATICS
+		locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true)); //true: fill histograms with kinematic-fit particle data
+
+		// Tracking Efficiency
+		locReaction->Add_AnalysisAction(new DCustomAction_TrackingEfficiency(locReaction, true));
+
+		_data.push_back(locReaction); //Register the DReaction with the factory
+	}
 
 	return NOERROR;
 }
@@ -950,3 +323,263 @@ jerror_t DReaction_factory_trackeff_missing::fini(void)
 	return NOERROR;
 }
 
+/************************************************************** ACTIONS AND CUTS **************************************************************/
+
+void DReaction_factory_trackeff_missing::Define_LooseCuts(void)
+{
+	// Missing Mass Cuts
+	dMissingMassCuts[Unknown] = pair<double, double>(-0.1, 0.1);
+	dMissingMassCuts[Proton] = pair<double, double>(-0.5, 3.0);
+	dMissingMassCuts[Neutron] = dMissingMassCuts[Proton];
+        dMissingMassCuts[PiPlus] = pair<double, double>(-1.0, 1.0);
+	dMissingMassCuts[PiMinus] = dMissingMassCuts[PiPlus];
+	dMissingMassCuts[omega] = pair<double, double>(0.7, 0.9);
+
+	// Invariant Mass Cuts: Mesons
+	dInvariantMassCuts[Pi0] = pair<double, double>(0.08, 0.19);
+	dInvariantMassCuts[KShort] = pair<double, double>(0.3, 0.7);
+	dInvariantMassCuts[Eta] = pair<double, double>(0.3, 0.8);
+	dInvariantMassCuts[omega] = pair<double, double>(0.74, 0.83);
+	dInvariantMassCuts[EtaPrime] = pair<double, double>(0.6, 1.3);
+	dInvariantMassCuts[phiMeson] = pair<double, double>(0.8, 1.2);
+	dInvariantMassCuts[Jpsi] = pair<double, double>(1.5, 4.0);
+
+	// Invariant Mass Cuts: Baryons
+	dInvariantMassCuts[Lambda] = pair<double, double>(1.0, 1.2);
+	dInvariantMassCuts[Sigma0] = pair<double, double>(1.1, 1.3);
+	dInvariantMassCuts[SigmaPlus] = pair<double, double>(1.1, 1.3);
+	dInvariantMassCuts[XiMinus] = pair<double, double>(1.1, 1.5);
+	dInvariantMassCuts[Xi0] = pair<double, double>(1.1, 1.5);
+
+	// Timing Cuts: Photon
+	dPIDTimingCuts[Gamma][SYS_BCAL] = 0.4;
+	dPIDTimingCuts[Gamma][SYS_FCAL] = 1.0;
+
+	// Timing Cuts: Leptons
+	dPIDTimingCuts[Electron][SYS_BCAL] = 0.6;
+	dPIDTimingCuts[Electron][SYS_FCAL] = 1.4;
+	dPIDTimingCuts[Electron][SYS_TOF] = 0.3;
+	dPIDTimingCuts[Positron] = dPIDTimingCuts[Electron];
+	dPIDTimingCuts[MuonMinus] = dPIDTimingCuts[Electron];
+	dPIDTimingCuts[MuonPlus] = dPIDTimingCuts[Electron];
+
+	// Timing Cuts: Mesons
+	dPIDTimingCuts[PiPlus][SYS_BCAL] = 0.6;
+	dPIDTimingCuts[PiPlus][SYS_FCAL] = 1.4;
+	dPIDTimingCuts[PiPlus][SYS_TOF] = 0.3;
+
+	dPIDTimingCuts[PiMinus][SYS_BCAL] = 0.6;
+	dPIDTimingCuts[PiMinus][SYS_FCAL] = 1.4;
+	dPIDTimingCuts[PiMinus][SYS_TOF] = 0.3;
+
+	dPIDTimingCuts[KPlus][SYS_BCAL] = 0.4;
+	dPIDTimingCuts[KPlus][SYS_FCAL] = 0.5;
+	dPIDTimingCuts[KPlus][SYS_TOF] = 0.25;
+	dPIDTimingCuts[KMinus] = dPIDTimingCuts[KPlus];
+
+	// Timing Cuts: Baryons
+	dPIDTimingCuts[Proton][SYS_BCAL] = 0.8;
+	dPIDTimingCuts[Proton][SYS_FCAL] = 1.0;
+	dPIDTimingCuts[Proton][SYS_TOF] = 0.5;
+
+	dPIDTimingCuts[AntiProton] = dPIDTimingCuts[Proton];
+}
+
+map<Particle_t, pair<double, double> > DReaction_factory_trackeff_missing::Get_DecayingPIDs_InvariantMass(DReaction* locReaction)
+{
+	//pair: cut (hist) edge low/high
+	map<Particle_t, pair<double, double> > locDecayingPIDs;
+	for(size_t loc_i = 1; loc_i < locReaction->Get_NumReactionSteps(); ++loc_i)
+	{
+		const DReactionStep* locReactionStep = locReaction->Get_ReactionStep(loc_i);
+		Particle_t locDecayingPID = locReactionStep->Get_InitialParticleID();
+		bool locMissingMassFlag = locReaction->Check_IfMissingDecayProduct(loc_i);
+		if(locMissingMassFlag)
+			continue;
+
+		auto locPIDIterator = dInvariantMassCuts.find(locDecayingPID);
+		if(locPIDIterator == dInvariantMassCuts.end())
+			continue;
+		auto locCutPair = locPIDIterator->second;
+		locDecayingPIDs[locDecayingPID] = locCutPair;
+	}
+	return locDecayingPIDs;
+}
+
+map<Particle_t, pair<int, deque<Particle_t> > > DReaction_factory_trackeff_missing::Get_DecayingPIDs_MissingMass(DReaction* locReaction)
+{
+	//int: decay step index
+	map<Particle_t, pair<int, deque<Particle_t> > > locDecayingPIDs;
+	for(size_t loc_i = 1; loc_i < locReaction->Get_NumReactionSteps(); ++loc_i)
+	{
+		const DReactionStep* locReactionStep = locReaction->Get_ReactionStep(loc_i);
+		Particle_t locDecayingPID = locReactionStep->Get_InitialParticleID();
+		bool locMissingMassFlag = locReaction->Check_IfMissingDecayProduct(loc_i);
+		if(!locMissingMassFlag)
+			continue;
+
+		//missing mass cut
+		auto locPIDIterator = dMissingMassCuts.find(locDecayingPID);
+		if(locPIDIterator == dMissingMassCuts.end())
+			continue;
+
+		//get production step, other PIDs in that step
+		deque<Particle_t> locMissingMassOffOfPIDs;
+		int locDecayFromStep = locReaction->Get_InitialParticleDecayFromIndices(loc_i).first;
+		locReaction->Get_ReactionStep(locDecayFromStep)->Get_FinalParticleIDs(locMissingMassOffOfPIDs);
+		for(size_t loc_j = 0; loc_j < locMissingMassOffOfPIDs.size(); ++loc_j)
+		{
+			if(locMissingMassOffOfPIDs[loc_j] != locDecayingPID)
+				continue;
+			locMissingMassOffOfPIDs.erase(locMissingMassOffOfPIDs.begin() + loc_j);
+			break;
+		}
+
+		locDecayingPIDs[locDecayingPID] = pair<int, deque<Particle_t> >(locDecayFromStep, locMissingMassOffOfPIDs);
+	}
+	return locDecayingPIDs;
+}
+
+void DReaction_factory_trackeff_missing::Add_PreComboCuts(DReaction* locReaction)
+{
+	// Highly Recommended: decaying particle mass cuts, applied during DParticleComboBlueprint construction
+	map<Particle_t, pair<double, double> > locDecayingPIDs = Get_DecayingPIDs_InvariantMass(locReaction);
+	for(auto& locMapPair : locDecayingPIDs)
+		locReaction->Set_InvariantMassCut(locMapPair.first, locMapPair.second.first, locMapPair.second.second);
+
+	map<Particle_t, pair<int, deque<Particle_t> > > locDecayingPIDs_Missing = Get_DecayingPIDs_MissingMass(locReaction);
+	for(auto& locMapPair : locDecayingPIDs_Missing)
+	{
+		auto locCutPair = dMissingMassCuts[locMapPair.first];
+		int locDecayFromStep = locMapPair.second.first;
+		auto locMissingMassOffOfPIDs = locMapPair.second.second;
+
+		//add the cut
+		if(locCutPair.first >= 0.0)
+			locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMass(locReaction, locDecayFromStep, locMissingMassOffOfPIDs, false, locCutPair.first, locCutPair.second));
+		else
+			locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, locDecayFromStep, locMissingMassOffOfPIDs, false, locCutPair.first, locCutPair.second));
+	}
+
+	// Highly Recommended: Very loose DAnalysisAction cuts, applied just after creating the combination (before saving it)
+
+	//get cut pair
+	pair<double, double> locCutPair;
+	Particle_t locMissingPID;
+	bool locMissingParticleFlag = locReaction->Get_MissingPID(locMissingPID); //false if none missing
+	if(!locMissingParticleFlag)
+		locCutPair = dMissingMassCuts[Unknown];
+	else
+		locCutPair = dMissingMassCuts[locMissingPID];
+
+	if(locCutPair.first >= 0.0)
+		locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMass(locReaction, false, locCutPair.first, locCutPair.second));
+	else
+		locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, locCutPair.first, locCutPair.second));
+}
+
+void DReaction_factory_trackeff_missing::Add_PIDActions(DReaction* locReaction)
+{
+	//Histogram before cuts
+	locReaction->Add_ComboPreSelectionAction(new DHistogramAction_PID(locReaction));
+
+	//Get, loop over detected PIDs in reaction
+	deque<Particle_t> locDetectedPIDs;
+	locReaction->Get_DetectedFinalPIDs(locDetectedPIDs);
+	for(auto locPID : locDetectedPIDs)
+	{
+		if(dPIDTimingCuts.find(locPID) == dPIDTimingCuts.end())
+			continue; //PID timing cut not defined!
+
+		//Add timing cuts //false: measured data
+		for(auto locSystemPair : dPIDTimingCuts[locPID])
+			locReaction->Add_ComboPreSelectionAction(new DCutAction_PIDDeltaT(locReaction, false, locSystemPair.second, locPID, locSystemPair.first));
+
+		//For kaon candidates, cut tracks that don't have a matching hit in a timing detector
+			//Kaons are rare, cut ~necessary to reduce high backgrounds
+		if((locPID == KPlus) || (locPID == KMinus))
+			locReaction->Add_ComboPreSelectionAction(new DCutAction_NoPIDHit(locReaction, locPID));
+	}
+
+	//Loose dE/dx cuts
+	locReaction->Add_ComboPreSelectionAction(new DCustomAction_dEdxCut_trackeff(locReaction, false)); //false: focus on keeping signal
+}
+
+void DReaction_factory_trackeff_missing::Add_MassHistograms(DReaction* locReaction, bool locUseKinFitResultsFlag, string locBaseUniqueName)
+{
+//	bool locConstrainMassFlag = locFSInfo->intermediateMassFits();
+//	if(locUseKinFitResultsFlag && locConstrainMassFlag)
+//		return;
+
+	//missing mass
+	if(!locUseKinFitResultsFlag)
+	{
+		//get cut pair
+		pair<double, double> locCutPair;
+		Particle_t locMissingPID;
+		bool locMissingParticleFlag = locReaction->Get_MissingPID(locMissingPID); //false if none missing
+		if(!locMissingParticleFlag)
+			locCutPair = dMissingMassCuts[Unknown];
+		else
+			locCutPair = dMissingMassCuts[locMissingPID];
+
+		//determine #bins
+		int locNumBins = int((locCutPair.second - locCutPair.first)*1000.0 + 0.001);
+		if(locNumBins < 200)
+			locNumBins *= 5; //get close to 1000 bins
+		if(locNumBins < 500)
+			locNumBins *= 2; //get close to 1000 bins
+
+		//add histogram action
+		if(locCutPair.first >= 0.0)
+			locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, false, locNumBins, locCutPair.first, locCutPair.second, locBaseUniqueName));
+		else
+			locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, locNumBins, locCutPair.first, locCutPair.second, locBaseUniqueName));
+	}
+
+	//invariant mass
+	// Highly Recommended: Very loose decaying particle mass cuts, applied during DParticleComboBlueprint construction
+	map<Particle_t, pair<double, double> > locDecayingPIDs = Get_DecayingPIDs_InvariantMass(locReaction);
+	for(auto& locMapPair : locDecayingPIDs)
+	{
+		//determine #bins
+		int locNumBins = int((locMapPair.second.second - locMapPair.second.first)*1000.0 + 0.001);
+		if(locNumBins < 200)
+			locNumBins *= 5; //get close to 1000 bins
+		if(locNumBins < 500)
+			locNumBins *= 2; //get close to 1000 bins
+
+		//build name string
+		Particle_t locPID = locMapPair.first;
+		string locActionUniqueName = string(ParticleType(locPID)) + string("_") + locBaseUniqueName;
+
+		//add histogram action
+		locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, locPID, locUseKinFitResultsFlag,
+			locNumBins, locMapPair.second.first, locMapPair.second.second, locActionUniqueName));
+	}
+
+	map<Particle_t, pair<int, deque<Particle_t> > > locDecayingPIDs_Missing = Get_DecayingPIDs_MissingMass(locReaction);
+	for(auto& locMapPair : locDecayingPIDs_Missing)
+	{
+		auto locCutPair = dMissingMassCuts[locMapPair.first];
+		int locDecayFromStep = locMapPair.second.first;
+		auto locMissingMassOffOfPIDs = locMapPair.second.second;
+
+		//determine #bins
+		int locNumBins = int((locCutPair.second - locCutPair.first)*1000.0 + 0.001);
+		if(locNumBins < 200)
+			locNumBins *= 5; //get close to 1000 bins
+		if(locNumBins < 500)
+			locNumBins *= 2; //get close to 1000 bins
+
+		//build name string
+		Particle_t locPID = locMapPair.first;
+		string locActionUniqueName = string(ParticleType(locPID)) + string("_") + locBaseUniqueName;
+
+		//add the cut
+		if(locCutPair.first >= 0.0)
+			locReaction->Add_AnalysisAction(new DHistogramAction_MissingMass(locReaction, locDecayFromStep, locMissingMassOffOfPIDs, locUseKinFitResultsFlag, locNumBins, locCutPair.first, locCutPair.second));
+		else
+			locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, locDecayFromStep, locMissingMassOffOfPIDs, locUseKinFitResultsFlag, locNumBins, locCutPair.first, locCutPair.second));
+	}
+}

--- a/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.h
+++ b/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.h
@@ -30,12 +30,28 @@ class DReaction_factory_trackeff_missing : public jana::JFactory<DReaction>
 		const char* Tag(void){return "trackeff_missing";}
 
 	private:
+		jerror_t init(void);
 		jerror_t brun(JEventLoop* locEventLoop, int32_t locRunNumber);
 		jerror_t evnt(JEventLoop* locEventLoop, uint64_t locEventNumber);
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
+		// Actions & cuts
+		void Define_LooseCuts(void);
+		void Add_PreComboCuts(DReaction* locReaction);
+		void Add_PIDActions(DReaction* locReaction);
+		void Add_MassHistograms(DReaction* locReaction, bool locUseKinFitResultsFlag, string locBaseUniqueName = "");
+
+		// Utilities
+		map<Particle_t, pair<double, double> > Get_DecayingPIDs_InvariantMass(DReaction* locReaction);
+		map<Particle_t, pair<int, deque<Particle_t> > > Get_DecayingPIDs_MissingMass(DReaction* locReaction);
+
 		double dBeamBunchPeriod;
 		deque<DReactionStep*> dReactionStepPool; //to prevent memory leaks
+
+		// Cuts
+		map<Particle_t, pair<double, double> > dMissingMassCuts; //Unknown = none missing //if negative, uses missing mass squared instead
+		map<Particle_t, pair<double, double> > dInvariantMassCuts;
+		map<Particle_t, map<DetectorSystem_t, double> > dPIDTimingCuts;
 };
 
 #endif // _DReaction_factory_trackeff_missing_

--- a/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.h
+++ b/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.h
@@ -38,7 +38,7 @@ class DReaction_factory_trackeff_missing : public jana::JFactory<DReaction>
 		// Actions & cuts
 		void Define_LooseCuts(void);
 		void Add_PIDActions(DReaction* locReaction);
-		void Add_MassCuts(DReaction* locReaction, bool locKinFitFlag = false);
+		bool Add_MassCuts(DReaction* locReaction, bool locKinFitFlag = false); //returns false if no cuts placed
 		void Add_MassHistograms(DReaction* locReaction, bool locKinFitFlag, string locBaseUniqueName = "");
 
 		// Utilities

--- a/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.h
+++ b/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.h
@@ -37,13 +37,13 @@ class DReaction_factory_trackeff_missing : public jana::JFactory<DReaction>
 
 		// Actions & cuts
 		void Define_LooseCuts(void);
-		void Add_PreComboCuts(DReaction* locReaction);
 		void Add_PIDActions(DReaction* locReaction);
-		void Add_MassHistograms(DReaction* locReaction, bool locUseKinFitResultsFlag, string locBaseUniqueName = "");
+		void Add_MassCuts(DReaction* locReaction, bool locKinFitFlag = false);
+		void Add_MassHistograms(DReaction* locReaction, bool locKinFitFlag, string locBaseUniqueName = "");
 
 		// Utilities
-		map<Particle_t, pair<double, double> > Get_DecayingPIDs_InvariantMass(DReaction* locReaction);
-		map<Particle_t, pair<int, deque<Particle_t> > > Get_DecayingPIDs_MissingMass(DReaction* locReaction);
+		set<Particle_t> Get_InvariantMassPIDs(DReaction* locReaction, bool locKinFitFlag = false);
+		map<Particle_t, pair<int, deque<Particle_t> > > Get_MissingMassPIDs(DReaction* locReaction, bool locKinFitFlag = false);
 
 		double dBeamBunchPeriod;
 		deque<DReactionStep*> dReactionStepPool; //to prevent memory leaks
@@ -51,6 +51,8 @@ class DReaction_factory_trackeff_missing : public jana::JFactory<DReaction>
 		// Cuts
 		map<Particle_t, pair<double, double> > dMissingMassCuts; //Unknown = none missing //if negative, uses missing mass squared instead
 		map<Particle_t, pair<double, double> > dInvariantMassCuts;
+		map<Particle_t, pair<double, double> > dMissingMassCuts_KinFit; //Unknown = none missing //if negative, uses missing mass squared instead
+		map<Particle_t, pair<double, double> > dInvariantMassCuts_KinFit;
 		map<Particle_t, map<DetectorSystem_t, double> > dPIDTimingCuts;
 };
 

--- a/src/plugins/monitoring/FCAL_Hadronic_Eff/JEventProcessor_FCAL_Hadronic_Eff.cc
+++ b/src/plugins/monitoring/FCAL_Hadronic_Eff/JEventProcessor_FCAL_Hadronic_Eff.cc
@@ -207,8 +207,11 @@ jerror_t JEventProcessor_FCAL_Hadronic_Eff::evnt(jana::JEventLoop* locEventLoop,
 		}
 
 		//Find closest FCAL Shower
-		double locBestDistance = 999.0;
-		const DFCALShower* locFCALShower = locParticleID->Get_ClosestToTrack_FCAL(locTrackTimeBased, locFCALShowers, locBestDistance);
+		const DFCALShower* locFCALShower = nullptr;
+		DFCALShowerMatchParams locClosestMatchParams;
+		double locStartTime = locTrackTimeBased->t0();
+		if(locParticleID->Get_ClosestToTrack(locTrackTimeBased->rt, locFCALShowers, false, locStartTime, locClosestMatchParams))
+			locFCALShower = locClosestMatchParams.dFCALShower;
 
 		//Is match to FCAL shower?
 		const DFCALShowerMatchParams* locFCALShowerMatchParams = locChargedTrackHypothesis->Get_FCALShowerMatchParams();

--- a/src/plugins/monitoring/SC_Eff/JEventProcessor_SC_Eff.cc
+++ b/src/plugins/monitoring/SC_Eff/JEventProcessor_SC_Eff.cc
@@ -33,7 +33,6 @@ jerror_t JEventProcessor_SC_Eff::init(void)
 	//action initialize not necessary: is empty
 	dMaxPIDDeltaTMap[SYS_BCAL] = 1.0;
 	dMaxPIDDeltaTMap[SYS_TOF] = 1.0;
-	dLooseSCDeltaPhiCut = 99999.9; //intentionally wide: accept and save all: for sideband subtraction
 
 	TDirectory* locOriginalDir = gDirectory;
 	gDirectory->mkdir("SC_Eff")->cd();
@@ -186,7 +185,7 @@ jerror_t JEventProcessor_SC_Eff::evnt(jana::JEventLoop* locEventLoop, uint64_t l
 		//Predict ST Surface Hit Location
 		DVector3 locPredictedSurfacePosition;
 		bool locProjBarrelRegion = false;
-		unsigned int locPredictedSCSector = locParticleID->PredictSCSector(locTrackTimeBased->rt, 999.0, &locPredictedSurfacePosition, &locProjBarrelRegion);
+		unsigned int locPredictedSCSector = locParticleID->PredictSCSector(locTrackTimeBased->rt, &locPredictedSurfacePosition, &locProjBarrelRegion);
 
 		//Save for hist if is matched
 		pair<int, double> locHitPair(locPredictedSCSector, locPredictedSurfacePosition.Z());
@@ -223,7 +222,7 @@ jerror_t JEventProcessor_SC_Eff::evnt(jana::JEventLoop* locEventLoop, uint64_t l
 			const DSCHit* locSCHit = locSCHits[loc_i];
 
 			DSCHitMatchParams locSCHitMatchParams;
-			if(!locParticleID->MatchToSC(locTrackTimeBased, locTrackTimeBased->rt, locSCHit, locTrackTimeBased->t0(), locSCHitMatchParams, true, &dLooseSCDeltaPhiCut))
+			if(!locParticleID->Distance_ToTrack(locTrackTimeBased->rt, locSCHit, locTrackTimeBased->t0(), locSCHitMatchParams))
 				continue;
 
 			double locDeltaT = locSCHitMatchParams.dHitTime - locSCHitMatchParams.dFlightTime - locChargedTrackHypothesis->time();

--- a/src/plugins/monitoring/SC_Eff/JEventProcessor_SC_Eff.h
+++ b/src/plugins/monitoring/SC_Eff/JEventProcessor_SC_Eff.h
@@ -56,7 +56,6 @@ class JEventProcessor_SC_Eff : public jana::JEventProcessor
 		int dMinHitRingsPerCDCSuperlayer, dMinHitPlanesPerFDCPackage;
 		DCutAction_TrackHitPattern* dCutAction_TrackHitPattern;
 		map<DetectorSystem_t, double> dMaxPIDDeltaTMap;
-		float dLooseSCDeltaPhiCut;
 
 		//HISTOGRAMS
 		TH2I* dHist_HitFound;

--- a/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.cc
+++ b/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.cc
@@ -207,13 +207,8 @@ jerror_t JEventProcessor_ST_online_Tresolution::evnt(JEventLoop *loop, uint64_t 
       // If st_match = true, there is a match between this track and the ST
       if (!st_match) continue;
      
-      sc_match_pid = dParticleID->MatchToSC(timeBasedTrack, 
-					    timeBasedTrack->rt, 
-					    st_params[0].dSCHit, 
-					    st_params[0].dSCHit->t, 
-					    locSCHitMatchParams, 
-					    true, NULL,
-					    &IntersectionPoint, &IntersectionDir); 
+      DVector3 IntersectionPoint, IntersectionMomentum;
+      bool sc_match_pid = dParticleID->Cut_MatchDistance(timeBasedTrack->rt, st_params[0].dSCHit, st_params[0].dSCHit->t, locSCHitMatchParams, true, &IntersectionPoint, &IntersectionMomentum);
       if(!sc_match_pid) continue; 
       // Cut on the number of particle votes to find the best RF time
       if (thisRFBunch->dNumParticleVotes < 2) continue;

--- a/src/plugins/monitoring/ST_online_efficiency/JEventProcessor_ST_online_efficiency.cc
+++ b/src/plugins/monitoring/ST_online_efficiency/JEventProcessor_ST_online_efficiency.cc
@@ -176,7 +176,7 @@ jerror_t JEventProcessor_ST_online_efficiency::evnt(JEventLoop *eventLoop, uint6
       // applied vertex cut
       if (!z_vertex_cut) continue;
       if (!r_vertex_cut) continue;
-      int st_pred_id = pid_algorithm[0]->PredictSCSector(timeBasedTrack->rt,0.05235,&locProjPos,&Barrel);
+      int st_pred_id = pid_algorithm[0]->PredictSCSector(timeBasedTrack->rt,&locProjPos,&Barrel);
       int st_pred_id_index = st_pred_id - 1;
       // Z intersection of charged track and SC 
       locSCzIntersection = locProjPos.z();

--- a/src/plugins/monitoring/ST_online_tracking/JEventProcessor_ST_online_tracking.cc
+++ b/src/plugins/monitoring/ST_online_tracking/JEventProcessor_ST_online_tracking.cc
@@ -207,22 +207,16 @@ jerror_t JEventProcessor_ST_online_tracking::evnt(JEventLoop *eventLoop, uint64_
       // Declare a vector which quantizes the point of the intersection of a charged particle 
       //   with a plane in the middle of the scintillator 
       DVector3 IntersectionPoint;
-      // Declare a vector which quantizes the unit vector of the charged particle track traversing
+      // Declare a vector which quantizes the momentum of the charged particle track traversing
       //   through the scintillator with its origin at the intersection point
-      DVector3 IntersectionDir;
+      DVector3 IntersectionMomentum;
       // Grab the paramteres associated to a track matched to the ST
       vector<DSCHitMatchParams> st_params;
       bool st_match = locDetectorMatches->Get_SCMatchParams(timeBasedTrack, st_params); 
       // If st_match = true, there is a match between this track and the ST
       if (!st_match) continue;
 
-      bool st_match_pid = dParticleID->MatchToSC(timeBasedTrack, 
-						 timeBasedTrack->rt, 
-						 st_params[0].dSCHit, 
-						 st_params[0].dSCHit->t, 
-						 locSCHitMatchParams, 
-						 true, NULL,
-						 &IntersectionPoint, &IntersectionDir);      
+      bool st_match_pid = dParticleID->Cut_MatchDistance(timeBasedTrack->rt, st_params[0].dSCHit, st_params[0].dSCHit->t, locSCHitMatchParams, true, &IntersectionPoint, &IntersectionMomentum);
       if(!st_match_pid) continue;  
 
       DVector3 momentum_vec;

--- a/src/plugins/monitoring/TOF_Eff/JEventProcessor_TOF_Eff.cc
+++ b/src/plugins/monitoring/TOF_Eff/JEventProcessor_TOF_Eff.cc
@@ -261,13 +261,21 @@ jerror_t JEventProcessor_TOF_Eff::evnt(jana::JEventLoop* locEventLoop, uint64_t 
 		}
 
 		//Find closest TOF point
+		double locStartTime = locTrackTimeBased->t0();
+		DTOFHitMatchParams locClosestMatchParams;
 		double locBestPointDeltaX = 999.9, locBestPointDeltaY = 999.9;
-		const DTOFPoint* locClosestTOFPoint = locParticleID->Get_ClosestToTrack_TOFPoint(locTrackTimeBased, locTOFPoints, locBestPointDeltaX, locBestPointDeltaY);
+		const DTOFPoint* locClosestTOFPoint = nullptr;
+		if(locParticleID->Get_ClosestToTrack(locTrackTimeBased->rt, locTOFPoints, false, locStartTime, locClosestMatchParams))
+		{
+			locClosestTOFPoint = locClosestMatchParams.dTOFPoint;
+			locBestPointDeltaX = locClosestMatchParams.dDeltaXToHit;
+			locBestPointDeltaY = locClosestMatchParams.dDeltaYToHit;
+		}
 
 		//Find closest TOF paddles
 		double locBestPaddleDeltaX = 999.9, locBestPaddleDeltaY = 999.9, locBestPaddleDistance_Vertical = 999.9, locBestPaddleDistance_Horizontal = 999.9;
 		//first in pair is vertical, second is horizontal // NULL If none / doesn't hit TOF
-		double locStartTime = locParticleID->Calc_PropagatedRFTime(locChargedTrackHypothesis, locEventRFBunch);
+		locStartTime = locParticleID->Calc_PropagatedRFTime(locChargedTrackHypothesis, locEventRFBunch);
 		const DTOFPaddleHit* locClosestTOFPaddleHit_Vertical = locParticleID->Get_ClosestTOFPaddleHit_Vertical(locTrackTimeBased->rt, locTOFPaddleHits, locStartTime, locBestPaddleDeltaX, locBestPaddleDistance_Vertical);
 		const DTOFPaddleHit* locClosestTOFPaddleHit_Horizontal = locParticleID->Get_ClosestTOFPaddleHit_Horizontal(locTrackTimeBased->rt, locTOFPaddleHits, locStartTime, locBestPaddleDeltaY, locBestPaddleDistance_Horizontal);
 


### PR DESCRIPTION
Re-organize track/SC/BCAL/FCAL/TOF matching routines: The matching/geometry logic is no longer duplicated across several functions.  This fixed several inconsistencies between the functions.  In addition, various minor bug fixes were made to how the tracks were propagated to the SC geometry.  Finally, the matching cuts for the BCAL and SC were updated. 

For tracking efficiencies, added 2 new channels: omega decays to 3pi, with the pi+ and pi- missing.  These are extremely clean.  Also, to help cleanup all channels, swim a reference trajectory for the missing momentum, and require that it match the SC.  Also require that it match either the BCAL or the FCAL + TOF.  Different matching cuts were used for this instead of those in the reconstruction, since the resolution on the missing tracks is worse than those for reconstructed tracks. 

As a bonus, pseudo-randomly sort beam photons by time (using sub-ps digits).  