### PR TITLE
Fcal energy weight time

### DIFF
--- a/src/libraries/FCAL/DFCALShower_factory.h
+++ b/src/libraries/FCAL/DFCALShower_factory.h
@@ -43,8 +43,11 @@ class DFCALShower_factory:public JFactory<DFCALShower>{
 		double expfit_param2;
 		double expfit_param3;
 		
-		double Timewalk_corr;
-
+		double timeConst0;
+                double timeConst1;
+		double timeConst2;
+                double timeConst3;
+                double timeConst4;
 
 		double FCAL_RADIATION_LENGTH;
 		double FCAL_CRITICAL_ENERGY;


### PR DESCRIPTION
Two modifications:

1) use the energy weighted average time of the hits to make the cluster time
2) implement a more flexible time-walk correction to compensate for timing shifts with energy

The latter depends on the addition of a new table to the CCDB.
