### PR TITLE
Make TAGGEDMCGEN backwards compatible with old REST files.

### DIFF
--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -503,6 +503,7 @@ jerror_t DEventSourceREST::Extract_DBeamPhoton(hddm_r::HDDM *record,
 		gamma->setMomentum(mom);
 		gamma->setPosition(pos);
 		gamma->setTime(locTAGMiter->getT());
+		gamma->dSystem = SYS_TAGM;
 
 	      auto locCovarianceMatrix = dResourcePool_TMatrixFSym->Get_SharedResource();
 	      locCovarianceMatrix->ResizeTo(7, 7);
@@ -527,6 +528,7 @@ jerror_t DEventSourceREST::Extract_DBeamPhoton(hddm_r::HDDM *record,
 		gamma->setMomentum(mom);
 		gamma->setPosition(pos);
 		gamma->setTime(locTAGHiter->getT());
+		gamma->dSystem = SYS_TAGH;
 
 	      auto locCovarianceMatrix = dResourcePool_TMatrixFSym->Get_SharedResource();
 	      locCovarianceMatrix->ResizeTo(7, 7);
@@ -537,6 +539,8 @@ jerror_t DEventSourceREST::Extract_DBeamPhoton(hddm_r::HDDM *record,
 		dbeam_photons.push_back(gamma);
    }
 
+	if((tag == "TAGGEDMCGEN") && dbeam_photons.empty())
+		return OBJECT_NOT_AVAILABLE; //EITHER: didn't hit a tagger counter //OR: old MC data (pre-saving TAGGEDMCGEN): try using TAGGEDMCGEN factory
 
 	// Copy into factories
 	factory->CopyTo(dbeam_photons);

--- a/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.cc
+++ b/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.cc
@@ -13,19 +13,6 @@ using namespace std;
 using namespace jana;
 
 //------------------
-// brun
-//------------------
-jerror_t DBeamPhoton_factory_TAGGEDMCGEN::brun(jana::JEventLoop *locEventLoop, int32_t runnumber)
-{
-	//Setting this flag makes it so that JANA does not delete the objects in _data.  This factory will manage this memory. 
-		//This is because some/all of these pointers are just copied from earlier objects, and should not be deleted.  
-	bool locIsRESTEvent = locEventLoop->GetJEvent().GetStatusBit(kSTATUS_REST);
-	if(!locIsRESTEvent) //If REST, will grab from file: IS owner
-		SetFactoryFlag(NOT_OBJECT_OWNER);
-	return NOERROR;
-}
-
-//------------------
 // evnt
 //------------------
 jerror_t DBeamPhoton_factory_TAGGEDMCGEN::evnt(jana::JEventLoop *locEventLoop, uint64_t eventnumber)
@@ -71,7 +58,7 @@ jerror_t DBeamPhoton_factory_TAGGEDMCGEN::evnt(jana::JEventLoop *locEventLoop, u
 	if(locBestPhoton == nullptr)
 		return NOERROR; //Uh oh.  Shouldn't be possible. 
 
-	_data.push_back(const_cast<DBeamPhoton*>(locBestPhoton));
+	_data.push_back(new DBeamPhoton(*locBestPhoton));
 	return NOERROR;
 }
 

--- a/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.h
+++ b/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.h
@@ -18,7 +18,7 @@ class DBeamPhoton_factory_TAGGEDMCGEN:public jana::JFactory<DBeamPhoton>{
 		const char* Tag(void){return "TAGGEDMCGEN";}
 
 	private:
-		jerror_t brun(jana::JEventLoop *locEventLoop, int32_t runnumber);
+
 		jerror_t evnt(jana::JEventLoop *locEventLoop, uint64_t eventnumber);	///< Called every event.
 };
 

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -713,7 +713,7 @@ int DTrackTimeBased_factory::GetThrownIndex(vector<const DMCThrown*>& locMCThrow
 		cdctrackhits[loc_i]->GetSingle(locCDCHit);
 		vector<const DCDCHit*> locTruthCDCHits;
       locCDCHit->Get(locTruthCDCHits);
-		if(locTruthCDCHits.empty()) continue; // merged simulation with real data bkgnd will not have truth hits associated
+		if(locTruthCDCHits.empty()) continue;
 
 		int itrack = locTruthCDCHits[0]->itrack;
 		if(locHitMatches.find(itrack) == locHitMatches.end())


### PR DESCRIPTION
It won't be 100% perfect, but it will be close.

Fix CDC truth/recon hit matching.