### PR TITLE
DBCALGeometry refactoring

### DIFF
--- a/src/libraries/BCAL/DBCALCluster.cc
+++ b/src/libraries/BCAL/DBCALCluster.cc
@@ -7,25 +7,27 @@
 
 #include "BCAL/DBCALCluster.h"
 #include "BCAL/DBCALPoint.h"
+#include "BCAL/DBCALGeometry.h"
 #include "units.h"
 
 #include <math.h>
 
-DBCALCluster::DBCALCluster( const DBCALPoint* point, double z_target_center )
-  : m_points ( 0 ),  m_hit_E_unattenuated_sum(0.0),  m_z_target_center(z_target_center) {
+DBCALCluster::DBCALCluster( const DBCALPoint* point, double z_target_center, const DBCALGeometry *locGeom )
+  : m_points ( 0 ),  m_hit_E_unattenuated_sum(0.0),  m_z_target_center(z_target_center), m_BCALGeom(locGeom) {
 
   m_points.push_back( point );
   makeFromPoints();
 }
 
-DBCALCluster::DBCALCluster(double z_target_center) : m_z_target_center(z_target_center) {
+DBCALCluster::DBCALCluster(double z_target_center, const DBCALGeometry *locGeom) 
+  : m_z_target_center(z_target_center), m_BCALGeom(locGeom) {
   clear(); //initialize all values to zero
 }
 
 float
 DBCALCluster::t0() const {
   
-  float path = DBCALGeometry::GetBCAL_inner_rad() / sin( m_theta );
+  float path = m_BCALGeom->GetBCAL_inner_rad() / sin( m_theta );
   
   return m_t - ( path / ( 30 * k_cm / k_nsec ) );
 }
@@ -36,11 +38,11 @@ DBCALCluster::addPoint( const DBCALPoint* point ){
   // offset phi of the point by +- 2PI to match the cluster
   if( phi() > point->phi() ){
     
-    if( fabs( phi() - point->phi() - 2*PI ) < PI ) point->add2Pi();
+    if( fabs( phi() - point->phi() - 2*M_PI ) < M_PI ) point->add2Pi();
   }
   else{
     
-    if( fabs( point->phi() - phi() - 2*PI ) < PI ) point->sub2Pi();
+    if( fabs( point->phi() - phi() - 2*M_PI ) < M_PI ) point->sub2Pi();
   }
   
   m_points.push_back( point );
@@ -53,11 +55,11 @@ DBCALCluster::removePoint( const DBCALPoint* point){
 
 if( phi() > point->phi() ){
 
-    if( fabs( phi() - point->phi() - 2*PI ) < PI ) point->add2Pi();
+    if( fabs( phi() - point->phi() - 2*M_PI ) < M_PI ) point->add2Pi();
   }
   else{
 
-    if( fabs( point->phi() - phi() - 2*PI ) < PI ) point->sub2Pi();
+    if( fabs( point->phi() - phi() - 2*M_PI ) < M_PI ) point->sub2Pi();
   }
 
   if(find(m_points.begin(),m_points.end(),point) != m_points.end()) m_points.erase( find(m_points.begin(),m_points.end(),point ));
@@ -90,11 +92,11 @@ DBCALCluster::mergeClust( const DBCALCluster& clust ){
     // offset phi of the point by +- 2PI to match the cluster if needed
     if( phi() > (**pt).phi() ){
       
-      if( fabs( phi() - (**pt).phi() - 2*PI ) < PI ) (**pt).add2Pi();
+      if( fabs( phi() - (**pt).phi() - 2*M_PI ) < M_PI ) (**pt).add2Pi();
     }
     else{
       
-      if( fabs( (**pt).phi() - phi() - 2*PI ) < PI ) (**pt).sub2Pi();
+      if( fabs( (**pt).phi() - phi() - 2*M_PI ) < M_PI ) (**pt).sub2Pi();
     }
     
     m_points.push_back( *pt );
@@ -235,10 +237,10 @@ DBCALCluster::makeFromPoints(){
   // Using m_E_points because the cluster z position only depends on the point z positions
   // and point energies.
   double sigma_z = sqrt(1.394*1.394/m_E_points + 0.859*0.859);
-  m_sig_theta = sigma_z*sin(m_theta)*sin(m_theta)/DBCALGeometry::GetBCAL_inner_rad();
+  m_sig_theta = sigma_z*sin(m_theta)*sin(m_theta)/m_BCALGeom->GetBCAL_inner_rad();
   
   m_phi = atan2(sum_sin_phi,sum_cos_phi);
-  if( m_phi < 0 ) m_phi += 2*PI;
+  if( m_phi < 0 ) m_phi += 2*M_PI;
   // calculate the RMS of phi
   m_sig_phi=0;
   for( vector< const DBCALPoint* >::const_iterator pt = m_points.begin();
@@ -256,8 +258,8 @@ DBCALCluster::makeFromPoints(){
 
     double deltaPhi = (**pt).phi() - m_phi;
     double deltaPhiAlt = ( (**pt).phi() > m_phi ?
-			   (**pt).phi() - m_phi - 2*PI :
-			   m_phi - (**pt).phi() - 2*PI );
+			   (**pt).phi() - m_phi - 2*M_PI :
+			   m_phi - (**pt).phi() - 2*M_PI );
     deltaPhi = min( fabs( deltaPhi ), fabs( deltaPhiAlt ) );
     m_sig_phi += deltaPhi * deltaPhi * wt1;
 
@@ -284,13 +286,13 @@ DBCALCluster::makeFromPoints(){
   double z = m_rho*cos(m_theta) + m_z_target_center;
   double r = m_rho*sin(m_theta); 
 
-  double bcal_down = DBCALGeometry::GetBCAL_center() + DBCALGeometry::GetBCAL_length()/2.0;
-  double bcal_up = DBCALGeometry::GetBCAL_center() - DBCALGeometry::GetBCAL_length()/2.0;
+  double bcal_down = m_BCALGeom->GetBCAL_center() + m_BCALGeom->GetBCAL_length()/2.0;
+  double bcal_up = m_BCALGeom->GetBCAL_center() - m_BCALGeom->GetBCAL_length()/2.0;
   if (z > bcal_down) z = bcal_down;
   if (z < bcal_up) z = bcal_up;
 
-  double r_min = DBCALGeometry::r(DBCALGeometry::cellId(1,1,1)); //This is the center of the first layer of the BCAL. This is the minimum value of r that a DBCALPoint will report.
-  double r_max = DBCALGeometry::r(DBCALGeometry::cellId(1,4,1)); //Maximum r that a DBCALPoint will report
+  double r_min = m_BCALGeom->r(m_BCALGeom->cellId(1,1,1)); //This is the center of the first layer of the BCAL. This is the minimum value of r that a DBCALPoint will report.
+  double r_max = m_BCALGeom->r(m_BCALGeom->cellId(1,4,1)); //Maximum r that a DBCALPoint will report
   if (r > r_max) r = r_max;
   if (r < r_min) r = r_min;
 
@@ -321,8 +323,8 @@ DBCALCluster::makeFromPoints(){
   if( m_sig_theta < 1E-6 ) m_sig_theta = m_points.at(0)->sigPhi()/sqrt(n_avg);
   
   // correct phi of the cluster if we've drifted outside of 0 - 2PI
-  if( m_phi > 2*PI ) m_phi -= 2*PI;
-  if( m_phi < 0 ) m_phi += 2*PI;
+  if( m_phi > 2*M_PI ) m_phi -= 2*M_PI;
+  if( m_phi < 0 ) m_phi += 2*M_PI;
 }
 
 void 

--- a/src/libraries/BCAL/DBCALCluster.h
+++ b/src/libraries/BCAL/DBCALCluster.h
@@ -25,8 +25,8 @@ public:
   
   JOBJECT_PUBLIC( DBCALCluster );
   
-  DBCALCluster(double z_target_center);
-  DBCALCluster(const DBCALPoint* point, double z_target_center);
+  DBCALCluster(double z_target_center, const DBCALGeometry *locGeom);
+  DBCALCluster(const DBCALPoint* point, double z_target_center, const DBCALGeometry *locGeom);
 
   vector< const DBCALPoint* > points() const { return m_points; }
   // Returns a vector of the single-ended hits used in the cluster.
@@ -95,6 +95,8 @@ private:
   float m_sig_phi;
 
   float m_z_target_center;
+  
+  const DBCALGeometry *m_BCALGeom;
   
 };
 

--- a/src/libraries/BCAL/DBCALCluster_factory.h
+++ b/src/libraries/BCAL/DBCALCluster_factory.h
@@ -16,6 +16,7 @@ using namespace jana;
 #include "BCAL/DBCALHit.h"
 #include "BCAL/DBCALCluster.h"
 #include "BCAL/DBCALUnifiedHit.h"
+#include "BCAL/DBCALGeometry.h"
 
 //#include "TTree.h"
 //#include "TFile.h"
@@ -61,6 +62,9 @@ private:
   float m_clust_hit_timecut;
   float m_timeCut;
   double m_z_target_center;
+  
+  const DBCALGeometry *m_BCALGeom;
+  
   vector<double> effective_velocities;
   vector< vector<double > > attenuation_parameters;
   /*

--- a/src/libraries/BCAL/DBCALCluster_factory_SINGLE.cc
+++ b/src/libraries/BCAL/DBCALCluster_factory_SINGLE.cc
@@ -31,6 +31,14 @@ jerror_t DBCALCluster_factory_SINGLE::brun(jana::JEventLoop *eventLoop, int32_t 
 	DApplication* app = dynamic_cast<DApplication*>(eventLoop->GetJApplication());
 	DGeometry* geom = app->GetDGeometry(runnumber);
 	geom->GetTargetZ(m_z_target_center);
+
+	// load BCAL geometry
+	vector<const DBCALGeometry *> BCALGeomVec;
+	eventLoop->Get(BCALGeomVec);
+	if(BCALGeomVec.size() == 0)
+		throw JException("Could not load DBCALGeometry object!");
+	dBCALGeom = BCALGeomVec[0];
+
 	return NOERROR;
 }
 
@@ -47,7 +55,7 @@ jerror_t DBCALCluster_factory_SINGLE::evnt(JEventLoop *loop, uint64_t eventnumbe
 	if(bcalpoints.size() == 0) return NOERROR;
 	
 	// Create DBCALCluster object and all all DBCALPoint objects to it
-	DBCALCluster *cluster = new DBCALCluster(m_z_target_center);
+	DBCALCluster *cluster = new DBCALCluster(m_z_target_center, dBCALGeom);
 	for(unsigned int i=0; i<bcalpoints.size(); i++){
 		cluster->addPoint(bcalpoints[i]);
 	}

--- a/src/libraries/BCAL/DBCALCluster_factory_SINGLE.h
+++ b/src/libraries/BCAL/DBCALCluster_factory_SINGLE.h
@@ -31,7 +31,10 @@ class DBCALCluster_factory_SINGLE:public jana::JFactory<DBCALCluster>{
 		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
 		double m_z_target_center;
+		const DBCALGeometry *dBCALGeom;
+
 };
 
 #endif // _DBCALCluster_factory_SINGLE_

--- a/src/libraries/BCAL/DBCALGeometry.cc
+++ b/src/libraries/BCAL/DBCALGeometry.cc
@@ -9,6 +9,7 @@
 
 
 #include <cmath>
+#include <TMath.h>
 #include "DBCALGeometry.h"
 
 #include <HDGEOMETRY/DGeometry.h>

--- a/src/libraries/BCAL/DBCALGeometry.cc
+++ b/src/libraries/BCAL/DBCALGeometry.cc
@@ -13,68 +13,6 @@
 
 #include <HDGEOMETRY/DGeometry.h>
 
-// On each module there is a 10x4 (r/phi) array of SiPMs
-
-#ifdef BCAL_SUM_CELL
-
-// The configuration below has 3x1 (r/phi) summed cells in the inner
-// and 2x2 summed cells in the outer region
-//int DBCALGeometry::NSUMSECSIN = 1;
-//int DBCALGeometry::NSUMSECSOUT = 2;
-//int DBCALGeometry::NSUMLAYSIN[] = {3,3};
-//int DBCALGeometry::NSUMLAYSOUT[] = {2,2};
-
-// 1.2.3.4 summing configuration
-int DBCALGeometry::NSUMSECSIN = 1;
-int DBCALGeometry::NSUMSECSOUT = 1;
-int DBCALGeometry::NSUMLAYSIN[] = {1,2,3};
-int DBCALGeometry::NSUMLAYSOUT[] = {4};
-
-// end of summing configuration
-
-#else
-
-// The configuration below has no summing of SiPMs
-int DBCALGeometry::NSUMSECSIN = 1;
-int DBCALGeometry::NSUMSECSOUT = 1;
-int DBCALGeometry::NSUMLAYSIN[] = {1,1,1,1,1,1};
-int DBCALGeometry::NSUMLAYSOUT[] = {1,1,1,1};
-// end of no summing configuration
-
-#endif
-
-int DBCALGeometry::NBCALSECSIN = 4/DBCALGeometry::NSUMSECSIN;
-int DBCALGeometry::NBCALSECSOUT = 4/DBCALGeometry::NSUMSECSOUT;
-float DBCALGeometry::BCAL_PHI_SHIFT = 0.0; // will be overwritten in constructor
-
-bool DBCALGeometry::initialized = false;
-float DBCALGeometry::BCALINNERRAD = 0.0;
-float DBCALGeometry::BCALOUTERRAD = 86.17;
-float DBCALGeometry::BCALFIBERLENGTH = 0.0;
-float DBCALGeometry::GLOBAL_CENTER = 0.0;
-  
-float DBCALGeometry::ATTEN_LENGTH = 520.;
-float DBCALGeometry::C_EFFECTIVE  = 16.75;
-
-float DBCALGeometry::m_radius[] = { 64.3, 
-				  66.3,
-				  68.3,
-				  70.3,
-				  72.3,
-				  74.3,
-				  76.3,
-				  78.77,
-				  81.24,
-				  83.70,
-				  86.17};
-
-float DBCALGeometry::fADC_radius[] = { 0,
-				  0,
-				  0,
-				  0,
-				  0};
-
-float DBCALGeometry::BCALMIDRAD = DBCALGeometry::m_radius[DBCALGeometry::BCALMID-1];
 
 DBCALGeometry::DBCALGeometry(int runnumber)  
 {
@@ -107,7 +45,7 @@ DBCALGeometry::DBCALGeometry(int runnumber)
   }
 
   // Initialize DBCALGeometry variables
-  if(!initialized) Initialize(runnumber);
+  Initialize(runnumber);
 
 }
 
@@ -148,38 +86,32 @@ DBCALGeometry::Initialize(int runnumber) {
   // Get overall phi shift of BCAL
   float my_BCAL_PHI_SHIFT;
   dgeom->GetBCALPhiShift(my_BCAL_PHI_SHIFT);
-  BCAL_PHI_SHIFT = my_BCAL_PHI_SHIFT*M_PI/180.0;  // convert to radians
-
-  initialized = true;
+  BCAL_PHI_SHIFT = my_BCAL_PHI_SHIFT*TMath::Pi()/180.0;  // convert to radians
 }
 
 float
-DBCALGeometry::GetBCAL_inner_rad() {
-	if(!initialized) Initialize();
+DBCALGeometry::GetBCAL_inner_rad() const {
 	return BCALINNERRAD;
 }
 
-float*
-DBCALGeometry::GetBCAL_radii() {
-	if(!initialized) Initialize();
+const float*
+DBCALGeometry::GetBCAL_radii() const {
 	return fADC_radius;
+	//return &(fADC_radius[0]);
 }
 
 float
-DBCALGeometry::GetBCAL_center() {
-	if(!initialized) Initialize();
+DBCALGeometry::GetBCAL_center() const {
 	return GLOBAL_CENTER;
 }
 
 float
-DBCALGeometry::GetBCAL_length() {
-	if(!initialized) Initialize();
+DBCALGeometry::GetBCAL_length() const {
 	return BCALFIBERLENGTH;
 }
 
 float
-DBCALGeometry::GetBCAL_phi_shift() {
-	if(!initialized) Initialize();
+DBCALGeometry::GetBCAL_phi_shift() const {
 	return BCAL_PHI_SHIFT;
 }
 
@@ -187,7 +119,7 @@ DBCALGeometry::GetBCAL_phi_shift() {
 // module
 //--------------
 int
-DBCALGeometry::module( int cellId ) {
+DBCALGeometry::module( int cellId ) const {
   
   return ( cellId & MODULE_MASK ) >> MODULE_SHIFT;
 }
@@ -196,7 +128,7 @@ DBCALGeometry::module( int cellId ) {
 // layer
 //--------------
 int
-DBCALGeometry::layer( int cellId ) {
+DBCALGeometry::layer( int cellId ) const {
   
   return ( cellId & LAYER_MASK ) >> LAYER_SHIFT;
 }
@@ -205,7 +137,7 @@ DBCALGeometry::layer( int cellId ) {
 // sector
 //--------------
 int
-DBCALGeometry::sector( int cellId ) {
+DBCALGeometry::sector( int cellId ) const {
   
   return ( cellId & SECTOR_MASK ) >> SECTOR_SHIFT;
 }
@@ -214,7 +146,7 @@ DBCALGeometry::sector( int cellId ) {
 // cellId
 //--------------
 int
-DBCALGeometry::cellId( int module, int layer, int sector ) {
+DBCALGeometry::cellId( int module, int layer, int sector ) const {
   
   return ( ( module << MODULE_SHIFT ) | 
            ( layer << LAYER_SHIFT   ) | 
@@ -225,7 +157,7 @@ DBCALGeometry::cellId( int module, int layer, int sector ) {
 // fADC_layer
 //--------------
 int
-DBCALGeometry::fADC_layer( int SiPM_cellId ) {
+DBCALGeometry::fADC_layer( int SiPM_cellId ) const {
   
   int cell_layer = DBCALGeometry::layer( SiPM_cellId );
   int fADC_layer = 0;
@@ -255,7 +187,7 @@ DBCALGeometry::fADC_layer( int SiPM_cellId ) {
 // fADC_sector
 //--------------
 int
-DBCALGeometry::fADC_sector( int SiPM_cellId ) {
+DBCALGeometry::fADC_sector( int SiPM_cellId ) const {
 
   int cell_layer = DBCALGeometry::layer( SiPM_cellId );
   int cell_sector = DBCALGeometry::sector( SiPM_cellId );
@@ -274,7 +206,7 @@ DBCALGeometry::fADC_sector( int SiPM_cellId ) {
 // fADCId
 //--------------
 int
-DBCALGeometry::fADCId( int module, int SiPM_layer, int SiPM_sector ) {
+DBCALGeometry::fADCId( int module, int SiPM_layer, int SiPM_sector ) const {
   // This is used to return the readout channel ID which may
   // differ from the cellID if summing is implemented.
   //
@@ -292,7 +224,7 @@ DBCALGeometry::fADCId( int module, int SiPM_layer, int SiPM_sector ) {
 // NSiPMs
 //--------------
 int
-DBCALGeometry::NSiPMs(int fADCId)
+DBCALGeometry::NSiPMs(int fADCId) const
 {
 	/// Return the number of SiPMs summed for the given fADCId
 	int fadc_lay = layer(fADCId);
@@ -312,7 +244,7 @@ DBCALGeometry::NSiPMs(int fADCId)
 // r
 //--------------
 float
-DBCALGeometry::r( int fADC_cell ) {
+DBCALGeometry::r( int fADC_cell ) const {
 
   int fADC_lay = layer( fADC_cell );
 
@@ -346,7 +278,7 @@ DBCALGeometry::r( int fADC_cell ) {
 // rSize
 //--------------
 float
-DBCALGeometry::rSize( int fADC_cell ) {
+DBCALGeometry::rSize( int fADC_cell ) const {
 
   int fADC_lay = layer( fADC_cell );
 
@@ -380,7 +312,7 @@ DBCALGeometry::rSize( int fADC_cell ) {
 // phi
 //--------------
 float
-DBCALGeometry::phi( int fADC_cell ) {
+DBCALGeometry::phi( int fADC_cell ) const {
 
   // int fADC_lay = layer( fADC_cell );
   // int fADC_sect = sector( fADC_cell );
@@ -395,16 +327,16 @@ DBCALGeometry::phi( int fADC_cell ) {
   // }
 
   // fADC_sect += nSects * ( module( fADC_cell ) - 1 );
-  // sectSize = 2 * PI / (NBCALMODS*nSects);
+  // sectSize = 2 * M_PI / (NBCALMODS*nSects);
   
   // float my_phi = sectSize * ( (float)fADC_sect - 0.5 );
   // my_phi += BCAL_PHI_SHIFT - 2.0*sectSize; // adjust for center of module and overall BCAL shift
   
   float globsect = getglobalsector(module(fADC_cell), sector(fADC_cell));
-  float sectSize = 2. * PI / 48. / 4;
+  float sectSize = 2. * M_PI / 48. / 4;
   // The first 2 sectors (half of mudule 1) have negative phi
   float my_phi = sectSize * (globsect-2.5);
-  if (my_phi < 0) my_phi += 2 * PI;
+  if (my_phi < 0) my_phi += 2 * M_PI;
   return my_phi;
 
 }
@@ -413,7 +345,7 @@ DBCALGeometry::phi( int fADC_cell ) {
 // phiSize
 //--------------
 float
-DBCALGeometry::phiSize( int fADC_cell ) {
+DBCALGeometry::phiSize( int fADC_cell ) const {
 
   // int fADC_lay = layer( fADC_cell );
 
@@ -424,9 +356,9 @@ DBCALGeometry::phiSize( int fADC_cell ) {
   //   nSects = 4/NSUMSECSOUT;
   // }
 
-  // float sectSize = 2 * PI / ( NBCALMODS * nSects );
+  // float sectSize = 2 * M_PI / ( NBCALMODS * nSects );
   
-  float sectSize = 2 * PI / 48 / 4;
+  float sectSize = 2 * M_PI / 48 / 4;
 
   return sectSize;
 }
@@ -436,18 +368,18 @@ DBCALGeometry::phiSize( int fADC_cell ) {
 //--------------
 /// Method to get the fADC cell ID from an (R, phi) combination.  R in cm and phi in radians.
 int
-DBCALGeometry::fADCcellId_rphi( float r, float phi ) {
+DBCALGeometry::fADCcellId_rphi( float r, float phi ) const {
   int fADC_cellId = 0;
   int SiPM_layer = 0;
 
   if (r < BCALINNERRAD) return 0;
   else if (r > BCALOUTERRAD) return 0;
 
-  float modulephiSize = (2 * PI) / 48;
+  float modulephiSize = (2 * M_PI) / 48;
   float sectorphiSize = modulephiSize / 4;
   float phi_nooffset = (phi + 2.0*sectorphiSize);
   if (phi_nooffset < 0) return 0;
-  else if (phi_nooffset > 2 * PI) return 0;
+  else if (phi_nooffset > 2 * M_PI) return 0;
 
   if (r < m_radius[1]) SiPM_layer = 1; 
   else if (r < m_radius[2]) SiPM_layer = 2; 
@@ -469,25 +401,29 @@ DBCALGeometry::fADCcellId_rphi( float r, float phi ) {
   return fADC_cellId;
 }
 
-int  DBCALGeometry::getglobalchannelnumber(int module, int layer, int sector, int end) {
+int  DBCALGeometry::getglobalchannelnumber(int module, int layer, int sector, int end) const {
   if (module<=0 || layer<=0 || sector<=0) return 0;
   else return (module-1)*32 + (layer-1)*8 + (sector-1)*2 + end + 1;
 }
-int DBCALGeometry::getendchannelnumber(int module, int layer, int sector) {
+
+int DBCALGeometry::getendchannelnumber(int module, int layer, int sector) const {
   if (module<=0 || layer<=0 || sector<=0) return 0;
   else return (module-1)*16 + (layer-1)*4 + sector;
 } 
-int DBCALGeometry::getglobalsector(int module, int sector) {
+
+int DBCALGeometry::getglobalsector(int module, int sector) const {
   if (module<=0 || sector<=0) return 0;
   else return (module-1)*4 + sector;
 }
-int DBCALGeometry::getsector(int globalsector) {
+
+int DBCALGeometry::getsector(int globalsector) const {
   if (globalsector<=0) return 0;
   int sector = globalsector%4;
   if (sector==0) sector=4;
   return sector;
 }
-int DBCALGeometry::getmodule(int globalsector) {
+
+int DBCALGeometry::getmodule(int globalsector) const {
   if (globalsector<=0) return 0;
   else return (globalsector-1)/4+1;
 }

--- a/src/libraries/BCAL/DBCALPoint.cc
+++ b/src/libraries/BCAL/DBCALPoint.cc
@@ -15,7 +15,9 @@ using namespace std;
 
 #include "units.h"
 
-DBCALPoint::DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2, double z_target_center, double attenuation_length, double c_effective, double track_p0, double track_p1, double track_p2)
+DBCALPoint::DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2, double z_target_center, 
+		double attenuation_length, double c_effective, double track_p0, double track_p1, 
+		double track_p2, const DBCALGeometry *locGeom) : m_BCALGeom(locGeom)
 {
   
   // this is a problem -- both hits are on the same end...
@@ -25,21 +27,21 @@ DBCALPoint::DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2,
 
   // check to be sure both hits are in the same cell
   
-  int cellId = DBCALGeometry::cellId( hit1.module, hit1.layer, hit1.sector );
+  int cellId = m_BCALGeom->cellId( hit1.module, hit1.layer, hit1.sector );
   assert( cellId == 
-             DBCALGeometry::cellId( hit2.module, hit2.layer, hit2.sector ) );
+             m_BCALGeom->cellId( hit2.module, hit2.layer, hit2.sector ) );
 
   // save typing
   
-  float fibLen = DBCALGeometry::GetBCAL_length();
+  float fibLen = m_BCALGeom->GetBCAL_length();
 
   // figure out which hit is upstream and which is downstream
   // (downstream means farthest from the target)
 
   const DBCALUnifiedHit& upHit = 
-     ( hit1.end == DBCALGeometry::kUpstream ? hit1 : hit2 );
+     ( hit1.end == m_BCALGeom->kUpstream ? hit1 : hit2 );
   const DBCALUnifiedHit& downHit = 
-     ( hit1.end == DBCALGeometry::kDownstream ? hit1 : hit2 );
+     ( hit1.end == m_BCALGeom->kDownstream ? hit1 : hit2 );
   
   double tUp = upHit.t;
   double tDown = downHit.t;
@@ -52,7 +54,7 @@ DBCALPoint::DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2,
   
   // get the position with respect to the center of the module -- positive
   // z in the downstream direction
-  m_zLocal = m_zGlobal - DBCALGeometry::GetBCAL_center(); 
+  m_zLocal = m_zGlobal - m_BCALGeom->GetBCAL_center(); 
 
   // set the z position relative to the center of the target
   m_z = m_zGlobal - z_target_center;
@@ -64,7 +66,7 @@ DBCALPoint::DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2,
   m_zLocal = 0.5 * c_effective * ( tUp - tDown ); 
 
   // set the z position relative to the center of the target
-  m_z = m_zLocal + DBCALGeometry::GetBCAL_center() - z_target_center;
+  m_z = m_zLocal + m_BCALGeom->GetBCAL_center() - z_target_center;
 */
 
   //At this point m_z may be unphysical, i.e. it may be outside the BCAL.
@@ -98,12 +100,12 @@ DBCALPoint::DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2,
   m_E_DS =  ( downHit.E / attDown );
   m_E =  ( m_E_US + m_E_DS ) / 2;
   
-  m_r = DBCALGeometry::r( cellId );
+  m_r = m_BCALGeom->r( cellId );
   //for a uniform distribution of width a, the RMS is a/sqrt(12)
-  m_sig_r = DBCALGeometry::rSize( cellId )/sqrt(12.0);
+  m_sig_r = m_BCALGeom->rSize( cellId )/sqrt(12.0);
   
-  m_phi = DBCALGeometry::phi( cellId );
-  m_sig_phi = DBCALGeometry::phiSize( cellId )/sqrt(12.0);
+  m_phi = m_BCALGeom->phi( cellId );
+  m_sig_phi = m_BCALGeom->phiSize( cellId )/sqrt(12.0);
   
   //make a rough guess of sigma_z for now
   //if we have TDC info
@@ -135,7 +137,7 @@ DBCALPoint::tInnerRadius() const {
  
   // the path length in the module
   
-  float modulePath = m_rho - DBCALGeometry::GetBCAL_inner_rad() / sin( m_theta );
+  float modulePath = m_rho - m_BCALGeom->GetBCAL_inner_rad() / sin( m_theta );
   
   // retard the time by that distance divided by the speed of light
 
@@ -171,11 +173,11 @@ DBCALPoint::convertCylindricalToSpherical(){
 void
 DBCALPoint::add2Pi() const {
 
-  const_cast< DBCALPoint* >( this )->m_phi += 2*PI;
+  const_cast< DBCALPoint* >( this )->m_phi += 2*M_PI;
 }
 
 void
 DBCALPoint::sub2Pi() const {
   
-  const_cast< DBCALPoint* >( this )->m_phi -= 2*PI;
+  const_cast< DBCALPoint* >( this )->m_phi -= 2*M_PI;
 }

--- a/src/libraries/BCAL/DBCALPoint.h
+++ b/src/libraries/BCAL/DBCALPoint.h
@@ -10,6 +10,7 @@
 
 #include "BCAL/DBCALHit.h"
 #include "BCAL/DBCALUnifiedHit.h"
+#include "BCAL/DBCALGeometry.h"
 
 #include <JANA/JObject.h>
 #include <JANA/JFactory.h>
@@ -30,7 +31,9 @@ public:
   JOBJECT_PUBLIC(DBCALPoint);
   
   // this constructor uses two hits to obtain a local z position
-  DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2, double z_target_center, double attenutation_length, double c_effective, double track_p0, double track_p1, double track_p2);
+  DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2, double z_target_center, 
+  			 double attenutation_length, double c_effective, double track_p0, double track_p1, double track_p2, 
+  			 const DBCALGeometry *locGeom);
   
   float E() const { return m_E; }
   float E_US() const { return m_E_US; }  ///< Return the attenuation corrected Energy of US Hit
@@ -97,6 +100,8 @@ private:
   // spherical coordinate locations
   float m_rho, m_sig_rho;        ///< spherical distance wrt target center
   float m_theta, m_sig_theta;    ///< polar angle wrt target center
+  
+  const DBCALGeometry *m_BCALGeom;
 
 };
 

--- a/src/libraries/BCAL/DBCALPoint_factory.h
+++ b/src/libraries/BCAL/DBCALPoint_factory.h
@@ -12,6 +12,7 @@ using namespace jana;
 
 #include "BCAL/DBCALPoint.h"
 #include "BCAL/DBCALUnifiedHit.h"
+#include "BCAL/DBCALGeometry.h"
 
 #include <TTree.h>
 
@@ -24,7 +25,7 @@ class DBCALHit;
 class DBCALPoint_factory : public JFactory<DBCALPoint> {
 
  public:
-  DBCALPoint_factory() {
+  DBCALPoint_factory() : m_BCALGeom(NULL) {
     PRINTCALIBRATION = false;
     if(gPARMS){
       gPARMS->SetDefaultParameter("BCALPOINT:PRINTCALIBRATION", PRINTCALIBRATION, "Print the calibration parameters.");
@@ -44,6 +45,9 @@ class DBCALPoint_factory : public JFactory<DBCALPoint> {
   effective_vel_t effective_velocities;
   track_parms_t track_parameters;
  
+  const DBCALGeometry *m_BCALGeom;
+
+ 	// =(
   static const int BCAL_NUM_MODULES  = 48;
   static const int BCAL_NUM_LAYERS   =  4;
   static const int BCAL_NUM_SECTORS  =  4;

--- a/src/libraries/BCAL/DBCALShower_factory_CURVATURE.h
+++ b/src/libraries/BCAL/DBCALShower_factory_CURVATURE.h
@@ -10,6 +10,7 @@
 
 #include <JANA/JFactory.h>
 #include "DBCALShower.h"
+#include "BCAL/DBCALGeometry.h"
 
 class DBCALShower_factory_CURVATURE:public jana::JFactory<DBCALShower>{
 	public:
@@ -44,6 +45,8 @@ class DBCALShower_factory_CURVATURE:public jana::JFactory<DBCALShower>{
   vector<double> recon_showers_theta;
   vector<double> recon_showers_E;
   vector<double> recon_showers_t;
+
+  const DBCALGeometry *dBCALGeom;
 
 };
 

--- a/src/libraries/BCAL/DBCALShower_factory_IU.cc
+++ b/src/libraries/BCAL/DBCALShower_factory_IU.cc
@@ -80,6 +80,13 @@ jerror_t DBCALShower_factory_IU::brun(JEventLoop *loop, int32_t runnumber) {
 	jerror_t result = LoadCovarianceLookupTables();
 	if (result!=NOERROR) return result;
 	
+	// load BCAL geometry
+  	vector<const DBCALGeometry *> BCALGeomVec;
+  	loop->Get(BCALGeomVec);
+  	if(BCALGeomVec.size() == 0)
+		throw JException("Could not load DBCALGeometry object!");
+	dBCALGeom = BCALGeomVec[0];
+	
   return NOERROR;
 }
 
@@ -117,7 +124,7 @@ DBCALShower_factory_IU::evnt( JEventLoop *loop, uint64_t eventnumber ){
     //so we need to make an adjustment so that the shower t is the time at
     //the shower location (x,y,z)
     double t = (**clItr).t();
-    double inner_rad = DBCALGeometry::GetBCAL_inner_rad();
+    double inner_rad = dBCALGeom->GetBCAL_inner_rad();
     double dist_in_BCAL = rho - inner_rad/sinTh;
     t = t + dist_in_BCAL/(30*k_cm/k_nsec);
     shower->t = t;

--- a/src/libraries/BCAL/DBCALShower_factory_IU.h
+++ b/src/libraries/BCAL/DBCALShower_factory_IU.h
@@ -15,6 +15,7 @@
 using namespace jana;
 
 #include "BCAL/DBCALShower.h"
+#include "BCAL/DBCALGeometry.h"
 
 #include "TH2F.h"
 #include <DMatrixDSym.h>
@@ -49,6 +50,8 @@ private:
   double exponential_param2;
 
   double m_zTarget;
+
+  const DBCALGeometry *dBCALGeom;
 
 };
 

--- a/src/libraries/BCAL/DBCALShower_factory_KLOE.cc
+++ b/src/libraries/BCAL/DBCALShower_factory_KLOE.cc
@@ -53,6 +53,7 @@ jerror_t DBCALShower_factory_KLOE::init()
   gPARMS->SetDefaultParameter( "BCALRECON:MERGE_THRESH_XYDIST", MERGE_THRESH_XYDIST );
   gPARMS->SetDefaultParameter( "BCALRECON:BREAK_THRESH_TRMS", BREAK_THRESH_TRMS );
   
+  /*  this is unused code
   if( !DBCALGeometry::summingOn() ){
 
     // these are energy calibration parameters -- no summing of cells
@@ -69,20 +70,21 @@ jerror_t DBCALShower_factory_KLOE::init()
   
   }
   else{
-    
-    // these are energy calibration parameters -- 1.2.3.4 summing
+    */
+
+  // these are energy calibration parameters -- 1.2.3.4 summing
   
-    //last updated for svn revision 9233
-    m_scaleZ_p0 = 0.99798;
-    m_scaleZ_p1 = 0.000361096;
-    m_scaleZ_p2 = -2.17338e-06;
-    m_scaleZ_p3 = 1.32201e-09;
+  //last updated for svn revision 9233
+  m_scaleZ_p0 = 0.99798;
+  m_scaleZ_p1 = 0.000361096;
+  m_scaleZ_p2 = -2.17338e-06;
+  m_scaleZ_p3 = 1.32201e-09;
   
-    m_nonlinZ_p0 = -0.0201272;
-    m_nonlinZ_p1 = 0.000103649;
-    m_nonlinZ_p2 = 0;
-    m_nonlinZ_p3 = 0;
-  }
+  m_nonlinZ_p0 = -0.0201272;
+  m_nonlinZ_p1 = 0.000103649;
+  m_nonlinZ_p2 = 0;
+  m_nonlinZ_p3 = 0;
+  //}
   
   return NOERROR;
 }
@@ -99,42 +101,42 @@ jerror_t DBCALShower_factory_KLOE::brun(JEventLoop *loop, int32_t runnumber)
     
     vector<const DBCALGeometry*> bcalGeomVect;
     loop->Get( bcalGeomVect );
-    const DBCALGeometry& bcalGeom = *(bcalGeomVect[0]);
+    bcalGeom = bcalGeomVect[0];
     
     //////////////////////////////////////////////////////////////////
     // Calculate Cell Position
     //////////////////////////////////////////////////////////////////
     
-    ATTEN_LENGTH = bcalGeom.ATTEN_LENGTH;
-    C_EFFECTIVE = bcalGeom.C_EFFECTIVE;
+    ATTEN_LENGTH = bcalGeom->ATTEN_LENGTH;
+    C_EFFECTIVE = bcalGeom->C_EFFECTIVE;
     
-    fiberLength = bcalGeom.GetBCAL_length(); // fiber length in cm
-    zOffset = bcalGeom.GetBCAL_center();
+    fiberLength = bcalGeom->GetBCAL_length(); // fiber length in cm
+    zOffset = bcalGeom->GetBCAL_center();
 
     //the following uses some sad notation in which modmin=0 and modmax=48, when in fact there are 48 modules labelled either 0-47 or 1-48 depending on one's whim, although if we are using the methods from DBCALGeometry (e.g. cellId()), we must start counting from 1 and if we are accessing arrays we must of course start from 0
     int   modmin = 0;
-    int   modmax = bcalGeom.NBCALMODS;
+    int   modmax = bcalGeom->NBCALMODS;
     int   rowmin1=0;
-    int   rowmax1= bcalGeom.NBCALLAYSIN;
+    int   rowmax1= bcalGeom->NBCALLAYSIN;
     int   rowmin2= rowmax1;
-    int   rowmax2= bcalGeom.NBCALLAYSOUT+rowmin2; 
+    int   rowmax2= bcalGeom->NBCALLAYSOUT+rowmin2; 
     int   colmin1=0;
-    int   colmax1=bcalGeom.NBCALSECSIN;
+    int   colmax1=bcalGeom->NBCALSECSIN;
     int   colmin2=0;
-    int   colmax2=bcalGeom.NBCALSECSOUT;
+    int   colmax2=bcalGeom->NBCALSECSOUT;
     
-    float r_inner= bcalGeom.GetBCAL_inner_rad();
+    float r_inner= bcalGeom->GetBCAL_inner_rad();
     
     for (int i = (rowmin1+1); i < (rowmax1+1); i++){
         //this loop starts from 1, so we can use i in cellId with no adjustment
-        int cellId = bcalGeom.cellId(1,i,1); //this gives us a cellId that we can use to get the radius. the module and sector numbers are irrelevant
+        int cellId = bcalGeom->cellId(1,i,1); //this gives us a cellId that we can use to get the radius. the module and sector numbers are irrelevant
         //rt is radius of center of layer - BCAL inner radius
-        rt[i]=bcalGeom.r(cellId)-r_inner;
+        rt[i]=bcalGeom->r(cellId)-r_inner;
     }
     
     for (int i = (rowmin2+1); i < (rowmax2+1); i++){
-        int cellId = bcalGeom.cellId(1,i,1);
-        rt[i]=bcalGeom.r(cellId)-r_inner;
+        int cellId = bcalGeom->cellId(1,i,1);
+        rt[i]=bcalGeom->r(cellId)-r_inner;
     }
     
     //these are r and phi positions of readout cells
@@ -147,9 +149,9 @@ jerror_t DBCALShower_factory_KLOE::brun(JEventLoop *loop, int32_t runnumber)
             for (int j = colmin1; j < colmax1; j++){
                 //in this case the loops start at 0, so we have to add 1 to the indices when calling cellId(). hooray!
                 //use DBCALGeometry to get r/phi position of each cell
-                int cellId = bcalGeom.cellId(k+1,i+1,j+1);
-                r[k][i][j]=bcalGeom.r(cellId);
-                phi[k][i][j]=bcalGeom.phi(cellId);
+                int cellId = bcalGeom->cellId(k+1,i+1,j+1);
+                r[k][i][j]=bcalGeom->r(cellId);
+                phi[k][i][j]=bcalGeom->phi(cellId);
                 //set x and y positions
                 xx[k][i][j]=r[k][i][j]*cos(phi[k][i][j]);
                 yy[k][i][j]=r[k][i][j]*sin(phi[k][i][j]);          
@@ -158,9 +160,9 @@ jerror_t DBCALShower_factory_KLOE::brun(JEventLoop *loop, int32_t runnumber)
         
         for (int i = rowmin2; i < rowmax2; i++){
             for (int j = colmin2; j < colmax2; j++){
-                int cellId = bcalGeom.cellId(k+1,i+1,j+1);
-                r[k][i][j]=bcalGeom.r(cellId);
-                phi[k][i][j]=bcalGeom.phi(cellId);
+                int cellId = bcalGeom->cellId(k+1,i+1,j+1);
+                r[k][i][j]=bcalGeom->r(cellId);
+                phi[k][i][j]=bcalGeom->phi(cellId);
 
                 xx[k][i][j]=r[k][i][j]*cos(phi[k][i][j]);
                 yy[k][i][j]=r[k][i][j]*sin(phi[k][i][j]);          
@@ -304,7 +306,7 @@ jerror_t DBCALShower_factory_KLOE::evnt(JEventLoop *loop, uint64_t eventnumber)
   
         float r = sqrt( shower->x * shower->x + shower->y * shower->y );
       
-        float zEntry = ( shower->z - m_z_target_center ) * ( DBCALGeometry::GetBCAL_inner_rad() / r );
+        float zEntry = ( shower->z - m_z_target_center ) * ( bcalGeom->GetBCAL_inner_rad() / r );
       
         float scale = m_scaleZ_p0  + m_scaleZ_p1*zEntry + 
             m_scaleZ_p2*(zEntry*zEntry) + m_scaleZ_p3*(zEntry*zEntry*zEntry);
@@ -570,32 +572,32 @@ void DBCALShower_factory_KLOE::PreCluster(JEventLoop *loop)
   int k=1;     // NUMBER OF NEARBY ROWS &/OR TO LOOK FOR MAX E CELL
     
   // extract the BCAL Geometry
-  vector<const DBCALGeometry*> bcalGeomVect;
-  loop->Get( bcalGeomVect );
-  const DBCALGeometry& bcalGeom = *(bcalGeomVect[0]);
+  //vector<const DBCALGeometry*> bcalGeomVect;
+  //loop->Get( bcalGeomVect );
+  //const DBCALGeometry& bcalGeom = *(bcalGeomVect[0]);
     
   // calculate cell position
     
   int   modmin = 0;
-  int   modmax = bcalGeom.NBCALMODS;
+  int   modmax = bcalGeom->NBCALMODS;
 
 
   //these values make sense as actually minima/maxima if it is implied that rowmin1=1,colmin1=1,colmin2=1
-  int   rowmax1= bcalGeom.NBCALLAYSIN;
+  int   rowmax1= bcalGeom->NBCALLAYSIN;
   int   rowmin2= rowmax1+1;
-  //int   rowmax2= bcalGeom.NBCALLAYSOUT+rowmin2-1;
-  int   colmax1=bcalGeom.NBCALSECSIN;
-  int   colmax2=bcalGeom.NBCALSECSOUT;
+  //int   rowmax2= bcalGeom->NBCALLAYSOUT+rowmin2-1;
+  int   colmax1=bcalGeom->NBCALSECSIN;
+  int   colmax2=bcalGeom->NBCALSECSOUT;
 
-  float r_middle= bcalGeom.BCALMIDRAD;
+  float r_middle= bcalGeom->GetBCAL_middle_rad();
 
   //radial size of the outermost inner layer
-  float thick_inner=bcalGeom.rSize(bcalGeom.cellId(1,bcalGeom.NBCALLAYSIN,1));
+  float thick_inner=bcalGeom->rSize(bcalGeom->cellId(1,bcalGeom->NBCALLAYSIN,1));
   //radial size of the innermost outer layer
-  float thick_outer=bcalGeom.rSize(bcalGeom.cellId(1,bcalGeom.NBCALLAYSIN+1,1));
+  float thick_outer=bcalGeom->rSize(bcalGeom->cellId(1,bcalGeom->NBCALLAYSIN+1,1));
 
   // this is the radial distance between the center of the innermost outer layer and the outermost inner layer
-  float dis_in_out=bcalGeom.r(bcalGeom.cellId(1,bcalGeom.NBCALLAYSIN+1,1))-bcalGeom.r(bcalGeom.cellId(1,bcalGeom.NBCALLAYSIN,1));
+  float dis_in_out=bcalGeom->r(bcalGeom->cellId(1,bcalGeom->NBCALLAYSIN+1,1))-bcalGeom->r(bcalGeom->cellId(1,bcalGeom->NBCALLAYSIN,1));
     
   float degree_permodule=360.0/(modmax-modmin);
   float half_degree_permodule=degree_permodule/2.0;

--- a/src/libraries/BCAL/DBCALShower_factory_KLOE.h
+++ b/src/libraries/BCAL/DBCALShower_factory_KLOE.h
@@ -15,6 +15,7 @@ using namespace jana;
 
 #include <BCAL/DBCALShower.h>
 #include <BCAL/DBCALPoint.h>
+#include <BCAL/DBCALGeometry.h>
 
 /// Form fully reconstructed showers from BCAL data based on the KLOE algorithm.
 /// The showers produced by this do have calibration applied to correct the
@@ -64,6 +65,8 @@ private:
     void Gser(float &gamser,float a,float x);
     void Gcf(float &gammcf,float a,float x);
     float Gammln(float xx_gln);
+
+	const DBCALGeometry *bcalGeom;
 
 #undef layermax_bcal
 

--- a/src/libraries/BCAL/DBCALUnifiedHit_factory.h
+++ b/src/libraries/BCAL/DBCALUnifiedHit_factory.h
@@ -9,6 +9,7 @@ using namespace jana;
 #include "BCAL/DBCALUnifiedHit.h"
 #include "BCAL/DBCALTDCHit.h"
 #include "BCAL/DBCALHit.h"
+#include "BCAL/DBCALGeometry.h"
 
 #include <TTree.h>
 
@@ -79,6 +80,8 @@ class DBCALUnifiedHit_factory : public JFactory<DBCALUnifiedHit> {
   };
 
   map<readout_channel,timewalk_coefficients> tdc_timewalk_map;
+
+  const DBCALGeometry *dBCALGeom;
 
   //write out tree with hit info?
   static const int enable_debug_output = 0;

--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -213,8 +213,14 @@ jerror_t DEventSourceHDDM::GetObjects(JEvent &event, JFactory_base *factory)
                uscale[i]=row["qru"];
                vscale[i]=row["qrv"];
             }
-         }
+         }     
       }
+      // load BCAL geometry
+  	  vector<const DBCALGeometry *> BCALGeomVec;
+  	  loop->Get(BCALGeomVec);
+  	  if(BCALGeomVec.size() == 0)
+		  throw JException("Could not load DBCALGeometry object!");
+	  dBCALGeom = BCALGeomVec[0];
    }
 
    // Warning: This class is not completely thread-safe and can fail if running
@@ -825,9 +831,9 @@ jerror_t DEventSourceHDDM::Extract_DBCALSiPMHit(hddm_s::HDDM *record,
       response->E      = uiter->getE();
       response->t      = uiter->getT();
       response->end    = DBCALGeometry::kUpstream;
-      response->cellId = DBCALGeometry::cellId(uiter->getModule(),
-                                               uiter->getLayer(), 
-                                               uiter->getSector());
+      response->cellId = dBCALGeom->cellId(uiter->getModule(),
+                                           uiter->getLayer(), 
+                                           uiter->getSector());
       data.push_back(response);
    }
          
@@ -841,9 +847,9 @@ jerror_t DEventSourceHDDM::Extract_DBCALSiPMHit(hddm_s::HDDM *record,
       response->E      = diter->getE();
       response->t      = diter->getT();
       response->end    = DBCALGeometry::kDownstream;
-      response->cellId = DBCALGeometry::cellId(diter->getModule(),
-                                               diter->getLayer(), 
-                                               diter->getSector());
+      response->cellId = dBCALGeom->cellId(diter->getModule(),
+                                           diter->getLayer(), 
+                                           diter->getSector());
       data.push_back(response);
    }
    

--- a/src/libraries/HDDM/DEventSourceHDDM.h
+++ b/src/libraries/HDDM/DEventSourceHDDM.h
@@ -36,6 +36,7 @@ using namespace std;
 #include "BCAL/DBCALTDCDigiHit.h"
 #include "BCAL/DBCALTruthShower.h"
 #include "BCAL/DBCALTruthCell.h"
+#include "BCAL/DBCALGeometry.h"
 #include "CDC/DCDCHit.h"
 #include "FDC/DFDCHit.h"
 #include "FCAL/DFCALTruthShower.h"
@@ -160,6 +161,8 @@ class DEventSourceHDDM:public JEventSource
 
       map<unsigned int, double> dTargetCenterZMap; //unsigned int is run number
       map<unsigned int, double> dBeamBunchPeriodMap; //unsigned int is run number
+
+	  const DBCALGeometry *dBCALGeom;
 
       JCalibration *jcalib;
       float uscale[192],vscale[192];

--- a/src/libraries/TRIGGER/DMCTrigger_factory.cc
+++ b/src/libraries/TRIGGER/DMCTrigger_factory.cc
@@ -37,9 +37,16 @@ jerror_t DMCTrigger_factory::init(void)
 //------------------
 jerror_t DMCTrigger_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 {
+    // load BCAL geometry
+  	vector<const DBCALGeometry *> BCALGeomVec;
+  	eventLoop->Get(BCALGeomVec);
+  	if(BCALGeomVec.size() == 0)
+	  throw JException("Could not load DBCALGeometry object!");
+	const DBCALGeometry *dBCALGeom = BCALGeomVec[0];
+
 	// Get attenuation parameters
-	double L_over_2 = DBCALGeometry::GetBCAL_length()/2.0;
-	double Xo = DBCALGeometry::ATTEN_LENGTH;
+	double L_over_2 = dBCALGeom->GetBCAL_length()/2.0;
+	double Xo = dBCALGeom->ATTEN_LENGTH;
 	unattenuate_to_center = exp(+L_over_2/Xo);
 
     USE_OLD_BCAL_HITS = 0;

--- a/src/plugins/Analysis/bcal_calib_cosmic_cdc/JEventProcessor_bcal_calib_cosmic_cdc.cc
+++ b/src/plugins/Analysis/bcal_calib_cosmic_cdc/JEventProcessor_bcal_calib_cosmic_cdc.cc
@@ -118,6 +118,13 @@ jerror_t JEventProcessor_bcal_calib_cosmic_cdc::init(void)
 jerror_t JEventProcessor_bcal_calib_cosmic_cdc::brun(JEventLoop *eventLoop, int32_t runnumber)
 {
 	// This is called whenever the run number changes
+	// load BCAL geometry
+  	vector<const DBCALGeometry *> BCALGeomVec;
+  	loop->Get(BCALGeomVec);
+  	if(BCALGeomVec.size() == 0)
+		throw JException("Could not load DBCALGeometry object!");
+	dBCALGeom = BCALGeomVec[0];
+	
 	return NOERROR;
 }
 
@@ -167,12 +174,12 @@ jerror_t JEventProcessor_bcal_calib_cosmic_cdc::evnt(JEventLoop *loop, uint64_t 
 		/// Store the parameters for both track intersections with the 5 layers
 		float r[5], phi[2][5], x[2][5], y[2][5];
 		float* bcal_radii;
-		bcal_radii = DBCALGeometry::GetBCAL_radii();
+		bcal_radii = dBCALGeom->GetBCAL_radii();
 		/// For each layer boundary, calculate the intersection of the DTrackCandidate
 		/// with the circle and store the r and phi value for both intersections.
 		for (int laybound=0; laybound<=4; laybound++) {
 
-			r[laybound] =  DBCALGeometry::bcal_radii[laybound];
+			r[laybound] =  dBCALGeom->bcal_radii[laybound];
 			
 			float A = 1 + track_m*track_m;
 			float B = 2 * track_m * track_c;
@@ -191,21 +198,21 @@ jerror_t JEventProcessor_bcal_calib_cosmic_cdc::evnt(JEventLoop *loop, uint64_t 
 			}
 			if (VERBOSE>=2)  {
 				for (int track=0; track<=1; track++) {
-					int fADC_cellId = DBCALGeometry::fADCcellId_rphi( r[laybound], phi[track][laybound]);
-					int module = DBCALGeometry::module( fADC_cellId );
-					int layer = DBCALGeometry::layer( fADC_cellId );
-					int sector = DBCALGeometry::sector( fADC_cellId );
-					int glosector = DBCALGeometry::getglobalsector(module,sector);
+					int fADC_cellId = dBCALGeom->fADCcellId_rphi( r[laybound], phi[track][laybound]);
+					int module = dBCALGeom->module( fADC_cellId );
+					int layer = dBCALGeom->layer( fADC_cellId );
+					int sector = dBCALGeom->sector( fADC_cellId );
+					int glosector = dBCALGeom->getglobalsector(module,sector);
 					printf("BCCC >>  intersection: boundary=%i (x,y)=(%6.2f,%6.2f)  (r,phi)=(%6.2f,%6.3f)  cellId 0x%4x  (mod,lay,sec,glosec) = (%2i,%2i,%2i,%3i)\n",
 						   laybound, x[track][laybound], y[track][laybound], r[laybound], phi[track][laybound], 
 						   fADC_cellId, module, layer, sector, glosector);
 				}
 			}
-			// fADC_cellId = DBCALGeometry::fADCcellId_rphi( r[laybound], phi[1][laybound]);
-			// module = DBCALGeometry::module( fADC_cellId );
-			// layer = DBCALGeometry::layer( fADC_cellId );
-			// sector = DBCALGeometry::sector( fADC_cellId );
-			// glosector = DBCALGeometry::getglobalsector(module,sector);
+			// fADC_cellId = dBCALGeom->fADCcellId_rphi( r[laybound], phi[1][laybound]);
+			// module = dBCALGeom->module( fADC_cellId );
+			// layer = dBCALGeom->layer( fADC_cellId );
+			// sector = dBCALGeom->sector( fADC_cellId );
+			// glosector = dBCALGeom->getglobalsector(module,sector);
 			// if (VERBOSE>=2)  {				
 			// 	printf("BCCC >>  intersection: boundary=%i (x,y)=(%6.2f,%6.2f)  (r,phi)=(%6.2f,%6.3f)  cellId 0x%4x  (mod,lay,sec,glosec) = (%2i,%2i,%2i,%3i)\n",
 			// 		   laybound, x[1][laybound], y[1][laybound], r[laybound], phi[1][laybound], fADC_cellId, module, layer, sector, glosector);
@@ -218,14 +225,14 @@ jerror_t JEventProcessor_bcal_calib_cosmic_cdc::evnt(JEventLoop *loop, uint64_t 
 			for (int layer=0; layer<=3; layer++) {
 				/// IN refers to inner radial boundary, OUT refers to outer radial boundary
 				/// Find the global sector number for the entrance and exit sectors in this layer
-				int fADC_cellIdIN = DBCALGeometry::fADCcellId_rphi( r[layer], phi[track][layer]);
-				int moduleIN = DBCALGeometry::module( fADC_cellIdIN );
-				int sectorIN = DBCALGeometry::sector( fADC_cellIdIN );
-				int globalsectorIN = DBCALGeometry::getglobalsector(moduleIN,sectorIN);
-				int fADC_cellIdOUT = DBCALGeometry::fADCcellId_rphi( r[layer+1], phi[track][layer+1]);
-				int moduleOUT = DBCALGeometry::module( fADC_cellIdOUT );
-				int sectorOUT = DBCALGeometry::sector( fADC_cellIdOUT );
-				int globalsectorOUT = DBCALGeometry::getglobalsector(moduleOUT,sectorOUT);
+				int fADC_cellIdIN = dBCALGeom->fADCcellId_rphi( r[layer], phi[track][layer]);
+				int moduleIN = dBCALGeom->module( fADC_cellIdIN );
+				int sectorIN = dBCALGeom->sector( fADC_cellIdIN );
+				int globalsectorIN = dBCALGeom->getglobalsector(moduleIN,sectorIN);
+				int fADC_cellIdOUT = dBCALGeom->fADCcellId_rphi( r[layer+1], phi[track][layer+1]);
+				int moduleOUT = dBCALGeom->module( fADC_cellIdOUT );
+				int sectorOUT = dBCALGeom->sector( fADC_cellIdOUT );
+				int globalsectorOUT = dBCALGeom->getglobalsector(moduleOUT,sectorOUT);
 				int globalsectormin, globalsectormax; // These are the ordered edge sectors, smallest and largets
 				/// Check that the cells are valid
 				if (fADC_cellIdIN<=0 || fADC_cellIdOUT<=0) {
@@ -263,11 +270,11 @@ jerror_t JEventProcessor_bcal_calib_cosmic_cdc::evnt(JEventLoop *loop, uint64_t 
 
 						for (int glosect=globalsectormin; glosect<=globalsectormax; glosect++) {
 							float dist = 0;
-							int sector = DBCALGeometry::getsector(glosect);
-							int module = DBCALGeometry::getmodule(glosect);
-							int fADCId = DBCALGeometry::cellId(module,layer+1,sector); // layers are 1 to 4
-							float phi = DBCALGeometry::phi(fADCId);
-							float phihalfSize = DBCALGeometry::phiSize(fADCId)/2.;
+							int sector = dBCALGeom->getsector(glosect);
+							int module = dBCALGeom->getmodule(glosect);
+							int fADCId = dBCALGeom->cellId(module,layer+1,sector); // layers are 1 to 4
+							float phi = dBCALGeom->phi(fADCId);
+							float phihalfSize = dBCALGeom->phiSize(fADCId)/2.;
 							float philess=phi-phihalfSize, phimore=phi+phihalfSize;
 							float mless, xless, yless, mmore, xmore, ymore;
 							/// For each sector, get line boundary on each side and find the (x,y) point
@@ -333,8 +340,8 @@ jerror_t JEventProcessor_bcal_calib_cosmic_cdc::evnt(JEventLoop *loop, uint64_t 
 	/// Loop over all DBCALHit objects in this event
 	for(unsigned int c_chan=0; c_chan<num_BCALHit; c_chan++){
 		const DBCALHit *BCALHit = BCALHit_vec[c_chan];
-		//int fADCId = DBCALGeometry::fADCId_fADC( BCALHit->module, BCALHit->layer, BCALHit->sector );
-		int fADCId = DBCALGeometry::cellId( BCALHit->module, BCALHit->layer, BCALHit->sector );
+		//int fADCId = dBCALGeom->fADCId_fADC( BCALHit->module, BCALHit->layer, BCALHit->sector );
+		int fADCId = dBCALGeom->cellId( BCALHit->module, BCALHit->layer, BCALHit->sector );
 		if (VERBOSE>=4) 
 			printf("BCCC >>    Hit: (module, layer, sector) = (%2i,%2i,%2i)  fADCId 0x%x\n",\
 				   BCALHit->module, BCALHit->layer, BCALHit->sector, fADCId);
@@ -362,10 +369,10 @@ jerror_t JEventProcessor_bcal_calib_cosmic_cdc::evnt(JEventLoop *loop, uint64_t 
 		for (unsigned int cellnum=0; cellnum<num_CellId; cellnum++) {
 			cell = CellId_vec[cellnum];
 			tdist = distance_vec[cellnum];
-			tmodule = DBCALGeometry::module( cell );
-			tlayer = DBCALGeometry::layer( cell );
-			tsector = DBCALGeometry::sector( cell );
-			tglobalsect = DBCALGeometry::getglobalsector(tmodule,tsector);
+			tmodule = dBCALGeom->module( cell );
+			tlayer = dBCALGeom->layer( cell );
+			tsector = dBCALGeom->sector( cell );
+			tglobalsect = dBCALGeom->getglobalsector(tmodule,tsector);
 			numcells = num_CellId;
 			use=0; 
 			dse=0;

--- a/src/plugins/Analysis/bcal_calib_cosmic_cdc/JEventProcessor_bcal_calib_cosmic_cdc.h
+++ b/src/plugins/Analysis/bcal_calib_cosmic_cdc/JEventProcessor_bcal_calib_cosmic_cdc.h
@@ -10,7 +10,7 @@
 
 #include <JANA/JEventProcessor.h>
 #include "TTree.h"
-
+#include "BCAL/DBCALGeometry.h"
 
 // Doxygen documentation
 /** 
@@ -47,6 +47,8 @@ class JEventProcessor_bcal_calib_cosmic_cdc:public jana::JEventProcessor{
 		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+	    const DBCALGeometry *dBCALGeom;
 
 		/// Command Line Parameters
 		int VERBOSE;

--- a/src/plugins/Analysis/event_size/JEventProcessor_event_size.cc
+++ b/src/plugins/Analysis/event_size/JEventProcessor_event_size.cc
@@ -142,6 +142,14 @@ jerror_t JEventProcessor_event_size::init(void)
 //------------------
 jerror_t JEventProcessor_event_size::brun(JEventLoop *eventLoop, int32_t runnumber)
 {
+	// load BCAL geometry
+  	vector<const DBCALGeometry *> BCALGeomVec;
+  	loop->Get(BCALGeomVec);
+  	if(BCALGeomVec.size() == 0)
+		throw JException("Could not load DBCALGeometry object!");
+	const DBCALGeometry *dBCALGeom = BCALGeomVec[0];
+
+	dBCALMid = dBCALGeom->GetBCAL_middle_cell();  // THIS IS PROBABLY WRONG!!!
 	// This is called whenever the run number changes
 	return NOERROR;
 }
@@ -191,7 +199,7 @@ jerror_t JEventProcessor_event_size::evnt(JEventLoop *loop, uint64_t eventnumber
 		if(bcalhits[i]->t < tmin_bcal)continue;
 		if(bcalhits[i]->t > tmax_bcal)continue;
 		
-		if(bcalhits[i]->layer < DBCALGeometry::BCALMID){
+		if(bcalhits[i]->layer < dBCALMid){
 			Nbcalhits_inner++;
 		}else{
 			Nbcalhits_outer++;

--- a/src/plugins/Analysis/event_size/JEventProcessor_event_size.h
+++ b/src/plugins/Analysis/event_size/JEventProcessor_event_size.h
@@ -86,6 +86,7 @@ class JEventProcessor_event_size:public jana::JEventProcessor{
 		double tmin_sc, tmax_sc;
 		double tmin_tagger, tmax_tagger;
 
+		int dBCALMid;
 };
 
 #endif // _JEventProcessor_event_size_

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.cc
@@ -185,7 +185,7 @@ bool DCustomAction_p2pi_hists::Perform_Action(JEventLoop* locEventLoop, const DP
 			if(locBeamPhotonEnergy > cohmin_energy && locBeamPhotonEnergy < cohedge_energy) {
 				dMM_M2pi->Fill(locP4_2pi.M(), locMissingP4.M());
 				
-				if(locParticles[1]->lorentzMomentum().Theta()*180/PI > 2. && locParticles[2]->lorentzMomentum().Theta()*180/PI > 2.) {
+				if(locParticles[1]->lorentzMomentum().Theta()*180/TMath::Pi() > 2. && locParticles[2]->lorentzMomentum().Theta()*180/TMath::Pi() > 2.) {
 					dMM_M2pi_noEle->Fill(locP4_2pi.M(), locMissingP4.M());
 					
 					if(locMissingP4.M() > minMMCut && locMissingP4.M() < maxMMCut) {

--- a/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.cc
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.cc
@@ -76,6 +76,13 @@ jerror_t JEventProcessor_BCAL_TDC_Timing::brun(JEventLoop *loop, int32_t runnumb
     DGeometry* geom = app->GetDGeometry(runnumber);
     geom->GetTargetZ(Z_TARGET);
 
+	// load BCAL geometry
+  	vector<const DBCALGeometry *> BCALGeomVec;
+  	loop->Get(BCALGeomVec);
+  	if(BCALGeomVec.size() == 0)
+		throw JException("Could not load DBCALGeometry object!");
+	dBCALGeom = BCALGeomVec[0];
+
     //////
     // THIS NEEDS TO CHANGE IF THERE IS A NEW TABLE
     //////
@@ -102,7 +109,7 @@ jerror_t JEventProcessor_BCAL_TDC_Timing::brun(JEventLoop *loop, int32_t runnumb
        float c1 = (*iter)[5];
        float c2 = (*iter)[6];
        float a_thresh = (*iter)[7];
-       int cellId = DBCALGeometry::cellId(module, layer, sector);
+       int cellId = dBCALGeom->cellId(module, layer, sector);
        readout_channel channel(cellId,end);
        tdc_timewalk_map[channel] = timewalk_coefficients(c0,c1,c2,a_thresh);
     }
@@ -172,7 +179,7 @@ jerror_t JEventProcessor_BCAL_TDC_Timing::evnt(JEventLoop *loop, uint64_t eventn
       //int the_cell = (bcalUnifiedHitVector[i]->module - 1) * 16 + (bcalUnifiedHitVector[i]->layer - 1) * 4 + bcalUnifiedHitVector[i]->sector;
       // There is one less layer of TDCs so the numbering relects this
       int the_tdc_cell = (bcalUnifiedHitVector[i]->module - 1) * 12 + (bcalUnifiedHitVector[i]->layer - 1) * 4 + bcalUnifiedHitVector[i]->sector;
-      int cellId = DBCALGeometry::cellId(bcalUnifiedHitVector[i]->module, bcalUnifiedHitVector[i]->layer, bcalUnifiedHitVector[i]->sector);
+      int cellId = dBCALGeom->cellId(bcalUnifiedHitVector[i]->module, bcalUnifiedHitVector[i]->layer, bcalUnifiedHitVector[i]->sector);
       // Get the underlying associated objects
       const DBCALHit * thisADCHit;
       const DBCALTDCHit * thisTDCHit;
@@ -369,8 +376,8 @@ jerror_t JEventProcessor_BCAL_TDC_Timing::evnt(JEventLoop *loop, uint64_t eventn
             // We can plot the difference of the projected position and the BCAL position as a function of the channel
             sprintf(name , "Module%.2iLayer%.2iSector%.2i", thisPoint->module(), thisPoint->layer(), thisPoint->sector());
             // These results are in slightly different coordinate systems. We want one where the center of the BCAL is z=0
-            double localTrackHitZ = proj_pos.z() - DBCALGeometry::GetBCAL_center();
-            double localBCALHitZ = thisPoint->z() - DBCALGeometry::GetBCAL_center() + Z_TARGET;
+            double localTrackHitZ = proj_pos.z() - dBCALGeom->GetBCAL_center();
+            double localBCALHitZ = thisPoint->z() - dBCALGeom->GetBCAL_center() + Z_TARGET;
 			Fill2DHistogram ("BCAL_TDC_Offsets", "Z Position", "AllPoints",
 							 localTrackHitZ, localBCALHitZ,
 							 "Z_{point} Vs. Z_{Track}; Z_{Track} [cm]; Z_{Point} [cm]",

--- a/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.h
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.h
@@ -25,6 +25,7 @@ class JEventProcessor_BCAL_TDC_Timing:public jana::JEventProcessor{
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
       double Z_TARGET;
+	  const DBCALGeometry *dBCALGeom;
 
       //Used as a key for maps
       class readout_channel {

--- a/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
+++ b/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
@@ -204,6 +204,14 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::brun(JEventLoop *eventLoop,
 	DApplication* app = dynamic_cast<DApplication*>(eventLoop->GetJApplication());
 	DGeometry* geom = app->GetDGeometry(runnumber);
 	geom->GetTargetZ(z_target_center);
+	
+	// load BCAL geometry
+  	vector<const DBCALGeometry *> BCALGeomVec;
+  	eventLoop->Get(BCALGeomVec);
+  	if(BCALGeomVec.size() == 0)
+		throw JException("Could not load DBCALGeometry object!");
+	dBCALGeom = BCALGeomVec[0];
+
 
 	return NOERROR;
 }
@@ -278,7 +286,7 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::evnt(JEventLoop *loop, uint
 
 		//float timediff = t_ADCus_vec[0]-t_ADCds_vec[0];
 		//float zpos = (timediff)*17./2;
-		float zpos = point->z() - DBCALGeometry::GetBCAL_center() + z_target_center;
+		float zpos = point->z() - dBCALGeom->GetBCAL_center() + z_target_center;
 		float intratio = (float)integralUS/(float)integralDS;
 		float logintratio = log(intratio);
 		float peakratio = (float)peakUS/(float)peakDS;

--- a/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.h
+++ b/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.h
@@ -9,6 +9,7 @@
 #define _JEventProcessor_BCAL_attenlength_gainratio_
 
 #include <JANA/JEventProcessor.h>
+#include "BCAL/DBCALGeometry.h"
 #include "TH2.h"
 
 class JEventProcessor_BCAL_attenlength_gainratio:public jana::JEventProcessor{
@@ -31,6 +32,8 @@ class JEventProcessor_BCAL_attenlength_gainratio:public jana::JEventProcessor{
 		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+		const DBCALGeometry *dBCALGeom;
 };
 
 #endif // _JEventProcessor_BCAL_attenlength_gainratio_

--- a/src/plugins/Calibration/BCAL_point_calib/JEventProcessor_BCAL_point_calib.cc
+++ b/src/plugins/Calibration/BCAL_point_calib/JEventProcessor_BCAL_point_calib.cc
@@ -322,20 +322,13 @@ jerror_t JEventProcessor_BCAL_point_calib::brun(JEventLoop *eventLoop, int32_t r
 	Run_Number = runnumber;
 	//BCAL_Neutrals->Fill();
 	//cout << " run number = " << RunNumber << endl;
-	/*
-	//Optional: Retrieve REST writer for writing out skims
-	eventLoop->GetSingle(dEventWriterREST);
-	*/
 
-	//vector<const DTrackFinder *> finders;
-	//eventLoop->Get(finders);
-	//finder = const_cast<DTrackFinder*>(finders[0]);
-
-	/*
-	//Recommeded: Create output ROOT TTrees (nothing is done if already created)
-	eventLoop->GetSingle(dEventWriterROOT);
-	dEventWriterROOT->Create_DataTrees(eventLoop);
-	*/
+	// load BCAL geometry
+  	vector<const DBCALGeometry *> BCALGeomVec;
+  	eventLoop->Get(BCALGeomVec);
+  	if(BCALGeomVec.size() == 0)
+		throw JException("Could not load DBCALGeometry object!");
+	dBCALGeom = BCALGeomVec[0];
 
 	return NOERROR;
 }
@@ -425,8 +418,7 @@ jerror_t JEventProcessor_BCAL_point_calib::evnt(JEventLoop *loop, uint64_t event
 	DVector3 mypos_4(0.0,0.0,0.0); // middle of Layer 4
 	
 	// get the inner radius of each layer (and the outer radius of layer 4)
-	float* bcal_radii;
-	bcal_radii = DBCALGeometry::GetBCAL_radii();
+	const float*bcal_radii = dBCALGeom->GetBCAL_radii();
 	
 	// the radii at the middle of each layer
 	double R1 = 0.5*(bcal_radii[0] + bcal_radii[1]); 

--- a/src/plugins/Calibration/BCAL_point_calib/JEventProcessor_BCAL_point_calib.h
+++ b/src/plugins/Calibration/BCAL_point_calib/JEventProcessor_BCAL_point_calib.h
@@ -14,6 +14,7 @@
 #include <ANALYSIS/DHistogramActions.h>
 #include "ANALYSIS/DAnalysisUtilities.h"
 //#include "TRACKING/DTrackFinder.h"
+#include <BCAL/DBCALGeometry.h>
 
 #include "DLorentzVector.h"
 #include "TMatrixD.h"
@@ -39,6 +40,7 @@ class JEventProcessor_BCAL_point_calib:public jana::JEventProcessor{
 
 		uint32_t BCALShowers_per_event;
 		int Run_Number;
+		const DBCALGeometry *dBCALGeom;
 
 		bool DEBUG;    // control the creation of extra histograms
 		bool VERBOSE;  // verbose output

--- a/src/plugins/Calibration/BCAL_point_time/JEventProcessor_BCAL_point_time.cc
+++ b/src/plugins/Calibration/BCAL_point_time/JEventProcessor_BCAL_point_time.cc
@@ -279,6 +279,14 @@ jerror_t JEventProcessor_BCAL_point_time::init(void)
 jerror_t JEventProcessor_BCAL_point_time::brun(JEventLoop *eventLoop, int32_t runnumber)
 {
 	// This is called whenever the run number changes
+	// load BCAL geometry
+  	vector<const DBCALGeometry *> BCALGeomVec;
+  	eventLoop->Get(BCALGeomVec);
+  	if(BCALGeomVec.size() == 0)
+		throw JException("Could not load DBCALGeometry object!");
+	dBCALGeom = BCALGeomVec[0];
+
+
 	return NOERROR;
 }
 
@@ -308,7 +316,7 @@ jerror_t JEventProcessor_BCAL_point_time::evnt(JEventLoop *loop, uint64_t eventn
 	if (numthrown==1) {
 		float pz = thrown[0]->pz();
 		float pt = sqrt(thrown[0]->px()*thrown[0]->px() + thrown[0]->py()*thrown[0]->py());
-		float z_p = pz/pt * DBCALGeometry::m_radius[0];
+		float z_p = pz/pt * dBCALGeom->m_radius[0];
 		theta_thrown = degperrad*atan2(pt,pz);
 		//float z_targ = thrown[0]->z();
 		z_coord = z_p;

--- a/src/plugins/Calibration/BCAL_point_time/JEventProcessor_BCAL_point_time.h
+++ b/src/plugins/Calibration/BCAL_point_time/JEventProcessor_BCAL_point_time.h
@@ -11,6 +11,7 @@
 #include <TDirectory.h>
 
 #include <JANA/JEventProcessor.h>
+#include <BCAL/DBCALGeometry.h> 
 
 class JEventProcessor_BCAL_point_time:public jana::JEventProcessor{
 	public:
@@ -29,6 +30,8 @@ class JEventProcessor_BCAL_point_time:public jana::JEventProcessor{
 		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+		const DBCALGeometry *dBCALGeom;
 };
 
 #endif // _JEventProcessor_BCAL_point_time_

--- a/src/plugins/monitoring/BCAL_Hadronic_Eff/JEventProcessor_BCAL_Hadronic_Eff.cc
+++ b/src/plugins/monitoring/BCAL_Hadronic_Eff/JEventProcessor_BCAL_Hadronic_Eff.cc
@@ -138,8 +138,12 @@ jerror_t JEventProcessor_BCAL_Hadronic_Eff::brun(jana::JEventLoop* locEventLoop,
 	//Effective velocities
 	locEventLoop->GetCalib("/BCAL/effective_velocities", effective_velocities);
 
-	//THE WORST THING EVER.  FIX THIS GEOMETRY CLASS.  NOTHING IN IT SHOULD BE STATIC.
-	DBCALGeometry::Initialize(locRunNumber);
+	// load BCAL geometry
+  	vector<const DBCALGeometry *> BCALGeomVec;
+  	locEventLoop->Get(BCALGeomVec);
+  	if(BCALGeomVec.size() == 0)
+		throw JException("Could not load DBCALGeometry object!");
+	dBCALGeom = BCALGeomVec[0];
 
 	return NOERROR;
 }
@@ -728,11 +732,11 @@ const DBCALUnifiedHit* JEventProcessor_BCAL_Hadronic_Eff::Find_ClosestTimeHit(co
 		double locClusterZ = locBCALCluster->rho()*cos(locBCALCluster->theta()) + dTargetCenterZ;
 
 		// calc the distance to upstream or downstream end of BCAL depending on where the hit was with respect to the cluster z position.
-		double locDistance = DBCALGeometry::GetBCAL_length()/2.0;
+		double locDistance = dBCALGeom->GetBCAL_length()/2.0;
 		if(locHit->end == 0)
-			locDistance += locClusterZ - DBCALGeometry::GetBCAL_center();
+			locDistance += locClusterZ - dBCALGeom->GetBCAL_center();
 		else
-			locDistance += DBCALGeometry::GetBCAL_center() - locClusterZ;
+			locDistance += dBCALGeom->GetBCAL_center() - locClusterZ;
 
 		//correct time, calc delta-t
 		int channel_calib = 16*(locHit->module - 1) + 4*(locHit->layer - 1) + locHit->sector - 1; //for CCDB

--- a/src/plugins/monitoring/BCAL_Hadronic_Eff/JEventProcessor_BCAL_Hadronic_Eff.h
+++ b/src/plugins/monitoring/BCAL_Hadronic_Eff/JEventProcessor_BCAL_Hadronic_Eff.h
@@ -85,6 +85,9 @@ class JEventProcessor_BCAL_Hadronic_Eff : public jana::JEventProcessor
 
 		//EFFECTIVE VELOCITIES
 		vector<double> effective_velocities;
+		
+		const DBCALGeometry *dBCALGeom;
+
 };
 
 template <typename DType> inline DType JEventProcessor_BCAL_Hadronic_Eff::Calc_DeltaSector(DType locHitSector, DType locProjectedSector) const

--- a/src/plugins/monitoring/BCAL_LEDonline/JEventProcessor_BCAL_LEDonline.cc
+++ b/src/plugins/monitoring/BCAL_LEDonline/JEventProcessor_BCAL_LEDonline.cc
@@ -320,6 +320,13 @@ jerror_t JEventProcessor_BCAL_LEDonline::init(void) {
 
 jerror_t JEventProcessor_BCAL_LEDonline::brun(JEventLoop *eventLoop, int32_t runnumber) {
 	// This is called whenever the run number changes
+	// load BCAL geometry
+  	vector<const DBCALGeometry *> BCALGeomVec;
+  	eventLoop->Get(BCALGeomVec);
+  	if(BCALGeomVec.size() == 0)
+		throw JException("Could not load DBCALGeometry object!");
+	dBCALGeom = BCALGeomVec[0];
+
 	return NOERROR;
 }
 
@@ -423,13 +430,13 @@ jerror_t JEventProcessor_BCAL_LEDonline::evnt(JEventLoop *loop, uint64_t eventnu
 			bcal_fadc_digi_nsamples_integral->Fill(hit->nsamples_integral);
 			bcal_fadc_digi_nsamples_pedestal->Fill(hit->nsamples_pedestal);
 			int layer = hit->layer;
-			int glosect = DBCALGeometry::getglobalsector(hit->module, hit->sector);
+			int glosect = dBCALGeom->getglobalsector(hit->module, hit->sector);
 			if (layer==1) bcal_fadc_digi_occ_layer1->Fill(glosect);
 			if (layer==2) bcal_fadc_digi_occ_layer2->Fill(glosect);
 			if (layer==3) bcal_fadc_digi_occ_layer3->Fill(glosect);
 			if (layer==4) bcal_fadc_digi_occ_layer4->Fill(glosect);
             
-			int channelnumber = DBCALGeometry::getglobalchannelnumber(hit->module, hit->layer, hit->sector, hit->end);
+			int channelnumber = dBCALGeom->getglobalchannelnumber(hit->module, hit->layer, hit->sector, hit->end);
 			if ( hit->pedestal > 0 ) {
 				double pedsubint = hit->pulse_integral-((float)hit->nsamples_integral/(float)hit->nsamples_pedestal)*hit->pedestal;
 				double pedsubpeak = hit->pulse_peak-hit->pedestal;
@@ -474,7 +481,7 @@ jerror_t JEventProcessor_BCAL_LEDonline::evnt(JEventLoop *loop, uint64_t eventnu
 				bcal_tdc_digi_reltime->Fill(f1tdchits[0]->time,f1tdchits[0]->trig_time);
 
 			int layer = hit->layer;
-			int glosect = DBCALGeometry::getglobalsector(hit->module, hit->sector);
+			int glosect = dBCALGeom->getglobalsector(hit->module, hit->sector);
 			if (layer==1) bcal_tdc_digi_occ_layer1->Fill(glosect);
 			if (layer==2) bcal_tdc_digi_occ_layer2->Fill(glosect);
 			if (layer==3) bcal_tdc_digi_occ_layer3->Fill(glosect);

--- a/src/plugins/monitoring/BCAL_LEDonline/JEventProcessor_BCAL_LEDonline.h
+++ b/src/plugins/monitoring/BCAL_LEDonline/JEventProcessor_BCAL_LEDonline.h
@@ -7,7 +7,7 @@
 #define _JEventProcessor_BCAL_LEDonline_
 
 #include <JANA/JEventProcessor.h>
-
+#include <BCAL/DBCALGeometry.h>
 
 class JEventProcessor_BCAL_LEDonline:public jana::JEventProcessor{
  public:
@@ -23,6 +23,8 @@ class JEventProcessor_BCAL_LEDonline:public jana::JEventProcessor{
   jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
   jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
   jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+  const DBCALGeometry *dBCALGeom;
 };
 
 #endif // _JEventProcessor_BCAL_LEDonline_

--- a/src/plugins/monitoring/BCAL_online/JEventProcessor_BCAL_online.cc
+++ b/src/plugins/monitoring/BCAL_online/JEventProcessor_BCAL_online.cc
@@ -446,6 +446,13 @@ jerror_t JEventProcessor_BCAL_online::init(void) {
 
 jerror_t JEventProcessor_BCAL_online::brun(JEventLoop *eventLoop, int32_t runnumber) {
 	// This is called whenever the run number changes
+	// load BCAL geometry
+  	vector<const DBCALGeometry *> BCALGeomVec;
+  	eventLoop->Get(BCALGeomVec);
+  	if(BCALGeomVec.size() == 0)
+		throw JException("Could not load DBCALGeometry object!");
+	dBCALGeom = BCALGeomVec[0];
+
 	return NOERROR;
 }
 
@@ -544,7 +551,7 @@ jerror_t JEventProcessor_BCAL_online::evnt(JEventLoop *loop, uint64_t eventnumbe
 		bcal_fadc_digi_nsamples_integral->Fill(hit->nsamples_integral);
 		bcal_fadc_digi_nsamples_pedestal->Fill(hit->nsamples_pedestal);
 		int layer = hit->layer;
-		int glosect = DBCALGeometry::getglobalsector(hit->module, hit->sector);
+		int glosect = dBCALGeom->getglobalsector(hit->module, hit->sector);
 		if (layer==1) bcal_fadc_digi_occ_layer1->Fill(glosect);
 		if (layer==2) bcal_fadc_digi_occ_layer2->Fill(glosect);
 		if (layer==3) bcal_fadc_digi_occ_layer3->Fill(glosect);
@@ -585,7 +592,7 @@ jerror_t JEventProcessor_BCAL_online::evnt(JEventLoop *loop, uint64_t eventnumbe
 			bcal_tdc_digi_reltime->Fill(f1tdchits[0]->time,f1tdchits[0]->trig_time);
 
 		int layer = hit->layer;
-		int glosect = DBCALGeometry::getglobalsector(hit->module, hit->sector);
+		int glosect = dBCALGeom->getglobalsector(hit->module, hit->sector);
 		if (layer==1) bcal_tdc_digi_occ_layer1->Fill(glosect);
 		if (layer==2) bcal_tdc_digi_occ_layer2->Fill(glosect);
 		if (layer==3) bcal_tdc_digi_occ_layer3->Fill(glosect);
@@ -728,7 +735,7 @@ jerror_t JEventProcessor_BCAL_online::evnt(JEventLoop *loop, uint64_t eventnumbe
 		vector<const DBCALUnifiedHit*> endhits;
 		point->Get(endhits);
 
-		int glosect = DBCALGeometry::getglobalsector(endhits[0]->module, endhits[0]->sector);
+		int glosect = dBCALGeom->getglobalsector(endhits[0]->module, endhits[0]->sector);
 		bcal_point_z_sector->Fill(glosect,point->z());
 		bcal_point_E_sector->Fill(glosect,point->E());
 		if (layer==1) bcal_point_aveE_sector_layer1->Fill(glosect,point->E());

--- a/src/plugins/monitoring/BCAL_online/JEventProcessor_BCAL_online.h
+++ b/src/plugins/monitoring/BCAL_online/JEventProcessor_BCAL_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_BCAL_online_
 
 #include <JANA/JEventProcessor.h>
-
+#include <BCAL/DBCALGeometry.h>
 
 class JEventProcessor_BCAL_online:public jana::JEventProcessor{
  public:
@@ -25,6 +25,8 @@ class JEventProcessor_BCAL_online:public jana::JEventProcessor{
   jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
   jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
   jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+  const DBCALGeometry *dBCALGeom;
 };
 
 #endif // _JEventProcessor_BCAL_online_

--- a/src/programs/Simulation/mcsmear/BCALSmearer.cc
+++ b/src/programs/Simulation/mcsmear/BCALSmearer.cc
@@ -353,7 +353,7 @@ void BCALSmearer::SortSiPMHits(map<bcal_index, CellHits> &SiPMHits, map<int, Sum
       
       // Get reference to SumHits object
       const bcal_index &idx = iter->first;
-      int fADCId = DBCALGeometry::fADCId( idx.module, idx.layer, idx.sector);
+      int fADCId = dBCALGeom->fADCId( idx.module, idx.layer, idx.sector);
       SumHits &sumhits = bcalfADC[fADCId];
       
       // Add CellHits object to list in SumHits
@@ -434,9 +434,9 @@ void BCALSmearer::SimpleDarkHitsSmear(map<int, SumHits> &bcalfADC)
    double sigma4 = bcal_config->BCAL_LAYER4_SIGMA_SCALE*bcal_config->BCAL_MEV_PER_ADC_COUNT; 
 
    // Loop over all fADC readout cells
-   for(int imodule=1; imodule<=DBCALGeometry::NBCALMODS; imodule++){
+   for(int imodule=1; imodule<=dBCALGeom->NBCALMODS; imodule++){
 
-      int n_layers = DBCALGeometry::NBCALLAYSIN + DBCALGeometry::NBCALLAYSOUT;
+      int n_layers = dBCALGeom->NBCALLAYSIN + dBCALGeom->NBCALLAYSOUT;
       for(int fADC_lay=1; fADC_lay<=n_layers; fADC_lay++){
          if(fADC_lay == 1) 
          	sigma = sigma1;
@@ -447,12 +447,12 @@ void BCALSmearer::SimpleDarkHitsSmear(map<int, SumHits> &bcalfADC)
          else if(fADC_lay == 4) 
          	sigma = sigma4;
 
-         int n_sectors = (fADC_lay <= DBCALGeometry::NBCALLAYSIN)? DBCALGeometry::NBCALSECSIN : DBCALGeometry::NBCALSECSOUT;
+         int n_sectors = (fADC_lay <= dBCALGeom->NBCALLAYSIN)? dBCALGeom->NBCALSECSIN : dBCALGeom->NBCALSECSOUT;
          for(int fADC_sec=1; fADC_sec<=n_sectors; fADC_sec++){
 
             // Use cellId(...) to convert fADC layer and sector into fADCId
-            // (see DBCALGeometry::fADCId)
-            int fADCId = DBCALGeometry::cellId(imodule, fADC_lay, fADC_sec);
+            // (see dBCALGeom->fADCId)
+            int fADCId = dBCALGeom->cellId(imodule, fADC_lay, fADC_sec);
             
             // Get SumHits object if it already exists or create new one 
             // if it doesn't.
@@ -538,14 +538,14 @@ void BCALSmearer::FindHits(double thresh_MeV, map<int, SumHits> &bcalfADC, map<i
       double preamp_gain_tdc = 5.0;
       double thresh_MeV_TDC = thresh_MeV/preamp_gain_tdc;
 	  //the outermost layer of the detector is not equipped with TDCs, so don't generate any TDC hits
-	  int layer = DBCALGeometry::layer(fADCId);
+	  int layer = dBCALGeom->layer(fADCId);
 
       for(int ii = 0; ii < (int)sumhits.EUP.size(); ii++){
         // correct simulation efficiencies 
 		if (config->APPLY_EFFICIENCY_CORRECTIONS
-		 		&& !gDRandom.DecideToAcceptHit(bcal_config->GetEfficiencyCorrectionFactor(GetCalibIndex(DBCALGeometry::module(fADCId),
-		 																				  DBCALGeometry::layer(fADCId),
-		 																				  DBCALGeometry::sector(fADCId)),
+		 		&& !gDRandom.DecideToAcceptHit(bcal_config->GetEfficiencyCorrectionFactor(GetCalibIndex(dBCALGeom->module(fADCId),
+		 																				  dBCALGeom->layer(fADCId),
+		 																				  dBCALGeom->sector(fADCId)),
 		 																				  DBCALGeometry::End::kUpstream)))
 		 			continue;
 		 			
@@ -555,9 +555,9 @@ void BCALSmearer::FindHits(double thresh_MeV, map<int, SumHits> &bcalfADC, map<i
       for(int ii = 0; ii < (int)sumhits.EDN.size(); ii++){                                                                     // they are not layer 4 hits and cross threshold.
         // correct simulation efficiencies 
 		if (config->APPLY_EFFICIENCY_CORRECTIONS
-		 		&& !gDRandom.DecideToAcceptHit(bcal_config->GetEfficiencyCorrectionFactor(GetCalibIndex(DBCALGeometry::module(fADCId),
-		 																				  DBCALGeometry::layer(fADCId),
-		 																				  DBCALGeometry::sector(fADCId)),
+		 		&& !gDRandom.DecideToAcceptHit(bcal_config->GetEfficiencyCorrectionFactor(GetCalibIndex(dBCALGeom->module(fADCId),
+		 																				  dBCALGeom->layer(fADCId),
+		 																				  dBCALGeom->sector(fADCId)),
 		 																				  DBCALGeometry::End::kDownstream)))
 		 			continue;
 
@@ -572,9 +572,9 @@ void BCALSmearer::FindHits(double thresh_MeV, map<int, SumHits> &bcalfADC, map<i
          // The module, fADC layer, and fADC sector are encoded in fADCId
          // (n.b. yes, these are the same methods used for extracting 
          // similar quantities from the cellId.)
-         hitlist.module = DBCALGeometry::module(fADCId);
-         hitlist.sumlayer = DBCALGeometry::layer(fADCId);
-         hitlist.sumsector = DBCALGeometry::sector(fADCId);
+         hitlist.module = dBCALGeom->module(fADCId);
+         hitlist.sumlayer = dBCALGeom->layer(fADCId);
+         hitlist.sumsector = dBCALGeom->sector(fADCId);
          
          hitlist.uphits = uphits;
          hitlist.dnhits = dnhits;
@@ -587,9 +587,9 @@ void BCALSmearer::FindHits(double thresh_MeV, map<int, SumHits> &bcalfADC, map<i
          // The module, fADC layer, and fADC sector are encoded in fADCId
          // (n.b. yes, these are the same methods used for extracting 
          // similar quantities from the cellId.)
-         hitlistTDC.module = DBCALGeometry::module(fADCId);
-         hitlistTDC.sumlayer = DBCALGeometry::layer(fADCId);
-         hitlistTDC.sumsector = DBCALGeometry::sector(fADCId);
+         hitlistTDC.module = dBCALGeom->module(fADCId);
+         hitlistTDC.sumlayer = dBCALGeom->layer(fADCId);
+         hitlistTDC.sumsector = dBCALGeom->sector(fADCId);
          
          hitlistTDC.uphits = uphitsTDC;
          hitlistTDC.dnhits = dnhitsTDC;

--- a/src/programs/Simulation/mcsmear/BCALSmearer.h
+++ b/src/programs/Simulation/mcsmear/BCALSmearer.h
@@ -76,6 +76,8 @@ class bcal_config_t
 	bool NO_SAMPLING_FLOOR_TERM;
 	bool NO_POISSON_STATISTICS;
 
+    const DBCALGeometry *dBCALGeom;
+
 	vector<vector<double> > attenuation_parameters; // Avg. of 525 (from calibDB BCAL/attenuation_parameters)
 	// Assume constant effective velocity instead of channel-dependent one
 	//vector<double> effective_velocities; // 16.75 (from calibDB BCAL/effective_velocities)
@@ -266,6 +268,13 @@ class BCALSmearer : public Smearer
 			bcal_config->NO_SAMPLING_FLUCTUATIONS = in_config->BCAL_NO_SAMPLING_FLUCTUATIONS;
 			bcal_config->NO_SAMPLING_FLOOR_TERM = in_config->BCAL_NO_SAMPLING_FLOOR_TERM;
 			bcal_config->NO_POISSON_STATISTICS = in_config->BCAL_NO_POISSON_STATISTICS;
+			
+			// load BCAL geometry
+  			vector<const DBCALGeometry *> BCALGeomVec;
+  			loop->Get(BCALGeomVec);
+  			if(BCALGeomVec.size() == 0)
+				throw JException("Could not load DBCALGeometry object!");
+			dBCALGeom = BCALGeomVec[0];
 		}
 		~BCALSmearer() {
 			delete bcal_config;

--- a/src/programs/Simulation/mcsmear/BCALSmearer.h
+++ b/src/programs/Simulation/mcsmear/BCALSmearer.h
@@ -76,8 +76,6 @@ class bcal_config_t
 	bool NO_SAMPLING_FLOOR_TERM;
 	bool NO_POISSON_STATISTICS;
 
-    const DBCALGeometry *dBCALGeom;
-
 	vector<vector<double> > attenuation_parameters; // Avg. of 525 (from calibDB BCAL/attenuation_parameters)
 	// Assume constant effective velocity instead of channel-dependent one
 	//vector<double> effective_velocities; // 16.75 (from calibDB BCAL/effective_velocities)
@@ -284,6 +282,7 @@ class BCALSmearer : public Smearer
 
 	protected:
 		bcal_config_t *bcal_config;
+        const DBCALGeometry *dBCALGeom;
 		
 		int inline GetCalibIndex(int module, int layer, int sector);
 


### PR DESCRIPTION
First round of refactoring of DBCALGeometry (there will be more).

- Removed static members, changed user classes to always retrieve object properly on a run-dependent basis, cleaned up the worst offenders.
- Started creating better interface and removed some unneeded code.
- Changed redundant constant PI to M_PI