### PR TITLE
Fix hdview2 crashes

### DIFF
--- a/src/programs/Analysis/hdview2/MyProcessor.cc
+++ b/src/programs/Analysis/hdview2/MyProcessor.cc
@@ -1998,11 +1998,13 @@ void MyProcessor::UpdateTrackLabels(void)
 	}
 	
 	// Have the pop-up window with the full particle list update it's labels
-	fulllistmf->UpdateTrackLabels(throwns, trks);
-	debugermf->SetTrackCandidates(TrksCand);
-	debugermf->SetTrackWireBased(TrksWireBased);
-	debugermf->SetTrackTimeBased(TrksTimeBased);
-	debugermf->UpdateTrackLabels();
+	if( fulllistmf ) fulllistmf->UpdateTrackLabels(throwns, trks);
+	if( debugermf  ) {
+		debugermf->SetTrackCandidates(TrksCand);
+		debugermf->SetTrackWireBased(TrksWireBased);
+		debugermf->SetTrackTimeBased(TrksTimeBased);
+		debugermf->UpdateTrackLabels();
+	}
 }                 
 
 //------------------------------------------------------------------


### PR DESCRIPTION
Make bulletproof by checking if auxillary mainframe pointers are notNULL before using them.