### PR TITLE
Updated FCAL geometry to new block size

### DIFF
--- a/src/libraries/FCAL/DFCALGeometry.h
+++ b/src/libraries/FCAL/DFCALGeometry.h
@@ -45,8 +45,8 @@ public:
 	enum { kMidBlock = ( kBlocksWide - 1 ) / 2 };
 	enum { kBeamHoleSize = 3 };
 
-	static double blockSize()  { return 4*k_cm; }
-	static double radius()  { return 1.2*k_m; }
+	static double blockSize()  { return 4.0157*k_cm; }
+	static double radius()  { return 1.20471*k_m; }
 	static double blockLength()  { return 45.0*k_cm; }
 	//	static double fcalFaceZ()  { return 625.3*k_cm; }
 


### PR DESCRIPTION
Changed block size to 4.0157 cm from 4 cm and radius to 1.20471 m from 1.2 m.