### PR TITLE
Prevent large offsets

### DIFF
--- a/src/plugins/Calibration/TAGM_TW/JEventProcessor_TAGM_TW.cc
+++ b/src/plugins/Calibration/TAGM_TW/JEventProcessor_TAGM_TW.cc
@@ -24,8 +24,8 @@ const int32_t PMIN = 0;
 const int32_t PMAX = 2000;
 const int32_t PBIN = (PMAX - PMIN)/16;
 
-const int32_t TMIN = -150;
-const int32_t TMAX = 150;
+const int32_t TMIN = -300;
+const int32_t TMAX = 300;
 const int32_t TBIN = (TMAX - TMIN)/0.01;
 
 const double TMIN_RF = -2.0;

--- a/src/plugins/Calibration/TAGM_TW/timing.py
+++ b/src/plugins/Calibration/TAGM_TW/timing.py
@@ -71,6 +71,15 @@ def main():
 	res_hist2 = TProfile("1sig","Timing resolution (1 sigma) of each TAGM channel;Channel;Resolution [ns]",122,1,123)
 	for i in range(1,NCOLUMNS+1):
 		# Get summed channels
+		init_adc = float(fadc_assignment.constant_set.data_table[channel][2])
+		if (abs(init_adc) > 50):
+			errorfile.write('Initial fadc offset for col ' + str(i) + ' is too large. Manually adjust and re-run plugin before proceeding\n')
+			print('Initial fadc offset for col ' + str(i) + ' is too large. Manually adjust and re-run plugin before proceeding\n')
+		init_tdc = float(tdc_assignment.constant_set.data_table[channel][2])
+		if (abs(init_tdc) > 50):
+			errorfile.write('Initial tdc offset for col ' + str(i) + ' is too large. Manually adjust and re-run plugin before proceeding\n')
+			print('Initial tdc offset for col ' + str(i) + ' is too large. Manually adjust and re-run plugin before proceeding\n')
+
 		if (calib_type == 'self'):
 			h_name = baseDir+"t_adc_all"
 			hist = rootfile.Get(h_name).Clone().ProjectionX(h_name+"_"+str(i),i,i)
@@ -117,13 +126,22 @@ def main():
 		# Write offset to file
 		if (calib_type == 'self'):
 			offset = float(tdc_assignment.constant_set.data_table[channel][2]) + new_offset
-			tdcfile.write(' 0\t' + str(i) + '\t' + str(offset) + '\n')
+			if (abs(offset) > 50):
+				errorfile.write(' 0\t' + str(i) + '\t' + str(offset) + '\n')
+			else:
+				tdcfile.write(' 0\t' + str(i) + '\t' + str(offset) + '\n')
 		elif (calib_type == 'rf'):
 			offset = float(fadc_assignment.constant_set.data_table[channel][2]) + new_offset
-			adcfile.write(' 0\t' + str(i) + '\t' + str(offset) + '\n')
+			if (abs(offset) > 50):
+				errorfile.write(' 0\t' + str(i) + '\t' + str(offset) + '\n')
+			else:
+				adcfile.write(' 0\t' + str(i) + '\t' + str(offset) + '\n')
 
 			offset = float(tdc_assignment.constant_set.data_table[channel][2]) + tdc_offset + new_offset
-			tdcfile.write(' 0\t' + str(i) + '\t' + str(offset) + '\n')
+			if (abs(offset) > 50):
+				errorfile.write(' 0\t' + str(i) + '\t' + str(offset) + '\n')
+			else:
+				tdcfile.write(' 0\t' + str(i) + '\t' + str(offset) + '\n')
 			offset_file.write(' 0\t' + str(i) + '\t' + str(tdc_offset + new_offset) + '\n')
 
 		channel += 1
@@ -243,7 +261,7 @@ def GetSelfTiming(hist):
 		return 0
 	maximum = GetMaximum(hist)
 	try:
-		FitResult = hist.Fit("gaus","sRWq","",maximum-2,maximum+2)
+		FitResult = hist.Fit("gaus","sRWq","",maximum-0.5,maximum+0.5)
 		offset = FitResult.Parameters()[1]
 		sigma = FitResult.Parameters()[2]
 	except:


### PR DESCRIPTION
-Updated plugin to have a larger t range to capture large tdc offsets
-Updated timing.py to check offset and prevent writing large, unrealistic offsets