### PR TITLE
Fix root crash

### DIFF
--- a/src/libraries/BCAL/DBCALShower_factory_IU.cc
+++ b/src/libraries/BCAL/DBCALShower_factory_IU.cc
@@ -272,7 +272,6 @@ DBCALShower_factory_IU::LoadCovarianceLookupTables(){
 			japp->RootWriteLock();
 			// change directory to memory so that histograms are not saved to file
 			TDirectory *savedir = gDirectory;
-			gROOT->cd();  
 
 			// Read in string
 			ifstream ifs;
@@ -321,6 +320,7 @@ DBCALShower_factory_IU::LoadCovarianceLookupTables(){
 			char histname[255];
 			sprintf(histname,"covariance_%i%i_thread%s",i,j,idstring.str().c_str());
 			CovarianceLookupTable[i][j] = new TH2F(histname,"Covariance histogram",nxbins,xbins,nybins,ybins);
+                        CovarianceLookupTable[i][j]->SetDirectory(nullptr);
 			// fill histogram
 			while(ss>>cont){
 				if (VERBOSE>1) printf("(%2i,%2i)  (%2i,%2i)  %e  ",i,j,xbin,ybin,cont);

--- a/src/libraries/FCAL/DFCALShower_factory.cc
+++ b/src/libraries/FCAL/DFCALShower_factory.cc
@@ -380,7 +380,6 @@ DFCALShower_factory::LoadCovarianceLookupTables(){
 			japp->RootWriteLock();
 			// change directory to memory so that histograms are not saved to file
 			TDirectory *savedir = gDirectory;
-			gROOT->cd();
 
 			char histname[255];
 			sprintf(histname,"covariance_%i%i_thread%s",i,j,idstring.str().c_str());
@@ -410,6 +409,7 @@ DFCALShower_factory::LoadCovarianceLookupTables(){
 			if (DUMMYTABLES) {
 				// create dummy histogram since something went wrong
 				CovarianceLookupTable[i][j] = new TH2F(histname,"Covariance histogram",10,0,12,10,0,12);
+	                        CovarianceLookupTable[i][j]->SetDirectory(nullptr);
 			} else {
 				// Parse string
 				int nxbins, nybins;
@@ -433,6 +433,7 @@ DFCALShower_factory::LoadCovarianceLookupTables(){
 				int ybin=1;
 				// create histogram
 				CovarianceLookupTable[i][j] = new TH2F(histname,"Covariance histogram",nxbins,xbins,nybins,ybins);
+	                        CovarianceLookupTable[i][j]->SetDirectory(nullptr);
 				// fill histogram
 				while(ss>>cont){
 					if (VERBOSE>1) printf("(%i,%i) (%i,%i) %e  ",i,j,xbin,ybin,cont);

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -129,7 +129,11 @@ jerror_t DEventSourceREST::GetEvent(JEvent &event)
          hddm_r::DataVersionStringList::iterator Versioniter;
          for (Versioniter = locVersionStrings.begin(); Versioniter != locVersionStrings.end(); ++Versioniter) {
         	 string HDDM_DATA_VERSION_STRING = Versioniter->getText();
-             gPARMS->SetDefaultParameter("REST:DATAVERSIONSTRING", HDDM_DATA_VERSION_STRING);
+             if(gPARMS->Exists("REST:DATAVERSIONSTRING"))
+                gPARMS->SetParameter("REST:DATAVERSIONSTRING", HDDM_DATA_VERSION_STRING);
+	     else
+	 	gPARMS->SetDefaultParameter("REST:DATAVERSIONSTRING", HDDM_DATA_VERSION_STRING);
+	     break;
          }
 
          //set REST calib context

--- a/src/libraries/HDDM/DEventWriterREST_factory.h
+++ b/src/libraries/HDDM/DEventWriterREST_factory.h
@@ -17,6 +17,8 @@ class DEventWriterREST_factory : public jana::JFactory<DEventWriterREST>
 		{
 			dOutputFileBaseName = "dana_rest";
 		   gPARMS->SetDefaultParameter("rest:FILENAME", dOutputFileBaseName);
+		string locDummyString = "";
+                gPARMS->SetDefaultParameter("REST:DATAVERSIONSTRING", locDummyString);
 			return NOERROR;
 		}
 


### PR DESCRIPTION
To create histograms in memory, do NOT create them in gROOT->cd().  This causes crashes at program exit.  Instead, call TH1::SetDirectory(nullptr).  Thus ends the 2 week saga.  

Also, fix minor bug about no default value for a parameter. 