### PR TITLE
Davidl rcdb osx

### DIFF
--- a/src/libraries/TAC/DTACHit_factory.cc
+++ b/src/libraries/TAC/DTACHit_factory.cc
@@ -11,6 +11,9 @@
  *      Author: Hovanes Egiyan
  */
 
+#include <cmath>
+using namespace std;
+
 #include "DTACHit_factory.h"
 
 // The parameter below can be overwritten from the command line

--- a/src/libraries/TAC/HitRebuilderTAC.cc
+++ b/src/libraries/TAC/HitRebuilderTAC.cc
@@ -5,6 +5,9 @@
  *      Author: Hovanes Egiyan
  */
 
+#include <cmath>
+using namespace std;
+
 #include <TAC/HitRebuilderTAC.h>
 
 using namespace std;

--- a/src/libraries/TRIGGER/DL1MCTrigger_factory.cc
+++ b/src/libraries/TRIGGER/DL1MCTrigger_factory.cc
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <cmath>
 using namespace std;
 
 #include <JANA/JApplication.h>
@@ -11,6 +12,11 @@ using namespace std;
 using namespace jana;
 
 #include "DL1MCTrigger_factory.h"
+
+#if HAVE_RCDB
+#include "RCDB/Connection.h"
+#include "RCDB/ConfigParser.h"
+#endif
 
 
 //------------------
@@ -441,6 +447,8 @@ jerror_t DL1MCTrigger_factory::fini(void)
 
 int  DL1MCTrigger_factory::Read_RCDB(int32_t runnumber){
 
+#if HAVE_RCDB
+
   vector<const DTranslationTable*> ttab;  
   eventLoop->Get(ttab);
   
@@ -802,6 +810,13 @@ int  DL1MCTrigger_factory::Read_RCDB(int32_t runnumber){
   }    // Loop over crates       
   
   return 0;
+
+#else // HAVE_RCDB
+
+  return 10; // RCDB is not available
+
+#endif
+
 }
 
 

--- a/src/libraries/TRIGGER/DL1MCTrigger_factory.h
+++ b/src/libraries/TRIGGER/DL1MCTrigger_factory.h
@@ -5,8 +5,6 @@
 
 #include "DL1MCTrigger.h"
 
-#include "RCDB/Connection.h"
-#include "RCDB/ConfigParser.h"
 
 #include "TTAB/DTranslationTable.h"
 

--- a/src/programs/Utilities/hdevio_sample/hdevio_sample.cc
+++ b/src/programs/Utilities/hdevio_sample/hdevio_sample.cc
@@ -103,7 +103,7 @@ int main(int narg, char *argv[])
 	}
 	
 	ofs.close();
-	if(buff) delete buff;
+	if(buff) delete[] buff;
 
 	return 0;
 }


### PR DESCRIPTION
This combines a couple of things:
1. Wraps the RCDB calls in trigger simulation in preprocessor directives to allow sim-recon to compile without RCDB (defaults will then be used for trigger simulation)

2. Fixed issues that prevented compilation OS X in both TRIGGER and TAC libraries.

3. Fixed small bug in hdevio_sample utility that was causing compiler warning