### PR TITLE
Tweak trackeff & Matching

### DIFF
--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -103,6 +103,10 @@ DParticleID::DParticleID(JEventLoop *loop)
 		cout << "DParticleID: Error loading values from PID data base" <<endl;
 		DELTA_R_FCAL = 15.0;
 	}
+
+	//IF YOU CHANGE THESE, PLEASE (!!) UPDATE THE CUT LINES DRAWN FOR THE MONITORING IN:
+	// src/plugins/Analysis/monitoring_hists/HistMacro_Matching_*.C
+
 	FCAL_CUT_PAR1=4.5;
 	gPARMS->SetDefaultParameter("FCAL:CUT_PAR1",FCAL_CUT_PAR1);
 
@@ -121,10 +125,10 @@ DParticleID::DParticleID(JEventLoop *loop)
 	BCAL_Z_CUT = 30.0;
 	gPARMS->SetDefaultParameter("BCAL:Z_CUT",BCAL_Z_CUT);
 
-	BCAL_PHI_CUT_PAR1 = 2.0;
+	BCAL_PHI_CUT_PAR1 = 3.0;
 	gPARMS->SetDefaultParameter("BCAL:PHI_CUT_PAR1",BCAL_PHI_CUT_PAR1);
 
-	BCAL_PHI_CUT_PAR2 = 10.0;
+	BCAL_PHI_CUT_PAR2 = 12.0;
 	gPARMS->SetDefaultParameter("BCAL:PHI_CUT_PAR2",BCAL_PHI_CUT_PAR2);
 
 	BCAL_PHI_CUT_PAR3 = 0.8;

--- a/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_BCAL.C
+++ b/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_BCAL.C
@@ -23,6 +23,18 @@
 	TH2I* locHist_TrackBCALModuleVsZ_HasHit_BCAL = (TH2I*)gDirectory->Get("TrackBCALModuleVsZ_HasHit");
 	TH2I* locHist_TrackBCALModuleVsZ_NoHit_BCAL = (TH2I*)gDirectory->Get("TrackBCALModuleVsZ_NoHit");
 
+	//Get original pad margins
+	double locLeftPadMargin = gStyle->GetPadLeftMargin();
+	double locRightPadMargin = gStyle->GetPadRightMargin();
+	double locTopPadMargin = gStyle->GetPadTopMargin();
+	double locBottomPadMargin = gStyle->GetPadBottomMargin();
+
+	//Set new pad margins
+	gStyle->SetPadLeftMargin(0.15);
+	gStyle->SetPadRightMargin(0.12);
+//	gStyle->SetPadTopMargin(locTopPadMargin);
+//	gStyle->SetPadBottomMargin(locBottomPadMargin);
+
 	//Get/Make Canvas
 	TCanvas *locCanvas = NULL;
 	if(TVirtualPad::Pad() == NULL)
@@ -38,11 +50,18 @@
 	if(locHist_BCAL_DeltaPhiVsP != NULL)
 	{
 		locHist_BCAL_DeltaPhiVsP->Rebin2D(2, 2);
+		locHist_BCAL_DeltaPhiVsP->GetYaxis()->SetTitleOffset(1.3);
 		locHist_BCAL_DeltaPhiVsP->GetXaxis()->SetTitleSize(0.05);
 		locHist_BCAL_DeltaPhiVsP->GetYaxis()->SetTitleSize(0.05);
 		locHist_BCAL_DeltaPhiVsP->GetXaxis()->SetLabelSize(0.05);
 		locHist_BCAL_DeltaPhiVsP->GetYaxis()->SetLabelSize(0.05);
 		locHist_BCAL_DeltaPhiVsP->Draw("COLZ");
+		TF1* locFunc_High = new TF1("BCAL_PhiCut_High", "[0] + [1]*exp(-1.0*[2]*x)", 0.0, 4.0);
+		locFunc_High->SetParameters(3.0, 12.0, 0.8);
+		locFunc_High->Draw("SAME");
+		TF1* locFunc_Low = new TF1("BCAL_PhiCut_Low", "-1.0*([0] + [1]*exp(-1.0*[2]*x))", 0.0, 4.0);
+		locFunc_Low->SetParameters(3.0, 12.0, 0.8);
+		locFunc_Low->Draw("SAME");
 		gPad->SetLogz();
 	}
 
@@ -52,11 +71,16 @@
 	if(locHist_BCAL_DeltaZVsZ != NULL)
 	{
 		locHist_BCAL_DeltaZVsZ->Rebin2D(2, 2);
+		locHist_BCAL_DeltaZVsZ->GetYaxis()->SetTitleOffset(1.3);
 		locHist_BCAL_DeltaZVsZ->GetXaxis()->SetTitleSize(0.05);
 		locHist_BCAL_DeltaZVsZ->GetYaxis()->SetTitleSize(0.05);
 		locHist_BCAL_DeltaZVsZ->GetXaxis()->SetLabelSize(0.05);
 		locHist_BCAL_DeltaZVsZ->GetYaxis()->SetLabelSize(0.05);
 		locHist_BCAL_DeltaZVsZ->Draw("COLZ");
+		TF1* locFunc_High = new TF1("BCAL_ZCut_High", "30.0", 0.0, 450.0);
+		locFunc_High->Draw("SAME");
+		TF1* locFunc_Low = new TF1("BCAL_ZCut_Low", "-30.0", 0.0, 450.0);
+		locFunc_Low->Draw("SAME");
 		gPad->SetLogz();
 	}
 
@@ -99,7 +123,7 @@
 		}
 		locAcceptanceHist->SetEntries(locMissingHist->GetEntries() + locFoundHist->GetEntries());
 		locAcceptanceHist->SetStats(kFALSE);
-
+		locAcceptanceHist->GetYaxis()->SetTitleOffset(1.3);
 		locAcceptanceHist->GetXaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetYaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetXaxis()->SetLabelSize(0.05);
@@ -146,7 +170,7 @@
 		}
 		locAcceptanceHist->SetEntries(locMissingHist->GetEntries() + locFoundHist->GetEntries());
 		locAcceptanceHist->SetStats(kFALSE);
-
+		locAcceptanceHist->GetYaxis()->SetTitleOffset(1.3);
 		locAcceptanceHist->GetXaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetYaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetXaxis()->SetLabelSize(0.05);
@@ -234,12 +258,17 @@
 		}
 		locAcceptanceHist->SetEntries(locMissingHist->GetEntries() + locFoundHist->GetEntries());
 		locAcceptanceHist->SetStats(kFALSE);
-
 		locAcceptanceHist->GetXaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetYaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetXaxis()->SetLabelSize(0.05);
 		locAcceptanceHist->GetYaxis()->SetLabelSize(0.05);
 		locAcceptanceHist->Draw("E1");
 	}
+
+	//Reset original pad margins
+	gStyle->SetPadLeftMargin(locLeftPadMargin);
+	gStyle->SetPadRightMargin(locRightPadMargin);
+	gStyle->SetPadTopMargin(locTopPadMargin);
+	gStyle->SetPadBottomMargin(locBottomPadMargin);
 }
 

--- a/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_FCAL.C
+++ b/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_FCAL.C
@@ -30,6 +30,18 @@
 	TH1I* locHist_TrackFCALR_HasHit_FCAL = (TH1I*)gDirectory->Get("TrackFCALR_HasHit");
 	TH1I* locHist_TrackFCALR_NoHit_FCAL = (TH1I*)gDirectory->Get("TrackFCALR_NoHit");
 
+	//Get original pad margins
+	double locLeftPadMargin = gStyle->GetPadLeftMargin();
+	double locRightPadMargin = gStyle->GetPadRightMargin();
+	double locTopPadMargin = gStyle->GetPadTopMargin();
+	double locBottomPadMargin = gStyle->GetPadBottomMargin();
+
+	//Set new pad margins
+	gStyle->SetPadLeftMargin(0.15);
+	gStyle->SetPadRightMargin(0.15);
+//	gStyle->SetPadTopMargin(locTopPadMargin);
+//	gStyle->SetPadBottomMargin(locBottomPadMargin);
+
 	//FCAL, by element (1 plot)
 	//Get/Make Canvas
 	TCanvas *locCanvas = NULL;
@@ -46,11 +58,14 @@
 	if(locHist_FCAL_TrackDistanceVsP != NULL)
 	{
 		locHist_FCAL_TrackDistanceVsP->Rebin2D(2, 2);
+		locHist_FCAL_TrackDistanceVsP->GetYaxis()->SetTitleOffset(1.3);
 		locHist_FCAL_TrackDistanceVsP->GetXaxis()->SetTitleSize(0.05);
 		locHist_FCAL_TrackDistanceVsP->GetYaxis()->SetTitleSize(0.05);
 		locHist_FCAL_TrackDistanceVsP->GetXaxis()->SetLabelSize(0.05);
 		locHist_FCAL_TrackDistanceVsP->GetYaxis()->SetLabelSize(0.05);
 		locHist_FCAL_TrackDistanceVsP->Draw("COLZ");
+		TF1* locFunc = new TF1("FCAL_LCut_VsP", "4.5", 0.0, 10.0);
+		locFunc->Draw("SAME");
 	}
 
 	locCanvas->cd(2);
@@ -59,11 +74,14 @@
 	if(locHist_FCAL_TrackDistanceVsTheta != NULL)
 	{
 		locHist_FCAL_TrackDistanceVsTheta->Rebin2D(2, 2);
+		locHist_FCAL_TrackDistanceVsTheta->GetYaxis()->SetTitleOffset(1.3);
 		locHist_FCAL_TrackDistanceVsTheta->GetXaxis()->SetTitleSize(0.05);
 		locHist_FCAL_TrackDistanceVsTheta->GetYaxis()->SetTitleSize(0.05);
 		locHist_FCAL_TrackDistanceVsTheta->GetXaxis()->SetLabelSize(0.05);
 		locHist_FCAL_TrackDistanceVsTheta->GetYaxis()->SetLabelSize(0.05);
 		locHist_FCAL_TrackDistanceVsTheta->Draw("COLZ");
+		TF1* locFunc = new TF1("FCAL_LCut_VsTheta", "4.5", 0.0, 20.0);
+		locFunc->Draw("SAME");
 	}
 
 	locCanvas->cd(3);
@@ -105,7 +123,7 @@
 		}
 		locAcceptanceHist->SetEntries(locMissingHist->GetEntries() + locFoundHist->GetEntries());
 		locAcceptanceHist->SetStats(kFALSE);
-
+		locAcceptanceHist->GetYaxis()->SetTitleOffset(1.3);
 		locAcceptanceHist->GetXaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetYaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetXaxis()->SetLabelSize(0.05);
@@ -121,7 +139,7 @@
 		TH2I* locFoundHist = locHist_TrackFCALRowVsColumn_HasHit_FCAL;
 		TH2I* locMissingHist = locHist_TrackFCALRowVsColumn_NoHit_FCAL;
 		string locHistName = string(locFoundHist->GetName()) + string("_Acceptance");
-		string locHistTitle = string("Track / FCAL Match Rate;") + string(locFoundHist->GetXaxis()->GetTitle()) + string(";") + string(locFoundHist->GetYaxis()->GetTitle());
+		string locHistTitle = string("FCAL Match Rate (p > 1 GeV/c);") + string(locFoundHist->GetXaxis()->GetTitle()) + string(";") + string(locFoundHist->GetYaxis()->GetTitle());
 		TH2D* locAcceptanceHist = new TH2D(locHistName.c_str(), locHistTitle.c_str(), locFoundHist->GetNbinsX(), locFoundHist->GetXaxis()->GetXmin(), locFoundHist->GetXaxis()->GetXmax(), locFoundHist->GetNbinsY(), locFoundHist->GetYaxis()->GetXmin(), locFoundHist->GetYaxis()->GetXmax());
 		for(Int_t loc_m = 1; loc_m <= locFoundHist->GetNbinsX(); ++loc_m)
 		{
@@ -149,7 +167,7 @@
 		}
 		locAcceptanceHist->SetEntries(locMissingHist->GetEntries() + locFoundHist->GetEntries());
 		locAcceptanceHist->SetStats(kFALSE);
-
+		locAcceptanceHist->GetYaxis()->SetTitleOffset(1.3);
 		locAcceptanceHist->GetXaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetYaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetXaxis()->SetLabelSize(0.05);
@@ -210,7 +228,7 @@
 		locMissingHist->Rebin(2);
 
 		string locHistName = string(locFoundHist->GetName()) + string("_Acceptance");
-		string locHistTitle = string("Track / FCAL Match Rate (p > 1 GeV/c);") + string(locFoundHist->GetXaxis()->GetTitle());
+		string locHistTitle = string("FCAL Match Rate (p > 1 GeV/c);") + string(locFoundHist->GetXaxis()->GetTitle());
 		TH1D* locAcceptanceHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locFoundHist->GetNbinsX(), locFoundHist->GetXaxis()->GetXmin(), locFoundHist->GetXaxis()->GetXmax());
 		for(Int_t loc_m = 1; loc_m <= locFoundHist->GetNbinsX(); ++loc_m)
 		{
@@ -240,5 +258,11 @@
 		locAcceptanceHist->GetYaxis()->SetLabelSize(0.05);
 		locAcceptanceHist->Draw("E1");
 	}
+
+	//Reset original pad margins
+	gStyle->SetPadLeftMargin(locLeftPadMargin);
+	gStyle->SetPadRightMargin(locRightPadMargin);
+	gStyle->SetPadTopMargin(locTopPadMargin);
+	gStyle->SetPadBottomMargin(locBottomPadMargin);
 }
 

--- a/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_SC.C
+++ b/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_SC.C
@@ -32,6 +32,18 @@
 	TH1I* locHist_SCPaddle_NoseRegion_HasHit = (TH1I*)gDirectory->Get("SCPaddle_NoseRegion_HasHit");
 	TH1I* locHist_SCPaddle_NoseRegion_NoHit = (TH1I*)gDirectory->Get("SCPaddle_NoseRegion_NoHit");
 
+	//Get original pad margins
+	double locLeftPadMargin = gStyle->GetPadLeftMargin();
+	double locRightPadMargin = gStyle->GetPadRightMargin();
+	double locTopPadMargin = gStyle->GetPadTopMargin();
+	double locBottomPadMargin = gStyle->GetPadBottomMargin();
+
+	//Set new pad margins
+	gStyle->SetPadLeftMargin(0.15);
+	gStyle->SetPadRightMargin(0.15);
+//	gStyle->SetPadTopMargin(locTopPadMargin);
+//	gStyle->SetPadBottomMargin(locBottomPadMargin);
+
 	//Get/Make Canvas
 	TCanvas *locCanvas = NULL;
 	if(TVirtualPad::Pad() == NULL)
@@ -46,12 +58,19 @@
 	gPad->SetGrid();
 	if(locHist_SC_TrackDeltaPhiVsZ_WireBased != NULL)
 	{
+		locHist_SC_TrackDeltaPhiVsZ_WireBased->GetYaxis()->SetTitleOffset(1.3);
 		locHist_SC_TrackDeltaPhiVsZ_WireBased->GetXaxis()->SetRangeUser(35.0, 105.0);
 		locHist_SC_TrackDeltaPhiVsZ_WireBased->GetXaxis()->SetTitleSize(0.05);
 		locHist_SC_TrackDeltaPhiVsZ_WireBased->GetYaxis()->SetTitleSize(0.05);
 		locHist_SC_TrackDeltaPhiVsZ_WireBased->GetXaxis()->SetLabelSize(0.05);
 		locHist_SC_TrackDeltaPhiVsZ_WireBased->GetYaxis()->SetLabelSize(0.05);
 		locHist_SC_TrackDeltaPhiVsZ_WireBased->Draw("COLZ");
+		TF1* locFunc_High = new TF1("SC_PhiCut_High_WB", "[0] + [1]*exp([2]*(x - [3]))", 30.0, 110.0);
+		locFunc_High->SetParameters(10.0, 0.1, 0.13, 60.0);
+		locFunc_High->Draw("SAME");
+		TF1* locFunc_Low = new TF1("SC_PhiCut_Low_WB", "-1.0*([0] + [1]*exp([2]*(x - [3])))", 30.0, 110.0);
+		locFunc_Low->SetParameters(10.0, 0.1, 0.13, 60.0);
+		locFunc_Low->Draw("SAME");
 	}
 
 	locCanvas->cd(2);
@@ -59,12 +78,19 @@
 	gPad->SetGrid();
 	if(locHist_SC_TrackDeltaPhiVsZ_TimeBased != NULL)
 	{
+		locHist_SC_TrackDeltaPhiVsZ_TimeBased->GetYaxis()->SetTitleOffset(1.3);
 		locHist_SC_TrackDeltaPhiVsZ_TimeBased->GetXaxis()->SetRangeUser(35.0, 105.0);
 		locHist_SC_TrackDeltaPhiVsZ_TimeBased->GetXaxis()->SetTitleSize(0.05);
 		locHist_SC_TrackDeltaPhiVsZ_TimeBased->GetYaxis()->SetTitleSize(0.05);
 		locHist_SC_TrackDeltaPhiVsZ_TimeBased->GetXaxis()->SetLabelSize(0.05);
 		locHist_SC_TrackDeltaPhiVsZ_TimeBased->GetYaxis()->SetLabelSize(0.05);
 		locHist_SC_TrackDeltaPhiVsZ_TimeBased->Draw("COLZ");
+		TF1* locFunc_High = new TF1("SC_PhiCut_High_TB", "[0] + [1]*exp([2]*(x - [3]))", 30.0, 110.0);
+		locFunc_High->SetParameters(7.0, 0.1, 0.28, 78.0);
+		locFunc_High->Draw("SAME");
+		TF1* locFunc_Low = new TF1("SC_PhiCut_Low_TB", "-1.0*([0] + [1]*exp([2]*(x - [3])))", 30.0, 110.0);
+		locFunc_Low->SetParameters(7.0, 0.1, 0.28, 78.0);
+		locFunc_Low->Draw("SAME");
 	}
 
 	locCanvas->cd(3);
@@ -107,7 +133,7 @@
 		}
 		locAcceptanceHist->SetEntries(locMissingHist->GetEntries() + locFoundHist->GetEntries());
 		locAcceptanceHist->SetStats(kFALSE);
-
+		locAcceptanceHist->GetYaxis()->SetTitleOffset(1.3);
 		locAcceptanceHist->GetXaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetYaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetXaxis()->SetLabelSize(0.05);
@@ -155,7 +181,7 @@
 		}
 		locAcceptanceHist->SetEntries(locMissingHist->GetEntries() + locFoundHist->GetEntries());
 		locAcceptanceHist->SetStats(kFALSE);
-
+		locAcceptanceHist->GetYaxis()->SetTitleOffset(1.3);
 		locAcceptanceHist->GetXaxis()->SetRangeUser(35.0, 105.0);
 		locAcceptanceHist->GetXaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetYaxis()->SetTitleSize(0.05);
@@ -317,5 +343,11 @@
 		locAcceptanceHist->GetYaxis()->SetLabelSize(0.05);
 		locAcceptanceHist->Draw("E1");
 	}
+
+	//Reset original pad margins
+	gStyle->SetPadLeftMargin(locLeftPadMargin);
+	gStyle->SetPadRightMargin(locRightPadMargin);
+	gStyle->SetPadTopMargin(locTopPadMargin);
+	gStyle->SetPadBottomMargin(locBottomPadMargin);
 }
 

--- a/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_TOF.C
+++ b/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_TOF.C
@@ -20,6 +20,18 @@
 	TH2I* locHist_TrackDeltaYVsVerticalPaddle = (TH2I*)gDirectory->Get("TOFTrackDeltaYVsVerticalPaddle");
 	TH2I* locHist_TrackDeltaYVsHorizontalPaddle = (TH2I*)gDirectory->Get("TOFTrackDeltaYVsHorizontalPaddle");
 
+	//Get original pad margins
+	double locLeftPadMargin = gStyle->GetPadLeftMargin();
+	double locRightPadMargin = gStyle->GetPadRightMargin();
+	double locTopPadMargin = gStyle->GetPadTopMargin();
+	double locBottomPadMargin = gStyle->GetPadBottomMargin();
+
+	//Set new pad margins
+	gStyle->SetPadLeftMargin(0.15);
+	gStyle->SetPadRightMargin(0.15);
+//	gStyle->SetPadTopMargin(locTopPadMargin);
+//	gStyle->SetPadBottomMargin(locBottomPadMargin);
+
 	//Get/Make Canvas
 	TCanvas *locCanvas = NULL;
 	if(TVirtualPad::Pad() == NULL)
@@ -39,6 +51,7 @@
 		locHist_TrackDeltaXVsVerticalPaddle->GetXaxis()->SetLabelSize(0.05);
 		locHist_TrackDeltaXVsVerticalPaddle->GetYaxis()->SetLabelSize(0.05);
 		locHist_TrackDeltaXVsVerticalPaddle->Draw("COLZ");
+		locHist_TrackDeltaXVsVerticalPaddle->GetYaxis()->SetTitleOffset(1.3);
 	}
 
 	locCanvas->cd(4);
@@ -51,6 +64,7 @@
 		locHist_TrackDeltaYVsHorizontalPaddle->GetXaxis()->SetLabelSize(0.05);
 		locHist_TrackDeltaYVsHorizontalPaddle->GetYaxis()->SetLabelSize(0.05);
 		locHist_TrackDeltaYVsHorizontalPaddle->Draw("COLZ");
+		locHist_TrackDeltaYVsHorizontalPaddle->GetYaxis()->SetTitleOffset(1.3);
 	}
 
 	//PADS 2 & 5: VS KINEMATICS
@@ -64,6 +78,10 @@
 		locHist_TOFTrackDistanceVsP->GetXaxis()->SetLabelSize(0.05);
 		locHist_TOFTrackDistanceVsP->GetYaxis()->SetLabelSize(0.05);
 		locHist_TOFTrackDistanceVsP->Draw("COLZ");
+		locHist_TOFTrackDistanceVsP->GetYaxis()->SetTitleOffset(1.3);
+		TF1* locFunc = new TF1("TOF_DCut", "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 10.0);
+		locFunc->SetParameters(1.1, 1.5, 6.15);
+		locFunc->Draw("SAME");
 	}
 
 	locCanvas->cd(5);
@@ -76,6 +94,7 @@
 		locHist_TOFTrackDistanceVsTheta->GetXaxis()->SetLabelSize(0.05);
 		locHist_TOFTrackDistanceVsTheta->GetYaxis()->SetLabelSize(0.05);
 		locHist_TOFTrackDistanceVsTheta->Draw("COLZ");
+		locHist_TOFTrackDistanceVsTheta->GetYaxis()->SetTitleOffset(1.3);
 	}
 
 	//PADS 3 & 6: IS THE CALIBRATION OK?
@@ -89,6 +108,7 @@
 		locHist_TrackDeltaXVsHorizontalPaddle->GetXaxis()->SetLabelSize(0.05);
 		locHist_TrackDeltaXVsHorizontalPaddle->GetYaxis()->SetLabelSize(0.05);
 		locHist_TrackDeltaXVsHorizontalPaddle->Draw("COLZ");
+		locHist_TrackDeltaXVsHorizontalPaddle->GetYaxis()->SetTitleOffset(1.3);
 	}
 
 	locCanvas->cd(6);
@@ -101,5 +121,12 @@
 		locHist_TrackDeltaYVsVerticalPaddle->GetXaxis()->SetLabelSize(0.05);
 		locHist_TrackDeltaYVsVerticalPaddle->GetYaxis()->SetLabelSize(0.05);
 		locHist_TrackDeltaYVsVerticalPaddle->Draw("COLZ");
+		locHist_TrackDeltaYVsVerticalPaddle->GetYaxis()->SetTitleOffset(1.3);
 	}
+
+	//Reset original pad margins
+	gStyle->SetPadLeftMargin(locLeftPadMargin);
+	gStyle->SetPadRightMargin(locRightPadMargin);
+	gStyle->SetPadTopMargin(locTopPadMargin);
+	gStyle->SetPadBottomMargin(locBottomPadMargin);
 }

--- a/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_TOF2.C
+++ b/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_TOF2.C
@@ -36,10 +36,22 @@
 	TH1I* locHist_TrackTOFR_HasHit_TOF = (TH1I*)gDirectory->Get("TrackTOFR_HasHit");
 	TH1I* locHist_TrackTOFR_NoHit_TOF = (TH1I*)gDirectory->Get("TrackTOFR_NoHit");
 
+	//Get original pad margins
+	double locLeftPadMargin = gStyle->GetPadLeftMargin();
+	double locRightPadMargin = gStyle->GetPadRightMargin();
+	double locTopPadMargin = gStyle->GetPadTopMargin();
+	double locBottomPadMargin = gStyle->GetPadBottomMargin();
+
+	//Set new pad margins
+	gStyle->SetPadLeftMargin(0.15);
+	gStyle->SetPadRightMargin(0.15);
+//	gStyle->SetPadTopMargin(locTopPadMargin);
+//	gStyle->SetPadBottomMargin(locBottomPadMargin);
+
 	//Get/Make Canvas
 	TCanvas *locCanvas = NULL;
 	if(TVirtualPad::Pad() == NULL)
-		locCanvas = new TCanvas("Matching_TOF", "Matching_TOF", 1200, 800);
+		locCanvas = new TCanvas("Matching_TOF2", "Matching_TOF2", 1200, 800);
 	else
 		locCanvas = gPad->GetCanvas();
 	locCanvas->Divide(3, 2);
@@ -56,7 +68,7 @@
 		TH2I* locFoundHist = locHist_TrackYVsVerticalPaddle_HasHit;
 		TH2I* locMissingHist = locHist_TrackYVsVerticalPaddle_NoHit;
 		string locHistName = string(locFoundHist->GetName()) + string("_Acceptance");
-		string locHistTitle = string("Track / TOF Paddle Match Rate;") + string(locFoundHist->GetXaxis()->GetTitle()) + string(";") + string(locFoundHist->GetYaxis()->GetTitle());
+		string locHistTitle = string("TOF Paddle Match Rate (p > 1 GeV/c);") + string(locFoundHist->GetXaxis()->GetTitle()) + string(";") + string(locFoundHist->GetYaxis()->GetTitle());
 
 		TH2D* locAcceptanceHist = new TH2D(locHistName.c_str(), locHistTitle.c_str(), locFoundHist->GetNbinsX(), locFoundHist->GetXaxis()->GetXmin(), locFoundHist->GetXaxis()->GetXmax(), locFoundHist->GetNbinsY(), locFoundHist->GetYaxis()->GetXmin(), locFoundHist->GetYaxis()->GetXmax());
 		for(Int_t loc_m = 1; loc_m <= locFoundHist->GetNbinsX(); ++loc_m)
@@ -86,6 +98,7 @@
 		locAcceptanceHist->SetEntries(locMissingHist->GetEntries() + locFoundHist->GetEntries());
 		locAcceptanceHist->SetStats(kFALSE);
 
+		locAcceptanceHist->GetYaxis()->SetTitleOffset(1.5);
 		locAcceptanceHist->GetXaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetYaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetXaxis()->SetLabelSize(0.05);
@@ -105,7 +118,7 @@
 		TH2I* locFoundHist = locHist_HorizontalPaddleVsTrackX_HasHit;
 		TH2I* locMissingHist = locHist_HorizontalPaddleVsTrackX_NoHit;
 		string locHistName = string(locFoundHist->GetName()) + string("_Acceptance");
-		string locHistTitle = string("Track / TOF Paddle Match Rate;") + string(locFoundHist->GetXaxis()->GetTitle()) + string(";") + string(locFoundHist->GetYaxis()->GetTitle());
+		string locHistTitle = string("TOF Paddle Match Rate (p > 1 GeV/c);") + string(locFoundHist->GetXaxis()->GetTitle()) + string(";") + string(locFoundHist->GetYaxis()->GetTitle());
 
 		TH2D* locAcceptanceHist = new TH2D(locHistName.c_str(), locHistTitle.c_str(), locFoundHist->GetNbinsX(), locFoundHist->GetXaxis()->GetXmin(), locFoundHist->GetXaxis()->GetXmax(), locFoundHist->GetNbinsY(), locFoundHist->GetYaxis()->GetXmin(), locFoundHist->GetYaxis()->GetXmax());
 		for(Int_t loc_m = 1; loc_m <= locFoundHist->GetNbinsX(); ++loc_m)
@@ -135,6 +148,7 @@
 		locAcceptanceHist->SetEntries(locMissingHist->GetEntries() + locFoundHist->GetEntries());
 		locAcceptanceHist->SetStats(kFALSE);
 
+		locAcceptanceHist->GetYaxis()->SetTitleOffset(1.2);
 		locAcceptanceHist->GetXaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetYaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetXaxis()->SetLabelSize(0.05);
@@ -154,7 +168,7 @@
 		TH2I* locFoundHist = locHist_PVsTheta_HasHit;
 		TH2I* locMissingHist = locHist_PVsTheta_NoHit;
 		string locHistName = string(locFoundHist->GetName()) + string("_Acceptance");
-		string locHistTitle = string("Track / TOF Point Match Rate;") + string(locFoundHist->GetXaxis()->GetTitle()) + string(";") + string(locFoundHist->GetYaxis()->GetTitle());
+		string locHistTitle = string("TOF Point Match Rate;") + string(locFoundHist->GetXaxis()->GetTitle()) + string(";") + string(locFoundHist->GetYaxis()->GetTitle());
 
 		TH2D* locAcceptanceHist = new TH2D(locHistName.c_str(), locHistTitle.c_str(), locFoundHist->GetNbinsX(), locFoundHist->GetXaxis()->GetXmin(), locFoundHist->GetXaxis()->GetXmax(), locFoundHist->GetNbinsY(), locFoundHist->GetYaxis()->GetXmin(), locFoundHist->GetYaxis()->GetXmax());
 		for(Int_t loc_m = 1; loc_m <= locFoundHist->GetNbinsX(); ++loc_m)
@@ -184,6 +198,7 @@
 		locAcceptanceHist->SetEntries(locMissingHist->GetEntries() + locFoundHist->GetEntries());
 		locAcceptanceHist->SetStats(kFALSE);
 
+		locAcceptanceHist->GetYaxis()->SetTitleOffset(1.2);
 		locAcceptanceHist->GetXaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetYaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetXaxis()->SetLabelSize(0.05);
@@ -200,7 +215,7 @@
 		TH2I* locFoundHist = locHist_TrackTOF2DPaddles_HasHit;
 		TH2I* locMissingHist = locHist_TrackTOF2DPaddles_NoHit;
 		string locHistName = string(locFoundHist->GetName()) + string("_Acceptance");
-		string locHistTitle = string("Track / TOF Point Match Rate;") + string(locFoundHist->GetXaxis()->GetTitle()) + string(";") + string(locFoundHist->GetYaxis()->GetTitle());
+		string locHistTitle = string("TOF Point Match Rate (p > 1 GeV/c);") + string(locFoundHist->GetXaxis()->GetTitle()) + string(";") + string(locFoundHist->GetYaxis()->GetTitle());
 
 		TH2D* locAcceptanceHist = new TH2D(locHistName.c_str(), locHistTitle.c_str(), locFoundHist->GetNbinsX(), locFoundHist->GetXaxis()->GetXmin(), locFoundHist->GetXaxis()->GetXmax(), locFoundHist->GetNbinsY(), locFoundHist->GetYaxis()->GetXmin(), locFoundHist->GetYaxis()->GetXmax());
 		for(Int_t loc_m = 1; loc_m <= locFoundHist->GetNbinsX(); ++loc_m)
@@ -230,6 +245,7 @@
 		locAcceptanceHist->SetEntries(locMissingHist->GetEntries() + locFoundHist->GetEntries());
 		locAcceptanceHist->SetStats(kFALSE);
 
+		locAcceptanceHist->GetYaxis()->SetTitleOffset(1.2);
 		locAcceptanceHist->GetXaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetYaxis()->SetTitleSize(0.05);
 		locAcceptanceHist->GetXaxis()->SetLabelSize(0.05);
@@ -249,7 +265,7 @@
 		locMissingHist->Rebin(10);
 
 		string locHistName = string(locFoundHist->GetName()) + string("_Acceptance");
-		string locHistTitle = string("Track / TOF Match Rate;") + string(locFoundHist->GetXaxis()->GetTitle());
+		string locHistTitle = string("TOF Match Rate;") + string(locFoundHist->GetXaxis()->GetTitle());
 		TH1D* locAcceptanceHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locFoundHist->GetNbinsX(), locFoundHist->GetXaxis()->GetXmin(), locFoundHist->GetXaxis()->GetXmax());
 		for(Int_t loc_m = 1; loc_m <= locFoundHist->GetNbinsX(); ++loc_m)
 		{
@@ -291,7 +307,7 @@
 		locMissingHist->Rebin(4);
 
 		string locHistName = string(locFoundHist->GetName()) + string("_Acceptance");
-		string locHistTitle = string("Track / TOF Match Rate (p > 1 GeV/c);") + string(locFoundHist->GetXaxis()->GetTitle());
+		string locHistTitle = string("TOF Match Rate (p > 1 GeV/c);") + string(locFoundHist->GetXaxis()->GetTitle());
 		TH1D* locAcceptanceHist = new TH1D(locHistName.c_str(), locHistTitle.c_str(), locFoundHist->GetNbinsX(), locFoundHist->GetXaxis()->GetXmin(), locFoundHist->GetXaxis()->GetXmax());
 		for(Int_t loc_m = 1; loc_m <= locFoundHist->GetNbinsX(); ++loc_m)
 		{
@@ -322,4 +338,11 @@
 		locAcceptanceHist->GetYaxis()->SetLabelSize(0.05);
 		locAcceptanceHist->Draw("E1");
 	}
+
+	//Reset original pad margins
+	gStyle->SetPadLeftMargin(locLeftPadMargin);
+	gStyle->SetPadRightMargin(locRightPadMargin);
+	gStyle->SetPadTopMargin(locTopPadMargin);
+	gStyle->SetPadBottomMargin(locBottomPadMargin);
 }
+

--- a/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
+++ b/src/plugins/Utilities/trackeff_missing/DReaction_factory_trackeff_missing.cc
@@ -253,8 +253,9 @@ jerror_t DReaction_factory_trackeff_missing::evnt(JEventLoop* locEventLoop, uint
 		locReaction->Add_AnalysisAction(new DCutAction_EachPIDFOM(locReaction, -9.9E9, true)); //cut particles with PID FOM = 0
 
 		// SHOWER BACKGROUND
-		locReaction->Add_AnalysisAction(new DCustomAction_CutExtraPi0(locReaction, 0.11, 0.16));
-		locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));
+		// IT's TOO DANGEROUS TO CUT ON EXTRA SHOWERS:
+		// IF THE TRACK WAS NOT RECONSTRUCTED, IT'S SHOWER IS "EXTRA"!!!! MAY BIAS EFFICIENCY
+//		locReaction->Add_AnalysisAction(new DCustomAction_CutExtraShowers(locReaction, 0.5));
 
 		//TRACK PURITY
 		locReaction->Add_AnalysisAction(new DCutAction_MinTrackHits(locReaction, 12));


### PR DESCRIPTION
Trackeff: Don't cut on unused showers. If the track was not reconstructed, its showers are "extra:" will bias efficiencies.

Matching: Tweak to BCAL cuts, add cut lines to matching macros. 