### PR TITLE
 make the use of walk correction based on applitudes the default

### DIFF
--- a/src/libraries/TOF/DTOFHit_factory.h
+++ b/src/libraries/TOF/DTOFHit_factory.h
@@ -51,6 +51,8 @@ class DTOFHit_factory:public jana::JFactory<DTOFHit>{
   // PARAMETERS:
   double DELTA_T_ADC_TDC_MAX;
   int USE_AMP_4WALKCORR;
+  int USE_NEW_4WALKCORR;
+  int USE_NEWAMP_4WALKCORR;
 
   tof_digi_constants_t adc_pedestals;
   tof_digi_constants_t adc_gains;
@@ -59,6 +61,8 @@ class DTOFHit_factory:public jana::JFactory<DTOFHit>{
   
   vector<vector<double> >timewalk_parameters;
   vector<vector<double> >timewalk_parameters_AMP;
+  vector<vector<double> >timewalk_parameters_NEW;
+  vector<vector<double> >timewalk_parameters_NEWAMP;
 
   
   DTOFHit* FindMatch(int plane, int bar, int end, double T);
@@ -89,6 +93,8 @@ class DTOFHit_factory:public jana::JFactory<DTOFHit>{
 
   double CalcWalkCorrIntegral(DTOFHit* hit);
   double CalcWalkCorrAmplitude(DTOFHit* hit);
+  double CalcWalkCorrNEW(DTOFHit* hit);
+  double CalcWalkCorrNEWAMP(DTOFHit* hit);
 
 
   bool CHECK_FADC_ERRORS;


### PR DESCRIPTION
This modifies the behavior of to create TOFHits. The default is to use TOF calibrations based on walk corrections with adc amplitude values. If the calibration tables are not available the code will resort back to using the old approach based on adc integrals.