### PR TITLE
Remove CERNLIB from SConscript

### DIFF
--- a/src/programs/Simulation/gen_2pi_primakoff/SConscript
+++ b/src/programs/Simulation/gen_2pi_primakoff/SConscript
@@ -6,7 +6,7 @@ import sbms
 Import('*')
 
 # Verify AMPTOOLS environment variable is set
-if os.getenv('AMPTOOLS', 'nada')!='nada' and os.getenv('CERN', 'nada')!='nada':
+if os.getenv('AMPTOOLS', 'nada')!='nada':
    
    env = env.Clone()
    
@@ -16,7 +16,7 @@ if os.getenv('AMPTOOLS', 'nada')!='nada' and os.getenv('CERN', 'nada')!='nada':
    sbms.AddHDDM(env)
    sbms.AddROOT(env)
    sbms.AddAmpTools(env)
-   sbms.AddCERNLIB(env)
+   #sbms.AddCERNLIB(env)
    
    sbms.executable(env)
 


### PR DESCRIPTION
Remove CERNLIB from SConscript since it is not actually required and that was all that was preventing it from compiling on OS X.