### PR TITLE
Random number seeds

### DIFF
--- a/src/libraries/AMPTOOLS_DATAIO/HDDMDataWriter.cc
+++ b/src/libraries/AMPTOOLS_DATAIO/HDDMDataWriter.cc
@@ -63,6 +63,12 @@ writeEvent( const Kinematics& kin, const vector<int>& ptype,
   hddm_s::VertexList vs = rs().addVertices();
   hddm_s::OriginList os = vs().addOrigins();
   hddm_s::ProductList ps = vs().addProducts(nParticles-1);
+  hddm_s::RandomList ranl = rs().addRandoms();
+
+  ranl().setSeed1(gRandom->Integer(std::numeric_limits<int32_t>::max()));
+  ranl().setSeed2(gRandom->Integer(std::numeric_limits<int32_t>::max()));
+  ranl().setSeed3(gRandom->Integer(std::numeric_limits<int32_t>::max()));
+  ranl().setSeed4(gRandom->Integer(std::numeric_limits<int32_t>::max()));
 
   os().setT(0.0);
   os().setVx(vx);

--- a/src/libraries/AMPTOOLS_DATAIO/HDDMDataWriter.cc
+++ b/src/libraries/AMPTOOLS_DATAIO/HDDMDataWriter.cc
@@ -1,16 +1,21 @@
 
 #include "TLorentzVector.h"
+#include "TRandom3.h"
 
 #include "AMPTOOLS_DATAIO/HDDMDataWriter.h"
 #include "HDDM/hddm_s.hpp"
 
-HDDMDataWriter::HDDMDataWriter(const string& outFile, int runNumber)
+HDDMDataWriter::HDDMDataWriter(const string& outFile, int runNumber, int seed)
 {
   m_OutputFile = new ofstream(outFile.c_str());
   m_OutputStream = new hddm_s::ostream(*m_OutputFile);
   m_runNumber = runNumber;
   
   m_eventCounter = 0;
+
+  // initialize root's pseudo-random generator
+  gRandom->SetSeed(seed);
+
 }
 
 HDDMDataWriter::~HDDMDataWriter()
@@ -38,7 +43,7 @@ writeEvent( const Kinematics& kin, const vector<int>& ptype,
     vz_min=vz_max;
     vz_max=tmp;
   }
-  writeEvent(kin, ptype,vx, vy, (vz_max - vz_min) * drand48() + vz_min);
+  writeEvent(kin, ptype,vx, vy, (vz_max - vz_min) * gRandom->Uniform() + vz_min);
 }
 
 

--- a/src/libraries/AMPTOOLS_DATAIO/HDDMDataWriter.h
+++ b/src/libraries/AMPTOOLS_DATAIO/HDDMDataWriter.h
@@ -16,7 +16,7 @@ class HDDMDataWriter
 
 public:
 	
-  HDDMDataWriter( const string& outFile, int runNumber=9000);
+  HDDMDataWriter( const string& outFile, int runNumber=9000, int seed=0);
   ~HDDMDataWriter();
   
   void writeEvent( const Kinematics& kin, const vector<int>& ptype,

--- a/src/libraries/AMPTOOLS_MCGEN/GammaPToXYP.cc
+++ b/src/libraries/AMPTOOLS_MCGEN/GammaPToXYP.cc
@@ -18,8 +18,8 @@
 
 GammaPToXYP::GammaPToXYP( float lowMassXY, float highMassXY, 
                           float massX, float massY, float beamMaxE, float beamPeakE, float beamLowE, float beamHighE,
-                          ProductionMechanism::Type type, float slope ) : 
-m_prodMech( ProductionMechanism::kProton, type, slope ), // last arg is t dependence
+                          ProductionMechanism::Type type, float slope, int seed ) : 
+m_prodMech( ProductionMechanism::kProton, type, slope, seed ),
 m_target( 0, 0, 0, 0.938272 ),
 m_childMass( 0 ) {
 

--- a/src/libraries/AMPTOOLS_MCGEN/GammaPToXYP.h
+++ b/src/libraries/AMPTOOLS_MCGEN/GammaPToXYP.h
@@ -22,7 +22,7 @@ class GammaPToXYP {
 public:
   
   GammaPToXYP( float lowMassXY, float highMassXY, float massX, float massY,
-               float beamMaxE, float beamPeakE, float beamLowE, float beamHigh, ProductionMechanism::Type type, float slope = 6.0 );
+               float beamMaxE, float beamPeakE, float beamLowE, float beamHigh, ProductionMechanism::Type type, float slope = 6.0, int seed = 0 );
   
   Kinematics* generate();
   

--- a/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.cc
+++ b/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.cc
@@ -13,7 +13,7 @@ const double ProductionMechanism::kPi = 3.14159;
 
 using namespace std;
 
-ProductionMechanism::ProductionMechanism( Recoil recoil, Type type, double slope ) :
+ProductionMechanism::ProductionMechanism( Recoil recoil, Type type, double slope, int seed ) :
 m_type( type ),
 m_lowMass( 0 ),
 m_highMass( 0 ),
@@ -24,6 +24,9 @@ m_lastWeight( 1. )
   kMneutron=ParticleMass(Neutron);
   // kMZ = 108.;      //  mass of Sn116 
   kMZ = 208.*0.931494;      //  use mass of Pb as it is in the particle table
+
+  // initialize pseudo-random generator
+  gRandom->SetSeed(seed);
 
   switch( recoil ){
     // I'm sure the distinction between these doesn't matter!  
@@ -51,10 +54,7 @@ ProductionMechanism::setGeneratorType( Type type ){
 TLorentzVector
 ProductionMechanism::produceResonance( const TLorentzVector& beam ){
 
-        // initialize pseudo-random generator
-        //gRandom = new TRandom3();
-        gRandom->SetSeed(0);
-	
+
 	TLorentzVector target( 0, 0, 0, kMproton );
 	
 	TLorentzRotation lab2cmBoost( -( target + beam ).BoostVector() );

--- a/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.h
+++ b/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.h
@@ -19,7 +19,7 @@ public:
 	enum Type { kResonant, kFlat };
 	enum Recoil { kProton, kNeutron, kZ };
 	
-	ProductionMechanism( Recoil recoil, Type type, double slope = 5.0 );
+	ProductionMechanism( Recoil recoil, Type type, double slope = 5.0, int seed = 0 );
 	
 	void setMassRange( double low, double high );
         void setGeneratorType( Type type );

--- a/src/programs/Simulation/gen_2pi_amp/gen_2pi_amp.cc
+++ b/src/programs/Simulation/gen_2pi_amp/gen_2pi_amp.cc
@@ -154,7 +154,7 @@ int main( int argc, char* argv[] ){
 		( genFlat ? ProductionMechanism::kFlat : ProductionMechanism::kResonant );
 
 	// generate over a range of mass -- the daughters are two charged pions
-	GammaPToXYP resProd( lowMass, highMass, ParticleMass(PiPlus), ParticleMass(PiMinus), beamMaxE, beamPeakE, beamLowE, beamHighE, type, slope );
+	GammaPToXYP resProd( lowMass, highMass, ParticleMass(PiPlus), ParticleMass(PiMinus), beamMaxE, beamPeakE, beamLowE, beamHighE, type, slope, seed );
 	
 	// seed the distribution with a sum of noninterfering Breit-Wigners
 	// we can easily compute the PDF for this and divide by that when
@@ -176,7 +176,7 @@ int main( int argc, char* argv[] ){
 	pTypes.push_back( PiMinus );
 	
 	HDDMDataWriter* hddmOut = NULL;
-	if( hddmname.size() != 0 ) hddmOut = new HDDMDataWriter( hddmname, runNum );
+	if( hddmname.size() != 0 ) hddmOut = new HDDMDataWriter( hddmname, runNum, seed);
 	ROOTDataWriter rootOut( outname );
 	
 	TFile* diagOut = new TFile( "gen_2pi_diagnostic.root", "recreate" );

--- a/src/programs/Simulation/gen_2pi_amp/gen_2pi_amp.cc
+++ b/src/programs/Simulation/gen_2pi_amp/gen_2pi_amp.cc
@@ -290,6 +290,7 @@ int main( int argc, char* argv[] ){
 					if( hddmOut ) hddmOut->writeEvent( *evt, pTypes );
 					rootOut.writeEvent( *evt );
 					++eventCounter;
+					if(eventCounter >= nEvents) break;
 				}
 			}
 			else{

--- a/src/programs/Simulation/gen_2pi_amp/gen_2pi_amp.cc
+++ b/src/programs/Simulation/gen_2pi_amp/gen_2pi_amp.cc
@@ -143,6 +143,7 @@ int main( int argc, char* argv[] ){
 	// random number initialization (set to 0 by default)
 	TRandom3* gRandom = new TRandom3();
 	gRandom->SetSeed(seed);
+	cout << "TRandom3 Seed : " << gRandom->GetSeed() << endl;
 
 	// setup AmpToolsInterface
 	AmpToolsInterface::registerAmplitude( TwoPiAngles_amp() );


### PR DESCRIPTION
* Switched the generated vertex distribution from drand32 to TRandom3
* Single seed from gen_2pi_amp is used for production kinematics and vertex distribution. Default is 0 (pseudo random), but can be specified on command line
* This same seed is used to generates 4 'random' numbers, which are saved to HDDM output for hdgeant3/4 and mcsmear