### PR TITLE
Remove track seed minimum

### DIFF
--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -21,8 +21,6 @@
 
 #define MAX_TB_PASSES 20
 #define MAX_WB_PASSES 20
-#define MIN_PROTON_P 0.3
-#define MIN_PION_P 0.08
 #define MAX_P 12.0
 #define ALPHA 1./137.
 
@@ -342,6 +340,11 @@ DTrackFitterKalmanSIMD::DTrackFitterKalmanSIMD(JEventLoop *loop):DTrackFitter(lo
 
    MIN_FIT_P = 0.050; // GeV
    gPARMS->SetDefaultParameter("TRKFIT:MIN_FIT_P", MIN_FIT_P, "Minimum fit momentum in GeV/c for fit to be considered successful");
+
+   MIN_PROTON_P = 0.0;
+   gPARMS->SetDefaultParameter("TRKFIT:MIN_PROTON_P", MIN_PROTON_P, "Minimum proton momentum for track seeds.");
+   MIN_PION_P = 0.0;
+   gPARMS->SetDefaultParameter("TRKFIT:MIN_PION_P", MIN_PION_P, "Minimum pion momentum for track seeds.");
 
    NUM_CDC_SIGMA_CUT=3.5;
    NUM_FDC_SIGMA_CUT=3.5;

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.h
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.h
@@ -510,6 +510,11 @@ class DTrackFitterKalmanSIMD: public DTrackFitter{
   double MIN_FIT_P;
   // Maximum seed momentum
   double MAX_SEED_P;
+  
+  // Minimum proton momentum
+  double MIN_PROTON_P;
+  // Minimum pion momentum
+  double MIN_PION_P;
 
   // parameters for scaling drift table for CDC
   double CDC_DRIFT_BSCALE_PAR1,CDC_DRIFT_BSCALE_PAR2;

--- a/src/plugins/Calibration/CDC_TimeToDistance/FitScripts/FitTimeToDistance.C
+++ b/src/plugins/Calibration/CDC_TimeToDistance/FitScripts/FitTimeToDistance.C
@@ -121,7 +121,7 @@ void FitTimeToDistance(TString inputROOTFile = "hd_root.root")
    //f1 = new TF2("f1",TimeToDistanceFieldOff, 0, 200, -0.18, 0.18, npar);
    //f2 = new TF2("f2",TimeToDistanceFieldOff, 0, 200, -0.18, 0.18, npar);
 
-   TProfile *constants = thisFile->Get("/CDC_TimeToDistance/CDC_TD_Constants");
+   TProfile *constants = (TProfile*) thisFile->Get("/CDC_TimeToDistance/CDC_TD_Constants");
    long_drift_func[0][0] = constants->GetBinContent(101);
    long_drift_func[0][1] = constants->GetBinContent(102);
    long_drift_func[0][2] = constants->GetBinContent(103);
@@ -208,17 +208,19 @@ void FitTimeToDistance(TString inputROOTFile = "hd_root.root")
    f2->Draw("cont2 list same");
    c3->Update();
 
-   ofstream outputTextFile;
-   outputTextFile.open("ccdb_Format.txt"); 
-   outputTextFile << fr->Parameter(0) << " " << fr->Parameter(1) << " " << fr->Parameter(2) << " " ;
-   outputTextFile << fr->Parameter(3) << " " << fr->Parameter(4) << " " << fr->Parameter(5) << " " ;
-   outputTextFile << fr->Parameter(6) << " " << fr->Parameter(7) << " " << fr->Parameter(8) << " " ;
-   outputTextFile << magnet_correction[0][0] << " " << magnet_correction[0][1] << endl; 
-   outputTextFile << fr->Parameter(9) << " " << fr->Parameter(10) << " " << fr->Parameter(11) << " " ;
-   outputTextFile << fr->Parameter(12) << " " << fr->Parameter(13) << " " << fr->Parameter(14) << " " ;
-   outputTextFile << fr->Parameter(15) << " " << fr->Parameter(16) << " " << fr->Parameter(17) << " " ;
-   outputTextFile << magnet_correction[1][0] << " " << magnet_correction[1][1] << endl;
-   outputTextFile.close();
+   if ((Int_t) fr == 0){ // Fit converged with no errors
+      ofstream outputTextFile;
+      outputTextFile.open(Form("ccdb_Format_%i.txt",run)); 
+      outputTextFile << fr->Parameter(0) << " " << fr->Parameter(1) << " " << fr->Parameter(2) << " " ;
+      outputTextFile << fr->Parameter(3) << " " << fr->Parameter(4) << " " << fr->Parameter(5) << " " ;
+      outputTextFile << fr->Parameter(6) << " " << fr->Parameter(7) << " " << fr->Parameter(8) << " " ;
+      outputTextFile << magnet_correction[0][0] << " " << magnet_correction[0][1] << endl; 
+      outputTextFile << fr->Parameter(9) << " " << fr->Parameter(10) << " " << fr->Parameter(11) << " " ;
+      outputTextFile << fr->Parameter(12) << " " << fr->Parameter(13) << " " << fr->Parameter(14) << " " ;
+      outputTextFile << fr->Parameter(15) << " " << fr->Parameter(16) << " " << fr->Parameter(17) << " " ;
+      outputTextFile << magnet_correction[1][0] << " " << magnet_correction[1][1] << endl;
+      outputTextFile.close();
+   }
 
    return;
 }


### PR DESCRIPTION
Track seed minimum was causing a pileup of events near this threshold for protons. This should help resolve a problem with an unphysical peak at low t calculated from target-recoil proton.