### PR TITLE
Exclusive pi0 skim update

### DIFF
--- a/src/plugins/Utilities/exclusivepi0skim/DCustomAction_CutPhotonKin.cc
+++ b/src/plugins/Utilities/exclusivepi0skim/DCustomAction_CutPhotonKin.cc
@@ -21,11 +21,12 @@ bool DCustomAction_CutPhotonKin::Perform_Action(JEventLoop* locEventLoop, const 
 		if(ParticleCharge(locParticles[loc_i]->PID()) == 0)
 		{
 			const DNeutralParticleHypothesis* locNeutralParticleHypothesis = static_cast<const DNeutralParticleHypothesis*>(locParticles[loc_i]);
-			const DNeutralShower* locNeutralShower = NULL;
-			locNeutralParticleHypothesis->GetSingle(locNeutralShower);
+			const DNeutralShower* locNeutralShower = locNeutralParticleHypothesis->Get_NeutralShower();
 
 			// make BCAL cut on photon here
 			if(locNeutralShower->dDetectorSystem != SYS_BCAL) return false;
+            // Require each photon to have at least 500 MeV of energy
+            if(locNeutralShower->dEnergy < 0.5)  return false;
 		}
 	}
 

--- a/src/plugins/Utilities/exclusivepi0skim/DReaction_factory_pi0calib.cc
+++ b/src/plugins/Utilities/exclusivepi0skim/DReaction_factory_pi0calib.cc
@@ -43,6 +43,7 @@ jerror_t DReaction_factory_pi0calib::init(void)
 	locReactionStep->Set_InitialParticleID(Pi0);
 	locReactionStep->Add_FinalParticleID(Gamma);
 	locReactionStep->Add_FinalParticleID(Gamma);
+    locReactionStep->Set_KinFitConstrainInitMassFlag(false);
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
 
@@ -62,34 +63,16 @@ jerror_t DReaction_factory_pi0calib::init(void)
     //These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination 
     //Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
     
-    locReaction->Set_NumPlusMinusRFBunches(0.5*4.008); //beam bunches are every 4.008 ns, (2.004 should be minimum cut value)
     locReaction->Set_MaxExtraGoodTracks(1);
     //locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);   // Use default AnLib cut of M(gg) = 80 - 190 MeV
 
 	// Require BCAL photons
 	locReaction->Add_AnalysisAction(new DCustomAction_CutPhotonKin(locReaction));
 
-	// Fiducial PID delta T cuts 
-	//Proton
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.5, Proton, SYS_TOF));  //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.5, Proton, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.5, Proton, SYS_FCAL)); //false: measured data
-	// Pi+
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, PiPlus, SYS_TOF));  //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.5, PiPlus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.5, PiPlus, SYS_FCAL)); //false: measured data
-	// Pi-
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.0, PiMinus, SYS_TOF));  //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.5, PiMinus, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.5, PiMinus, SYS_FCAL)); //false: measured data
-	// Gamma
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 3.0, Gamma, SYS_BCAL)); //false: measured data
-	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction, false, 2.5, Gamma, SYS_FCAL)); //false: measured data 
-//	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction,false,2.0,Unknown,SYS_NULL,"LooseDeltaTCut"));
-
-	// Cuts for future analysis actions applied in CustomAction for now
+	// Make some back-to-backness and other exclusivity cuts 
     locReaction->Add_AnalysisAction(new DCustomAction_p2gamma_cuts(locReaction, false));
 
+    // Require kin fit CL > 1%
 	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.01));
 
 	_data.push_back(locReaction); //Register the DReaction with the factory

--- a/src/plugins/Utilities/exclusivepi0skim/DReaction_factory_pi0calib.cc
+++ b/src/plugins/Utilities/exclusivepi0skim/DReaction_factory_pi0calib.cc
@@ -59,12 +59,12 @@ jerror_t DReaction_factory_pi0calib::init(void)
 	/**************************************************** pi0calib Analysis Actions ****************************************************/
 
 	// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
-		//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination 
-		//Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
-
-		locReaction->Set_MaxPhotonRFDeltaT(0.5*4.008); //beam bunches are every 4.008 ns, (2.004 should be minimum cut value)
-		locReaction->Set_MaxExtraGoodTracks(1);
-		locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+    //These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination 
+    //Pre-defined actions can be found in ANALYSIS/DHistogramActions.h and ANALYSIS/DCutActions.h
+    
+    locReaction->Set_NumPlusMinusRFBunches(0.5*4.008); //beam bunches are every 4.008 ns, (2.004 should be minimum cut value)
+    locReaction->Set_MaxExtraGoodTracks(1);
+    //locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);   // Use default AnLib cut of M(gg) = 80 - 190 MeV
 
 	// Require BCAL photons
 	locReaction->Add_AnalysisAction(new DCustomAction_CutPhotonKin(locReaction));
@@ -88,7 +88,7 @@ jerror_t DReaction_factory_pi0calib::init(void)
 //	locReaction->Add_AnalysisAction(new DCutAction_PIDDeltaT(locReaction,false,2.0,Unknown,SYS_NULL,"LooseDeltaTCut"));
 
 	// Cuts for future analysis actions applied in CustomAction for now
-        locReaction->Add_AnalysisAction(new DCustomAction_p2gamma_cuts(locReaction, false));
+    locReaction->Add_AnalysisAction(new DCustomAction_p2gamma_cuts(locReaction, false));
 
 	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.01));
 


### PR DESCRIPTION
- update plugin for new analysis library
- only write out the showers and vertex information, since that's what is needed for the calibration
  note that we write out one "event" per combo... but having multiple combos that pass the kinematic fitter in this case should be pretty rare