### PR TITLE
* programs/Utilities/hddm/hddm-cpp.cpp [rtj]

### DIFF
--- a/src/programs/Utilities/hddm/hddm-cpp.cpp
+++ b/src/programs/Utilities/hddm/hddm-cpp.cpp
@@ -1320,6 +1320,7 @@ int main(int argC, char* argV[])
    "      else {\n"
    "         if (MY(next_start) > 0) {\n"
    "            m_istr.seekg(MY(next_start), std::ios_base::beg);\n"
+   "            MY(istr)->clear();\n"
    "            MY(last_start) = MY(next_start);\n"
    "            MY(last_offset) = 0;\n"
    "            MY(next_start) = 0;\n"


### PR DESCRIPTION
   - add a clear() on the istream when a user does setPosition() after
     having hit eof. Without this clear, reading from the stream will
     continue to return eof, even after the read position has moved
     away from the end of the file. This is needed in order to support
     cyclic reading of input hdmm background-merge files in mcsmear.