### PR TITLE
Davidl cdc fdc pulse

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -1668,20 +1668,47 @@ void DEVIOWorkerThread::Parsef125Bank(uint32_t rocid, uint32_t* &iptr, uint32_t 
 					uint32_t nsamples_pedestal = 1;  // The firmware pedestal divided by 2^PBIT where PBIT is a config. parameter
 
 					if( pe ) {
-						pe->NEW_Df125FDCPulse(rocid, slot, channel, itrigger
-									, pulse_number        // NPK
-									, pulse_time          // le_time
-									, quality_factor      // time_quality_bit
-									, overflow_count      // overflow_count
-									, pedestal            // pedestal
-									, sum                 // integral
-									, pulse_peak          // peak_amp
-									, peak_time           // peak_time
-									, word1               // word1
-									, word2               // word2
-									, nsamples_pedestal   // nsamples_pedestal
-									, nsamples_integral   // nsamples_integral
-									, false);             // emulated
+					
+						// The following is a temporary fix. In late 2017 the CDC group started
+						// using data type 9 (i.e. FDC pulse peak). This caused many conflicts
+						// with plugins downstream that were built around there being a Df125CDCPulse
+						// object associated with the DCDCDigiHit. In order to quickly solve
+						// the issue as the run was starting, this fix was made to produce Df125CDCPulse
+						// object from this data iff rocid<30 indicating the data came from the
+						// CDC. 
+						if( rocid<30 ){
+
+							pe->NEW_Df125CDCPulse(rocid, slot, channel, itrigger
+										, pulse_number        // NPK
+										, pulse_time          // le_time
+										, quality_factor      // time_quality_bit
+										, overflow_count      // overflow_count
+										, pedestal            // pedestal
+										, sum                 // integral
+										, pulse_peak          // peak_amp
+										, word1               // word1
+										, word2               // word2
+										, nsamples_pedestal   // nsamples_pedestal
+										, nsamples_integral   // nsamples_integral
+										, false);             // emulated
+						
+						}else{
+					
+							pe->NEW_Df125FDCPulse(rocid, slot, channel, itrigger
+										, pulse_number        // NPK
+										, pulse_time          // le_time
+										, quality_factor      // time_quality_bit
+										, overflow_count      // overflow_count
+										, pedestal            // pedestal
+										, sum                 // integral
+										, pulse_peak          // peak_amp
+										, peak_time           // peak_time
+										, word1               // word1
+										, word2               // word2
+										, nsamples_pedestal   // nsamples_pedestal
+										, nsamples_integral   // nsamples_integral
+										, false);             // emulated
+						}
 					}
 				}
                 break;

--- a/src/libraries/DAQ/JEventSource_EVIO.cc
+++ b/src/libraries/DAQ/JEventSource_EVIO.cc
@@ -4068,21 +4068,44 @@ void JEventSource_EVIO::Parsef125Bank(int32_t rocid, const uint32_t* &iptr, cons
                     // opposed to the new firmware that puts the same infomation
                     // into a single data type. The emulation framework is also
                     // being revamped.
-                    objs->hit_objs.push_back( new Df125FDCPulse(rocid, slot, channel, itrigger
-                                , pulse_number        // NPK
-                                , pulse_time          // le_time
-                                , quality_factor      // time_quality_bit
-                                , overflow_count      // overflow_count
-                                , pedestal            // pedestal
-                                , sum                 // integral
-                                , pulse_peak          // peak_amp
-                                , peak_time           // peak_time
-                                , word1               // word1
-                                , word2               // word2
-                                , nsamples_pedestal   // nsamples_pedestal
-                                , nsamples_integral   // nsamples_integral
-                                , false)              // emulated
-                            );
+						  
+						  // hard-cod destination object CDC/FDC based on rocid
+						  
+						  if( rocid < 30 ){
+
+                  	  objs->hit_objs.push_back( new Df125CDCPulse(rocid, slot, channel, itrigger
+                              	  , pulse_number        // NPK
+                              	  , pulse_time          // le_time
+                              	  , quality_factor      // time_quality_bit
+                              	  , overflow_count      // overflow_count
+                              	  , pedestal            // pedestal
+                              	  , sum                 // integral
+                              	  , pulse_peak          // peak_amp
+                              	  , word1               // word1
+                              	  , word2               // word2
+                              	  , nsamples_pedestal   // nsamples_pedestal
+                              	  , nsamples_integral   // nsamples_integral
+                              	  , false)              // emulated
+                           	 );
+						  
+						  }else{
+						  
+                  	  objs->hit_objs.push_back( new Df125FDCPulse(rocid, slot, channel, itrigger
+                              	  , pulse_number        // NPK
+                              	  , pulse_time          // le_time
+                              	  , quality_factor      // time_quality_bit
+                              	  , overflow_count      // overflow_count
+                              	  , pedestal            // pedestal
+                              	  , sum                 // integral
+                              	  , pulse_peak          // peak_amp
+                              	  , peak_time           // peak_time
+                              	  , word1               // word1
+                              	  , word2               // word2
+                              	  , nsamples_pedestal   // nsamples_pedestal
+                              	  , nsamples_integral   // nsamples_integral
+                              	  , false)              // emulated
+                           	 );
+							}
                 }
 
                 // n.b. We don't record last_slot, last_channel, etc... here since those


### PR DESCRIPTION
Temporarily generate Df125CDCPulse objects from FDC pulse data (type 9). This is the same changes from Naomi's earlier pull request that was closed but never merged.