### PR TITLE
removed the 7GeV energy cut from the monitoring plugins again

### DIFF
--- a/src/plugins/Analysis/p2pi_hists/DReaction_factory_p2pi_hists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DReaction_factory_p2pi_hists.cc
@@ -85,9 +85,6 @@ jerror_t DReaction_factory_p2pi_hists::evnt(JEventLoop* locEventLoop, uint64_t l
 	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_p2pi(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
 
-	// Cut low beam energy as tagger settings change during 2017-01
-	locReaction->Add_AnalysisAction(new DCutAction_BeamEnergy(locReaction, false, 7.0, 12.0));
-	
 	// Custom histograms for p2pi
 	locReaction->Add_AnalysisAction(new DCustomAction_p2pi_hists(locReaction, false));
 
@@ -159,9 +156,6 @@ jerror_t DReaction_factory_p2pi_hists::evnt(JEventLoop* locEventLoop, uint64_t l
 	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_p2pi(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
 
-	// Cut low beam energy as tagger settings change during 2017-01
-	locReaction->Add_AnalysisAction(new DCutAction_BeamEnergy(locReaction, false, 7.0, 12.0));
-	
 	//MASSES
 	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 1000, -0.1, 0.1));
 	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, 0, locRhoPIDs, false, 900, 0.3, 1.2, "Rho"));

--- a/src/plugins/Analysis/p2pi_hists/HistMacro_p2pi.C
+++ b/src/plugins/Analysis/p2pi_hists/HistMacro_p2pi.C
@@ -200,14 +200,12 @@
 	tx.SetTextAlign(11);
 	tx.SetTextSize(0.07);
 	char text[100];
-	sprintf(text, "E_{#gamma} > 7 GeV");
-	tx.DrawLatex(0.05, 0.6, text);
 	sprintf(text, "Post KinFit Cut");
-	tx.DrawLatex(0.05, 0.5, text);
+	tx.DrawLatex(0.05, 0.6, text);
 	sprintf(text, "M(#rho) = %0.3f GeV/c^{2}", rho_mass);
-	tx.DrawLatex(0.05, 0.4, text);
+	tx.DrawLatex(0.05, 0.5, text);
 	sprintf(text, "N(#rho) = %0.2f / 1k Trigger", n_rho_kinfit/n_triggers*1000);
-	tx.DrawLatex(0.05, 0.3, text);
+	tx.DrawLatex(0.05, 0.4, text);
 
 }
 

--- a/src/plugins/Analysis/p3pi_hists/DReaction_factory_p3pi_hists.cc
+++ b/src/plugins/Analysis/p3pi_hists/DReaction_factory_p3pi_hists.cc
@@ -28,9 +28,6 @@ void DReaction_factory_p3pi_hists::PIDCuts(DReaction* locReaction)
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, Gamma, SYS_FCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_p3pi(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
-
-	// Cut low beam energy as tagger settings change during 2017-01
-	locReaction->Add_AnalysisAction(new DCutAction_BeamEnergy(locReaction, false, 7.0, 12.0));
 }
 	
 

--- a/src/plugins/Analysis/p3pi_hists/HistMacro_p3pi.C
+++ b/src/plugins/Analysis/p3pi_hists/HistMacro_p3pi.C
@@ -307,16 +307,14 @@
 	  tx.SetTextAlign(11);
 	  tx.SetTextSize(0.06);
 	  char text[100];
-	  sprintf(text, "E_{#gamma} > 7 GeV");
-	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/4., text);
 	  sprintf(text, "Post KinFit");
-	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/16., text);
+	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/4., text);
 	  sprintf(text, "M(#omega) = %0.3f GeV/c^{2}", omega_mass);
-	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/64., text);
+	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/16., text);
 	  sprintf(text, "#Gamma(#omega) = %0.3f GeV/c^{2}", omega_width);
-	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/256., text);
+	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/64., text);
 	  sprintf(text, "N(#omega) = %0.2f / 1k Trigger", n_omega_kinfit/n_triggers*1000);
-	  tx.DrawLatex(0.1,  locHist_KinFitConLev->GetMaximum()/1024., text);
+	  tx.DrawLatex(0.1,  locHist_KinFitConLev->GetMaximum()/256., text);
 	}
 }
 

--- a/src/plugins/Analysis/ppi0gamma_hists/DReaction_factory_ppi0gamma_hists.cc
+++ b/src/plugins/Analysis/ppi0gamma_hists/DReaction_factory_ppi0gamma_hists.cc
@@ -28,9 +28,6 @@ void DReaction_factory_ppi0gamma_hists::PIDCuts(DReaction* locReaction)
 	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, Gamma, SYS_FCAL)); //false: measured data
 	locReaction->Add_AnalysisAction(new DCustomAction_dEdxCut_ppi0gamma(locReaction, false)); //false: focus on keeping signal
 	locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction, "PostPIDCuts"));
-
-	// Cut low beam energy as tagger settings change during 2017-01
-	locReaction->Add_AnalysisAction(new DCutAction_BeamEnergy(locReaction, false, 7.0, 12.0));
 }
 	
 

--- a/src/plugins/Analysis/ppi0gamma_hists/HistMacro_ppi0gamma.C
+++ b/src/plugins/Analysis/ppi0gamma_hists/HistMacro_ppi0gamma.C
@@ -307,16 +307,14 @@
 	  tx.SetTextAlign(11);
 	  tx.SetTextSize(0.06);
 	  char text[100];
-	  sprintf(text, "E_{#gamma} > 7 GeV");
-	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/4., text);
 	  sprintf(text, "Post KinFit");
-	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/16., text);
+	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/4., text);
 	  sprintf(text, "M(#omega) = %0.3f GeV/c^{2}", omega_mass);
-	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/64., text);
+	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/16., text);
 	  sprintf(text, "#Gamma(#omega) = %0.3f GeV/c^{2}", omega_width);
-	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/256., text);
+	  tx.DrawLatex(0.1, locHist_KinFitConLev->GetMaximum()/64., text);
 	  sprintf(text, "N(#omega) = %0.2f / 1k Trigger", n_omega_kinfit/n_triggers*1000);
-	  tx.DrawLatex(0.1,  locHist_KinFitConLev->GetMaximum()/1024., text);
+	  tx.DrawLatex(0.1,  locHist_KinFitConLev->GetMaximum()/256., text);
 	}
 }
 


### PR DESCRIPTION
It was just a temporary measure during the spring 2017 run in order to compare 100nA to 150nA running. The tagger part for low energies was switched off during the latter.