### PR TITLE
Fix bug in SC matching.

### DIFF
--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -821,11 +821,18 @@ bool DParticleID::Distance_ToTrack(const DReferenceTrajectory* rt, const DSCHit*
 	if(rt == nullptr)
 		return false;
 
-	// Find intersection with a "barrel" approximation for the start counter
-	double locPathLength = 9.9E9, locFlightTime = 9.9E9, locFlightTimeVariance = 9.9E9, locDeltaPhi = 9.9E9;
+	//The track may be projected to hit a different paddle than the one it actually hit!!!!
+	//First, we need to find where the track is projected to intersect the start counter geometry
 	DVector3 locProjPos, locProjMom, locPaddleNorm;
-	if(!ProjectTo_SC(rt, locSCHit->sector, locDeltaPhi, locProjPos, locProjMom, locPaddleNorm, locPathLength, locFlightTime, locFlightTimeVariance))
+	double locDeltaPhi, locPathLength, locFlightTime, locFlightTimeVariance;
+	int locSCPlane;
+	unsigned int locBestSCSector = PredictSCSector(rt, locDeltaPhi, locProjPos, locProjMom, locPaddleNorm, locPathLength, locFlightTime, locFlightTimeVariance, locSCPlane);
+	if(locBestSCSector == 0)
 		return false;
+
+	//Now, the input SC hit may have been on a separate SC paddle than the projection
+	//So, we have to assume that the locProjPos.Z() for the projected paddle is accurate enough for the hit paddle (no other way to get it).
+	//In fact, we assume that everything from the above is accurate except for locDeltaPhi (we'll recalculate it at the end)
 
 	// Check that the hit is not out of time with respect to the track
 	if(fabs(locSCHit->t - locFlightTime - locInputStartTime) > OUT_OF_TIME_CUT)
@@ -878,6 +885,14 @@ bool DParticleID::Distance_ToTrack(const DReferenceTrajectory* rt, const DSCHit*
 		*locOutputProjMom = locProjMom;
 	}
 
+	// Correct the locDeltaPhi in case the projected and input SC hit paddles are different
+	DVector3 sc_pos_at_projz = sc_pos[sc_index][locSCPlane] + (locProjPos.Z() - sc_pos[sc_index][locSCPlane].z())*sc_dir[sc_index][locSCPlane];
+	locDeltaPhi = sc_pos_at_projz.Phi() - locProjPos.Phi();
+	while(locDeltaPhi > TMath::Pi())
+		locDeltaPhi -= M_TWO_PI;
+	while(locDeltaPhi < -1.0*TMath::Pi())
+		locDeltaPhi += M_TWO_PI;
+
 	// For the dEdx measurement we now need to take into account that L does not
 	// compensate for the position in z at which the start counter paddle starts
 	double ds = 0.3*locProjMom.Mag()/fabs(locProjMom.Dot(locPaddleNorm));
@@ -896,13 +911,14 @@ bool DParticleID::Distance_ToTrack(const DReferenceTrajectory* rt, const DSCHit*
 	return true;
 }
 
-bool DParticleID::ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locSCSector, double& locDeltaPhi, DVector3& locProjPos, DVector3& locProjMom, DVector3& locPaddleNorm, double& locPathLength, double& locFlightTime, double& locFlightTimeVariance) const
+bool DParticleID::ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locSCSector, double& locDeltaPhi, DVector3& locProjPos, DVector3& locProjMom, DVector3& locPaddleNorm, double& locPathLength, double& locFlightTime, double& locFlightTimeVariance, int& locSCPlane) const
 {
 	if(rt == nullptr)
 		return false;
 
 	// Find intersection with a "barrel" approximation for the start counter
 	unsigned int sc_index = locSCSector - 1;
+	locSCPlane = -1;
 	if(rt->GetIntersectionWithPlane(sc_pos[sc_index][0], sc_norm[sc_index][0], locProjPos, locProjMom, &locPathLength, &locFlightTime, &locFlightTimeVariance) != NOERROR)
 		return false;
 
@@ -918,16 +934,9 @@ bool DParticleID::ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locS
 	if (locProjPos.Z() < sc_pos_soss) //unphysical, adjust: due to track projection uncertainty (or it really did miss)
 		locProjPos.SetZ(sc_pos_soss);
 
-	// Initialize the normal vector for the SC paddle to the long, unbent region
-	locPaddleNorm = sc_norm[sc_index][0];
-
 	// Check to see if hit occured in the straight section
 	if (locProjPos.Z() <= sc_pos_eoss)
-	{
-		// Apply a user-specified matching cut in the leg region
-		DVector3 sc_pos_at_projz = sc_pos[sc_index][0] + (locProjPos.Z() - sc_pos_soss)*sc_dir[sc_index][0];
-		locDeltaPhi = sc_pos_at_projz.Phi() - locProjPos.Phi();
-	}
+		locSCPlane = 0;
 	else //bend or nose
 	{
 		//loop through SC planes
@@ -949,21 +958,26 @@ bool DParticleID::ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locS
 			else if(locProjPos.Z() > sc_pos[sc_index][loc_i + 1].z())
 				continue; //past the end of this plane, go to next plane
 
-			DVector3 sc_pos_at_projz = sc_pos[sc_index][loc_i] + (locProjPos.Z() - sc_pos[sc_index][loc_i].z())*sc_dir[sc_index][loc_i];
-			locDeltaPhi = sc_pos_at_projz.Phi() - locProjPos.Phi();
-			locPaddleNorm = sc_norm[sc_index][loc_i];
+			locSCPlane = loc_i;
 			break;
 		}
 
 		// Check to see if the projections changed their mind, and put the hit in the straight section after all
 		if(locProjPos.Z() < sc_pos_eoss) // Assume hit just past the end of straight section
 		{
-			locProjPos.SetZ(sc_pos_eoss + 0.0001); //some tolerance
-			DVector3 sc_pos_at_projz = sc_pos[sc_index][0] + (locProjPos.Z() - sc_pos_soss)*sc_dir[sc_index][0];
-			locDeltaPhi = sc_pos_at_projz.Phi() - locProjPos.Phi();
+			locProjPos.SetZ(sc_pos_eoss - 0.0001); //some tolerance
+			locSCPlane = 0;
 		}
 	}
+	if(locSCPlane == -1)
+		return false; //should be impossible ...
 
+	//normal to the plane
+	locPaddleNorm = sc_norm[sc_index][locSCPlane];
+
+	//Calculate delta-phi
+	DVector3 sc_pos_at_projz = sc_pos[sc_index][locSCPlane] + (locProjPos.Z() - sc_pos[sc_index][locSCPlane].z())*sc_dir[sc_index][locSCPlane];
+	locDeltaPhi = sc_pos_at_projz.Phi() - locProjPos.Phi();
 	while(locDeltaPhi > TMath::Pi())
 		locDeltaPhi -= M_TWO_PI;
 	while(locDeltaPhi < -1.0*TMath::Pi())
@@ -1670,31 +1684,57 @@ unsigned int DParticleID::PredictSCSector(const DReferenceTrajectory* rt, DVecto
 	if(rt == nullptr)
 		return 0;
 
-	unsigned int locBestSCSector = 0;
-	double min_dphi=1e6;
 	DVector3 locProjPos, locProjMom, locPaddleNorm;
-	// loop over geometry for all SC paddles looking for track intersections
-	for(unsigned int locSCSector = 1; locSCSector <= 30; ++locSCSector)
-	{
-		double locPathLength = 9.9E9, locFlightTime = 9.9E9, locFlightTimeVariance = 9.9E9, locDeltaPhi = 9.9E9;
-		if(!ProjectTo_SC(rt, locSCSector, locDeltaPhi, locProjPos, locProjMom, locPaddleNorm, locPathLength, locFlightTime, locFlightTimeVariance))
-			return 0;
-
-		if(fabs(locDeltaPhi) >= fabs(min_dphi))
-			continue;
-
-		min_dphi = locDeltaPhi;
-		locBestSCSector = locSCSector;
-	}
+	double locDeltaPhi, locPathLength, locFlightTime, locFlightTimeVariance;
+	int locSCPlane;
+	unsigned int locBestSCSector = PredictSCSector(rt, locDeltaPhi, locProjPos, locProjMom, locPaddleNorm, locPathLength, locFlightTime, locFlightTimeVariance, locSCPlane);
+	if(locBestSCSector == 0)
+		return 0;
 
 	if(locProjBarrelRegion != NULL)
 		*locProjBarrelRegion = (locProjPos.Z() < sc_pos[locBestSCSector - 1][1].Z()); // End of straight section
 
 	if(locMinDPhi != NULL)
-		*locMinDPhi = min_dphi;
+		*locMinDPhi = locDeltaPhi;
 
 	if(locOutputProjPos != NULL)
 		*locOutputProjPos = locProjPos;
+	return locBestSCSector;
+}
+
+// Predict the start counter paddle that would match a track whose reference
+// trajectory is given by rt.
+unsigned int DParticleID::PredictSCSector(const DReferenceTrajectory* rt, double& locDeltaPhi, DVector3& locProjPos, DVector3& locProjMom, DVector3& locPaddleNorm, double& locPathLength, double& locFlightTime, double& locFlightTimeVariance, int& locSCPlane) const
+{
+	if(rt == nullptr)
+		return 0;
+
+	unsigned int locBestSCSector = 0;
+	locDeltaPhi=1e6;
+	// loop over geometry for all SC paddles looking for track intersections
+	for(unsigned int locSCSector = 1; locSCSector <= 30; ++locSCSector)
+	{
+		double locTempDeltaPhi, locTempPathLength, locTempFlightTime, locTempFlightTimeVariance;
+		DVector3 locTempProjPos, locTempProjMom, locTempPaddleNorm;
+		int locTempSCPlane;
+		if(!ProjectTo_SC(rt, locSCSector, locTempDeltaPhi, locTempProjPos, locTempProjMom, locTempPaddleNorm, locTempPathLength, locTempFlightTime, locTempFlightTimeVariance, locTempSCPlane))
+			continue;
+
+		if(fabs(locTempDeltaPhi) >= fabs(locDeltaPhi))
+			continue;
+
+		locDeltaPhi = locTempDeltaPhi;
+		locProjPos = locTempProjPos;
+		locProjMom = locTempProjMom;
+		locPaddleNorm = locTempPaddleNorm;
+		locPathLength = locTempPathLength;
+		locFlightTime = locTempFlightTime;
+		locFlightTimeVariance = locTempFlightTimeVariance;
+		locSCPlane = locTempSCPlane;
+
+		locBestSCSector = locSCSector;
+	}
+
 	return locBestSCSector;
 }
 

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -85,7 +85,7 @@ class DParticleID:public jana::JObject
 		bool Distance_ToTrack(const DReferenceTrajectory* rt, const DBCALShower* locBCALShower, double locInputStartTime, DBCALShowerMatchParams& locShowerMatchParams, DVector3* locOutputProjPos = nullptr, DVector3* locOutputProjMom = nullptr) const;
 		bool Distance_ToTrack(const DReferenceTrajectory* rt, const DTOFPoint* locTOFPoint, double locInputStartTime, DTOFHitMatchParams& locTOFHitMatchParams, DVector3* locOutputProjPos = nullptr, DVector3* locOutputProjMom = nullptr) const;
 		bool Distance_ToTrack(const DReferenceTrajectory* rt, const DSCHit* locSCHit, double locInputStartTime, DSCHitMatchParams& locSCHitMatchParams, DVector3* locOutputProjPos = nullptr, DVector3* locOutputProjMom = nullptr) const;
-		bool ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locSCSector, double& locDeltaPhi, DVector3& locProjPos, DVector3& locProjMom, DVector3& locPaddleNorm, double& locPathLength, double& locFlightTime, double& locFlightTimeVariance) const;
+		bool ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locSCSector, double& locDeltaPhi, DVector3& locProjPos, DVector3& locProjMom, DVector3& locPaddleNorm, double& locPathLength, double& locFlightTime, double& locFlightTimeVariance, int& locSCPlane) const;
 
 		/********************************************************** CUT MATCH DISTANCE **********************************************************/
 
@@ -125,6 +125,7 @@ class DParticleID:public jana::JObject
 		bool PredictBCALWedge(const DReferenceTrajectory *rt, unsigned int &module,unsigned int &sector, DVector3 *intersection = nullptr) const;
 		bool PredictTOFPaddles(const DReferenceTrajectory *rt, unsigned int &hbar,unsigned int &vbar, DVector3 *intersection = nullptr) const;
 		unsigned int PredictSCSector(const DReferenceTrajectory* rt, DVector3* locOutputProjPos = nullptr, bool* locProjBarrelRegion = nullptr, double* locMinDPhi = nullptr) const;
+		unsigned int PredictSCSector(const DReferenceTrajectory* rt, double& locDeltaPhi, DVector3& locProjPos, DVector3& locProjMom, DVector3& locPaddleNorm, double& locPathLength, double& locFlightTime, double& locFlightTimeVariance, int& locSCPlane) const;
 
 		/********************************************************** MISCELLANEOUS **********************************************************/
 


### PR DESCRIPTION
The track may be projected to hit a different paddle than the one it actually hit!
For the projected track position, just use the track, looping over
paddles until finding the best one.

Then, recompute delta-phi to compare to SC hits.