### PR TITLE
Improved monitoring for FCal hit timing

### DIFF
--- a/src/plugins/monitoring/FCAL_online/JEventProcessor_FCAL_online.cc
+++ b/src/plugins/monitoring/FCAL_online/JEventProcessor_FCAL_online.cc
@@ -405,11 +405,14 @@ jerror_t JEventProcessor_FCAL_online::evnt(JEventLoop *eventLoop, uint64_t event
 
     if( hits.size() > 1 )
       m_hitTmT0->Fill( locTime );
-
+    
+    if (fabs(locTime) < 20){
+      m_hitTmT02D->Fill( hit.column, hit.row, locTime );
+      m_hitTmT0Sq2D->Fill( hit.column, hit.row, locTime*locTime );
+      m_hitOcc2D->Fill( hit.column, hit.row );
+    }
+    
     m_hitE2D->Fill( hit.column, hit.row, hit.E*k_to_MeV );
-    m_hitTmT02D->Fill( hit.column, hit.row, locTime );
-    m_hitTmT0Sq2D->Fill( hit.column, hit.row, locTime*locTime );
-    m_hitOcc2D->Fill( hit.column, hit.row );
   }
 
 //  japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK

--- a/src/plugins/monitoring/FCAL_online/fcal_hit_timing.C
+++ b/src/plugins/monitoring/FCAL_online/fcal_hit_timing.C
@@ -99,7 +99,7 @@
     }
 
     hitTmT02DRMS->SetMinimum(  0 );
-    hitTmT02DRMS->SetMaximum(  50 );
+    hitTmT02DRMS->SetMaximum(  10 );
     hitTmT02DRMS->SetStats( 0 );
     c1->cd( 4 );
     hitTmT02DRMS->Draw( "colz" );


### PR DESCRIPTION
Use only hit times with |t-t0| < 20ns for the 2D RMS calculation. This matches the 1D distribution and is no longer dominated by very large values.