### PR TITLE
* programs/Simulation/HDGeant/hitTag.c [rtj]

### DIFF
--- a/src/programs/Simulation/HDGeant/gukine.F
+++ b/src/programs/Simulation/HDGeant/gukine.F
@@ -268,22 +268,27 @@ c         print *, ngen,' background photons generated this event'
 *           distribute evenly in the log of total momentum(theta).
 *           Otherwise, distribute evenly in total momentum(theta).
 *           3/17/2009  DL
-                            IF (plog_particle_gun.EQ.0) THEN
+*
+            IF (plog_particle_gun.EQ.0) THEN
                PABS=PKINE(1)+PKINE(4)*(RNDM(1)-0.5)
-                            ELSE
+            ELSE
                pmin=PKINE(1)-0.5*PKINE(4)
                pmax=PKINE(1)+0.5*PKINE(4)
-               IF (pmin.LE.0) pmin=0.100
+               IF (pmin.LE.0) THEN
+                  pmin=0.100
+               ENDIF
                PABS=pmin*(pmax/pmin)**RNDM(1)
-                            ENDIF
-                            IF (tlog_particle_gun.EQ.0) THEN
+            ENDIF
+            IF (tlog_particle_gun.EQ.0) THEN
                THETA=REAL((PKINE(2)+PKINE(5)*(RNDM(2)-0.5))*DEGRAD)
-                            ELSE
+            ELSE
                thetamin=PKINE(2)-0.5*PKINE(5)
                thetamax=PKINE(2)+0.5*PKINE(5)
-               IF (thetamin.LE.0) thetamin=0.9
-               THETA=REAL((thetamin*(thetamax/thetamin)**RNDM(2))*DEGRAD)
-                            ENDIF
+               IF (thetamin.LE.0) THEN
+                  thetamin=0.9
+               ENDIF
+               THETA=REAL(thetamin*(thetamax/thetamin)**RNDM(2)*DEGRAD)
+            ENDIF
             PHI=REAL((PKINE(3)+PKINE(6)*(RNDM(3)-0.5))*DEGRAD)
          ELSE
             IK=IKINE

--- a/src/programs/Simulation/HDGeant/hitTag.c
+++ b/src/programs/Simulation/HDGeant/hitTag.c
@@ -49,7 +49,6 @@
 #define FIXED_TWO_HIT_RESOL     25.
 #define FIXED_MAX_HITS          5000
 #define C_CM_PER_NS             29.9792458
-#define REF_TIME_Z_CM           65.
 #define TAG_T_MIN_NS            -200
 #define TAG_T_MAX_NS            +200
 
@@ -66,6 +65,8 @@ static int microCount = 0;
 static int hodoCount = 0;
 static int printDone = 0;
 static float beam_period = -1.0;
+
+float get_reference_plane_();
 
 /* register hits during event initialization (from gukine) */
 
@@ -91,7 +92,8 @@ void hitTagger (float xin[4], float xout[4],
    int hodo_chan;
    double Etag = 0;
    double E = pin[3];
-   double t = xin[3]*1e9-(xin[2]-REF_TIME_Z_CM)/C_CM_PER_NS;
+   float ref_time_z_cm = get_reference_plane_();
+   double t = xin[3]*1e9-(xin[2]-ref_time_z_cm)/C_CM_PER_NS;
    t = floor(t/beam_period+0.5)*beam_period;
 
    /* read tagger set endpoint energy from calibdb */


### PR DESCRIPTION
   - fix a bug found by Elton, where the time reference z-plane was
     hard-wired to 65 cm, and it should be fetching the value from ccdb.

* programs/Simulation/HDGeant/gukine.F [rtj]
   - fix a fortran formatting error, where indentation is confusing, and
     one of the line goes past column 72 -- a fortran no-no that should
     be flagged by the compiler. Next version of gfortran maybe?