### PR TITLE
Davidl rootspy macro

### DIFF
--- a/src/plugins/monitoring/highlevel_online/HistMacro_PID.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_PID.C
@@ -16,8 +16,8 @@
 {
 
 // The following are empty versions of routines defined in RootSpy
-// compiled exectuables. These are defined here for when this
-// macro is run outside of a RootSpy executable.
+// compiled executables. These are defined here for when this
+// macro is run outside that context.
 #ifndef ROOTSPY_MACROS
 #define rs_SetFlag(A) cout<<"rs_SetFlag ignored outside of RootSpy context"<<endl
 #define rs_GetFlag(A) 0

--- a/src/plugins/monitoring/highlevel_online/HistMacro_PID.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_PID.C
@@ -15,6 +15,19 @@
 
 {
 
+// The following are empty versions of routines defined in RootSpy
+// compiled exectuables. These are defined here for when this
+// macro is run outside of a RootSpy executable.
+#ifndef ROOTSPY_MACROS
+#define rs_SetFlag(A) cout<<"rs_SetFlag ignored outside of RootSpy context"<<endl
+#define rs_GetFlag(A) 0
+#define rs_ResetHisto(A) cout<<"rs_ResetHisto ignored outside of RootSpy context"<<endl
+#define rs_RestoreHisto(A) cout<<"rs_RestoreHisto ignored outside of RootSpy context"<<endl
+#define InsertSeriesData(A) cout<<"InsertSeriesData ignored outside of RootSpy context"<<endl
+#define InsertSeriesMassFit(A,B,C,D,E,F) cout<<"InsertSeriesMassFit ignored outside of RootSpy context"<<endl
+#endif
+
+
 // This is a trick to get ROOT to use a function for a TF1 without
 // defining it in global namespace. This is needed since ROOTSpy
 // requires all macros to be nameless. The start of the actual


### PR DESCRIPTION
Define dummy routines for things like InsertSeriesMassFit that are normally provided by RootSpy executables. This change allows the macro to be run outside of the RootSpy context.