### PR TITLE
* libraries/HDDM/DEventSourceHDDM.cc [rtj]

### DIFF
--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -1280,7 +1280,7 @@ jerror_t DEventSourceHDDM::Extract_DCDCHit(JEventLoop* locEventLoop, hddm_s::HDD
          hit->d      = 0.; // initialize to zero to avoid any NaN
          hit->itrack = 0;  // track information is in TRUTH tag
          hit->ptype  = 0;  // ditto
-         if(locTruthHits.size() == hits.size())
+         if((int)locTruthHits.size() == (int)hits.size())
            hit->AddAssociatedObject(locTruthHits[locIndex]); //guaranteed to be in order
          data.push_back(hit);
          ++locIndex;


### PR DESCRIPTION
   - cast size() member to int, suppress unsigned/signed in compare
     warning from gcc.