### PR TITLE
Identify bad CCDB constants

### DIFF
--- a/src/plugins/Calibration/TAGM_TW/README.md
+++ b/src/plugins/Calibration/TAGM_TW/README.md
@@ -10,10 +10,10 @@ To fully align the TAGM with the rest of the detectors, use HLDetectorTiming.
 
 ## Running TAGM_TW
 When running `hd_root` with the **TAGM_TW** plugin, make sure to include 
-the option `-PTAGMHit:DELTA_T_ADC_TDC_MAX=200` in order to pick up any 
+the option `-PTAGMHit:DELTA_T_ADC_TDC_MAX=300` in order to pick up any 
 large offsets.
 
-`hd_root -PPLUGINS=TAGM_TW -PTAGMHit:DELTA_T_ADC_TDC_MAX=200 /path/to/file/hd_rawdata_XXXXXX_00*`
+`hd_root -PPLUGINS=TAGM_TW -PTAGMHit:DELTA_T_ADC_TDC_MAX=300 /path/to/file/hd_rawdata_XXXXXX_00*`
 
 Be aware that the CCDB table /PHOTON_BEAM/microscope/integral_cuts can 
 interfere with the pulse height distributions. To set these values to 0 
@@ -31,7 +31,7 @@ At the same time, the uncorrected TDC time can be adjusted to be aligned
 with the new ADC time. This is a rough calibration of the raw TDC time 
 which will avoid the timewalk from absorbing large offsets.
 
-**For this step, it is important to include -PTAGMHit:DELTA_T_ADC_TDC_MAX=200
+**For this step, it is important to include -PTAGMHit:DELTA_T_ADC_TDC_MAX=300
 when running TAGM_TW. Occasionally, the initial time difference is very large.**
 
 1. `python timing.py -b <rootfile> <run number> rf <CCDB variation>`
@@ -61,6 +61,26 @@ or
 2. `ccdb add PHOTON_BEAM/microscope/fadc_time_offsets -v <variation> -r #-# adc_offsets-######.txt`
 3. `ccdb add PHOTON_BEAM/microscope/tdc_time_offsets -v <variation> -r #-# tdc_offsets-######.txt`
 4. `ccdb add PHOTON_BEAM/microscope/tdc_timewalk_corrections -v <variation> -r #-# tw-corr-######.txt`
+
+## Check for bad CCDB values
+Sometimes bad constants make their way into the CCDB. These can be found by 
+running ccdbquery.py. The likely problems are wrong names for columns 101 and 102 
+due to manual updates as well as unrealistically large offsets for the adc and tdc.
+
+1. `python ccdbquery.py`
+
+This provides 3 files: bad-cols.txt, bad-adc.txt, and bad-tdc.txt.
+
+bad-cols.txt lists the run numbers where columns 101 and 102 are 120 and 121.
+
+bad-adc.txt and bad-tdc.txt list the run and channel of the bad offset. 
+** Note: this is channel, not column number. ** The adc/tdc tables have 122 entries.
+Channel corresponds to their entry number. These are typically invidual channels as
+they require more statistics to calibrate.
+
+Using these files, the CCDB constants can be updated either by hand or by a custom script.
+For the adc/tdc offsets, it is recommended to set any large offset to 7 as that is a typical
+timing offset.
 
 ## Calibration validation
 After all steps are complete, a calibration validation can be performed. Run 

--- a/src/plugins/Calibration/TAGM_TW/ccdbquery.py
+++ b/src/plugins/Calibration/TAGM_TW/ccdbquery.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+
+# This script finds bad constants for the TAGM
+# Created by Alex Barnes, November 13, 2017
+
+##################################################################
+
+import os,sys
+
+# Set up CCDB connection for reading tables
+import ccdb, rcdb
+from ccdb import Directory, TypeTable, Assignment, ConstantSet
+
+# CCDB_HOME and CCDB_CONNECTION environment variables must be set!
+ccdb_home = os.environ["CCDB_HOME"]
+sqlite_connect_str = os.environ["CCDB_CONNECTION"]
+
+# Create CCDB API class
+## This class has all CCDB manipulation functions
+provider = ccdb.AlchemyProvider()
+## Use usual connection string to connect to database
+provider.connect(sqlite_connect_str)
+print 'CCDB is connected? ' + str(getattr(provider,"is_connected"))
+## Provide a username for CCDB updates
+provider.authentication.current_user_name = "anonymous"	
+
+def main():
+	db = rcdb.RCDBProvider("mysql://rcdb@hallddb.jlab.org/rcdb")
+	rcdbQuery = '@is_production and @status_approved'
+	rcdbRunList = db.select_runs(rcdbQuery, 30274, 31057)
+
+	colfile = open('bad-cols.txt','w')
+	colfile.write('Problem runs\n')
+
+	adcfile = open('bad-adc.txt', 'w')
+	adcfile.write('Runs\tChannel\n')
+
+	tdcfile = open('bad-tdc.txt', 'w')
+	tdcfile.write('Runs\tChannel\n')
+
+	variation = 'default'
+
+	for entry in rcdbRunList:
+		run = entry.number
+
+		# check for wrong 101 and 102 columns
+		fadc_assignment = provider.get_assignment("/PHOTON_BEAM/microscope/fadc_time_offsets",run,variation)
+		adc_101 = float(fadc_assignment.constant_set.data_table[120][1])
+		adc_102 = float(fadc_assignment.constant_set.data_table[121][1])
+
+		tdc_assignment = provider.get_assignment("/PHOTON_BEAM/microscope/tdc_time_offsets",run,variation)
+		tdc_101 = float(tdc_assignment.constant_set.data_table[120][1])
+		tdc_102 = float(tdc_assignment.constant_set.data_table[121][1])
+		if (adc_101 == 120 or adc_102 == 121 or tdc_101 == 120 or tdc_102 == 121):
+			colfile.write(str(run) + '\n')
+
+		# check for large adc and tdc offsets
+		for i in range(122):
+			adc = float(fadc_assignment.constant_set.data_table[i][2])
+			if (abs(adc) > 100.0):
+				adcfile.write(str(run) + '\t' + str(i) + '\n')
+			tdc = float(tdc_assignment.constant_set.data_table[i][2])
+			if (abs(tdc) > 100.0):
+				tdcfile.write(str(run) + '\t' + str(i) + '\n')
+
+if __name__ == "__main__":
+	main()

--- a/src/plugins/Calibration/TAGM_TW/tw.py
+++ b/src/plugins/Calibration/TAGM_TW/tw.py
@@ -50,7 +50,7 @@ def main():
 	outfile.Close()
 
 def tw_corr(h,row,col,newV, offsets, offsets_ind, run):
-	if (col % 10):
+	if not (col % 10):
 		print('Calibrating column ' + str(col))
 	# Create list of columns with individual readout
 	indCol = [9,27,81,99]


### PR DESCRIPTION
-Updated README to specify using a 300 delta adc/tdc instead of 200.
-Updated tw.py to print a status update every 10 columns.
-Added ccdbquery.py to find bad constants.