### PR TITLE
add call to return derived types to memory pool, presumably so they c…

### DIFF
--- a/src/libraries/DAQ/DParsedEvent.h
+++ b/src/libraries/DAQ/DParsedEvent.h
@@ -166,6 +166,7 @@ class DParsedEvent{
 			MyTypes(returntopool)
 			MyTypes(clearvectors)
 			MyBORTypes(clearvectors)
+      MyDerivedTypes(returntopool)
 			MyDerivedTypes(clearvectors)
 			MyNoPoolTypes(deletepool)
 			MyNoPoolTypes(clearpoolvectors)


### PR DESCRIPTION
…an be deallocated;  this fixes a memory leak when running over EVIO files