### PR TITLE
Custom sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ src/SBMS/*.pyc
 .clone_done
 .getarg_patches_done
 .sconstruct_done
+.patches_done
 sim-recon_prereqs_version.xml
 *.png
 *.swp

--- a/src/SBMS/sbms.py
+++ b/src/SBMS/sbms.py
@@ -645,6 +645,8 @@ def AddSQLite(env):
         env.AppendUnique(LIBS    = 'SQLiteCpp')
 	sqlite_home = os.getenv('SQLITE_HOME')
 	if(sqlite_home != None) :
+		SQLITE_CPPPATH = ["%s/include" % (sqlite_home)]
+		env.AppendUnique(CPPPATH = SQLITE_CPPPATH)
 		AddSQLite.SQLITE_LINKFLAGS = "-Wl,-rpath=%s/lib" % (sqlite_home)
 		AddLinkFlags(env, AddSQLite.SQLITE_LINKFLAGS)
 	env.AppendUnique(LIBS = 'sqlite3')

--- a/src/SBMS/sbms.py
+++ b/src/SBMS/sbms.py
@@ -643,8 +643,11 @@ def AddSQLite(env):
         SQLITECPP_LIBPATH = ["%s/lib" % (sqlitecpp_home)]
         env.AppendUnique(LIBPATH = SQLITECPP_LIBPATH)
         env.AppendUnique(LIBS    = 'SQLiteCpp')
-	AddSQLite.SQLITE_LINKFLAGS= "-lsqlite3"
-	AddLinkFlags(env, AddSQLite.SQLITE_LINKFLAGS)
+	sqlite_home = os.getenv('SQLITE_HOME')
+	if(sqlite_home != None) :
+		AddSQLite.SQLITE_LINKFLAGS = "-Wl,-rpath=%s/lib" % (sqlite_home)
+		AddLinkFlags(env, AddSQLite.SQLITE_LINKFLAGS)
+	env.AppendUnique(LIBS = 'sqlite3')
 
 
 ##################################


### PR DESCRIPTION
Require a custom built sqlite library. This is to provide a universal fix (good on CentOS6) for the newly required sqlitecpp package.
