### PR TITLE
The earlier fix for is-truecombo caused crashes elsewhere.

### DIFF
--- a/src/libraries/ANALYSIS/DChargedTrack_factory_Combo.cc
+++ b/src/libraries/ANALYSIS/DChargedTrack_factory_Combo.cc
@@ -62,7 +62,7 @@ jerror_t DChargedTrack_factory_Combo::evnt(jana::JEventLoop *locEventLoop, uint6
 		{
 			//create new DChargedTrackHypothesis object
 			auto locNewChargedTrackHypothesis = dChargedTrackHypothesisFactory->Create_ChargedTrackHypothesis(locEventLoop, locTimeBasedTrack, locDetectorMatches, locEventRFBunch);
-			locNewChargedTrackHypothesis->AddAssociatedObject(locChargedTrack);
+			locNewChargedTrackHypothesis->AddAssociatedObject(locNewChargedTrack);
 			dCreatedHypotheses.push_back(locNewChargedTrackHypothesis);
 			locNewChargedTrack->dChargedTrackHypotheses.push_back(locNewChargedTrackHypothesis);
 		}

--- a/src/libraries/ANALYSIS/DMCThrownMatching.h
+++ b/src/libraries/ANALYSIS/DMCThrownMatching.h
@@ -275,11 +275,20 @@ inline const DMCThrown* DMCThrownMatching::Get_MatchingMCThrown(const DChargedTr
 
 inline const DMCThrown* DMCThrownMatching::Get_MatchingMCThrown(const DChargedTrack* locChargedTrack, double& locMatchFOM) const
 {
-	map<const DChargedTrack*, pair<const DMCThrown*, double> >::const_iterator locIterator = dChargedToThrownMap.find(locChargedTrack);
-	if(locIterator == dChargedToThrownMap.end())
+	auto locIterator = dChargedToThrownMap.find(locChargedTrack);
+	if(locIterator != dChargedToThrownMap.end())
+	{
+		locMatchFOM = locIterator->second.second;
+		return locIterator->second.first;
+	}
+
+	//See if there's an associated charged track (e.g. input is "Combo" factory charged track, but matching done with default-factory objects
+	vector<const DChargedTrack*> locAssocTracks;
+	locChargedTrack->Get(locAssocTracks);
+	if(locAssocTracks.empty())
 		return NULL;
-	locMatchFOM = locIterator->second.second;
-	return locIterator->second.first;
+
+	return Get_MatchingMCThrown(locAssocTracks[0], locMatchFOM);
 }
 
 inline const DMCThrown* DMCThrownMatching::Get_MatchingMCThrown(const DNeutralParticleHypothesis* locNeutralParticleHypothesis, double& locMatchFOM) const

--- a/src/libraries/ANALYSIS/DParticleComboCreator.cc
+++ b/src/libraries/ANALYSIS/DParticleComboCreator.cc
@@ -316,15 +316,10 @@ const DChargedTrackHypothesis* DParticleComboCreator::Create_ChargedHypo(const D
 	locNewHypo->Share_FromInput(locOrigHypo, true, false, true); //share all but timing info
 
 	auto locTrackPOCAX4 = dSourceComboTimeHandler->Get_ChargedPOCAToVertexX4(locOrigHypo, locIsProductionVertex, locReactionFullCombo, locVertexPrimaryFullCombo, locBeamParticle, false, locVertex);
-
 	locNewHypo->Set_TimeAtPOCAToVertex(locTrackPOCAX4.T());
 
 	locNewHypo->Set_T0(locPropagatedRFTime, locOrigHypo->t0_err(), locOrigHypo->t0_detector());
-
-	vector<const DChargedTrack*> locAssocTracks;
-	locChargedTrack->Get(locAssocTracks);
-	auto locAssocTrack = locAssocTracks.empty() ? locChargedTrack : locAssocTracks[0];
-	locNewHypo->AddAssociatedObject(locAssocTrack);
+	locNewHypo->AddAssociatedObject(locChargedTrack);
 
 	dParticleID->Calc_ChargedPIDFOM(locNewHypo);
 


### PR DESCRIPTION
Change the previous solution so that it doesn't break things.