### PR TITLE
add timing cut to matching ADC hits with TDC hits. This required also

### DIFF
--- a/src/libraries/TOF/DTOFHit_factory.h
+++ b/src/libraries/TOF/DTOFHit_factory.h
@@ -45,6 +45,10 @@ class DTOFHit_factory:public jana::JFactory<DTOFHit>{
   double t_base,t_base_tdc;
   double tdc_adc_time_offset;
 
+  // Timing Cut Values
+  double TimeCenterCut;
+  double TimeWidthCut;
+
   // ADC to Energy conversion for individual PMT channels
   double adc2E[176]; // 4*44 channels
 


### PR DESCRIPTION
the introduction of a new calibration table TOF/"HitTimeCut"
the table contains two values low limit and high limit for the cut
and  expects the ADC and TDC distribution to peak at the same location,
which should be the case if the global calibration is done correctly