### PR TITLE
Change calibration to include wider TDC-ADC range and other updates

### DIFF
--- a/src/plugins/Calibration/TAGM_TW/JEventProcessor_TAGM_TW.cc
+++ b/src/plugins/Calibration/TAGM_TW/JEventProcessor_TAGM_TW.cc
@@ -20,13 +20,21 @@ const uint32_t NCOLUMNS = 102;
 const uint32_t NSINGLES = 20;
 const uint32_t NROWS = 5;
 
-const int32_t TMIN = -50;
-const int32_t TMAX = 50;
+const int32_t PMIN = 0;
+const int32_t PMAX = 2000;
+const int32_t PBIN = (PMAX - PMIN)/16;
+
+const int32_t TMIN = -150;
+const int32_t TMAX = 150;
 const int32_t TBIN = (TMAX - TMIN)/0.1;
 
 const double TMIN_RF = -2.0;
 const double TMAX_RF = 2.0;
 const double TBIN_RF = (TMAX_RF - TMIN_RF)/0.1;
+
+const double TMIN_TW = -10.0;
+const double TMAX_TW = 15.0;
+const double TBIN_TW = (TMAX_RF - TMIN_RF)/0.1;
 
 // Define histograms
 //    timewalk
@@ -82,19 +90,19 @@ jerror_t JEventProcessor_TAGM_TW::init(void)
    gDirectory->mkdir("tdc-rf")->cd();
    for (uint32_t i = 0; i < NCOLUMNS; ++i)
    {
-      h_dt_vs_pp_tdc[i] = new TH2I(Form("h_dt_vs_pp_tdc_%i",i+1),
+      h_dt_vs_pp_tdc[i] = new TH2I(Form("h_dt_vs_pp_tdc_%i", i+1),
                                Form("#delta t vs. pulse peak for TAGM column %i;\
-                               Pulse peak (adc counts);TDC - RF (ns)",i+1),\
-                               1000,0,2000,250,-10,15);
+                               Pulse peak (adc counts);TDC - RF (ns)", i+1), \
+                               PBIN, PMIN, PMAX, TBIN_TW, TMIN_TW, TMAX_TW);
    }
    for (uint32_t i = 0; i < NROWS; ++i)
    {
       for (uint32_t j = 0; j < 4; ++j)
       {
-         h_dt_vs_pp_tdc_ind[i][j] = new TH2I(Form("h_dt_vs_pp_tdc_ind_%i_%i",i+1,j+1),
+         h_dt_vs_pp_tdc_ind[i][j] = new TH2I(Form("h_dt_vs_pp_tdc_ind_%i_%i", i+1, j+1),
                                         Form("#delta t vs. pulse peak for TAGM ind. column %i, row %i;\
-                                        Pulse peak (adc counts);TDC - RF (ns)",j+1,i+1),
-                                        1000,0,2000,250,-10,15);
+                                        Pulse peak (adc counts);TDC - RF (ns)", j+1, i+1),
+                                        PBIN, PMIN, PMAX, TBIN_TW, TMIN_TW, TMAX_TW);
 
       }
    }
@@ -103,36 +111,36 @@ jerror_t JEventProcessor_TAGM_TW::init(void)
    gDirectory->mkdir("t-rf")->cd();
    for (uint32_t i = 0; i < NCOLUMNS; ++i)
    {
-      h_dt_vs_pp[i] = new TH2I(Form("h_dt_vs_pp_%i",i+1),
+      h_dt_vs_pp[i] = new TH2I(Form("h_dt_vs_pp_%i", i+1),
                                Form("#delta t vs. pulse peak for TAGM column %i;\
-                               Pulse peak (adc counts);T - RF (ns)",i+1),\
-                               1000,0,2000,250,-10,15);
+                               Pulse peak (adc counts);T - RF (ns)", i+1),\
+                               PBIN, PMIN, PMAX, TBIN_TW, TMIN_TW, TMAX_TW);
    }
    for (uint32_t i = 0; i < NROWS; ++i)
    {
       for (uint32_t j = 0; j < 4; ++j)
       {
-         h_dt_vs_pp_ind[i][j] = new TH2I(Form("h_dt_vs_pp_ind_%i_%i",i+1,j+1),
+         h_dt_vs_pp_ind[i][j] = new TH2I(Form("h_dt_vs_pp_ind_%i_%i", i+1, j+1),
                                     Form("#delta t vs. pulse peak for TAGM ind. column %i, row %i;\
-                                    Pulse peak (adc counts);T - RF (ns)",j+1,i+1),
-                                    1000,0,2000,250,-10,15);
+                                    Pulse peak (adc counts);T - RF (ns)", j+1, i+1),
+                                    PBIN, PMIN, PMAX, TBIN_TW, TMIN_TW, TMAX_TW);
 
       }
    }
    tagmDir->cd();
 
    h_tdc_adc_all =      new TH2I("tdc_adc_all","Summed channels;TDC - ADC (ns);Column",
-                                  TBIN,TMIN,TMAX,NCOLUMNS,1,NCOLUMNS+1);
+                                  TBIN, TMIN, TMAX, NCOLUMNS,1, NCOLUMNS+1);
    h_tdc_adc_all_ind =  new TH2I("tdc_adc_all_ind","Individual channels;TDC - ADC (ns);Column",
-                                  TBIN,TMIN,TMAX,NSINGLES,1,NSINGLES+1);
-   h_t_adc_all =      new TH2I("t_adc_all","Summed channels;TDC - ADC (ns);Column",
-                                TBIN,TMIN,TMAX,NCOLUMNS,1,NCOLUMNS+1);
-   h_t_adc_all_ind =  new TH2I("t_adc_all_ind","Individual channels;TDC - ADC (ns);Column",
-                                TBIN,TMIN,TMAX,NSINGLES,1,NSINGLES+1);
-   h_adc_rf_all =     new TH2I("adc_rf_all","Summed channels;ADC - RF (ns);Column",
-                                TBIN_RF,TMIN_RF,TMAX_RF,NCOLUMNS,1,NCOLUMNS+1);
-   h_adc_rf_all_ind = new TH2I("adc_rf_all_ind","Individual channels;ADC - RF (ns);Column",
-                                TBIN_RF,TMIN_RF,TMAX_RF,NSINGLES,1,NSINGLES+1);
+                                  TBIN, TMIN, TMAX, NSINGLES,1, NSINGLES+1);
+   h_t_adc_all =        new TH2I("t_adc_all","Summed channels;TDC - ADC (ns);Column",
+                                  TBIN, TMIN, TMAX, NCOLUMNS,1, NCOLUMNS+1);
+   h_t_adc_all_ind =    new TH2I("t_adc_all_ind","Individual channels;TDC - ADC (ns);Column",
+                                  TBIN, TMIN, TMAX, NSINGLES,1, NSINGLES+1);
+   h_adc_rf_all =       new TH2I("adc_rf_all","Summed channels;ADC - RF (ns);Column",
+                                  TBIN_RF, TMIN_RF, TMAX_RF, NCOLUMNS,1, NCOLUMNS+1);
+   h_adc_rf_all_ind =   new TH2I("adc_rf_all_ind","Individual channels;ADC - RF (ns);Column",
+                                  TBIN_RF, TMIN_RF, TMAX_RF, NSINGLES,1, NSINGLES+1);
 
    return NOERROR;
 	
@@ -185,7 +193,7 @@ jerror_t JEventProcessor_TAGM_TW::evnt(JEventLoop *loop, uint64_t eventnumber)
       double tm_t  = hits[i]->t;
       double adc_t = hits[i]->time_fadc;
       double tdc_t = hits[i]->time_tdc;
-      double rf_adc = dRFTimeFactory->Step_TimeToNearInputTime(locRFTime->dTime,adc_t);
+      double rf_adc = dRFTimeFactory->Step_TimeToNearInputTime(locRFTime->dTime, adc_t);
 
       if (row == 0)
       {

--- a/src/plugins/Calibration/TAGM_TW/README.md
+++ b/src/plugins/Calibration/TAGM_TW/README.md
@@ -9,6 +9,10 @@ To fully align the TAGM with the rest of the detectors, use HLDetectorTiming.
 CCDB version 1.06 or greater is needed for timing.py to work.
 
 ## Running TAGM_TW
+When running `hd_root` with the **TAGM_TW** plugin, make sure to include 
+the option `-PTAGMHit:DELTA_T_ADC_TDC_MAX=200` in order to pick up any 
+large offsets.
+
 Follow these steps after running `hd_root` with the **TAGM_TW** plugin. 
 Be aware that the CCDB table /PHOTON_BEAM/microscope/integral_cuts can 
 interfere with the pulse height distributions. To set these values to 0 
@@ -26,8 +30,10 @@ which will avoid the timewalk from absorbing large offsets.
 
 1. `python timing.py -b <rootfile> <run number> rf <CCDB variation>`
 2. `This produces the file adc_offsets-######.txt and tdc_offsets-######.txt`
+3. `./push-to-ccdb.sh <run number> <variation> adc tdc`
+or
 3. `ccdb add PHOTON_BEAM/microscope/fadc_time_offsets -v <variation> -r #-# adc_offsets-######.txt`
-3. `ccdb add PHOTON_BEAM/microscope/tdc_time_offsets -v <variation> -r #-# tdc_offsets-######.txt`
+4. `ccdb add PHOTON_BEAM/microscope/tdc_time_offsets -v <variation> -r #-# tdc_offsets-######.txt`
 
 ## Timewalk corrections
 The timewalk corrections are to be performed after the initial ADC-RF and raw TDC-ADC calibrations have been performed.
@@ -41,6 +47,8 @@ allows for large timewalks to be included in the fit.
 1. `python tw.py -b <rootfile> <run number>`
 2. `This creates the files results.root and tw-corr.txt`
 3. `root -l -b 'display.C("results.root")' to check the fits`
+4. `./push-to-ccdb.sh <run number> <variation> tw`
+or
 4. `ccdb add /PHOTON_BEAM/microscope/tdc_timewalk_corrections -v <variation> -r #-# tw-corr.txt`
 
 ## Corrected TDC-RF calibration
@@ -53,6 +61,8 @@ both.
 
 1. `python timing.py -b <rootfile> <run number> self <CCDB variation>`
 2. `This overwrites the previous tdc_offsets-#####.txt file`
+3. `./push-to-ccdb.sh <run number> <variation> tdc`
+or
 3. `ccdb add PHOTON_BEAM/microscope/tdc_time_offsets -v <variation> -r #-# tdc_offsets-######.txt`
 
 ## Calibration validation

--- a/src/plugins/Calibration/TAGM_TW/README.md
+++ b/src/plugins/Calibration/TAGM_TW/README.md
@@ -6,14 +6,15 @@ TDC and ADC.
 
 To fully align the TAGM with the rest of the detectors, use HLDetectorTiming.
 
-CCDB version 1.06 or greater is needed for timing.py to work.
+**CCDB version 1.06 or greater is needed for timing.py to work.**
 
 ## Running TAGM_TW
 When running `hd_root` with the **TAGM_TW** plugin, make sure to include 
 the option `-PTAGMHit:DELTA_T_ADC_TDC_MAX=200` in order to pick up any 
 large offsets.
 
-Follow these steps after running `hd_root` with the **TAGM_TW** plugin. 
+`hd_root -PPLUGINS=TAGM_TW -PTAGMHit:DELTA_T_ADC_TDC_MAX=200 /path/to/file/hd_rawdata_XXXXXX_00*`
+
 Be aware that the CCDB table /PHOTON_BEAM/microscope/integral_cuts can 
 interfere with the pulse height distributions. To set these values to 0 
 on the fly, run with the option -PTAGMHit:CUT_FACTOR=0.
@@ -21,12 +22,17 @@ on the fly, run with the option -PTAGMHit:CUT_FACTOR=0.
 Also, be aware that the reference RF source for this plugin is the TAGH. 
 Make sure that the TAGH RF signal is calibrated before proceeding.
 
+Follow these steps after running `hd_root`. 
+
 ## Initial ADC-RF and raw TDC-ADC calibration
 This is the first step to calibrate the TAGM. Because the ADC is already 
 timewalk corrected, this can be immediately aligned with an RF bucket. 
 At the same time, the uncorrected TDC time can be adjusted to be aligned 
 with the new ADC time. This is a rough calibration of the raw TDC time 
 which will avoid the timewalk from absorbing large offsets.
+
+**For this step, it is important to include -PTAGMHit:DELTA_T_ADC_TDC_MAX=200
+when running TAGM_TW. Occasionally, the initial time difference is very large.**
 
 1. `python timing.py -b <rootfile> <run number> rf <CCDB variation>`
 2. `This produces the file adc_offsets-######.txt and tdc_offsets-######.txt`
@@ -36,13 +42,17 @@ or
 4. `ccdb add PHOTON_BEAM/microscope/tdc_time_offsets -v <variation> -r #-# tdc_offsets-######.txt`
 
 ## Timewalk corrections
-The timewalk corrections are to be performed after the initial ADC-RF and raw TDC-ADC calibrations have been performed.
+The timewalk corrections are to be performed after the initial ADC-RF and 
+raw TDC-ADC calibrations have been performed.
 
 The timewalk plugin uses the TAGH RF as a reference. For a given hit, the 
 RF time closest to the ADC time is selected and set as the RF time. The time 
 difference between the TDC time and the RF time is taken. By doing it this 
 way, there are not multiple timewalk distributions every beam period. This 
 allows for large timewalks to be included in the fit.
+
+**The constants from the previous step must be pushed to the CCDB and a new root
+file created using TAGM_TW before performing this step.**
 
 1. `python tw.py -b <rootfile> <run number>`
 2. `This creates the files results.root and tw-corr.txt`
@@ -59,6 +69,9 @@ This step takes the timewalk corrected TDC time and compares it with the ADC.
 Since the ADC is already aligned with the RF, this will align the TDC with 
 both.
 
+**The constants from the previous step must be pushed to the CCDB and a new root
+file created using TAGM_TW before performing this step.**
+
 1. `python timing.py -b <rootfile> <run number> self <CCDB variation>`
 2. `This overwrites the previous tdc_offsets-#####.txt file`
 3. `./push-to-ccdb.sh <run number> <variation> tdc`
@@ -68,6 +81,9 @@ or
 ## Calibration validation
 After all steps are complete, a calibration validation can be performed. Run 
 the plugin again with the new constants.
+
+**The constants from the previous step must be pushed to the CCDB and a new root
+file created using TAGM_TW before performing this step.**
 
 1. `python timing.py -b <rootfile> <run number> validate <CCDB variation>`
 2. `This produces a file problem-channels.txt containing any errors or fits 

--- a/src/plugins/Calibration/TAGM_TW/timing.py
+++ b/src/plugins/Calibration/TAGM_TW/timing.py
@@ -202,10 +202,7 @@ def GetRFTiming(hist,beamPeriod):
 	if (hist.GetMaximum() < 5):
 		print 'Insufficient number of entries for histogram ' + histname
 		return 0
-	mean = hist.GetMean()
-	maxBin = hist.GetMaximumBin()
-	maxContent = hist.GetBinContent(maxBin)
-	maximum = hist.GetBinCenter(maxBin)
+	maximum = GetMaximum(hist)
 	try:
 		if (maximum < -0.5):
 			fitfunc = TF1("fitfunc","[0]*TMath::Exp(-0.5*pow((x-[1])/[2],2))+[0]*TMath::Exp(-0.5*pow((x-[1]-[3])/[2],2))",-beamPeriod/2,0)
@@ -240,8 +237,9 @@ def GetSelfTiming(hist):
 	if (hist.GetMaximum() < 5):
 		print 'Insufficient number of entries for histogram ' + histname
 		return 0
+	maximum = GetMaximum(hist)
 	try:
-		FitResult = hist.Fit("gaus","sRWq","",-20,20)
+		FitResult = hist.Fit("gaus","sRWq","",maximum-2,maximum+2)
 		offset = FitResult.Parameters()[1]
 		sigma = FitResult.Parameters()[2]
 	except:
@@ -281,6 +279,11 @@ def SigError(type,row,col,sig):
 		sigError = type + ': Individual column ' + str(col) + ' row ' + str(row) + \
 			   ' has a sigma (' + str(sig) + ') greater than 1.0 ns\n'
 	return sigError
+
+def GetMaximum(hist):
+	maxBin = hist.GetMaximumBin()
+	maximum = hist.GetBinCenter(maxBin)
+	return maximum
 
 
 if __name__ == "__main__":

--- a/src/plugins/Calibration/TAGM_TW/tw.py
+++ b/src/plugins/Calibration/TAGM_TW/tw.py
@@ -29,7 +29,6 @@ def main():
 	outfile.cd()
 
 	# If the histogram is empty use the summed output hist instead
-	indCol = [9,27,81,99]
 	base = "TAGM_TW/tdc-rf/h_dt_vs_pp_tdc_"
 	for i in range(1,103):
 		# Summed outputs
@@ -38,25 +37,11 @@ def main():
 		p = tw_corr(h,0,i,newV)
 		p.Write()
 
-		# Individual fiber readouts
-		if i in indCol:
-			for j in range(5):
-				h = rootfile.Get(base+"ind_"+str(j+1)+"_"+str(indCol.index(i)+1))
-				h.Write()
-				if not (h.GetEntries() > 300):
-					h = rootfile.Get(base + str(i)).Clone()
-					h.SetName(base+"ind_"+str(j+1)+"_"+str(indCol.index(i)+1))
-				p = tw_corr(h,j+1,i,newV)
-                                p.Write()
-			
-	# Include defaults for columns 101 and 102
-	#file1 = open('tw-corr.txt','a')
-	#for i in range(2):
-	#	file1.write('0   ' + str(101 + i) + '   ' + '1   ' + '-1   ' +
-        #            	    '0   ' + '8   ' + '0\n')
 	outfile.Close()
 
 def tw_corr(h,row,col,newV):
+	# Create list of columns with individual readout
+	indCol = [9,27,81,99]
 	# Open files for writing constants
 	if (row == 0 and col == 1):
 		file1 = open('tw-corr.txt','w')
@@ -85,6 +70,7 @@ def tw_corr(h,row,col,newV):
 		f1.SetParName(2,"c2")
 		f1.SetParName(3,"c3")
 
+		h.RebinX(16)
 		p = h.ProfileX()
 		fitResult = p.Fit("f1","sRWq")
 
@@ -103,6 +89,10 @@ def tw_corr(h,row,col,newV):
 	# Write constants to file
 	file1.write(str(row) + '   ' + str(col) + '   ' + str(c0) + '   ' + str(c1) + '   ' +
                     str(c2) + '   ' + str(c3) + '   ' + str(dtmean) + '\n')
+	if col in indCol:
+		for j in range(1,6):
+			file1.write(str(j) + '   ' + str(col) + '   ' + str(c0) + '   ' + str(c1) + '   ' +
+        		            str(c2) + '   ' + str(c3) + '   ' + str(dtmean) + '\n')
 	file1.close()
 
 	return p


### PR DESCRIPTION
* Change plugin and timing.py script to -150 to 150 ns to find large offsets
* Change individual channels to use summed output timewalk constants
* Change TDC-ADC offset fitting to use distribution maximum to provide a fitting range around the peak
* Add script `push-to-ccdb.sh` to push new constants to the ccdb
* Update README.md to include procedure changes