### PR TITLE
* This is a coordinated update to the way electromagnetic background

### DIFF
--- a/src/programs/Simulation/HDGeant/backgrounds.inc
+++ b/src/programs/Simulation/HDGeant/backgrounds.inc
@@ -7,13 +7,17 @@ c  date: March 22, 2005
 c
 c  Notes:
 c  -------
-c  bgrate: 	the rate (1/ns) of beam photons above the threshold BCUTE
-c          	for discrete bremsstrahlung to generate during the ADC gate;
-c          	default value of 0 represents a background-free simulation.
-c  bggate:	time (ns) of the start (1) and end (2) of the gate during
-c		which random background is simulated, relative to the time
-c               of the photon that originated the event.
+c  bgrate: the rate (1/ns) of beam photons above the threshold BCUTE
+c          for discrete bremsstrahlung to generate during the ADC gate;
+c          default value of 0 represents a background-free simulation.
+c  bggate: time (ns) of the start (1) and end (2) of the gate during
+c          which random background is simulated, relative to the time
+c          of the photon that originated the event.
+c  bgtagonly: flag saying whether to tag and track all of the background
+c          beam photons generated within bggate (bgtagonly=0), or to
+c          only record their tags but not track them (bgtagonly=1).
 
       real bgrate
       real bggate(2)
-      common /backgrounds/bgrate,bggate
+      integer bgtagonly
+      common /backgrounds/bgrate,bggate,bgtagonly

--- a/src/programs/Simulation/HDGeant/beamgen.F
+++ b/src/programs/Simulation/HDGeant/beamgen.F
@@ -21,6 +21,7 @@
 #include "geant321/gcomis.inc"
 #include "geant321/gctrak.inc"
 #include "controlparams.inc"
+#include "backgrounds.inc"
 #include "cobrems.inc"
  
       real vertex(4),plab(5),pbeam
@@ -44,7 +45,7 @@ c  freq > freqMaximum is generated; a few ppm of these is no problem.
       real xMinimum,freqMaximum,beamStartZ,Theta02
       common /coherentGen/xMinimum,freqMaximum,beamStartZ,Theta02
       data xMinimum/0.01/
-      data freqMaximum/9.0e-4/
+      data freqMaximum/1.0e-4/
       data beamStartZ/-2400.0/
       data Theta02/1.8/
       save /coherentGen/
@@ -58,7 +59,7 @@ c  freq > freqMaximum is generated; a few ppm of these is no problem.
       data freqIntegral/nProfileBins*0/
       save /freqTables/
       real Wincoh
-      parameter (Wincoh=0.1)
+      data Wincoh/0.1/
 
       integer nubuf
       real ubuf(10)
@@ -98,14 +99,36 @@ c  freq > freqMaximum is generated; a few ppm of these is no problem.
          x1 = 1
          x0 = xMinimum**(1./nProfileBins)
          freqProfile(1) = dNcdxdp((x0+x1)/2,TWOPI/4)
-         freqIntegral(1) = freqProfile(1)*(x1-x0)
          do ip=2,nProfileBins
             x1 = x0
             x0 = xMinimum**(ip*1./nProfileBins)
             freqProfile(ip) = dNcdxdp((x0+x1)/2,TWOPI/4)
+         enddo
+         freqMaximum = 0
+         do ip=1,nProfileBins-5
+            if (freqProfile(ip).lt.freqProfile(ip+1)*0.8) then
+               freqProfile(ip) = freqProfile(ip+1)*0.8
+            elseif (freqProfile(ip).lt.freqProfile(ip+2)*0.6) then
+               freqProfile(ip) = freqProfile(ip+2)*0.6
+            elseif (freqProfile(ip).lt.freqProfile(ip+3)*0.4) then
+               freqProfile(ip) = freqProfile(ip+3)*0.4
+            elseif (freqProfile(ip).lt.freqProfile(ip+4)*0.2) then
+               freqProfile(ip) = freqProfile(ip+4)*0.2
+            endif
+            if (freqMaximum < freqProfile(ip)) then
+               freqMaximum = freqProfile(ip)
+            endif
+         enddo
+         x1 = 1
+         x0 = xMinimum**(1./nProfileBins)
+         freqIntegral(1) = freqProfile(1)*(x1-x0)
+         do ip=2,nProfileBins
+            x1 = x0
+            x0 = xMinimum**(ip*1./nProfileBins)
             freqIntegral(ip) = freqIntegral(ip-1)
      +                        +freqProfile(ip)*(x1-x0)
          enddo
+         freqMaximum = REAL(4*TWOPI)*freqIntegral(nProfileBins)
       endif
       do i=1,1000000000
          call GRNDM(rndm,5)
@@ -148,6 +171,10 @@ c  freq > freqMaximum is generated; a few ppm of these is no problem.
             freq = freq*(Theta02+theta2)**2/Theta02
             freq = freq*x*(-log(xMinimum))
             freq = freq*Wincoh
+            if (freq.gt.freqMaximum) then
+               Wincoh = Wincoh * 0.8
+               cycle
+            endif
             ppol = 0
          endif
          if (freq.gt.freqMaximum) then
@@ -210,8 +237,10 @@ c  freq > freqMaximum is generated; a few ppm of these is no problem.
       nubuf = 3
 #endif
       call settofg(vertex,t0)
-      call GSVERT(vertex,0,0,ubuf,nubuf,nvert)
-      call GSKINE(plab,1,nvert,0,0,nt) ! push the beam photon on the stack
+      if (bgtagonly.eq.0) then
+        call GSVERT(vertex,0,0,ubuf,nubuf,nvert)
+        call GSKINE(plab,1,nvert,0,0,nt) ! push the beam photon on the stack
+      endif
       vertex(4) = TOFG
       if (genbeam_mode(1).eq.0) then
          call hitTagger(vertex,vertex,plab,plab,0.,1,0,0)

--- a/src/programs/Simulation/HDGeant/control.in
+++ b/src/programs/Simulation/HDGeant/control.in
@@ -146,26 +146,51 @@ HALO  5e-5
 
 c The following lines control the rate (GHz) of background beam photons
 c that are overlayed on each event in the simulation, in addition to the
-c particles produced by the standard generation mechanism.  A value of
-c 1.10 corresponds to nominal GlueX running conditions at an intensity of
-c 10^7 tagged photons on target per second.  To disable the generation of
-c random beam background, comment this line out or set the value of BGRATE
-c to zero.  Background beam photons are generated during the time interval
-c given by the BGGATE card, whose two arguments specify the earliest and
-c latest times (ns relative to the time of the original photon that caused
-c the event) that a random beam photon could produce background hits
-c somewhere in the detector.  Note that for this to work, the BEAM card
-c must be present (see above).  This means that background generation is
-c disabled when the simulation operates in particle gun mode.
-c If Emin is set in the BEAM card (see above), the rate of background photons
-c is automatically rescaled as follows:
-c       Rate(E_gamma > Thr)  =  Rate(E_gamma > 0.12 GeV) * K,
-c where K is a scale factor calculated inside uginit.F:
-c       K = 1 for Thr = 0.12 GeV,
-c       K > 1 for Thr < 0.12 GeV. 
-c Note, K is calculated assuming the beam energies Emax = 12, Epeak = 9. 
-cBGRATE 1.10
+c particles produced by the standard generation mechanism. BGGATE expects
+c two values in ns, which define the window around the trigger time that
+c background beam photons are overlaid on the simulation. The value you
+c should enter for BGRATE depends on many details of the photon beam: the
+c endpoint energy, the low-energy cutoff to be used in generating beam
+c photons, the location of coherent edge, the electron beam spot size and
+c emittance at the primary collimator, the electron beam current, etc. To
+c find the setting that is right for you, follow these steps in order.
+c  1) Check the BEAM card above that it has correct values for the electron
+c     beam energy (field 1) and the low-energy cutoff that you want to use
+c     in your simulation (field 3). Remember these values.
+c  2) Open a new tab in a web browser and enter the following URL,
+c     http://zeus.phys.uconn.edu/halld/cobrems/ratetool.cgi which displays
+c     a form containing many fields describing the electron beam and the
+c     photon beamline. Enter the correct values in all fields in the
+c     left-most column of parameters. The right column of parameters 
+c     defines the windows over which the tool will compute integrals of
+c     the beam rate. Set the "end-point" window to span the full range
+c     from your beamEmin (see step 1 above) to the electron beam endpoint,
+c     Then click the Plot Spectrum button. After a few seconds, the form will
+c     respond with a few plots and rate numbers in bold text. Record the
+c     value given for the "end-point rate". This is your BGRATE value.
+c  3) Enter your BGRATE value found in step 2 after BGRATE in the line
+c     below, and remove any characters before the BGRATE keyword. You are
+c     now ready to go. If you ever change anything in the beamline geometry
+c     eg. the collimator diameter, the coherent edge position, or the value
+c     of beamEmin, do not forget to come back and change your BGRATE.
 cBGGATE -200. 200.
+cBGRATE 4.80
+
+c The above cards BGRATE, BGGATE normally cause the simulation to add
+c accidental tagger hits to the simulated output record, in addition to
+c adding these beam photons to the list of particles to be tracked through
+c the detector. If you want the accidental tagger hits to be added to the
+c simulated output record but you do not want to track the background
+c beam photons, remove the comment in front of BGTAGONLY below.
+c NOTICE: If you turn on BGTAGONLY then you might as well raise the
+c minimum energy of beam photons being generated to the lower bound of
+c the tagger energy range you are interested in, which might be 3 GeV for
+c low-intensity running, 7 GeV for high-intensity running, or even 8 GeV
+c if you are only interested in the region of the coherent peak. This
+c minimum is the third field of the BEAM card above. Remember that if
+c you change beamEmin, you also need to change BGRATE to match, as 
+c described above.
+cBGTAGONLY 1
 
 c The following line controls the uncertainty of the event time reference
 c relative to the RF structure of the beam. The event time reference is

--- a/src/programs/Simulation/HDGeant/gukine.F
+++ b/src/programs/Simulation/HDGeant/gukine.F
@@ -116,7 +116,7 @@
       DIMENSION VERTEX(4),PLAB(5)
       DIMENSION RNDM(20)
 
-      real tgen
+      real tgen, tgend
       real unif01(100)
       integer i,j
       character*20 pname
@@ -231,8 +231,8 @@
             do j=1,100
               tgen=tgen-log(unif01(j))/bgrate
               if (tgen.gt.bggate(2)) goto 10
-              tgen=beam_period_ns*floor(tgen/beam_period_ns+0.5)
-              call beamgen(tgen)
+              tgend=beam_period_ns*floor(tgen/beam_period_ns+0.5)
+              call beamgen(tgend)
               ngen=ngen+1
             enddo
           enddo

--- a/src/programs/Simulation/HDGeant/uginit.F
+++ b/src/programs/Simulation/HDGeant/uginit.F
@@ -204,6 +204,11 @@ c The following parameters are declared in controlparams.inc above.
       character*10 genbeam_modes
       equivalence (genbeam_mode(1), genbeam_modes)
 
+c The following parameters are declared in backgrounds.inc above.
+      data bgrate/0/
+      data bggate/0,0/
+      data bgtagonly/0/
+
 C  Use this parameter to set up a minimum photon energy 
 C  for the coherent bremsstrahlung beam generator - see beamgen.F
       real    xMinimum,freqMaximum,beamStartZ,Theta02

--- a/src/programs/Simulation/HDGeant/uginit.F
+++ b/src/programs/Simulation/HDGeant/uginit.F
@@ -279,6 +279,7 @@ C..geant..
       call ffkey('tlog', tlog_particle_gun,1,'INTEGER')
       CALL FFKEY('bgrate',bgrate,1,'REAL')
       CALL FFKEY('bggate',bggate,2,'REAL')
+      CALL FFKEY('bgtagonly',bgtagonly,1,'INTEGER')
       CALL FFKEY('savehits',writenohits,1,'INTEGER')
       CALL FFKEY('showersincol',showersincol,1,'INTEGER')
       call FFKEY('driftclusters',driftclusters,1,'INTEGER')
@@ -344,12 +345,6 @@ c        endif
      +        ' beamEmin is specified with negative value,',
      +        ' cannot continue.'
          stop
-      elseif (beamEmin.gt.0.12) then
-         print *
-         print *, 'Error in uginit:',
-     +        ' beamEmin is larger than a default value of 0.12 GeV,',
-     +        ' cannot continue.'
-         stop
       endif
 
       if (genbeam_mode(1).ne.0.and.beamE0.gt.0.and.infile(1).eq.0) then
@@ -380,13 +375,27 @@ c        endif
             
 *     Scale BG rate according to the threshold set on energy of bremsstrahlung
 *     photons. bgrate corresponds to  Rate(E_brem = 0.12 GeV).
+*     
+*     Note added by RTJ, March 4, 2017
+*     I am disabling this ad-hoc formula for automatically adjusting BGRATE
+*     according to the beamEmin value, because it assumes too much:
+*      (1) that the collimator is 3.4mm -- generally NOT true, and
+*      (2) that the value of Emin is low enough that BGRATE is insensitive
+*          to the diamond orientation. 
+*     All of this relies too much on the user understanding the limits
+*     of the approximations involved, and I think in the end users are
+*     being fooled into thinking the simulation is valid for a given set
+*     of collimators and energy cuts when it isn't. In its place, I am
+*     adding an explanation in control.in that whenever you enable the
+*     BGRATE card, you need to do a quick calculation to get the right
+*     number to give for the rate that matches with the value of beamEmin
+*     that is set in the BEAM card.
 
       if (beamEmin.gt.0) then
-         bgrate   = bgrate*(0.12*9.1625*LOG(0.12/beamEmin)/4.936 + 1.0)
+*        bgrate   = bgrate*(0.12*9.1625*LOG(0.12/beamEmin)/4.936 + 1.0)
          xMinimum = beamEmin/beamE0
          print *,'uginit.F:  BGRATE rate is ',bgrate
       endif
-
 
       if (bgrate .lt. 0) then
         print *


### PR DESCRIPTION
  is simulated in hdgeant. There are three major changes included:
   1) Fix a bug in gukine that made the simulation generate far
      too many background photons when the value of bgrate rose
      to the level near 1/beam_period_ns. This was a very severe
      bug, introduced in a recent change I made, which made the
      em bg simulation all but useless in hdgeant. This restores
      the former correct functioning of this feature.
   2) Introduce a new feature requested by Sean Dobbs that allows
      the simulation to generate accidental tags from out-of-time beam
      photons without paying the full price of tracking them through
      the detector. This option is now implemented as a new card in
      control.in called BGTAGONLY which has a single integer field,
      either zero (former behavior) or non-zero (new behavior).
   3) Improve the efficiency of the bg photons generator in hdgeant.
      The former code generated energy and polarization spectra with
      the correct distributions, but it was not very efficient in that
      most of the trial gammas generated were discarded by a harsh
      keep/reject threshold. This is now better tuned, and also more
      less likely to generate warnings about freqMaximum being exceeded.

* control.in [rtj]
   - add new card BGTAGONLY with comment
   - add a more helpful comment for the BGRATE card

* backgrounds.inc, uginit.F [rtj]
   - add support for the new card BGTAGONLY

* gukine.F [rtj]
   - fix the bug mentioned above that caused the rate of generated
     bg beam photons to diverge as the bgrate approached 1/beam_period_ns.

* beamgen.F [rtj]
   - improvements to the efficiency of the importance sampling algorithm
     that is used to sample the coherent bremsstrahlung distribution