### PR TITLE
* gukine.F, hddmImput.c [rtj]

### DIFF
--- a/src/programs/Simulation/HDGeant/gukine.F
+++ b/src/programs/Simulation/HDGeant/gukine.F
@@ -171,6 +171,16 @@
       endif
       if (itry .eq. 0) then
         itry = loadInput(override_run_number,IDRUN)
+        do while (itry .ne. 0)
+          itry = nextInput()
+          if (itry .eq. 0) then
+            itry = loadInput(override_run_number,IDRUN)
+          else
+            ieorun = 1
+            ieotri = 1
+            return
+          endif
+        enddo
 *
 *       Check for random number seeds in the input file. If they are
 *       there, then the values of iseed1 and iseed2 will be overwritten

--- a/src/programs/Simulation/HDGeant/guout.F
+++ b/src/programs/Simulation/HDGeant/guout.F
@@ -92,6 +92,6 @@ C     endif
 C     FDPREE() should only be called if FLUKA is being used
       if (IHADR.ge.3) call fdpree()
 
-      call gidclear()
+      call gidClear()
 
       END


### PR DESCRIPTION
   - make the code that reads from an input hddm file created by an
     external MC generator more robust against how that file was
     written. Previously, hdgeant would segfault if an output file
     from a previous run of hdgeant were fed back as input. The
     code should not segfault on a valid hddm input file.
* guout.F [rtj]
   - change the spelling of external C++ function to make it use
     the same camelCase as the original code.