### PR TITLE
Get rid of CINT/CLING condition on inclusion of hdv_mainframe.h

### DIFF
--- a/src/programs/Analysis/hdview2/trk_mainframe.h
+++ b/src/programs/Analysis/hdview2/trk_mainframe.h
@@ -38,10 +38,8 @@
 
 
 class hdv_mainframe;
-#if !(defined(__CINT__) || defined(__CLING__))
 
 #include "hdv_mainframe.h"
-#endif
 
 
 class DCoordinateSystem;


### PR DESCRIPTION
Please let @faustus123 look at this one. It is an attempt to get rid of an error/warning in the sim-recon build.
