### PR TITLE
Many changes

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisResults_factory.cc
+++ b/src/libraries/ANALYSIS/DAnalysisResults_factory.cc
@@ -411,7 +411,8 @@ const DParticleCombo* DAnalysisResults_factory::Handle_ComboFit(const DReactionV
 
 	//A given combo can be used for multiple DReactions, each with a different fit type or update-cov flag
 	auto locUpdateCovMatricesFlag = locReaction->Get_KinFitUpdateCovarianceMatricesFlag();
-	auto locComboKinFitTuple = std::make_tuple(locParticleCombo, locKinFitType, locUpdateCovMatricesFlag);
+	auto locNoConstrainMassSteps = DAnalysis::Get_NoConstrainMassSteps(locReaction);
+	auto locComboKinFitTuple = std::make_tuple(locParticleCombo, locKinFitType, locUpdateCovMatricesFlag, locNoConstrainMassSteps);
 
 	//Check if same fit with this combo already done. If so, return it.
 	auto locComboIterator = dPreToPostKinFitComboMap.find(locComboKinFitTuple);

--- a/src/libraries/ANALYSIS/DAnalysisResults_factory.h
+++ b/src/libraries/ANALYSIS/DAnalysisResults_factory.h
@@ -74,7 +74,7 @@ class DAnalysisResults_factory : public jana::JFactory<DAnalysisResults>
 		DKinFitter* dKinFitter;
 		DKinFitUtils_GlueX* dKinFitUtils;
 		map<pair<set<shared_ptr<DKinFitConstraint>>, bool>, DKinFitResults*> dConstraintResultsMap; //used for determining if kinfit results will be identical //bool: update cov matrix flag
-		map<tuple<const DParticleCombo*, DKinFitType, bool>, const DParticleCombo*> dPreToPostKinFitComboMap;
+		map<tuple<const DParticleCombo*, DKinFitType, bool, set<size_t>>, const DParticleCombo*> dPreToPostKinFitComboMap; //set: no-mass-constrain steps //bool: update cov matrix flag
 
 		DResourcePool<DKinFitResults> dResourcePool_KinFitResults;
 		vector<DKinFitResults*> dCreatedKinFitResults;

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -544,6 +544,7 @@ void DEventWriterROOT::Create_Branches_Thrown(DTreeBranchRegister& locBranchRegi
 	locBranchRegister.Register_Single<Int_t>(Build_BranchName("ThrownBeam", "PID"));
 	locBranchRegister.Register_Single<TLorentzVector>(Build_BranchName("ThrownBeam", "X4")); //reported at target center
 	locBranchRegister.Register_Single<TLorentzVector>(Build_BranchName("ThrownBeam", "P4"));
+	locBranchRegister.Register_Single<Float_t>(Build_BranchName("ThrownBeam", "HitEnergy"));
 
 	//EVENT-WIDE INFO
 	locBranchRegister.Register_Single<ULong64_t>("NumPIDThrown_FinalState"); //19 digits
@@ -1322,6 +1323,8 @@ void DEventWriterROOT::Fill_ThrownInfo(DTreeFillData* locTreeFillData, const DMC
 
 	//THROWN BEAM
 	locTreeFillData->Fill_Single<Int_t>(Build_BranchName("ThrownBeam", "PID"), PDGtype(locMCReaction->beam.PID()));
+//REDO: locMCThrownMatching == null!
+	locTreeFillData->Fill_Single<Float_t>(Build_BranchName("ThrownBeam", "HitEnergy"), locMCThrownMatching->Get_ReconMCGENBeamPhoton()->energy());
 
 	DVector3 locThrownBeamX3 = locMCReaction->beam.position();
 	TLorentzVector locThrownBeamTX4(locThrownBeamX3.X(), locThrownBeamX3.Y(), locThrownBeamX3.Z(), locMCReaction->beam.time());

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -544,7 +544,7 @@ void DEventWriterROOT::Create_Branches_Thrown(DTreeBranchRegister& locBranchRegi
 	locBranchRegister.Register_Single<Int_t>(Build_BranchName("ThrownBeam", "PID"));
 	locBranchRegister.Register_Single<TLorentzVector>(Build_BranchName("ThrownBeam", "X4")); //reported at target center
 	locBranchRegister.Register_Single<TLorentzVector>(Build_BranchName("ThrownBeam", "P4"));
-	locBranchRegister.Register_Single<Float_t>(Build_BranchName("ThrownBeam", "HitEnergy"));
+	locBranchRegister.Register_Single<Float_t>(Build_BranchName("ThrownBeam", "GeneratedEnergy"));
 
 	//EVENT-WIDE INFO
 	locBranchRegister.Register_Single<ULong64_t>("NumPIDThrown_FinalState"); //19 digits
@@ -1324,7 +1324,7 @@ void DEventWriterROOT::Fill_ThrownInfo(DTreeFillData* locTreeFillData, const DMC
 	//THROWN BEAM
 	locTreeFillData->Fill_Single<Int_t>(Build_BranchName("ThrownBeam", "PID"), PDGtype(locMCReaction->beam.PID()));
 //REDO: locMCThrownMatching == null!
-	locTreeFillData->Fill_Single<Float_t>(Build_BranchName("ThrownBeam", "HitEnergy"), locMCThrownMatching->Get_ReconMCGENBeamPhoton()->energy());
+//	locTreeFillData->Fill_Single<Float_t>(Build_BranchName("ThrownBeam", "GeneratedEnergy"), locMCThrownMatching->Get_ReconMCGENBeamPhoton()->energy());
 
 	DVector3 locThrownBeamX3 = locMCReaction->beam.position();
 	TLorentzVector locThrownBeamTX4(locThrownBeamX3.X(), locThrownBeamX3.Y(), locThrownBeamX3.Z(), locMCReaction->beam.time());

--- a/src/libraries/ANALYSIS/DHistogramActions_Thrown.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Thrown.h
@@ -80,7 +80,7 @@ class DHistogramAction_ParticleComboGenReconComparison : public DAnalysisAction
 		DAnalysisAction(locReaction, "Hist_ParticleComboGenReconComparison", locUseKinFitResultsFlag, locActionUniqueString), 
 		dNumDeltaPOverPBins(500), dNumDeltaThetaBins(240), dNumDeltaPhiBins(400), dNumDeltaTBins(500), dNumDeltaVertexZBins(300), dNum2DPBins(250), dNum2DThetaBins(140),
 		dNumRFDeltaTBins(202), dNumPullBins(500), dNum2DPullBins(250), dMinDeltaPOverP(-0.4), dMaxDeltaPOverP(0.4), dMinDeltaTheta(-1.0), dMaxDeltaTheta(1.0), dMinDeltaPhi(-6.0), dMaxDeltaPhi(6.0), dMinDeltaT(-5.0), 
-		dMaxDeltaT(5.0), dMinDeltaVertexZ(-15.0), dMaxDeltaVertexZ(15.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinRFDeltaT(-10.1), dMaxRFDeltaT(10.1)
+		dMaxDeltaT(5.0), dMinDeltaVertexZ(-15.0), dMaxDeltaVertexZ(15.0), dMinP(0.0), dMaxP(12.0), dMinTheta(0.0), dMaxTheta(140.0), dMinRFDeltaT(-10.1), dMaxRFDeltaT(10.1)
 		{
 			dPullTypes.resize(8);
 			dPullTypes[0] = d_EPull;  dPullTypes[1] = d_PxPull;  dPullTypes[2] = d_PyPull;  dPullTypes[3] = d_PzPull;
@@ -162,8 +162,8 @@ class DHistogramAction_ThrownParticleKinematics : public DAnalysisAction
 	public:
 		DHistogramAction_ThrownParticleKinematics(const DReaction* locReaction, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Hist_ThrownParticleKinematics", false, locActionUniqueString), 
-		dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400), dNumVertexXYBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180),
-		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0)
+		dNumPBins(600), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400), dNumVertexXYBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180),
+		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(12.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0)
 		{
 			dFinalStatePIDs.push_back(Gamma);  dFinalStatePIDs.push_back(Neutron);
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
@@ -172,8 +172,8 @@ class DHistogramAction_ThrownParticleKinematics : public DAnalysisAction
 
 		DHistogramAction_ThrownParticleKinematics(string locActionUniqueString) : 
 		DAnalysisAction(NULL, "Hist_ThrownParticleKinematics", false, locActionUniqueString), 
-		dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400), dNumVertexXYBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180),
-		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0)
+		dNumPBins(600), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400), dNumVertexXYBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180),
+		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(12.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0)
 		{
 			dFinalStatePIDs.push_back(Gamma);  dFinalStatePIDs.push_back(Neutron);
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
@@ -182,8 +182,8 @@ class DHistogramAction_ThrownParticleKinematics : public DAnalysisAction
 
 		DHistogramAction_ThrownParticleKinematics(void) : 
 		DAnalysisAction(NULL, "Hist_ThrownParticleKinematics", false, ""), 
-		dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400), dNumVertexXYBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180),
-		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0)
+		dNumPBins(600), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400), dNumVertexXYBins(400), dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180),
+		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(12.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0), dMaxVertexZ(200.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0)
 		{
 			dFinalStatePIDs.push_back(Gamma);  dFinalStatePIDs.push_back(Neutron);
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
@@ -222,9 +222,9 @@ class DHistogramAction_ReconnedThrownKinematics : public DAnalysisAction
 	public:
 		DHistogramAction_ReconnedThrownKinematics(const DReaction* locReaction, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Hist_ReconnedThrownKinematics", false, locActionUniqueString), 
-		dMinThrownMatchFOM(5.73303E-7), dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400), dNumVertexXYBins(400),
+		dMinThrownMatchFOM(5.73303E-7), dNumPBins(600), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400), dNumVertexXYBins(400),
 		dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumBetaBins(400),
-		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0),
+		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(12.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0),
 		dMaxVertexZ(200.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2)
 		{
 			dFinalStatePIDs.push_back(Gamma);  dFinalStatePIDs.push_back(Neutron);
@@ -236,9 +236,9 @@ class DHistogramAction_ReconnedThrownKinematics : public DAnalysisAction
 
 		DHistogramAction_ReconnedThrownKinematics(string locActionUniqueString) : 
 		DAnalysisAction(NULL, "Hist_ReconnedThrownKinematics", false, locActionUniqueString), 
-		dMinThrownMatchFOM(5.73303E-7), dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400), dNumVertexXYBins(400),
+		dMinThrownMatchFOM(5.73303E-7), dNumPBins(600), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400), dNumVertexXYBins(400),
 		dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumBetaBins(400),
-		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0),
+		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(12.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0),
 		dMaxVertexZ(200.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2)
 		{
 			dFinalStatePIDs.push_back(Gamma);  dFinalStatePIDs.push_back(Neutron);
@@ -250,9 +250,9 @@ class DHistogramAction_ReconnedThrownKinematics : public DAnalysisAction
 
 		DHistogramAction_ReconnedThrownKinematics(void) : 
 		DAnalysisAction(NULL, "Hist_ReconnedThrownKinematics", false, ""), 
-		dMinThrownMatchFOM(5.73303E-7), dNumPBins(500), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400), dNumVertexXYBins(400),
+		dMinThrownMatchFOM(5.73303E-7), dNumPBins(600), dNumThetaBins(560), dNumPhiBins(360), dNumVertexZBins(600), dNumTBins(400), dNumVertexXYBins(400),
 		dNum2DPBins(250), dNum2DThetaBins(140), dNum2DPhiBins(180), dNumBetaBins(400),
-		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0),
+		dMinT(-20.0), dMaxT(20.0), dMinP(0.0), dMaxP(12.0), dMinTheta(0.0), dMaxTheta(140.0), dMinPhi(-180.0), dMaxPhi(180.0), dMinVertexZ(0.0),
 		dMaxVertexZ(200.0), dMinVertexXY(-10.0), dMaxVertexXY(10.0), dMinBeta(-0.2), dMaxBeta(1.2)
 		{
 			dFinalStatePIDs.push_back(Gamma);  dFinalStatePIDs.push_back(Neutron);
@@ -299,7 +299,7 @@ class DHistogramAction_GenReconTrackComparison : public DAnalysisAction
 		dNumDeltaPOverPBins(500), dNumDeltaThetaBins(240), dNumDeltaPhiBins(400), dNumDeltaTBins(500), dNumDeltaVertexZBins(300), dNum2DPBins(250), dNum2DThetaBins(140),
 		dNumRFDeltaTBins(202), dNumPullBins(500), dNum2DPullBins(250), dNumMCMatchingFOMBins(500), dMinDeltaPOverP(-0.4), dMaxDeltaPOverP(0.4), dMinDeltaTheta(-1.0), 
 		dMaxDeltaTheta(1.0), dMinDeltaPhi(-6.0), dMaxDeltaPhi(6.0), dMinDeltaT(-5.0), dMaxDeltaT(5.0), dMinDeltaVertexZ(-15.0), dMaxDeltaVertexZ(15.0), 
-		dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinRFDeltaT(-10.1), dMaxRFDeltaT(10.1)
+		dMinP(0.0), dMaxP(12.0), dMinTheta(0.0), dMaxTheta(140.0), dMinRFDeltaT(-10.1), dMaxRFDeltaT(10.1)
 		{
 			dFinalStatePIDs.push_back(Gamma);  dFinalStatePIDs.push_back(Neutron);
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
@@ -315,7 +315,7 @@ class DHistogramAction_GenReconTrackComparison : public DAnalysisAction
 		dNumDeltaPOverPBins(500), dNumDeltaThetaBins(240), dNumDeltaPhiBins(400), dNumDeltaTBins(500), dNumDeltaVertexZBins(300), dNum2DPBins(250), dNum2DThetaBins(140),
 		dNumRFDeltaTBins(202), dNumPullBins(500), dNum2DPullBins(250), dNumMCMatchingFOMBins(500), dMinDeltaPOverP(-0.4), dMaxDeltaPOverP(0.4), dMinDeltaTheta(-1.0), 
 		dMaxDeltaTheta(1.0), dMinDeltaPhi(-6.0), dMaxDeltaPhi(6.0), dMinDeltaT(-5.0), dMaxDeltaT(5.0), dMinDeltaVertexZ(-15.0), dMaxDeltaVertexZ(15.0), 
-		dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinRFDeltaT(-10.1), dMaxRFDeltaT(10.1)
+		dMinP(0.0), dMaxP(12.0), dMinTheta(0.0), dMaxTheta(140.0), dMinRFDeltaT(-10.1), dMaxRFDeltaT(10.1)
 		{
 			dFinalStatePIDs.push_back(Gamma);  dFinalStatePIDs.push_back(Neutron);
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
@@ -331,7 +331,7 @@ class DHistogramAction_GenReconTrackComparison : public DAnalysisAction
 		dNumDeltaPOverPBins(500), dNumDeltaThetaBins(240), dNumDeltaPhiBins(400), dNumDeltaTBins(500), dNumDeltaVertexZBins(300), dNum2DPBins(250), dNum2DThetaBins(140),
 		dNumRFDeltaTBins(202), dNumPullBins(500), dNum2DPullBins(250), dNumMCMatchingFOMBins(500), dMinDeltaPOverP(-0.4), dMaxDeltaPOverP(0.4), dMinDeltaTheta(-1.0), 
 		dMaxDeltaTheta(1.0), dMinDeltaPhi(-6.0), dMaxDeltaPhi(6.0), dMinDeltaT(-5.0), dMaxDeltaT(5.0), dMinDeltaVertexZ(-15.0), dMaxDeltaVertexZ(15.0), 
-		dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0), dMinRFDeltaT(-10.1), dMaxRFDeltaT(10.1)
+		dMinP(0.0), dMaxP(12.0), dMinTheta(0.0), dMaxTheta(140.0), dMinRFDeltaT(-10.1), dMaxRFDeltaT(10.1)
 		{
 			dFinalStatePIDs.push_back(Gamma);  dFinalStatePIDs.push_back(Neutron);
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
@@ -404,7 +404,7 @@ class DHistogramAction_TruePID : public DAnalysisAction
 	public:
 		DHistogramAction_TruePID(const DReaction* locReaction, string locActionUniqueString = "") : 
 		DAnalysisAction(locReaction, "Hist_TruePID", false, locActionUniqueString),
-		dNumPBins(300), dNum2DPBins(150), dNumThetaBins(140), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0)/*, dMinThrownMatchFOM(5.73303E-7)*/
+		dNumPBins(300), dNum2DPBins(150), dNumThetaBins(140), dMinP(0.0), dMaxP(12.0), dMinTheta(0.0), dMaxTheta(140.0)/*, dMinThrownMatchFOM(5.73303E-7)*/
 		{
 			dAnalysisUtilities = NULL;
 		}

--- a/src/libraries/ANALYSIS/DReaction.h
+++ b/src/libraries/ANALYSIS/DReaction.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <set>
 
 #include "JANA/JObject.h"
 #include "JANA/JEventLoop.h"
@@ -189,6 +190,17 @@ inline bool Check_ChannelEquality(const DReaction* lhs, const DReaction* rhs, bo
 	auto Equality_Checker = [&locSameOrderFlag, &locRightSubsetOfLeftFlag](const DReactionStep* lhs, const DReactionStep* rhs) -> bool
 		{return DAnalysis::Check_ChannelEquality(lhs, rhs, locSameOrderFlag, locRightSubsetOfLeftFlag);};
 	return std::equal(locSteps_lhs.begin(), locSteps_lhs.end(), locSteps_rhs.begin(), Equality_Checker);
+}
+
+inline set<size_t> Get_NoConstrainMassSteps(const DReaction* locReaction)
+{
+	set<size_t> locNoConstrainMassSteps;
+	for(size_t loc_i = 0; loc_i < locReaction->Get_NumReactionSteps(); ++loc_i)
+	{
+		if(!locReaction->Get_ReactionStep(loc_i)->Get_KinFitConstrainInitMassFlag())
+			locNoConstrainMassSteps.insert(loc_i);
+	}
+	return locNoConstrainMassSteps;
 }
 
 /****************************************************** NAMESPACE-SCOPE INLINE FUNCTIONS: PIDS *******************************************************/

--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -2341,6 +2341,7 @@ jerror_t DEventSourceHDDM::Extract_DTAGMHit(hddm_s::HDDM *record,
             taghit->row = hiter->getRow();
 	    taghit->has_fADC = true;
 	    taghit->has_TDC = true;           
+	    taghit->bg = hiter->getBg();
 	    data.push_back(taghit);
          }
       }
@@ -2401,6 +2402,7 @@ jerror_t DEventSourceHDDM::Extract_DTAGHHit( hddm_s::HDDM *record,
             taghit->counter_id = hiter->getCounterId();
 	    taghit->has_fADC = true;
 	    taghit->has_TDC = true;
+	    taghit->bg = hiter->getBg();
             data.push_back(taghit);
          }
       }

--- a/src/libraries/PID/DBeamPhoton.h
+++ b/src/libraries/PID/DBeamPhoton.h
@@ -19,7 +19,7 @@ class DBeamPhoton: public DKinematicData
 		DetectorSystem_t dSystem; //SYS_TAGM or SYS_TAGH
 
 		void toStrings(vector<pair<string,string> > &items)const{
-			AddString(items, "E(GeV)", "%3.3f", momentum().Mag());
+			AddString(items, "E(GeV)", "%f", momentum().Mag());
 			AddString(items, "System", "%s", SystemName(dSystem));
 			AddString(items, "Counter", "%d", dCounter);
 			AddString(items, "t(ns)", "%3.1f", time());

--- a/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.cc
+++ b/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.cc
@@ -1,0 +1,96 @@
+// $Id$
+//
+//    File: DBeamPhoton_factory_TAGGEDMCGEN.cc
+// Created: Thu Dec  3 17:27:55 EST 2009
+// Creator: staylor (on Linux ifarml6 2.6.18-128.el5 x86_64)
+//
+
+#include <iostream>
+#include <iomanip>
+using namespace std;
+
+#include "DBeamPhoton_factory_TAGGEDMCGEN.h"
+using namespace jana;
+
+//------------------
+// init
+//------------------
+jerror_t DBeamPhoton_factory_TAGGEDMCGEN::init(void)
+{
+	return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t DBeamPhoton_factory_TAGGEDMCGEN::brun(jana::JEventLoop *locEventLoop, int32_t runnumber)
+{
+	DApplication* dapp = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry* locGeometry = dapp->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+	dTargetCenterZ = 0.0;
+	locGeometry->GetTargetZ(dTargetCenterZ);
+
+	return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t DBeamPhoton_factory_TAGGEDMCGEN::evnt(jana::JEventLoop *locEventLoop, uint64_t eventnumber)
+{
+	DVector3 pos(0.0, 0.0, dTargetCenterZ);
+
+	vector<const DTAGMHit*> tagm_hits;
+	locEventLoop->Get(tagm_hits, "TRUTH");
+	for (unsigned int ih=0; ih < tagm_hits.size(); ++ih)
+	{
+		if (tagm_hits[ih]->bg != 0) continue;
+		if (tagm_hits[ih]->row > 0) continue;
+		DVector3 mom(0.0, 0.0, tagm_hits[ih]->E);
+		DBeamPhoton *gamma = new DBeamPhoton;
+		gamma->setPID(Gamma);
+		gamma->setMomentum(mom);
+		gamma->setPosition(pos);
+		gamma->setTime(tagm_hits[ih]->t);
+	    gamma->dSystem = SYS_TAGM;
+		gamma->dCounter = tagm_hits[ih]->column;
+		gamma->AddAssociatedObject(tagm_hits[ih]);
+		_data.push_back(gamma);
+	}
+
+	vector<const DTAGHHit*> tagh_hits;
+	locEventLoop->Get(tagh_hits, "TRUTH");
+	for (unsigned int ih=0; ih < tagh_hits.size(); ++ih)
+	{
+		if (tagh_hits[ih]->bg != 0) continue;
+		DVector3 mom(0.0, 0.0, tagh_hits[ih]->E);
+		DBeamPhoton *gamma = new DBeamPhoton;
+		gamma->setPID(Gamma);
+		gamma->setMomentum(mom);
+		gamma->setPosition(pos);
+		gamma->setTime(tagh_hits[ih]->t);
+	    gamma->dSystem = SYS_TAGH;
+		gamma->dCounter = tagh_hits[ih]->counter_id;
+		gamma->AddAssociatedObject(tagh_hits[ih]);
+		_data.push_back(gamma);
+	}
+
+	return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t DBeamPhoton_factory_TAGGEDMCGEN::erun(void)
+{
+	return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t DBeamPhoton_factory_TAGGEDMCGEN::fini(void)
+{
+	return NOERROR;
+}
+

--- a/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.h
+++ b/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.h
@@ -1,0 +1,34 @@
+// $Id$
+//
+//    File: DBeamPhoton_factory_TAGGEDMCGEN.h
+// Created: Mon Aug  5 14:29:24 EST 2014
+// Creator: pmatt (on Linux ifarml6 2.6.18-128.el5 x86_64)
+//
+
+#ifndef _DBeamPhoton_factory_TAGGEDMCGEN_
+#define _DBeamPhoton_factory_TAGGEDMCGEN_
+
+#include <JANA/JFactory.h>
+#include <PID/DBeamPhoton.h>
+#include <TAGGER/DTAGMHit.h>
+#include <TAGGER/DTAGHHit.h>
+#include <DANA/DApplication.h>
+
+class DBeamPhoton_factory_TAGGEDMCGEN:public jana::JFactory<DBeamPhoton>{
+	public:
+		DBeamPhoton_factory_TAGGEDMCGEN(){};
+		~DBeamPhoton_factory_TAGGEDMCGEN(){};
+		const char* Tag(void){return "TAGGEDMCGEN";}
+
+	private:
+		jerror_t init(void);						///< Called once at program start.
+		jerror_t brun(jana::JEventLoop *locEventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+		jerror_t evnt(jana::JEventLoop *locEventLoop, uint64_t eventnumber);	///< Called every event.
+		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+		double dTargetCenterZ;
+};
+
+#endif // _DBeamPhoton_factory_TAGGEDMCGEN_
+

--- a/src/libraries/PID/DMCReaction.h
+++ b/src/libraries/PID/DMCReaction.h
@@ -28,7 +28,7 @@ class DMCReaction:public JObject{
 			AddString(items, "type", "%2d", type);
 			AddString(items, "weight", "%3.1f", weight);
 			AddString(items, "mass target(GeV)", "%3.1f", target.mass());
-			AddString(items, "energy beam(GeV/c^2)", "%3.1f", beam.energy());
+			AddString(items, "energy beam(GeV/c^2)", "%f", beam.energy());
 		}
 
 	protected:

--- a/src/libraries/PID/PID_init.cc
+++ b/src/libraries/PID/PID_init.cc
@@ -5,6 +5,7 @@ using namespace jana;
 
 #include "DBeamPhoton_factory.h"
 #include "DBeamPhoton_factory_TRUTH.h"
+#include "DBeamPhoton_factory_TAGGEDMCGEN.h"
 #include "DParticleID_factory.h"
 #include "DParticleID_factory_PID1.h"
 #include "DChargedTrack_factory.h"
@@ -38,6 +39,7 @@ jerror_t PID_init(JEventLoop *loop)
 	loop->AddFactory(new JFactory<DBeamPhoton>("MCGEN"));
 	loop->AddFactory(new DBeamPhoton_factory);
 	loop->AddFactory(new DBeamPhoton_factory_TRUTH);
+	loop->AddFactory(new DBeamPhoton_factory_TAGGEDMCGEN);
 	loop->AddFactory(new DParticleID_factory);
 	loop->AddFactory(new DParticleID_factory_PID1);
 	loop->AddFactory(new DChargedTrack_factory);

--- a/src/libraries/TAGGER/DTAGHHit.h
+++ b/src/libraries/TAGGER/DTAGHHit.h
@@ -24,6 +24,7 @@ class DTAGHHit:public jana::JObject{
       double time_fadc;
       double npe_fadc;
       bool has_fADC, has_TDC, is_double;
+      int bg = -1; //if MC, 0 for the photon that generated the event, nonzero otherwise //ignore if not MC
 
       void toStrings(vector<pair<string,string> > &items)const{
         AddString(items, "counter_id", "%d", counter_id);
@@ -37,6 +38,7 @@ class DTAGHHit:public jana::JObject{
         AddString(items, "has_fADC", "%d", (int)has_fADC);
         AddString(items, "has_TDC", "%d", (int)has_TDC);
         AddString(items, "is_double", "%d", (int)is_double);
+        AddString(items, "bg", "%d", bg);
       }
 };
 

--- a/src/libraries/TAGGER/DTAGMHit.h
+++ b/src/libraries/TAGGER/DTAGMHit.h
@@ -25,6 +25,7 @@ class DTAGMHit:public jana::JObject{
       double time_fadc;
       double npix_fadc;
       bool has_fADC,has_TDC;
+      int bg = -1; //if MC, 0 for the photon that generated the event, nonzero otherwise //ignore if not MC
 
       void toStrings(vector<pair<string,string> > &items) const {
         AddString(items, "row", "%d", row);
@@ -38,6 +39,7 @@ class DTAGMHit:public jana::JObject{
         AddString(items, "npix_fadc", "%f", (float)npix_fadc);
         AddString(items, "has_fADC", "%d", (int)has_fADC);
         AddString(items, "has_TDC", "%d", (int)has_TDC);
+        AddString(items, "bg", "%d", bg);
       }
 };
 

--- a/src/plugins/Analysis/Z2pi_trees/DCustomAction_Z2pi_hists.cc
+++ b/src/plugins/Analysis/Z2pi_trees/DCustomAction_Z2pi_hists.cc
@@ -75,6 +75,9 @@ void DCustomAction_Z2pi_hists::Initialize(JEventLoop* locEventLoop)
 
 	dEgamma_M2pi = GetOrCreate_Histogram<TH2I>("Egamma_M2pi", "E_{#gamma} vs M_{#pi^{+}#pi^{-}}; M_{#pi^{+}#pi^{-}}; E_{#gamma}", 200, 0.0, 2.0, endpoint_energy_bins,0,endpoint_energy);		
 
+	//Return to the base directory
+	ChangeTo_BaseDirectory();
+
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }
 

--- a/src/plugins/Analysis/Z2pi_trees/DCustomAction_Z2pi_trees.cc
+++ b/src/plugins/Analysis/Z2pi_trees/DCustomAction_Z2pi_trees.cc
@@ -76,6 +76,9 @@ void DCustomAction_Z2pi_trees::Initialize(JEventLoop* locEventLoop)
 
 	dEgamma_M2pi = GetOrCreate_Histogram<TH2I>("Egamma_M2pi", "E_{#gamma} vs M_{#pi^{+}#pi^{-}}; M_{#pi^{+}#pi^{-}}; E_{#gamma}", 200, 0.0, 1.0, endpoint_energy_bins,0,endpoint_energy);		
 
+	//Return to the base directory
+	ChangeTo_BaseDirectory();
+
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }
 

--- a/src/plugins/Analysis/Z2pi_trees/DCustomAction_Z2pi_unusedHists.cc
+++ b/src/plugins/Analysis/Z2pi_trees/DCustomAction_Z2pi_unusedHists.cc
@@ -242,6 +242,9 @@ void DCustomAction_Z2pi_unusedHists::Initialize(JEventLoop* locEventLoop)
 				}
 			}
 		}
+
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_hists.cc
+++ b/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_hists.cc
@@ -72,6 +72,8 @@ void DCustomAction_p2gamma_hists::Initialize(JEventLoop* locEventLoop)
 		
 		dMinEgamma_M2g = GetOrCreate_Histogram<TH2I>("MinEgamma_M2g", "Minimum E_{#gamma} vs M_{#gamma#gamma}; M_{#gamma#gamma}; Minimum E_{#gamma}", 500, 0., 1., 200, 0., 2.);
 
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_unusedHists.cc
+++ b/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_unusedHists.cc
@@ -148,6 +148,9 @@ void DCustomAction_p2gamma_unusedHists::Initialize(JEventLoop* locEventLoop)
 				}
 			}
 		}
+
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p2k_hists/DCustomAction_p2k_hists.cc
+++ b/src/plugins/Analysis/p2k_hists/DCustomAction_p2k_hists.cc
@@ -76,6 +76,8 @@ void DCustomAction_p2k_hists::Initialize(JEventLoop* locEventLoop)
 		dKplus_P_Theta_RhoTag = GetOrCreate_Histogram<TH2I>("Kplus_P_Theta_RhoTag","K+ p vs #theta; #theta; p (GeV)",180,0,180,200,0.,10.);
 		dKminus_P_Theta_RhoTag = GetOrCreate_Histogram<TH2I>("Kminus_P_Theta_RhoTag","K- p vs #theta; #theta; p (GeV)",180,0,180,200,0.,10.);
 
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p2pi0_hists/DCustomAction_p2pi0_hists.cc
+++ b/src/plugins/Analysis/p2pi0_hists/DCustomAction_p2pi0_hists.cc
@@ -49,6 +49,9 @@ void DCustomAction_p2pi0_hists::Initialize(JEventLoop* locEventLoop)
 
 		dProton_dEdx_P = GetOrCreate_Histogram<TH2I>("Proton_dEdx_P","dE/dx vs p; p; dE/dx",200,0,2,500,0,5);
 		dProton_P_Theta = GetOrCreate_Histogram<TH2I>("Proton_P_Theta","p vs #theta; #theta; p (GeV/c)",180,0,180,120,0,12);
+
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.cc
@@ -91,6 +91,9 @@ void DCustomAction_p2pi_hists::Initialize(JEventLoop* locEventLoop)
 			dBaryonM_CosTheta_Egamma2 = GetOrCreate_Histogram<TH2I>("BaryonM_CosTheta_Egamma2", "Baryon M_{p#pi^{+}} vs cos#theta: 2.5 < E_{#gamma} < 3.0; cos#theta; M_{p#pi^{+}}", 100, -1, 1, 100, 1.0, 2.5);
 			dBaryonM_CosTheta_Egamma3 = GetOrCreate_Histogram<TH2I>("BaryonM_CosTheta_Egamma3", "Baryon M_{p#pi^{+}} vs cos#theta: E_{#gamma} > 3.0; cos#theta; M_{p#pi^{+}}", 100, -1, 1, 100, 1.0, 2.5);
 		}
+
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.cc
@@ -242,6 +242,8 @@ void DCustomAction_p2pi_unusedHists::Initialize(JEventLoop* locEventLoop)
 				}
 			}
 		}
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p2pi_trees/DCustomAction_p2pi_hists.cc
+++ b/src/plugins/Analysis/p2pi_trees/DCustomAction_p2pi_hists.cc
@@ -90,6 +90,9 @@ void DCustomAction_p2pi_hists::Initialize(JEventLoop* locEventLoop)
 			dBaryonM_CosTheta_Egamma2 = GetOrCreate_Histogram<TH2I>("BaryonM_CosTheta_Egamma2", "Baryon M_{p#pi^{+}} vs cos#theta: 2.5 < E_{#gamma} < 3.0; cos#theta; M_{p#pi^{+}}", 100, -1, 1, 100, 1.0, 2.5);
 			dBaryonM_CosTheta_Egamma3 = GetOrCreate_Histogram<TH2I>("BaryonM_CosTheta_Egamma3", "Baryon M_{p#pi^{+}} vs cos#theta: E_{#gamma} > 3.0; cos#theta; M_{p#pi^{+}}", 100, -1, 1, 100, 1.0, 2.5);
 		}
+
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p2pi_trees/DCustomAction_p2pi_unusedHists.cc
+++ b/src/plugins/Analysis/p2pi_trees/DCustomAction_p2pi_unusedHists.cc
@@ -242,6 +242,8 @@ void DCustomAction_p2pi_unusedHists::Initialize(JEventLoop* locEventLoop)
 				}
 			}
 		}
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraPi0.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraPi0.cc
@@ -21,6 +21,9 @@ void DCustomAction_CutExtraPi0::Initialize(JEventLoop* locEventLoop)
 		CreateAndChangeTo_ActionDirectory();
 
 		dHist_Pi0InvariantMass = GetOrCreate_Histogram<TH1I>("InvariantMass_Pi0", ";#gamma#gamma Invariant Mass (GeV/c^{2})", 600, 0.0, 0.3);
+
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_HistOmegaVsMissProton.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_HistOmegaVsMissProton.cc
@@ -30,6 +30,9 @@ void DCustomAction_HistOmegaVsMissProton::Initialize(JEventLoop* locEventLoop)
 		string locHistTitle = ";#it{#gamma}#it{p}#rightarrow#it{#pi}^{+}#it{#pi}^{-}#it{#gamma}#it{#gamma} Missing Mass (GeV/c^{2})";
 		locHistTitle += string(";#it{#pi}^{+}#it{#pi}^{-}#it{#gamma}#it{#gamma} Invariant Mass (GeV/c^{2})");
 		dHist_OmegaVsMissProton = GetOrCreate_Histogram<TH2I>("OmegaVsMissProton", locHistTitle, 325, 0.3, 1.6, 300, 0.5, 1.1);
+
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_p3pi_hists.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_p3pi_hists.cc
@@ -40,6 +40,8 @@ void DCustomAction_p3pi_hists::Initialize(JEventLoop* locEventLoop)
 		dDeltaE_M3pi_ProtonTag = GetOrCreate_Histogram<TH2I>("dDeltaE_M3pi_ProtonTag", "#Delta E vs M_{#pi^{+}#pi^{-}#pi^{0}}: Proton Tag; M_{#pi^{+}#pi^{-}#pi^{0}}; #Delta E (tagger - p#pi^{+}#pi^{-}#pi^{0})", 200, 0.0, 2.0, 200, -5., 5.);
 		dMM2_DeltaE_ProtonTag = GetOrCreate_Histogram<TH2I>("dMM2_DeltaE_ProtonTag", "MM^{2} vs #Delta E: Proton Tag; #Delta E (tagger - p#pi^{+}#pi^{-}#pi^{0}); MM^{2}", 200, -5., 5., 200, -1., 1.);
 		
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_CutExtraPi0.cc
+++ b/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_CutExtraPi0.cc
@@ -21,6 +21,9 @@ void DCustomAction_CutExtraPi0::Initialize(JEventLoop* locEventLoop)
 		CreateAndChangeTo_ActionDirectory();
 
 		dHist_Pi0InvariantMass = GetOrCreate_Histogram<TH1I>("InvariantMass_Pi0", ";#gamma#gamma Invariant Mass (GeV/c^{2})", 600, 0.0, 0.3);
+
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_HistOmegaVsMissProton.cc
+++ b/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_HistOmegaVsMissProton.cc
@@ -30,6 +30,9 @@ void DCustomAction_HistOmegaVsMissProton::Initialize(JEventLoop* locEventLoop)
 		string locHistTitle = ";#it{#gamma}#it{p}#rightarrow#it{#pi}^{+}#it{#pi}^{-}#it{#gamma}#it{#gamma} Missing Mass (GeV/c^{2})";
 		locHistTitle += string(";#it{#pi}^{+}#it{#pi}^{-}#it{#gamma}#it{#gamma} Invariant Mass (GeV/c^{2})");
 		dHist_OmegaVsMissProton = GetOrCreate_Histogram<TH2I>("OmegaVsMissProton", locHistTitle, 325, 0.3, 1.6, 300, 0.5, 1.1);
+
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }

--- a/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_ppi0gamma_hists.cc
+++ b/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_ppi0gamma_hists.cc
@@ -37,6 +37,8 @@ void DCustomAction_ppi0gamma_hists::Initialize(JEventLoop* locEventLoop)
 		dDeltaE_M3pi_ProtonTag = GetOrCreate_Histogram<TH2I>("dDeltaE_M3pi_ProtonTag", "#Delta E vs M_{#pi^{+}#pi^{-}#pi^{0}}: Proton Tag; M_{#pi^{+}#pi^{-}#pi^{0}}; #Delta E (tagger - p#pi^{+}#pi^{-}#pi^{0})", 200, 0.0, 2.0, 200, -5., 5.);
 		dMM2_DeltaE_ProtonTag = GetOrCreate_Histogram<TH2I>("dMM2_DeltaE_ProtonTag", "MM^{2} vs #Delta E: Proton Tag; #Delta E (tagger - p#pi^{+}#pi^{-}#pi^{0}); MM^{2}", 200, -5., 5., 200, -1., 1.);
 		
+		//Return to the base directory
+		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }


### PR DESCRIPTION
1) Fix bug where 2 reactions are identical but one has different mass
constraints than the other.

2) In custom analysis actions, cd to main dir after creating hists.

3) Add "bg" member to DTAG*Hit objects, which should signal whether the
tagger hit corresponds to the MC photon which caused the event.