### PR TITLE
Bombproof against start counter geometry not being available

### DIFF
--- a/src/libraries/TRACKING/DTrackCandidate_factory.cc
+++ b/src/libraries/TRACKING/DTrackCandidate_factory.cc
@@ -451,7 +451,7 @@ jerror_t DTrackCandidate_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
       // paddle but the z-position at the radius r just outside the start 
       // counter barrel region is downstream of the nose, which does not make
       // sense for a particle that is actually heading upstream...
-      if (mom.Theta()>M_PI_2){
+      if (mom.Theta()>M_PI_2 && !sc_pos.empty()){
 	double zsc=sc_pos[0][1].z();
 	if (pos.z()>zsc){
 	  unsigned int best_sc_sector_id=0;


### PR DESCRIPTION
For CPP, the start counter will likely be removed. The cpp_HDDS.xml file implements this. This change checks that the internal variable sc_pos in the DTrackCandidate factory is not empty before accessing it.