### PR TITLE
Set RCDB envars directly

### DIFF
--- a/src/SBMS/sbms_setenv.py
+++ b/src/SBMS/sbms_setenv.py
@@ -123,10 +123,10 @@ def mk_setenv_csh(env):
 	if rcdb_home != None:
 		str += '# RCDB\n'
 		str += 'setenv RCDB_HOME %s\n' % rcdb_home
-		str += 'if ( -e $RCDB_HOME/environment.csh ) then\n'
-		str += '  source $RCDB_HOME/environment.csh\n'
-		str += 'endif\n'
 		str += 'setenv RCDB_CONNECTION %s\n' % rcdb_conn
+		str += 'setenv %s ${RCDB_HOME}/cpp/lib:${%s}\n' % (LDLPV, LDLPV)
+		str += 'setenv PYTHONPATH ${RCDB_HOME}/python:${PYTHONPATH}\n'
+		str += 'setenv PATH ${RCDB_HOME}/bin:${RCDB_HOME}/cpp/bin:${PATH}\n'
 		str += '\n'
 
 	# ROOT


### PR DESCRIPTION
Set RCDB envars directly rather than use the environment.csh script that comes with RCDB which seems to be broken.