### PR TITLE
Davidl monitoring

### DIFF
--- a/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
+++ b/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
@@ -175,6 +175,8 @@ jerror_t JEventProcessor_highlevel_online::init(void)
 	dTimingCutMap[Positron][SYS_BCAL] = 2.5;
 	dTimingCutMap[Positron][SYS_FCAL] = 3.0;
 
+	japp->RootReadLock();
+
 	// All histograms go in the "highlevel" directory
 	TDirectory *main = gDirectory;
 
@@ -321,6 +323,8 @@ jerror_t JEventProcessor_highlevel_online::init(void)
 	// back to main dir
 	main->cd();
   
+	japp->RootReadLock();
+ 
 	return NOERROR;
 }
 

--- a/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
+++ b/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
@@ -323,7 +323,7 @@ jerror_t JEventProcessor_highlevel_online::init(void)
 	// back to main dir
 	main->cd();
   
-	japp->RootReadLock();
+	japp->RootUnLock();
  
 	return NOERROR;
 }

--- a/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
+++ b/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
@@ -175,7 +175,7 @@ jerror_t JEventProcessor_highlevel_online::init(void)
 	dTimingCutMap[Positron][SYS_BCAL] = 2.5;
 	dTimingCutMap[Positron][SYS_FCAL] = 3.0;
 
-	japp->RootReadLock();
+	japp->RootWriteLock();
 
 	// All histograms go in the "highlevel" directory
 	TDirectory *main = gDirectory;

--- a/src/plugins/monitoring/occupancy_online/JEventProcessor_occupancy_online.cc
+++ b/src/plugins/monitoring/occupancy_online/JEventProcessor_occupancy_online.cc
@@ -89,7 +89,7 @@ JEventProcessor_occupancy_online::~JEventProcessor_occupancy_online()
 //------------------
 jerror_t JEventProcessor_occupancy_online::init(void)
 {
-	japp->RootReadLock();
+	japp->RootWriteLock();
 
 	// All histograms go in the "occupancy" directory
 	TDirectory *main = gDirectory;
@@ -261,7 +261,7 @@ jerror_t JEventProcessor_occupancy_online::init(void)
 	// back to main dir
 	main->cd();
   
-	japp->RootReadLock();
+	japp->RootUnLock();
  
 	return NOERROR;
 }

--- a/src/plugins/monitoring/occupancy_online/JEventProcessor_occupancy_online.cc
+++ b/src/plugins/monitoring/occupancy_online/JEventProcessor_occupancy_online.cc
@@ -89,6 +89,8 @@ JEventProcessor_occupancy_online::~JEventProcessor_occupancy_online()
 //------------------
 jerror_t JEventProcessor_occupancy_online::init(void)
 {
+	japp->RootReadLock();
+
 	// All histograms go in the "occupancy" directory
 	TDirectory *main = gDirectory;
 	gDirectory->mkdir("occupancy")->cd();
@@ -259,6 +261,8 @@ jerror_t JEventProcessor_occupancy_online::init(void)
 	// back to main dir
 	main->cd();
   
+	japp->RootReadLock();
+ 
 	return NOERROR;
 }
 


### PR DESCRIPTION
Two things:

1.  Use JApplication ROOT RW lock when creating histos in occupancy and highlevel online plugins.

2. Add option to hdevio_scan to skip a number of EVIO events when processing.