### PR TITLE
Do not mask global gRandom with member of same name (use global).

### DIFF
--- a/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.cc
+++ b/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.cc
@@ -52,7 +52,7 @@ TLorentzVector
 ProductionMechanism::produceResonance( const TLorentzVector& beam ){
 
         // initialize pseudo-random generator
-        gRandom = new TRandom3();
+        //gRandom = new TRandom3();
         gRandom->SetSeed(0);
 	
 	TLorentzVector target( 0, 0, 0, kMproton );

--- a/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.h
+++ b/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.h
@@ -56,7 +56,7 @@ private:
   vector< BreitWignerGenerator > m_bwGen;    
   DecayChannelGenerator m_decGen;
 
-  TRandom3 *gRandom;
+  //TRandom3 *gRandom;
 };
 
 #endif


### PR DESCRIPTION
This fixes a problem that causes seg. faults on OS X, but really should be addressed independent of platform. The issue is that the ProductionMechanism class had a member gRandom which is the same name as a global variable defined in ROOT (also a TRandom3). If the intent was to have a private TRandom3, then this change should be discarded and the name of the member changed to something other than "gRandom".  If that is done then it should be checked with gen_2pi_primakoff on OS X to make sure it works.