### PR TITLE
When calculating average number of digihits for occupancy plugin used…

### DIFF
--- a/src/plugins/monitoring/occupancy_online/DigiHits_occupancy.C
+++ b/src/plugins/monitoring/occupancy_online/DigiHits_occupancy.C
@@ -187,7 +187,7 @@
 			double sumw = 0.0;
 			for(int jbin=1; jbin<=yaxis->GetNbins(); jbin++){
 				double w = digihits_trig1->GetBinContent(ibin, jbin);
-				double y = yaxis->GetBinCenter(jbin);
+				double y = yaxis->GetBinLowEdge(jbin);
 				sumw += y*w;
 				sum  += w; 
 			}


### PR DESCRIPTION
… in monitoring, use low edge of bin rather than center of bin for coordinate. Using center of bin shifts the answer by 0.5 which would be correct if values were evenly distributed throughout the bin. For these though, the values are all left justified.