### PR TITLE
Trackeff arrays

### DIFF
--- a/src/libraries/ANALYSIS/DCutActions.cc
+++ b/src/libraries/ANALYSIS/DCutActions.cc
@@ -4,6 +4,11 @@
 
 #include "ANALYSIS/DCutActions.h"
 
+void DCutAction_MinTrackHits::Initialize(JEventLoop* locEventLoop)
+{
+	locEventLoop->GetSingle(dParticleID);
+}
+
 string DCutAction_MinTrackHits::Get_ActionName(void) const
 {
 	ostringstream locStream;
@@ -20,7 +25,12 @@ bool DCutAction_MinTrackHits::Perform_Action(JEventLoop* locEventLoop, const DPa
 		const DChargedTrackHypothesis* locChargedTrackHypothesis = static_cast<const DChargedTrackHypothesis*>(locParticles[loc_i]);
 		const DTrackTimeBased* locTrackTimeBased = NULL;
 		locChargedTrackHypothesis->GetSingle(locTrackTimeBased);
-		unsigned int locNumTrackHits = locTrackTimeBased->Ndof + 5;
+
+		set<int> locCDCRings, locFDCPlanes;
+		dParticleID->Get_CDCRings(locTrackTimeBased->dCDCRings, locCDCRings);
+		dParticleID->Get_FDCPlanes(locTrackTimeBased->dFDCPlanes, locFDCPlanes);
+
+		unsigned int locNumTrackHits = locCDCRings.size() + locFDCPlanes.size();
 		if(locNumTrackHits < dMinTrackHits)
 			return false;
 	}

--- a/src/libraries/ANALYSIS/DCutActions.h
+++ b/src/libraries/ANALYSIS/DCutActions.h
@@ -72,15 +72,16 @@ class DCutAction_MinTrackHits : public DAnalysisAction
 	public:
 		DCutAction_MinTrackHits(const DReaction* locReaction, unsigned int locMinTrackHits, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Cut_MinTrackHits", false, locActionUniqueString),
-		dMinTrackHits(locMinTrackHits){}
+		dMinTrackHits(locMinTrackHits), dParticleID(nullptr){}
 
 		string Get_ActionName(void) const;
-		void Initialize(JEventLoop* locEventLoop){}
+		void Initialize(JEventLoop* locEventLoop);
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 
 		unsigned int dMinTrackHits;
+		const DParticleID* dParticleID;
 };
 
 class DCutAction_ThrownTopology : public DAnalysisAction

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.cc
@@ -204,6 +204,8 @@ bool DCustomAction_CutNoDetectorHit::Perform_Action(JEventLoop* locEventLoop, co
 
 	//Check for slow protons stopping in target: don't expect any hits
 	bool locMassiveParticleFlag = (ParticleMass(dMissingPID) + 0.001 > ParticleMass(Proton));
+	if((locP < 0.2) && locMassiveParticleFlag)
+		return false; //don't even bother to try
 	if((locP < 0.3) && locMassiveParticleFlag)
 		return true;
 	if((locP < 0.4) && (locTheta < 30.0) && locMassiveParticleFlag)

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_TrackingEfficiency.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_TrackingEfficiency.cc
@@ -65,7 +65,7 @@ void DCustomAction_TrackingEfficiency::Initialize(JEventLoop* locEventLoop)
 
 	//TRACKING INFO:
 	locBranchRegister.Register_Single<UInt_t>("NumUnusedWireBased");
-        locBranchRegister.Register_Single<UInt_t>("NumUnusedTimeBased");
+	locBranchRegister.Register_Single<UInt_t>("NumUnusedTimeBased");
 	locBranchRegister.Register_FundamentalArray<Float_t>("ReconMatchFOM_WireBased", "NumUnusedWireBased"); //FOM < 0 if nothing, no-match
 	locBranchRegister.Register_FundamentalArray<Float_t>("ReconTrackingFOM_WireBased", "NumUnusedWireBased"); //FOM < 0 if nothing, no-match
 	locBranchRegister.Register_ClonesArray<TVector3>("ReconP3_WireBased"); //wire-based
@@ -83,17 +83,6 @@ void DCustomAction_TrackingEfficiency::Initialize(JEventLoop* locEventLoop)
 	locBranchRegister.Register_FundamentalArray<Float_t>("ReconP3_CovPyPy", "NumUnusedTimeBased");
 	locBranchRegister.Register_FundamentalArray<Float_t>("ReconP3_CovPyPz", "NumUnusedTimeBased");
 	locBranchRegister.Register_FundamentalArray<Float_t>("ReconP3_CovPzPz", "NumUnusedTimeBased");
-
-	//HADRONIC BCAL SHOWER EFFICIENCY: TIMING, MATCHING //cannot get accurate PID without missing-track study
-	locBranchRegister.Register_Single<UChar_t>("ProjectedBCALSector"); //4*(module - 1) + sector: 1 -> 192 //0 if proj to miss
-	locBranchRegister.Register_Single<Float_t>("ProjectedBCALHitPhi"); //degrees
-	locBranchRegister.Register_Single<Float_t>("ProjectedBCALHitZ");
-	locBranchRegister.Register_Single<Float_t>("NearestShowerEnergy"); // < 0 if none in time: PID:OUT_OF_TIME_CUT
-	locBranchRegister.Register_Single<Float_t>("TrackDeltaPhiToShower"); //is signed: BCAL - Track //degrees
-	locBranchRegister.Register_Single<Float_t>("TrackDeltaZToShower"); //is signed: BCAL - Track
-	locBranchRegister.Register_Single<Bool_t>("IsMatchedToBCALShower");
-	locBranchRegister.Register_Single<Float_t>("BCALDeltaT");
-	locBranchRegister.Register_Single<Float_t>("BCALTimeFOM");
 
 	//REGISTER BRANCHES
 	dTreeInterface->Create_Branches(locBranchRegister);
@@ -170,7 +159,7 @@ bool DCustomAction_TrackingEfficiency::Perform_Action(JEventLoop* locEventLoop, 
 	//kinfit results are unique for each DParticleCombo: no need to check for duplicates
 
 	//FILL CHANNEL INFO
-	dTreeFillData.Fill_Single<ULong64_t>("BeamEnergy", locEventLoop->GetJEvent().GetEventNumber());
+	dTreeFillData.Fill_Single<ULong64_t>("EventNumber", locEventLoop->GetJEvent().GetEventNumber());
 	dTreeFillData.Fill_Single<Float_t>("BeamEnergy", locBeamParticle->energy());
 	dTreeFillData.Fill_Single<Float_t>("BeamRFDeltaT", locBeamRFDeltaT);
 	dTreeFillData.Fill_Single<UChar_t>("NumExtraTracks", (UChar_t)locNumExtraTracks);
@@ -205,14 +194,20 @@ bool DCustomAction_TrackingEfficiency::Perform_Action(JEventLoop* locEventLoop, 
 		vector<const DTrackWireBased*> locUnusedWireBasedTracks;
 		dAnalysisUtilities->Get_UnusedWireBasedTracks(locEventLoop, locParticleCombo, locUnusedWireBasedTracks);
 
-		double locBestWireBasedMatchFOM = -1.0;
-		const DTrackWireBased* locBestTrackWireBased = NULL;
+		//loop over unused tracks
+		size_t locNumWireBasedTracks = 0;
 		for(size_t loc_i = 0; loc_i < locUnusedWireBasedTracks.size(); ++loc_i)
 		{
-			if(locUnusedWireBasedTracks[loc_i]->PID() != dMissingPID)
+			const DTrackWireBased* locWireBasedTrack = locUnusedWireBasedTracks[loc_i];
+			if(locWireBasedTrack->PID() != dMissingPID)
 				continue; //only use tracking results with correct PID
 
-			const TMatrixFSym& locCovarianceMatrix = *(locUnusedWireBasedTracks[loc_i]->errorMatrix());
+			DVector3 locWireBasedDP3 = locWireBasedTrack->momentum();
+			TVector3 locWireBasedP3(locWireBasedDP3.X(), locWireBasedDP3.Y(), locWireBasedDP3.Z());
+			dTreeFillData.Fill_Array<TVector3>("ReconP3_WireBased", locWireBasedP3, locNumWireBasedTracks);
+			dTreeFillData.Fill_Array<Float_t>("ReconTrackingFOM_WireBased", locWireBasedTrack->FOM, locNumWireBasedTracks);
+
+			const TMatrixFSym& locCovarianceMatrix = *(locWireBasedTrack->errorMatrix());
 			TMatrixDSym locDCovarianceMatrix(3);
 			for(unsigned int loc_j = 0; loc_j < 3; ++loc_j)
 			{
@@ -224,41 +219,22 @@ bool DCustomAction_TrackingEfficiency::Perform_Action(JEventLoop* locEventLoop, 
 			//invert matrix
 			TDecompLU locDecompLU(locDCovarianceMatrix);
 			//check to make sure that the matrix is decomposable and has a non-zero determinant
-			if((!locDecompLU.Decompose()) || (fabs(locDCovarianceMatrix.Determinant()) < 1.0E-300))
-				continue; // matrix is not invertible
-			locDCovarianceMatrix.Invert();
-
-			DVector3 locDeltaP3 = locUnusedWireBasedTracks[loc_i]->momentum() - locMissingP3;
-			double locMatchFOM = Calc_MatchFOM(locDeltaP3, locDCovarianceMatrix);
-
-			if(locMatchFOM > locBestWireBasedMatchFOM)
+			if(locDecompLU.Decompose() && (fabs(locDCovarianceMatrix.Determinant()) >= 1.0E-300))
 			{
-				locBestWireBasedMatchFOM = locMatchFOM;
-				locBestTrackWireBased = locUnusedWireBasedTracks[loc_i];
+				locDCovarianceMatrix.Invert();
+				DVector3 locDeltaP3 = locWireBasedTrack->momentum() - locMissingP3;
+				double locMatchFOM = Calc_MatchFOM(locDeltaP3, locDCovarianceMatrix);
+				dTreeFillData.Fill_Array<Float_t>("ReconMatchFOM_WireBased", locMatchFOM, locNumWireBasedTracks);
 			}
-		}
+			else //not invertable
+				dTreeFillData.Fill_Array<Float_t>("ReconMatchFOM_WireBased", -1.0, locNumWireBasedTracks);
 
-		//FILL WIRE-BASED TRACKING INFO:
-		dTreeFillData.Fill_Single<Float_t>("ReconMatchFOM_WireBased", locBestWireBasedMatchFOM); //FOM < 0 if nothing, no-match
-		if(locBestTrackWireBased == nullptr)
-		{
-			dTreeFillData.Fill_Single<Float_t>("ReconTrackingFOM_WireBased", -1.0);
-			dTreeFillData.Fill_Single<TVector3>("ReconP3_WireBased", TVector3());
+			++locNumWireBasedTracks;
 		}
-		else
-		{
-			dTreeFillData.Fill_Single<Float_t>("ReconTrackingFOM_WireBased", locBestTrackWireBased->FOM);
-			DVector3 locWireBasedDP3 = locBestTrackWireBased->momentum();
-			TVector3 locWireBasedP3(locWireBasedDP3.X(), locWireBasedDP3.Y(), locWireBasedDP3.Z());
-			dTreeFillData.Fill_Single<TVector3>("ReconP3_WireBased", locWireBasedP3);
-		}
+		dTreeFillData.Fill_Single<UInt_t>("NumUnusedWireBased", locNumWireBasedTracks);
 	}
 	else //is a REST event, no wire-based tracks
-	{
-		dTreeFillData.Fill_Single<Float_t>("ReconMatchFOM_WireBased", -1.0);
-		dTreeFillData.Fill_Single<Float_t>("ReconTrackingFOM_WireBased", -1.0);
-		dTreeFillData.Fill_Single<TVector3>("ReconP3_WireBased", TVector3());
-	}
+		dTreeFillData.Fill_Single<UInt_t>("NumUnusedWireBased", 0);
 
 	/************************************************* TIME-BASED TRACKS *************************************************/
 
@@ -266,15 +242,20 @@ bool DCustomAction_TrackingEfficiency::Perform_Action(JEventLoop* locEventLoop, 
 	vector<const DTrackTimeBased*> locUnusedTimeBasedTracks;
 	dAnalysisUtilities->Get_UnusedTimeBasedTracks(locEventLoop, locParticleCombo, locUnusedTimeBasedTracks);
 
-	//find the best-matching time-based track corresponding to the missing particle
-	double locBestTimeBasedMatchFOM = -1.0;
-	const DTrackTimeBased* locBestTrackTimeBased = NULL;
+	//loop over unused tracks
+	size_t locNumTimeBasedTracks = 0;
 	for(size_t loc_i = 0; loc_i < locUnusedTimeBasedTracks.size(); ++loc_i)
 	{
-		if(locUnusedTimeBasedTracks[loc_i]->PID() != dMissingPID)
+		const DTrackTimeBased* locTimeBasedTrack = locUnusedTimeBasedTracks[loc_i];
+		if(locTimeBasedTrack->PID() != dMissingPID)
 			continue; //only use tracking results with correct PID
 
-		const TMatrixFSym& locCovarianceMatrix = *(locUnusedTimeBasedTracks[loc_i]->errorMatrix());
+		DVector3 locTimeBasedDP3 = locTimeBasedTrack->momentum();
+		TVector3 locTimeBasedP3(locTimeBasedDP3.X(), locTimeBasedDP3.Y(), locTimeBasedDP3.Z());
+		dTreeFillData.Fill_Array<TVector3>("ReconP3", locTimeBasedP3, locNumTimeBasedTracks);
+		dTreeFillData.Fill_Array<Float_t>("ReconTrackingFOM", locTimeBasedTrack->FOM, locNumTimeBasedTracks);
+
+		const TMatrixFSym& locCovarianceMatrix = *(locTimeBasedTrack->errorMatrix());
 		TMatrixDSym locDCovarianceMatrix(3);
 		for(unsigned int loc_j = 0; loc_j < 3; ++loc_j)
 		{
@@ -286,132 +267,32 @@ bool DCustomAction_TrackingEfficiency::Perform_Action(JEventLoop* locEventLoop, 
 		//invert matrix
 		TDecompLU locDecompLU(locDCovarianceMatrix);
 		//check to make sure that the matrix is decomposable and has a non-zero determinant
-		if((!locDecompLU.Decompose()) || (fabs(locDCovarianceMatrix.Determinant()) < 1.0E-300))
-			continue; // matrix is not invertible
-		locDCovarianceMatrix.Invert();
-
-		DVector3 locDeltaP3 = locUnusedTimeBasedTracks[loc_i]->momentum() - locMissingP3;
-		double locMatchFOM = Calc_MatchFOM(locDeltaP3, locDCovarianceMatrix);
-
-		if(locMatchFOM > locBestTimeBasedMatchFOM)
+		if(locDecompLU.Decompose() && (fabs(locDCovarianceMatrix.Determinant()) >= 1.0E-300))
 		{
-			locBestTimeBasedMatchFOM = locMatchFOM;
-			locBestTrackTimeBased = locUnusedTimeBasedTracks[loc_i];
+			locDCovarianceMatrix.Invert();
+			DVector3 locDeltaP3 = locTimeBasedTrack->momentum() - locMissingP3;
+			double locMatchFOM = Calc_MatchFOM(locDeltaP3, locDCovarianceMatrix);
+			dTreeFillData.Fill_Array<Float_t>("ReconMatchFOM", locMatchFOM, locNumTimeBasedTracks);
 		}
-	}
+		else //not invertible
+			dTreeFillData.Fill_Array<Float_t>("ReconMatchFOM", -1.0, locNumTimeBasedTracks);
 
-	//FILL TRACKING INFO: //"Recon:" Time-based track
-	dTreeFillData.Fill_Single<Float_t>("ReconMatchFOM", locBestTimeBasedMatchFOM); //FOM < 0 if nothing, no-match
-	if(locBestTrackTimeBased == nullptr)
-	{
-		dTreeFillData.Fill_Single<Float_t>("ReconTrackingFOM", -1.0);
-		dTreeFillData.Fill_Single<TVector3>("ReconP3", TVector3());
-		dTreeFillData.Fill_Single<Float_t>("MeasuredMissingE", -999.0);
-		dTreeFillData.Fill_Single<UInt_t>("TrackCDCRings", 0);
-		dTreeFillData.Fill_Single<UInt_t>("TrackFDCPlanes", 0);
+		DLorentzVector locTotalMeasuredMissingP4 = locMeasuredMissingP4 - locTimeBasedTrack->lorentzMomentum();
+		dTreeFillData.Fill_Array<Float_t>("MeasuredMissingE", locTotalMeasuredMissingP4.E(), locNumTimeBasedTracks);
+		dTreeFillData.Fill_Array<UInt_t>("TrackCDCRings", locTimeBasedTrack->dCDCRings, locNumTimeBasedTracks);
+		dTreeFillData.Fill_Array<UInt_t>("TrackFDCPlanes", locTimeBasedTrack->dFDCPlanes, locNumTimeBasedTracks);
 
 		//RECON P3 ERROR MATRIX
-		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPx", -1.0);
-		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPy", -1.0);
-		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPz", -1.0);
-		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPyPy", -1.0);
-		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPyPz", -1.0);
-		dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPzPz", -1.0);
+		dTreeFillData.Fill_Array<Float_t>("ReconP3_CovPxPx", locCovarianceMatrix(0, 0), locNumTimeBasedTracks);
+		dTreeFillData.Fill_Array<Float_t>("ReconP3_CovPxPy", locCovarianceMatrix(0, 1), locNumTimeBasedTracks);
+		dTreeFillData.Fill_Array<Float_t>("ReconP3_CovPxPz", locCovarianceMatrix(0, 2), locNumTimeBasedTracks);
+		dTreeFillData.Fill_Array<Float_t>("ReconP3_CovPyPy", locCovarianceMatrix(1, 1), locNumTimeBasedTracks);
+		dTreeFillData.Fill_Array<Float_t>("ReconP3_CovPyPz", locCovarianceMatrix(1, 2), locNumTimeBasedTracks);
+		dTreeFillData.Fill_Array<Float_t>("ReconP3_CovPzPz", locCovarianceMatrix(2, 2), locNumTimeBasedTracks);
 
-		//HADRONIC BCAL SHOWER EFFICIENCY: TIMING, MATCHING
-		dTreeFillData.Fill_Single<Float_t>("ProjectedBCALHitPhi", 0.0);
-		dTreeFillData.Fill_Single<Float_t>("ProjectedBCALHitZ", 0.0);
-		dTreeFillData.Fill_Single<UChar_t>("ProjectedBCALSector", 0);
-		dTreeFillData.Fill_Single<Float_t>("NearestShowerEnergy", 0.0);
-		dTreeFillData.Fill_Single<Float_t>("TrackDeltaPhiToShower", 0.0);
-		dTreeFillData.Fill_Single<Float_t>("TrackDeltaZToShower", 0.0);
-		dTreeFillData.Fill_Single<Bool_t>("IsMatchedToBCALShower", false);
-		dTreeFillData.Fill_Single<Float_t>("BCALDeltaT", 0.0);
-		dTreeFillData.Fill_Single<Float_t>("BCALTimeFOM", -1.0);
-
-		//FILL TTREE
-		dTreeInterface->Fill(dTreeFillData);
-		return true;
+		++locNumTimeBasedTracks;
 	}
-
-	//RESUME FILL TRACKING INFO: //"Recon:" Time-based track
-	dTreeFillData.Fill_Single<Float_t>("ReconTrackingFOM", locBestTrackTimeBased->FOM);
-	DVector3 locDP3 = locBestTrackTimeBased->momentum();
-	TVector3 locP3(locDP3.X(), locDP3.Y(), locDP3.Z());
-	dTreeFillData.Fill_Single<TVector3>("ReconP3", locP3);
-	DLorentzVector locTotalMeasuredMissingP4 = locMeasuredMissingP4 - locBestTrackTimeBased->lorentzMomentum();
-	dTreeFillData.Fill_Single<Float_t>("MeasuredMissingE", locTotalMeasuredMissingP4.E());
-	dTreeFillData.Fill_Single<UInt_t>("TrackCDCRings", locBestTrackTimeBased->dCDCRings);
-	dTreeFillData.Fill_Single<UInt_t>("TrackFDCPlanes", locBestTrackTimeBased->dFDCPlanes);
-
-	//RECON P3 ERROR MATRIX
-	const TMatrixFSym& locCovarianceMatrix = *(locBestTrackTimeBased->errorMatrix());
-	dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPx", locCovarianceMatrix(0, 0));
-	dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPy", locCovarianceMatrix(0, 1));
-	dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPxPz", locCovarianceMatrix(0, 2));
-	dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPyPy", locCovarianceMatrix(1, 1));
-	dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPyPz", locCovarianceMatrix(1, 2));
-	dTreeFillData.Fill_Single<Float_t>("ReconP3_CovPzPz", locCovarianceMatrix(2, 2));
-
-	/********************************************* BCAL SHOWER RECONSTRUCTION ********************************************/
-
-	//Predict BCAL Surface Hit Location
-	unsigned int locPredictedSurfaceModule = 0, locPredictedSurfaceSector = 0;
-	DVector3 locPredictedSurfacePosition;
-	dParticleID->PredictBCALWedge(locBestTrackTimeBased->rt, locPredictedSurfaceModule, locPredictedSurfaceSector, &locPredictedSurfacePosition);
-	unsigned int locTrackProjectedBCALSector = 4*(locPredictedSurfaceModule - 1) + locPredictedSurfaceSector; //0 if misses
-
-	//FILL PROJECTED HIT POSITION
-	dTreeFillData.Fill_Single<UChar_t>("ProjectedBCALSector", locTrackProjectedBCALSector);
-	dTreeFillData.Fill_Single<Float_t>("ProjectedBCALHitPhi", locPredictedSurfacePosition.Phi()*180.0/TMath::Pi());
-	dTreeFillData.Fill_Single<Float_t>("ProjectedBCALHitZ", locPredictedSurfacePosition.Z());
-
-	DBCALShowerMatchParams locBestBCALMatchParams;
-	double locStartTime = locBestTrackTimeBased->t0();
-	bool locBCALHitFoundFlag = dParticleID->Get_ClosestToTrack(locBestTrackTimeBased->rt, locBCALShowers, false, locStartTime, locBestBCALMatchParams);
-
-	//If none, fill and return
-	if(!locBCALHitFoundFlag)
-	{
-		//HADRONIC BCAL SHOWER EFFICIENCY
-		dTreeFillData.Fill_Single<Float_t>("NearestShowerEnergy", -1.0);
-		dTreeFillData.Fill_Single<Float_t>("TrackDeltaPhiToShower", 0.0);
-		dTreeFillData.Fill_Single<Float_t>("TrackDeltaZToShower", 0.0);
-		dTreeFillData.Fill_Single<Bool_t>("IsMatchedToBCALShower", false);
-		dTreeFillData.Fill_Single<Float_t>("BCALDeltaT", 0.0);
-		dTreeFillData.Fill_Single<Float_t>("BCALTimeFOM", -1.0);
-
-		//FILL TTREE
-		dTreeInterface->Fill(dTreeFillData);
-		return true;
-	}
-
-	//HADRONIC BCAL SHOWER EFFICIENCY
-	dTreeFillData.Fill_Single<Float_t>("NearestShowerEnergy", locBestBCALMatchParams.dBCALShower->E);
-	dTreeFillData.Fill_Single<Float_t>("TrackDeltaPhiToShower", locBestBCALMatchParams.dDeltaPhiToShower*180.0/TMath::Pi());
-	dTreeFillData.Fill_Single<Float_t>("TrackDeltaZToShower", locBestBCALMatchParams.dDeltaZToShower);
-
-	//See if shower is matched
-	locStartTime = locBestTrackTimeBased->t0();
-	if(!dParticleID->Cut_MatchDistance(locBestTrackTimeBased->rt, locBestBCALMatchParams.dBCALShower, locStartTime, locBestBCALMatchParams))
-	{
-		//SHOWER NOT MATCHED
-		dTreeFillData.Fill_Single<Bool_t>("IsMatchedToBCALShower", false);
-		dTreeFillData.Fill_Single<Float_t>("BCALDeltaT", 0.0);
-		dTreeFillData.Fill_Single<Float_t>("BCALTimeFOM", -1.0);
-
-		//FILL TTREE
-		dTreeInterface->Fill(dTreeFillData);
-		return true;
-	}
-
-	locStartTime = dParticleID->Calc_PropagatedRFTime(locBestTrackTimeBased, locEventRFBunch);
-	double locDeltaT = locBestBCALMatchParams.dBCALShower->t - locBestBCALMatchParams.dFlightTime - locStartTime;
-
-	//FILL SHOWER MATCHED
-	dTreeFillData.Fill_Single<Bool_t>("IsMatchedToBCALShower", true);
-	dTreeFillData.Fill_Single<Float_t>("BCALDeltaT", locDeltaT);
-	dTreeFillData.Fill_Single<Float_t>("BCALTimeFOM", -1.0);
+	dTreeFillData.Fill_Single<UInt_t>("NumUnusedTimeBased", locNumTimeBasedTracks);
 
 	//FILL TTREE
 	dTreeInterface->Fill(dTreeFillData);

--- a/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
+++ b/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
@@ -218,7 +218,7 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 
 
 
-
+	//Loop over reactions and do setup
 	for(auto& locReaction : locReactions)
 	{
 		/**************************************************** Control Settings ****************************************************/


### PR DESCRIPTION
For track effs, save arrays of recon tracks instead of "best."
If heavy & missing-p < 200 MeV/c, don't try to get efficiency
Fix cut on #track-hits: cannot use tracking NDF any more, since each FDC hit adds 2 degrees of freedom. 