### PR TITLE
Don't correct for attenuation longer than the BCAL length.

### DIFF
--- a/src/libraries/BCAL/DBCALPoint.cc
+++ b/src/libraries/BCAL/DBCALPoint.cc
@@ -90,10 +90,15 @@ DBCALPoint::DBCALPoint(const DBCALUnifiedHit& hit1, const DBCALUnifiedHit& hit2,
   
   // now compute attentuation factors for each end based on distance
   // the light must travel
-  
+  // Make sure not to correct the energy by a distance longer than the length
+  // of the BCAL.
+
   float dUp = 0.5 * fibLen + m_zLocal;
   float dDown = 0.5 * fibLen - m_zLocal;
-
+  if (dUp>fibLen)   dUp=fibLen;
+  if (dUp<0)        dUp=0;
+  if (dDown>fibLen) dDown=fibLen;
+  if (dDown<0)      dDown=0;
   float attUp = exp( -dUp / attenuation_length );
   float attDown = exp( -dDown / attenuation_length );
  


### PR DESCRIPTION
Points that are reconstructed outside of the BCAL should be attenuation corrected by at most the length of the BCAL.  These points will probably be cut at higher levels so this is double protection.