### PR TITLE
Allow user to set run number for accessing DGeometry

### DIFF
--- a/src/programs/Analysis/hdview2/hdv_mainframe.cc
+++ b/src/programs/Analysis/hdview2/hdv_mainframe.cc
@@ -93,7 +93,7 @@ hdv_mainframe::hdv_mainframe(const TGWindow *p, UInt_t w, UInt_t h):TGMainFrame(
 {
   //Get pointer to DGeometry object
   DApplication* dapp=dynamic_cast<DApplication*>(japp);
-  const DGeometry *dgeom  = dapp->GetDGeometry(9999);
+  const DGeometry *dgeom  = dapp->GetDGeometry(RUNNUMBER);
   
   dgeom->GetFDCWires(fdcwires);
   

--- a/src/programs/Analysis/hdview2/hdview2.cc
+++ b/src/programs/Analysis/hdview2/hdview2.cc
@@ -16,6 +16,8 @@ extern JApplication *japp;
 JEventLoop *eventloop =NULL;
 MyProcessor *myproc = NULL;
 
+int32_t RUNNUMBER = 9999; // set with RUNNUMBER config paramter
+
 void PrintFactoryList(JApplication *japp);
 void ParseCommandLineArguments(int &narg, char *argv[], JApplication *japp);
 void Usage(JApplication *japp);
@@ -31,6 +33,9 @@ int main(int narg, char *argv[])
 	// Instantiate a DApplication object. This has to be done BEFORE
 	// creating the TApplication object since that modifies the argument list.
 	japp = new DApplication(narg, argv);
+	
+	// Check if user specified a run number via config. parameter
+	try{ gPARMS->GetParameter("RUNNUMBER", RUNNUMBER); }catch(...){}
 	
 	// Create a ROOT TApplication object
 	TApplication app("HDView", &narg, argv);

--- a/src/programs/Analysis/hdview2/hdview2.h
+++ b/src/programs/Analysis/hdview2/hdview2.h
@@ -20,6 +20,8 @@ extern DApplication *dapp;
 extern JEventLoop *eventloop;
 extern MyProcessor *myproc;
 
+extern int32_t RUNNUMBER;
+
 jerror_t hdv_getevent(void);
 jerror_t hdv_drawevent(void);
 


### PR DESCRIPTION
Allow user to set run number for accessing DGeometry via RUNNUMBER config parameter. This is needed since DGeomtery is accessed before the first event is read and if the geometry is being read from the ccdb (as opposed to HDDS_HOME) it needs a valid run number.