### PR TITLE
* programs/Simulation/HDGeant/gukine.F [rtj]

### DIFF
--- a/src/programs/Simulation/HDGeant/gukine.F
+++ b/src/programs/Simulation/HDGeant/gukine.F
@@ -232,7 +232,7 @@
               tgen=tgen-log(unif01(j))/bgrate
               if (tgen.gt.bggate(2)) goto 10
               tgend=beam_period_ns*floor(tgen/beam_period_ns+0.5)
-              call beamgen(tgend)
+              call beamgen(tgend + 1e-3)
               ngen=ngen+1
             enddo
           enddo


### PR DESCRIPTION
   - shift bg photons in the tagger out from the center of their bucket
     by 1ps. This is only detectable before mcsmear, but it helps me
     during debugging to know which hit is the true one.