### PR TITLE
Nsj cdc readout oldparser fix

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -1667,8 +1667,25 @@ void DEVIOWorkerThread::Parsef125Bank(uint32_t rocid, uint32_t* &iptr, uint32_t 
 					uint32_t nsamples_integral = 0;  // must be overwritten later in GetObjects with value from Df125Config value
 					uint32_t nsamples_pedestal = 1;  // The firmware pedestal divided by 2^PBIT where PBIT is a config. parameter
 
+                                        //assign to CDC or FDC based on hard coded rocid
+
 					if( pe ) {
-						pe->NEW_Df125FDCPulse(rocid, slot, channel, itrigger
+                                          if ( rocid<30 ) {
+ 						pe->NEW_Df125CDCPulse(rocid, slot, channel, itrigger
+									, pulse_number        // NPK
+									, pulse_time          // le_time
+									, quality_factor      // time_quality_bit
+									, overflow_count      // overflow_count
+									, pedestal            // pedestal
+									, sum                 // integral
+									, pulse_peak          // peak_amp
+									, word1               // word1
+									, word2               // word2
+									, nsamples_pedestal   // nsamples_pedestal
+									, nsamples_integral   // nsamples_integral
+									, false);             // emulated
+                                          } else {
+ 						pe->NEW_Df125FDCPulse(rocid, slot, channel, itrigger
 									, pulse_number        // NPK
 									, pulse_time          // le_time
 									, quality_factor      // time_quality_bit
@@ -1682,6 +1699,9 @@ void DEVIOWorkerThread::Parsef125Bank(uint32_t rocid, uint32_t* &iptr, uint32_t 
 									, nsamples_pedestal   // nsamples_pedestal
 									, nsamples_integral   // nsamples_integral
 									, false);             // emulated
+                                          }
+
+
 					}
 				}
                 break;

--- a/src/libraries/DAQ/JEventSource_EVIO.cc
+++ b/src/libraries/DAQ/JEventSource_EVIO.cc
@@ -4068,6 +4068,26 @@ void JEventSource_EVIO::Parsef125Bank(int32_t rocid, const uint32_t* &iptr, cons
                     // opposed to the new firmware that puts the same infomation
                     // into a single data type. The emulation framework is also
                     // being revamped.
+
+                  // hard-code destination object CDC/FDC based on rocid
+
+		  if (rocid<30) {
+
+                    objs->hit_objs.push_back( new Df125CDCPulse(rocid, slot, channel, itrigger
+                                , pulse_number        // NPK
+                                , pulse_time          // le_time
+                                , quality_factor      // time_quality_bit
+                                , overflow_count      // overflow_count
+                                , pedestal            // pedestal
+                                , sum                 // integral
+                                , pulse_peak          // peak_amp
+                                , word1               // word1
+                                , word2               // word2
+                                , nsamples_pedestal   // nsamples_pedestal
+                                , nsamples_integral   // nsamples_integral
+                                , false)              // emulated
+                            );
+		  } else {
                     objs->hit_objs.push_back( new Df125FDCPulse(rocid, slot, channel, itrigger
                                 , pulse_number        // NPK
                                 , pulse_time          // le_time
@@ -4083,6 +4103,7 @@ void JEventSource_EVIO::Parsef125Bank(int32_t rocid, const uint32_t* &iptr, cons
                                 , nsamples_integral   // nsamples_integral
                                 , false)              // emulated
                             );
+                  }
                 }
 
                 // n.b. We don't record last_slot, last_channel, etc... here since those


### PR DESCRIPTION
There are 2 commits in here.  The first is for the old parser, the second is for the new parser.

These assign FA125 data type 9 to CDCPulse if rocid<30, to FDCPulse otherwise 