### PR TITLE
change matching window for fADC with TDC hits and find all matches to…

### DIFF
--- a/src/libraries/TOF/DTOFHit_factory.cc
+++ b/src/libraries/TOF/DTOFHit_factory.cc
@@ -43,7 +43,7 @@ jerror_t DTOFHit_factory::init(void)
   gPARMS->SetDefaultParameter("TOF:USE_NEW_4WALKCORR", USE_NEW_4WALKCORR,
 			      "Use NEW walk correction function with 4 parameters");
   
-  DELTA_T_ADC_TDC_MAX = 10.0; // ns
+  DELTA_T_ADC_TDC_MAX = 20.0; // ns
   //	DELTA_T_ADC_TDC_MAX = 30.0; // ns, value based on the studies from cosmic events
   gPARMS->SetDefaultParameter("TOF:DELTA_T_ADC_TDC_MAX", DELTA_T_ADC_TDC_MAX, 
 			      "Maximum difference in ns between a (calibrated) fADC time and F1TDC time for them to be matched in a single hit");
@@ -366,6 +366,21 @@ jerror_t DTOFHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 	hit->has_fADC=false;
 	
 	_data.push_back(hit);
+      } else if (hit->has_TDC) { // this tof ADC hit has already a matching TDC, make new tof ADC hit
+	DTOFHit *newhit = new DTOFHit;
+	newhit->plane = hit->plane;
+	newhit->bar = hit->bar;
+	newhit->end = hit->end;
+	newhit->dE = hit->dE;
+	newhit->Amp = hit->Amp;
+	newhit->t_fADC = hit->t_fADC;
+	newhit->has_fADC = hit->has_fADC;
+	newhit->t_TDC=numeric_limits<double>::quiet_NaN();
+	newhit->t = hit->t_fADC;  // set initial time to the ADC time, in case there's no matching TDC hit	
+	newhit->has_TDC=false;
+	newhit->AddAssociatedObject(digihit);
+	_data.push_back(newhit);
+	hit = newhit;
       }
       hit->has_TDC=true;
       hit->t_TDC=T;


### PR DESCRIPTION
… put into the list

change the hit factory: make default time window for matching fADC hits with TDC hits bigger
and put all TDC hits into the hit list with best possible match of an fADC hit.
