### PR TITLE
* control.in [rtj]

### DIFF
--- a/src/programs/Simulation/HDGeant/control.in
+++ b/src/programs/Simulation/HDGeant/control.in
@@ -39,6 +39,7 @@ c      colld  - diameter of collimator in m
 c      Eemit  - electron beam emittance in m.rad
 c      radthick - dimaond radiator thickneess in m
 c Omitting the final parameter Emin results in the default value being used.
+c Setting Epeak to zero selects an amorphous radiator instead of diamond.
 cBEAM 10. 9.999 0.0012 76.00 0.005 10.e-9 20.e-6
 
 c The GENBEAM card configures the simulation program to act purely as a


### PR DESCRIPTION
   - add a line documenting a previous feature that was known only to
     me, that setting Epeak to zero in the BEAM card would select an
     amorphous radiator instead of diamond.