### PR TITLE
Fix memory-leak-like behavior when processing many files

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.h
+++ b/src/libraries/DAQ/DEVIOWorkerThread.h
@@ -109,8 +109,8 @@ class DEVIOWorkerThread{
 		void       ParsePhysicsBank(uint32_t* &iptr, uint32_t *iend);
 		void  ParseBuiltTriggerBank(uint32_t* &iptr, uint32_t *iend);
 		void          ParseDataBank(uint32_t* &iptr, uint32_t *iend);
-        void       ParseDVertexBank(uint32_t* &iptr, uint32_t *iend);
-        void ParseDEventRFBunchBank(uint32_t* &iptr, uint32_t *iend);
+		void       ParseDVertexBank(uint32_t* &iptr, uint32_t *iend);
+		void ParseDEventRFBunchBank(uint32_t* &iptr, uint32_t *iend);
 
 		void        ParseJLabModuleData(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
 		void                ParseTIBank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);


### PR DESCRIPTION
This will attempt to free memory after an EVIO file has been completely read. Large pools of objects are used for each EVIO file read in. If many files are read in one job then this memory use accumulates, looking like a memory leak and eventually exhausting system memory. This (in principle) should not affect jobs processing a single EVIO file.
