### PR TITLE
Davidl DCODAControlEvent syncskim

### DIFF
--- a/src/libraries/DAQ/DAQ_init.cc
+++ b/src/libraries/DAQ/DAQ_init.cc
@@ -29,6 +29,7 @@ using namespace jana;
 #include "DCAEN1290TDCConfig.h"
 #include "DCAEN1290TDCHit.h"
 #include "DCODAEventInfo.h"
+#include "DCODAControlEvent.h"
 #include "DCODAROCInfo.h"
 #include "DTSscalers.h"
 #include "DEPICSvalue.h"
@@ -74,6 +75,7 @@ jerror_t DAQ_init(JEventLoop *loop)
 	loop->AddFactory(new JFactory<DCAEN1290TDCConfig>());
 	loop->AddFactory(new JFactory<DCAEN1290TDCHit>());
 	loop->AddFactory(new JFactory<DCODAEventInfo>());
+	loop->AddFactory(new JFactory<DCODAControlEvent>());
 	loop->AddFactory(new JFactory<DCODAROCInfo>());
 	loop->AddFactory(new JFactory<DTSscalers>());
 	loop->AddFactory(new JFactory<DEPICSvalue>());

--- a/src/libraries/DAQ/DCODAControlEvent.h
+++ b/src/libraries/DAQ/DCODAControlEvent.h
@@ -1,0 +1,34 @@
+// $Id$
+// $HeadURL$
+//
+//    File: DCODAControlEvent.h
+// Created: Sat Dec 16 07:55:18 EST 2017
+// Creator: davidl (on Darwin harriet.local 13.3.0 i386)
+//
+
+#ifndef _DCODAControlEvent_
+#define _DCODAControlEvent_
+
+#include <JANA/JObject.h>
+using namespace jana;
+
+class DCODAControlEvent:public JObject{
+	public:
+		JOBJECT_PUBLIC(DCODAControlEvent);
+		
+		uint16_t event_type;
+		uint32_t unix_time;
+		vector<uint32_t> words;
+		
+		// This method is used primarily for pretty printing
+		// the second argument to AddString is printf style format
+		void toStrings(vector<pair<string,string> > &items)const{
+			AddString(items, "event_type"    , "%04x" , event_type);
+			AddString(items, "unix_time"     , "%ld"  , unix_time);
+			AddString(items, "Nwords"        , "%d"   , words.size());
+		}
+		
+};
+
+#endif // _DCODAControlEvent_
+

--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -622,7 +622,6 @@ void DEVIOWorkerThread::Parsef250scalerBank(uint32_t* &iptr, uint32_t *iend)
 //---------------------------------
 void DEVIOWorkerThread::ParseControlEvent(uint32_t* &iptr, uint32_t *iend)
 {
-	for(auto pe : current_parsed_events) pe->event_status_bits |= (1<<kSTATUS_CONTROL_EVENT);
 
 	time_t t = (time_t)iptr[2];
 	string tstr = ctime(&t);
@@ -638,6 +637,14 @@ void DEVIOWorkerThread::ParseControlEvent(uint32_t* &iptr, uint32_t *iend)
 	}
 	
 	jout << "Control event: " << type << " - " << tstr << endl;
+
+	for(auto pe : current_parsed_events) {
+		pe->event_status_bits |= (1<<kSTATUS_CONTROL_EVENT);
+		auto controlevent = pe->NEW_DCODAControlEvent();
+		controlevent->event_type = iptr[1]>>16;
+		controlevent->unix_time = t;
+		for(auto p = iptr; p!=iend; p++) controlevent->words.push_back(*p);
+	}
 
 	iptr = &iptr[(*iptr) + 1];
 }

--- a/src/libraries/DAQ/DParsedEvent.h
+++ b/src/libraries/DAQ/DParsedEvent.h
@@ -48,6 +48,7 @@ using namespace jana;
 #include <DAQ/DCAEN1290TDCConfig.h>
 #include <DAQ/DCAEN1290TDCHit.h>
 #include <DAQ/DCODAEventInfo.h>
+#include <DAQ/DCODAControlEvent.h>
 #include <DAQ/DCODAROCInfo.h>
 #include <DAQ/DL1Info.h>
 #include <DAQ/DEPICSvalue.h>
@@ -94,6 +95,7 @@ using namespace jana;
 		X(DCAEN1290TDCConfig) \
 		X(DCAEN1290TDCHit) \
 		X(DCODAEventInfo) \
+		X(DCODAControlEvent) \
 		X(DCODAROCInfo) \
 		X(DL1Info) \
 		X(DEPICSvalue) \

--- a/src/plugins/Utilities/syncskim/JEventProcessor_syncskim.h
+++ b/src/plugins/Utilities/syncskim/JEventProcessor_syncskim.h
@@ -8,6 +8,8 @@
 #ifndef _JEventProcessor_syncskim_
 #define _JEventProcessor_syncskim_
 
+#include <atomic>
+
 #include <JANA/JEventProcessor.h>
 
 #include <TTree.h>
@@ -29,6 +31,11 @@ class JEventProcessor_syncskim:public jana::JEventProcessor{
 		double sum_y;
 		double sum_xy;
 		double sum_x2;
+		
+		// Some TAC runs were taken without sync events. For these we use the 
+		// CODA control events as a backup
+		std::atomic<double> last_control_event_t;
+		std::atomic<double> last_physics_event_t;
 
 	private:
 		jerror_t init(void);						///< Called once at program start.


### PR DESCRIPTION
This merges a previous pull request that added the DCODAControlEvent class and new changes that make use of this class in the syncskim plugin used for recording beam trips.

The first pull request failed due to my forgetting to add a new header file. Closing and re-opening that request failed since the system tried to use the same directory name as from the previous attempt and wouldn't overwrite it. This one uses a different branch so as to ensure a new directory name.