### PR TITLE
add parameters to disable CDC Hit timing cut, parameter to set a thre…

### DIFF
--- a/src/libraries/CDC/DCDCHit_factory.cc
+++ b/src/libraries/CDC/DCDCHit_factory.cc
@@ -19,6 +19,12 @@ static double DIGI_THRESHOLD = -1.0e8;
 //------------------
 jerror_t DCDCHit_factory::init(void)
 {
+  Disable_CDC_TimingCuts = 0; // this can be changed by a parameter in brun()
+  // Note: That has to be done in brun() because the parameters are read from ccdb at every call to brun()
+  gPARMS->SetDefaultParameter("CDCHit:Disable_TimingCuts", Disable_CDC_TimingCuts,
+                              "Disable CDC timing Cuts if this variable is not zero!");
+  
+
   gPARMS->SetDefaultParameter("CDC:DIGI_THRESHOLD",DIGI_THRESHOLD,
 			      "Do not convert CDC digitized hits into DCDCHit objects"
 			      " that would have q less than this");
@@ -28,14 +34,14 @@ jerror_t DCDCHit_factory::init(void)
   gPARMS->SetDefaultParameter("CDCHit:RemoveCorrelationHits", RemoveCorrelationHits,
 			      "Remove hits correlated in time with saturation hits!");
   
-  RemoveCorrelationHitsCut = 1.5;
-  gPARMS->SetDefaultParameter("CDCHit:RemoveCorrelationHitsCut", RemoveCorrelationHitsCut,
+  CorrelationHitsCut = 1.5;
+  gPARMS->SetDefaultParameter("CDCHit:CorrelationHitsCut", CorrelationHitsCut,
 			      "Cut in units of 8ns bins to remove correlated hits with Saturation hits!");
   
   CorrelatedHitPeak = 3.5;
   gPARMS->SetDefaultParameter("CDCHit:CorrelatedHitPeak", CorrelatedHitPeak,
                               "Location of peak time around which we cut correlated times in units of 8ns bins");
-
+  
   // Setting this flag makes it so that JANA does not delete the objects in _data.
   // This factory will manage this memory.
   SetFactoryFlag(NOT_OBJECT_OWNER);
@@ -62,6 +68,15 @@ jerror_t DCDCHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
     //jout<<"CDC Timing Cuts: "<<LowTCut<<" ... "<<HighTCut<<endl;
   }
 
+  if (Disable_CDC_TimingCuts) {
+    
+    LowTCut = -10000.;
+    HighTCut = 10000.;
+    jout << "Disable CDC Hit Timing Cuts!" << endl;
+    
+  }
+  
+
   eventLoop->Get(ttab);
   
   return NOERROR;
@@ -78,80 +93,79 @@ jerror_t DCDCHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
   
   vector<const DCDCHit*> hits;
   loop->Get(hits, "Calib");
-
-
+  
+  
   vector<cdchit_info_t> hit_info_vec;
-
+  
   // loop over hits and find roc/slot/con numbers
   for (unsigned int k=0 ;k<hits.size(); k++){
     const DCDCHit *hit = hits[k];
     vector <const Df125CDCPulse*> pulse;
     hit->Get(pulse);
-
+    
     cdchit_info_t hit_info;
     if(pulse.size()==0) {
-        // for hits without lower-level hit info, e.g. HDDM data, we have to use the translation table
-        // to figure out which DAQ channels his hit corresponds to
-        try {
-            DTranslationTable::DChannelInfo channel_info;
-            channel_info.det_sys = DTranslationTable::CDC;
-            channel_info.cdc.ring = hit->ring;
-            channel_info.cdc.straw = hit->straw;
-            DTranslationTable::csc_t daq_index = ttab[0]->GetDAQIndex(channel_info);
-
-            hit_info.rocid = daq_index.rocid;
-            hit_info.slot = daq_index.slot;
-            hit_info.connector = daq_index.channel / 24;
-        } catch(...) { 
-            cout << "Cannot find Translation Table data for hit on ring " << hit->ring
-                 << " straw " << hit->straw << ", skipping this info ..." << endl;
-            continue;
-        }
+      // for hits without lower-level hit info, e.g. HDDM data, we have to use the translation table
+      // to figure out which DAQ channels his hit corresponds to
+      try {
+	DTranslationTable::DChannelInfo channel_info;
+	channel_info.det_sys = DTranslationTable::CDC;
+	channel_info.cdc.ring = hit->ring;
+	channel_info.cdc.straw = hit->straw;
+	DTranslationTable::csc_t daq_index = ttab[0]->GetDAQIndex(channel_info);
+	
+	hit_info.rocid = daq_index.rocid;
+	hit_info.slot = daq_index.slot;
+	hit_info.connector = daq_index.channel / 24;
+      } catch(...) { 
+	cout << "Cannot find Translation Table data for hit on ring " << hit->ring
+	     << " straw " << hit->straw << ", skipping this info ..." << endl;
+	continue;
+      }
     } else {
-        hit_info.rocid = pulse[0]->rocid;
-        hit_info.slot = pulse[0]->slot;
-        hit_info.connector = pulse[0]->channel / 24;
+      hit_info.rocid = pulse[0]->rocid;
+      hit_info.slot = pulse[0]->slot;
+      hit_info.connector = pulse[0]->channel / 24;
     }
-
+    
     hit_info.time = hit->t;
     hit_info.max = 0;
-
+    
     if (hit->QF > 1) {
-        hit_info.max = 1;
+      hit_info.max = 1;
     }
-
+    
     hit_info_vec.push_back(hit_info);
   }
   
-
+  
   vector<bool> Mark4Removal(hit_info_vec.size(), false);
-
+  
   if (RemoveCorrelationHits && (hit_info_vec.size()>0) ) {
     
-      for (unsigned int k=0 ;k<hit_info_vec.size()-1; k++){
-          
-          if (hit_info_vec[k].max){
-	
-              for (unsigned int n=k+1 ;n<hit_info_vec.size(); n++){
-
-                  //if (n==k)
-                  //  continue;
-	  
-                  //if ((RocID[k] == RocID[n]) && (Slot[k] == Slot[n]) && (Connector[k] == Connector[n]) ){
-                  if(hit_info_vec[k] == hit_info_vec[n]) {
-                      double dt = (hit_info_vec[k].time - hit_info_vec[n].time)/8.; // units of samples (8ns)
-                      if ( fabs(dt+CorrelatedHitPeak)<RemoveCorrelationHitsCut) {
-                          Mark4Removal[k] = true;
-                          Mark4Removal[n] = true;
-                          //cout<<"remove "<<hits[n]->ring<<" "<<hits[n]->straw<<endl;
-                      }
-                      
-                  }
-                  
-              }
-          }
-      }
+    for (unsigned int k=0 ;k<hit_info_vec.size()-1; k++){
       
+      if (hit_info_vec[k].max){
+	
+	for (unsigned int n=k+1 ;n<hit_info_vec.size(); n++){
+	  
+	  //if (n==k)
+	  //  continue;
+	  
+	  //if ((RocID[k] == RocID[n]) && (Slot[k] == Slot[n]) && (Connector[k] == Connector[n]) ){
+	  if(hit_info_vec[k] == hit_info_vec[n]) {
+	    double dt = (hit_info_vec[k].time - hit_info_vec[n].time)/8.; // units of samples (8ns)
+	    if ( fabs(dt+CorrelatedHitPeak)<CorrelationHitsCut) {
+	      Mark4Removal[n] = true;
+	      //cout<<"remove "<<hits[n]->ring<<" "<<hits[n]->straw<<endl;
+	    }
+            
+	  }
+          
+	}
+      }
+    }
+    
   }
 
   

--- a/src/libraries/CDC/DCDCHit_factory.h
+++ b/src/libraries/CDC/DCDCHit_factory.h
@@ -21,25 +21,26 @@ class DCDCHit_factory: public jana::JFactory<DCDCHit>{
  public:
   DCDCHit_factory(){};
   ~DCDCHit_factory(){};
-
+  
   // we need to store information on the hits with respect to their readout channels in order to look for correlated hits
   struct cdchit_info_t{
-      uint32_t rocid;
-      uint32_t slot;
-      uint32_t connector;
-
-      double time;
-      double max;
-
-      inline bool operator==(const struct cdchit_info_t &rhs) const {
-          return (rocid==rhs.rocid) && (slot==rhs.slot) && (connector==rhs.connector);
-      }
+    uint32_t rocid;
+    uint32_t slot;
+    uint32_t connector;
+    
+    double time;
+    double max;
+    
+    inline bool operator==(const struct cdchit_info_t &rhs) const {
+      return (rocid==rhs.rocid) && (slot==rhs.slot) && (connector==rhs.connector);
+    }
   };
-
-
+  
+  
   int RemoveCorrelationHits;
-  double RemoveCorrelationHitsCut;
+  double CorrelationHitsCut;
   double CorrelatedHitPeak;
+  int Disable_CDC_TimingCuts;
 
   // timing cut limits
   double LowTCut;
@@ -51,7 +52,7 @@ class DCDCHit_factory: public jana::JFactory<DCDCHit>{
   jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
   jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
   jerror_t fini(void);						///< Called after last event of last event source has been processed.
-
+  
   vector<const DTranslationTable *> ttab;
 };
 

--- a/src/libraries/CDC/DCDCHit_factory_Calib.cc
+++ b/src/libraries/CDC/DCDCHit_factory_Calib.cc
@@ -20,6 +20,8 @@ using namespace std;
 
 using namespace jana;
 
+int CDC_HIT_THRESHOLD = 0;
+
 //#define ENABLE_UPSAMPLING
 
 //------------------
@@ -27,22 +29,25 @@ using namespace jana;
 //------------------
 jerror_t DCDCHit_factory_Calib::init(void)
 {
-
-    // default values
-    Nrings = 0;
-    a_scale = 0.;
-    t_scale = 0.;
-    t_base = 0.;
-
-    // Set default number of number of detector channels
-    maxChannels = 3522;
-
-    /// set the base conversion scales
-    a_scale = 4.0E3/1.0E2; 
-    t_scale = 8.0/10.0;    // 8 ns/count and integer time is in 1/10th of sample
-    t_base  = 0.;       // ns
-
-    return NOERROR;
+  
+  gPARMS->SetDefaultParameter("CDC:CDC_HIT_THRESHOLD", CDC_HIT_THRESHOLD,
+                              "Remove CDC Hits with peak amplitudes smaller than CDC_HIT_THRESHOLD");
+  
+  // default values
+  Nrings = 0;
+  a_scale = 0.;
+  t_scale = 0.;
+  t_base = 0.;
+  
+  // Set default number of number of detector channels
+  maxChannels = 3522;
+  
+  /// set the base conversion scales
+  a_scale = 4.0E3/1.0E2; 
+  t_scale = 8.0/10.0;    // 8 ns/count and integer time is in 1/10th of sample
+  t_base  = 0.;       // ns
+  
+  return NOERROR;
 }
 
 //------------------
@@ -50,112 +55,112 @@ jerror_t DCDCHit_factory_Calib::init(void)
 //------------------
 jerror_t DCDCHit_factory_Calib::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 {
-    // Only print messages for one thread whenever run number change
-    static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
-    static set<int> runs_announced;
-    pthread_mutex_lock(&print_mutex);
-    bool print_messages = false;
-    if(runs_announced.find(runnumber) == runs_announced.end()){
-        print_messages = true;
-        runs_announced.insert(runnumber);
-    }
-    pthread_mutex_unlock(&print_mutex);
-
-    // calculate the number of straws in each ring
-    CalcNstraws(eventLoop, runnumber, Nstraws);
-    Nrings = Nstraws.size();
-
-    vector<double> raw_gains;
-    vector<double> raw_pedestals;
-    vector<double> raw_time_offsets;
-
-    if(print_messages) jout << "In DCDCHit_factory, loading constants..." << std::endl;
-
-    // load scale factors
-    map<string,double> scale_factors;
-    if (eventLoop->GetCalib("/CDC/digi_scales", scale_factors))
-        jout << "Error loading /CDC/digi_scales !" << endl;
-    if (scale_factors.find("CDC_ADC_ASCALE") != scale_factors.end())
-        a_scale = scale_factors["CDC_ADC_ASCALE"];
-    else
-        jerr << "Unable to get CDC_ADC_ASCALE from /CDC/digi_scales !" << endl;
-
+  // Only print messages for one thread whenever run number change
+  static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
+  static set<int> runs_announced;
+  pthread_mutex_lock(&print_mutex);
+  bool print_messages = false;
+  if(runs_announced.find(runnumber) == runs_announced.end()){
+    print_messages = true;
+    runs_announced.insert(runnumber);
+  }
+  pthread_mutex_unlock(&print_mutex);
+  
+  // calculate the number of straws in each ring
+  CalcNstraws(eventLoop, runnumber, Nstraws);
+  Nrings = Nstraws.size();
+  
+  vector<double> raw_gains;
+  vector<double> raw_pedestals;
+  vector<double> raw_time_offsets;
+  
+  if(print_messages) jout << "In DCDCHit_factory, loading constants..." << std::endl;
+  
+  // load scale factors
+  map<string,double> scale_factors;
+  if (eventLoop->GetCalib("/CDC/digi_scales", scale_factors))
+    jout << "Error loading /CDC/digi_scales !" << endl;
+  if (scale_factors.find("CDC_ADC_ASCALE") != scale_factors.end())
+    a_scale = scale_factors["CDC_ADC_ASCALE"];
+  else
+    jerr << "Unable to get CDC_ADC_ASCALE from /CDC/digi_scales !" << endl;
+  
 #ifdef ENABLE_UPSAMPLING
-    //t_scale=1.;
+  //t_scale=1.;
 #else
-    if (scale_factors.find("CDC_ADC_TSCALE") != scale_factors.end())
-        t_scale = scale_factors["CDC_ADC_TSCALE"];
-    else
-        jerr << "Unable to get CDC_ADC_TSCALE from /CDC/digi_scales !" << endl;
+  if (scale_factors.find("CDC_ADC_TSCALE") != scale_factors.end())
+    t_scale = scale_factors["CDC_ADC_TSCALE"];
+  else
+    jerr << "Unable to get CDC_ADC_TSCALE from /CDC/digi_scales !" << endl;
 #endif
-
-    // load base time offset
-    map<string,double> base_time_offset;
-    if (eventLoop->GetCalib("/CDC/base_time_offset",base_time_offset))
-        jout << "Error loading /CDC/base_time_offset !" << endl;
-    if (base_time_offset.find("CDC_BASE_TIME_OFFSET") != base_time_offset.end())
-        t_base = base_time_offset["CDC_BASE_TIME_OFFSET"];
-    else
-        jerr << "Unable to get CDC_BASE_TIME_OFFSET from /CDC/base_time_offset !" << endl;
-
-    // load constant tables
-    if (eventLoop->GetCalib("/CDC/wire_gains", raw_gains))
-        jout << "Error loading /CDC/wire_gains !" << endl;
-    if (eventLoop->GetCalib("/CDC/pedestals", raw_pedestals))
-        jout << "Error loading /CDC/pedestals !" << endl;
-    if (eventLoop->GetCalib("/CDC/timing_offsets", raw_time_offsets))
-        jout << "Error loading /CDC/timing_offsets !" << endl;
-
-    // fill the tables
-    FillCalibTable(gains, raw_gains, Nstraws);
-    FillCalibTable(pedestals, raw_pedestals, Nstraws);
-    FillCalibTable(time_offsets, raw_time_offsets, Nstraws);
-
-    // Verify that the right number of rings was read for each set of constants
-    char str[256];
-    if (gains.size() != Nrings) {
-        sprintf(str, "Bad # of rings for CDC gain from CCDB! CCDB=%zu , should be %d", gains.size(), Nrings);
-        std::cerr << str << std::endl;
-        throw JException(str);
+  
+  // load base time offset
+  map<string,double> base_time_offset;
+  if (eventLoop->GetCalib("/CDC/base_time_offset",base_time_offset))
+    jout << "Error loading /CDC/base_time_offset !" << endl;
+  if (base_time_offset.find("CDC_BASE_TIME_OFFSET") != base_time_offset.end())
+    t_base = base_time_offset["CDC_BASE_TIME_OFFSET"];
+  else
+    jerr << "Unable to get CDC_BASE_TIME_OFFSET from /CDC/base_time_offset !" << endl;
+  
+  // load constant tables
+  if (eventLoop->GetCalib("/CDC/wire_gains", raw_gains))
+    jout << "Error loading /CDC/wire_gains !" << endl;
+  if (eventLoop->GetCalib("/CDC/pedestals", raw_pedestals))
+    jout << "Error loading /CDC/pedestals !" << endl;
+  if (eventLoop->GetCalib("/CDC/timing_offsets", raw_time_offsets))
+    jout << "Error loading /CDC/timing_offsets !" << endl;
+  
+  // fill the tables
+  FillCalibTable(gains, raw_gains, Nstraws);
+  FillCalibTable(pedestals, raw_pedestals, Nstraws);
+  FillCalibTable(time_offsets, raw_time_offsets, Nstraws);
+  
+  // Verify that the right number of rings was read for each set of constants
+  char str[256];
+  if (gains.size() != Nrings) {
+    sprintf(str, "Bad # of rings for CDC gain from CCDB! CCDB=%zu , should be %d", gains.size(), Nrings);
+    std::cerr << str << std::endl;
+    throw JException(str);
+  }
+  if (pedestals.size() != Nrings) {
+    sprintf(str, "Bad # of rings for CDC pedestal from CCDB! CCDB=%zu , should be %d", pedestals.size(), Nrings);
+    std::cerr << str << std::endl;
+    throw JException(str);
+  }
+  if (time_offsets.size() != Nrings) {
+    sprintf(str, "Bad # of rings for CDC time_offset from CCDB!"
+	    " CCDB=%zu , should be %d", time_offsets.size(), Nrings);
+    std::cerr << str << std::endl;
+    throw JException(str);
+  }
+  
+  // Verify the right number of straws was read for each ring for each set of constants
+  for (unsigned int i=0; i < Nrings; i++) {
+    if (gains[i].size() != Nstraws[i]) {
+      sprintf(str, "Bad # of straws for CDC gain from CCDB!"
+	      " CCDB=%zu , should be %d for ring %d",
+	      gains[i].size(), Nstraws[i], i+1);
+      std::cerr << str << std::endl;
+      throw JException(str);
     }
-    if (pedestals.size() != Nrings) {
-        sprintf(str, "Bad # of rings for CDC pedestal from CCDB! CCDB=%zu , should be %d", pedestals.size(), Nrings);
-        std::cerr << str << std::endl;
-        throw JException(str);
+    if (pedestals[i].size() != Nstraws[i]) {
+      sprintf(str, "Bad # of straws for CDC pedestal from CCDB!"
+	      " CCDB=%zu , should be %d for ring %d",
+	      pedestals[i].size(), Nstraws[i], i+1);
+      std::cerr << str << std::endl;
+      throw JException(str);
     }
-    if (time_offsets.size() != Nrings) {
-        sprintf(str, "Bad # of rings for CDC time_offset from CCDB!"
-                " CCDB=%zu , should be %d", time_offsets.size(), Nrings);
-        std::cerr << str << std::endl;
-        throw JException(str);
+    if (time_offsets[i].size() != Nstraws[i]) {
+      sprintf(str, "Bad # of straws for CDC time_offset from CCDB!"
+	      " CCDB=%zu , should be %d for ring %d",
+	      time_offsets[i].size(), Nstraws[i], i+1);
+      std::cerr << str << std::endl;
+      throw JException(str);
     }
+  }
 
-    // Verify the right number of straws was read for each ring for each set of constants
-    for (unsigned int i=0; i < Nrings; i++) {
-        if (gains[i].size() != Nstraws[i]) {
-            sprintf(str, "Bad # of straws for CDC gain from CCDB!"
-                    " CCDB=%zu , should be %d for ring %d",
-                    gains[i].size(), Nstraws[i], i+1);
-            std::cerr << str << std::endl;
-            throw JException(str);
-        }
-        if (pedestals[i].size() != Nstraws[i]) {
-            sprintf(str, "Bad # of straws for CDC pedestal from CCDB!"
-                    " CCDB=%zu , should be %d for ring %d",
-                    pedestals[i].size(), Nstraws[i], i+1);
-            std::cerr << str << std::endl;
-            throw JException(str);
-        }
-        if (time_offsets[i].size() != Nstraws[i]) {
-            sprintf(str, "Bad # of straws for CDC time_offset from CCDB!"
-                    " CCDB=%zu , should be %d for ring %d",
-                    time_offsets[i].size(), Nstraws[i], i+1);
-            std::cerr << str << std::endl;
-            throw JException(str);
-        }
-    }
-
-    return NOERROR;
+  return NOERROR;
 }
 
 //------------------
@@ -163,133 +168,137 @@ jerror_t DCDCHit_factory_Calib::brun(jana::JEventLoop *eventLoop, int32_t runnum
 //------------------
 jerror_t DCDCHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
 {
-    /// Generate DCDCHit object for each DCDCDigiHit object.
-    /// This is where the first set of calibration constants
-    /// is applied to convert from digitzed units into natural
-    /// units.
-    ///
-    /// Note that this code does NOT get called for simulated
-    /// data in HDDM format. The HDDM event source will copy
-    /// the precalibrated values directly into the _data vector.
-
-    /// In order to use the new Flash125 data types and maintain compatibility with the old code, what is below is a bit of a mess
-
-    vector<const DCDCDigiHit*> digihits;
-    loop->Get(digihits);
-    char str[256];
-    for (unsigned int i=0; i < digihits.size(); i++) {
-        const DCDCDigiHit *digihit = digihits[i];
-
-        //if ( (digihit->QF & 0x1) != 0 ) continue; // Cut bad timing quality factor hits... (should check effect on efficiency)
-
-        const int &ring  = digihit->ring;
-        const int &straw = digihit->straw;
-
-        // Make sure ring and straw are in valid range
-        if ( (ring < 1) || (ring > (int)Nrings)) {
-            sprintf(str, "DCDCDigiHit ring out of range!"
-                    " ring=%d (should be 1-%d)", ring, Nrings);
-            throw JException(str);
-        }
-        if ( (straw < 1) || (straw > (int)Nstraws[ring-1])) {
-	  sprintf(str, "DCDCDigiHit straw out of range!"
-		  " straw=%d for ring=%d (should be 1-%d)",
-		  straw, ring, Nstraws[ring-1]);
-	  throw JException(str);
-        }
-
-
-        // Grab the pedestal from the digihit since this should be consistent between the old and new formats
-        int raw_ped           = digihit->pedestal;
-        int maxamp            = digihit->pulse_peak; 
-
-        // There are a few values from the new data type that are critical for the interpretation of the data
-        uint16_t ABIT = 0; // 2^{ABIT} Scale factor for amplitude
-        uint16_t PBIT = 0; // 2^{PBIT} Scale factor for pedestal
-
-        // This is the place to make quality cuts on the data. 
-        const Df125PulsePedestal* PPobj = NULL;
-        digihit->GetSingle(PPobj);
-        if( PPobj != NULL ) { 
-            // Use the old format - mostly handle error conditions
-            // This code will at some point become deprecated in the future...
-            // This applies to the firmware for data taken until the fall of 2015.
-            // Mode 8: Raw data and processed data (except pulse integral).
-            // Mode 7: Processed data only.
-
-            // This error state is only present in mode 8
-            if (digihit->pulse_time==0.) continue;
-
-            // There is a slight difference between Mode 7 and 8 data
-            // The following condition signals an error state in the flash algorithm
-            // Do not make hits out of these
-            if (PPobj != NULL){
-                if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
-                if (PPobj->pulse_number == 1) continue; // Unintentionally had 2 pulses found in fall 2014 data (0-1 counting issue)
-            }
-            
-            const Df125PulseIntegral* PIobj = NULL;
-            digihit->GetSingle(PIobj);
-            if (PPobj == NULL || PIobj == NULL) continue; // We don't want hits where ANY of the associated information is missing
-
-            // this amplitude is not set in the translation table for this old data format, so make a (reasonable?) guess
-            maxamp = digihit->pulse_integral / 28.8;
-        } else {
-            // Use the modern (2017+) data versions
-            // Configuration data needed to interpret the hits is stored in the data stream
-            vector<const Df125Config*> configs;
-            digihit->Get(configs);
-            if( configs.empty() ){
-                static int Nwarnings = 0;
-                if(Nwarnings<10){
-                    _DBG_ << "NO Df125Config object associated with Df125CDCPulse object!" << endl;
-                    Nwarnings++;
-                    if(Nwarnings==10) _DBG_ << " --- LAST WARNING!! ---" << endl;
-                }
-            }else{
-            	// Set some constants to defaults until they appear correctly in the config words in the future
-					const Df125Config *config = configs[0];
-					ABIT = config->ABIT == 0xffff ? 3 : config->ABIT;
-					PBIT = config->PBIT == 0xffff ? 0 : config->PBIT;
- 				}
-        }
-
-        // Complete the pedestal subtraction here since we should know the correct number of samples.
-        int scaled_ped = raw_ped << PBIT;
-        
-        if (maxamp > 0) maxamp = maxamp << ABIT;
-        //if (maxamp <= scaled_ped) continue;
-
-        maxamp = maxamp - scaled_ped;
-
-        // Apply calibration constants here
-        double t_raw = double(digihit->pulse_time);
-
-        double q = a_scale * gains[ring-1][straw-1] * (double)maxamp * 28.8;
-        double amp =  maxamp;
-
-        double t = t_scale * t_raw - time_offsets[ring-1][straw-1] + t_base;
-
-        DCDCHit *hit = new DCDCHit;
-        hit->ring  = ring;
-        hit->straw = straw;
-
-        // Values for d, itrack, ptype only apply to MC data
-        // note that ring/straw counting starts at 1
-        hit->q = q;
-        hit->amp = amp;
-        hit->t = t;
-        hit->d = 0.0;
-	hit->QF = digihit->QF;
-        hit->itrack = -1;
-        hit->ptype = 0;
-
-        hit->AddAssociatedObject(digihit);
-
-        _data.push_back(hit);
+  /// Generate DCDCHit object for each DCDCDigiHit object.
+  /// This is where the first set of calibration constants
+  /// is applied to convert from digitzed units into natural
+  /// units.
+  ///
+  /// Note that this code does NOT get called for simulated
+  /// data in HDDM format. The HDDM event source will copy
+  /// the precalibrated values directly into the _data vector.
+  
+  /// In order to use the new Flash125 data types and maintain compatibility with the old code, what is below is a bit of a mess
+  
+  vector<const DCDCDigiHit*> digihits;
+  loop->Get(digihits);
+  char str[256];
+  for (unsigned int i=0; i < digihits.size(); i++) {
+    const DCDCDigiHit *digihit = digihits[i];
+    
+    //if ( (digihit->QF & 0x1) != 0 ) continue; // Cut bad timing quality factor hits... (should check effect on efficiency)
+    
+    const int &ring  = digihit->ring;
+    const int &straw = digihit->straw;
+    
+    // Make sure ring and straw are in valid range
+    if ( (ring < 1) || (ring > (int)Nrings)) {
+      sprintf(str, "DCDCDigiHit ring out of range!"
+	      " ring=%d (should be 1-%d)", ring, Nrings);
+      throw JException(str);
     }
-
-    return NOERROR;
+    if ( (straw < 1) || (straw > (int)Nstraws[ring-1])) {
+      sprintf(str, "DCDCDigiHit straw out of range!"
+	      " straw=%d for ring=%d (should be 1-%d)",
+	      straw, ring, Nstraws[ring-1]);
+      throw JException(str);
+    }
+    
+    
+    // Grab the pedestal from the digihit since this should be consistent between the old and new formats
+    int raw_ped           = digihit->pedestal;
+    int maxamp            = digihit->pulse_peak; 
+    
+    // There are a few values from the new data type that are critical for the interpretation of the data
+    uint16_t ABIT = 0; // 2^{ABIT} Scale factor for amplitude
+    uint16_t PBIT = 0; // 2^{PBIT} Scale factor for pedestal
+    
+    // This is the place to make quality cuts on the data. 
+    const Df125PulsePedestal* PPobj = NULL;
+    digihit->GetSingle(PPobj);
+    if( PPobj != NULL ) { 
+      // Use the old format - mostly handle error conditions
+      // This code will at some point become deprecated in the future...
+      // This applies to the firmware for data taken until the fall of 2015.
+      // Mode 8: Raw data and processed data (except pulse integral).
+      // Mode 7: Processed data only.
+      
+      // This error state is only present in mode 8
+      if (digihit->pulse_time==0.) continue;
+      
+      // There is a slight difference between Mode 7 and 8 data
+      // The following condition signals an error state in the flash algorithm
+      // Do not make hits out of these
+      if (PPobj != NULL){
+	if (PPobj->pedestal == 0 || PPobj->pulse_peak == 0) continue;
+	if (PPobj->pulse_number == 1) continue; // Unintentionally had 2 pulses found in fall 2014 data (0-1 counting issue)
+      }
+      
+      const Df125PulseIntegral* PIobj = NULL;
+      digihit->GetSingle(PIobj);
+      if (PPobj == NULL || PIobj == NULL) continue; // We don't want hits where ANY of the associated information is missing
+      
+      // this amplitude is not set in the translation table for this old data format, so make a (reasonable?) guess
+      maxamp = digihit->pulse_integral / 28.8;
+    } else {
+      // Use the modern (2017+) data versions
+      // Configuration data needed to interpret the hits is stored in the data stream
+      vector<const Df125Config*> configs;
+      digihit->Get(configs);
+      if( configs.empty() ){
+	static int Nwarnings = 0;
+	if(Nwarnings<10){
+	  _DBG_ << "NO Df125Config object associated with Df125CDCPulse object!" << endl;
+	  Nwarnings++;
+	  if(Nwarnings==10) _DBG_ << " --- LAST WARNING!! ---" << endl;
+	}
+      }else{
+	// Set some constants to defaults until they appear correctly in the config words in the future
+	const Df125Config *config = configs[0];
+	ABIT = config->ABIT == 0xffff ? 3 : config->ABIT;
+	PBIT = config->PBIT == 0xffff ? 0 : config->PBIT;
+      }
+    }
+    
+    // Complete the pedestal subtraction here since we should know the correct number of samples.
+    int scaled_ped = raw_ped << PBIT;
+    
+    if (maxamp > 0) maxamp = maxamp << ABIT;
+    //if (maxamp <= scaled_ped) continue;
+    
+    maxamp = maxamp - scaled_ped;
+    
+    if (maxamp<CDC_HIT_THRESHOLD) {
+      continue;
+    }
+    
+    // Apply calibration constants here
+    double t_raw = double(digihit->pulse_time);
+    
+    double q = a_scale * gains[ring-1][straw-1] * (double)maxamp * 28.8;
+    double amp =  maxamp;
+    
+    double t = t_scale * t_raw - time_offsets[ring-1][straw-1] + t_base;
+    
+    DCDCHit *hit = new DCDCHit;
+    hit->ring  = ring;
+    hit->straw = straw;
+    
+    // Values for d, itrack, ptype only apply to MC data
+    // note that ring/straw counting starts at 1
+    hit->q = q;
+    hit->amp = amp;
+    hit->t = t;
+    hit->d = 0.0;
+    hit->QF = digihit->QF;
+    hit->itrack = -1;
+    hit->ptype = 0;
+    
+    hit->AddAssociatedObject(digihit);
+    
+    _data.push_back(hit);
+  }
+  
+  return NOERROR;
 }
 
 
@@ -298,7 +307,7 @@ jerror_t DCDCHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
 //------------------
 jerror_t DCDCHit_factory_Calib::erun(void)
 {
-    return NOERROR;
+  return NOERROR;
 }
 
 //------------------
@@ -306,7 +315,7 @@ jerror_t DCDCHit_factory_Calib::erun(void)
 //------------------
 jerror_t DCDCHit_factory_Calib::fini(void)
 {
-    return NOERROR;
+  return NOERROR;
 }
 
 //------------------
@@ -314,32 +323,32 @@ jerror_t DCDCHit_factory_Calib::fini(void)
 //------------------
 void DCDCHit_factory_Calib::CalcNstraws(jana::JEventLoop *eventLoop, int32_t runnumber, vector<unsigned int> &Nstraws)
 {
-    DGeometry *dgeom;
-    vector<vector<DCDCWire *> >cdcwires;
-
-    // Get pointer to DGeometry object
-    DApplication* dapp=dynamic_cast<DApplication*>(eventLoop->GetJApplication());
-    dgeom  = dapp->GetDGeometry(runnumber);
-
-    // Get the CDC wire table from the XML
-    dgeom->GetCDCWires(cdcwires);
-
-    // Fill array with the number of straws for each layer
-    // Also keep track of the total number of straws, i.e., the total number of detector channels
-    maxChannels = 0;
-    Nstraws.clear();
-    for (unsigned int i=0; i<cdcwires.size(); i++) {
-        Nstraws.push_back( cdcwires[i].size() );
-        maxChannels += cdcwires[i].size();
+  DGeometry *dgeom;
+  vector<vector<DCDCWire *> >cdcwires;
+  
+  // Get pointer to DGeometry object
+  DApplication* dapp=dynamic_cast<DApplication*>(eventLoop->GetJApplication());
+  dgeom  = dapp->GetDGeometry(runnumber);
+  
+  // Get the CDC wire table from the XML
+  dgeom->GetCDCWires(cdcwires);
+  
+  // Fill array with the number of straws for each layer
+  // Also keep track of the total number of straws, i.e., the total number of detector channels
+  maxChannels = 0;
+  Nstraws.clear();
+  for (unsigned int i=0; i<cdcwires.size(); i++) {
+    Nstraws.push_back( cdcwires[i].size() );
+    maxChannels += cdcwires[i].size();
+  }
+  
+  // clear up all of the wire information
+  for (unsigned int i=0; i<cdcwires.size(); i++) {
+    for (unsigned int j=0; j<cdcwires[i].size(); j++) {
+      delete cdcwires[i][j];
     }
-
-    // clear up all of the wire information
-    for (unsigned int i=0; i<cdcwires.size(); i++) {
-        for (unsigned int j=0; j<cdcwires[i].size(); j++) {
-            delete cdcwires[i][j];
-        }
-    }    
-    cdcwires.clear();
+  }    
+  cdcwires.clear();
 }
 
 
@@ -347,28 +356,28 @@ void DCDCHit_factory_Calib::CalcNstraws(jana::JEventLoop *eventLoop, int32_t run
 // FillCalibTable
 //------------------
 void DCDCHit_factory_Calib::FillCalibTable(vector< vector<double> > &table, vector<double> &raw_table, 
-        vector<unsigned int> &Nstraws)
+					   vector<unsigned int> &Nstraws)
 {
-    int ring = 0;
-    int straw = 0;
-
-    // reset table before filling it
-    table.clear();
-    table.resize( Nstraws.size() );
-
-    for (unsigned int channel=0; channel<raw_table.size(); channel++,straw++) {
-        // make sure that we don't try to load info for channels that don't exist
-        if (channel == maxChannels) break;
-
-        // if we've hit the end of the ring, move on to the next
-        if (straw == (int)Nstraws[ring]) {
-            ring++;
-            straw = 0;
-        }
-
-        table[ring].push_back( raw_table[channel] );
+  int ring = 0;
+  int straw = 0;
+  
+  // reset table before filling it
+  table.clear();
+  table.resize( Nstraws.size() );
+  
+  for (unsigned int channel=0; channel<raw_table.size(); channel++,straw++) {
+    // make sure that we don't try to load info for channels that don't exist
+    if (channel == maxChannels) break;
+    
+    // if we've hit the end of the ring, move on to the next
+    if (straw == (int)Nstraws[ring]) {
+      ring++;
+      straw = 0;
     }
-
+    
+    table[ring].push_back( raw_table[channel] );
+  }
+  
 }
 
 
@@ -377,102 +386,74 @@ void DCDCHit_factory_Calib::FillCalibTable(vector< vector<double> > &table, vect
 //   Allow a few different interfaces
 //------------------------------------
 const double DCDCHit_factory_Calib::GetConstant(const cdc_digi_constants_t &the_table,
-        const int in_ring, const int in_straw) const {
-
-    char str[256];
-
-    if ( (in_ring <= 0) || (static_cast<unsigned int>(in_ring) > Nrings)) {
-        sprintf(str, "Bad ring # requested in DCDCHit_factory::GetConstant()!"
-                " requested=%d , should be %ud", in_ring, Nrings);
-        std::cerr << str << std::endl;
-        throw JException(str);
-    }
-    if ( (in_straw <= 0) || 
-            (static_cast<unsigned int>(in_straw) > Nstraws[in_ring]))
+						const int in_ring, const int in_straw) const {
+  
+  char str[256];
+  
+  if ( (in_ring <= 0) || (static_cast<unsigned int>(in_ring) > Nrings)) {
+    sprintf(str, "Bad ring # requested in DCDCHit_factory::GetConstant()!"
+	    " requested=%d , should be %ud", in_ring, Nrings);
+    std::cerr << str << std::endl;
+    throw JException(str);
+  }
+  if ( (in_straw <= 0) || 
+       (static_cast<unsigned int>(in_straw) > Nstraws[in_ring]))
     {
-        sprintf(str, "Bad straw # requested in DCDCHit_factory::GetConstant()!"
-                " requested=%d , should be %ud", in_straw, Nstraws[in_ring]);
-        std::cerr << str << std::endl;
-        throw JException(str);
+      sprintf(str, "Bad straw # requested in DCDCHit_factory::GetConstant()!"
+	      " requested=%d , should be %ud", in_straw, Nstraws[in_ring]);
+      std::cerr << str << std::endl;
+      throw JException(str);
     }
-
-    return the_table[in_ring-1][in_straw-1];
+  
+  return the_table[in_ring-1][in_straw-1];
 }
 
 const double DCDCHit_factory_Calib::GetConstant(const cdc_digi_constants_t &the_table,
-        const DCDCDigiHit *in_digihit) const {
-
-    char str[256];
-
-    if ( (in_digihit->ring <= 0) || 
-            (static_cast<unsigned int>(in_digihit->ring) > Nrings))
+						const DCDCDigiHit *in_digihit) const {
+  
+  char str[256];
+  
+  if ( (in_digihit->ring <= 0) || 
+       (static_cast<unsigned int>(in_digihit->ring) > Nrings))
     {
-        sprintf(str, "Bad ring # requested in DCDCHit_factory::GetConstant()!"
-                " requested=%d , should be %ud", in_digihit->ring, Nrings);
-        std::cerr << str << std::endl;
-        throw JException(str);
+      sprintf(str, "Bad ring # requested in DCDCHit_factory::GetConstant()!"
+	      " requested=%d , should be %ud", in_digihit->ring, Nrings);
+      std::cerr << str << std::endl;
+      throw JException(str);
     }
-    if ( (in_digihit->straw <= 0) || 
-            (static_cast<unsigned int>(in_digihit->straw) > Nstraws[in_digihit->ring]))
+  if ( (in_digihit->straw <= 0) || 
+       (static_cast<unsigned int>(in_digihit->straw) > Nstraws[in_digihit->ring]))
     {
-        sprintf(str, "Bad straw # requested in DCDCHit_factory::GetConstant()!"
-                " requested=%d , should be %ud",
-                in_digihit->straw, Nstraws[in_digihit->ring]);
-        std::cerr << str << std::endl;
-        throw JException(str);
+      sprintf(str, "Bad straw # requested in DCDCHit_factory::GetConstant()!"
+	      " requested=%d , should be %ud",
+	      in_digihit->straw, Nstraws[in_digihit->ring]);
+      std::cerr << str << std::endl;
+      throw JException(str);
     }
-
-    return the_table[in_digihit->ring-1][in_digihit->straw-1];
+  
+  return the_table[in_digihit->ring-1][in_digihit->straw-1];
 }
 
 const double DCDCHit_factory_Calib::GetConstant(const cdc_digi_constants_t &the_table,
-        const DCDCHit *in_hit) const {
-
-    char str[256];
-
-    if ( (in_hit->ring <= 0) || (static_cast<unsigned int>(in_hit->ring) > Nrings)) {
-        sprintf(str, "Bad ring # requested in DCDCHit_factory::GetConstant()!"
-                " requested=%d , should be %ud", in_hit->ring, Nrings);
-        std::cerr << str << std::endl;
-        throw JException(str);
-    }
-    if ( (in_hit->straw <= 0) || 
-            (static_cast<unsigned int>(in_hit->straw) > Nstraws[in_hit->ring])) {
-        sprintf(str, "Bad straw # requested in DCDCHit_factory::GetConstant()!"
-                " requested=%d , should be %ud",
-                in_hit->straw, Nstraws[in_hit->ring]);
-        std::cerr << str << std::endl;
-        throw JException(str);
-    }
-
-    return the_table[in_hit->ring-1][in_hit->straw-1];
+						const DCDCHit *in_hit) const {
+  
+  char str[256];
+  
+  if ( (in_hit->ring <= 0) || (static_cast<unsigned int>(in_hit->ring) > Nrings)) {
+    sprintf(str, "Bad ring # requested in DCDCHit_factory::GetConstant()!"
+	    " requested=%d , should be %ud", in_hit->ring, Nrings);
+    std::cerr << str << std::endl;
+    throw JException(str);
+  }
+  if ( (in_hit->straw <= 0) || 
+       (static_cast<unsigned int>(in_hit->straw) > Nstraws[in_hit->ring])) {
+    sprintf(str, "Bad straw # requested in DCDCHit_factory::GetConstant()!"
+	    " requested=%d , should be %ud",
+	    in_hit->straw, Nstraws[in_hit->ring]);
+    std::cerr << str << std::endl;
+    throw JException(str);
+  }
+  
+  return the_table[in_hit->ring-1][in_hit->straw-1];
 }
-/*
-   const double DCDCHit_factory::GetConstant(const cdc_digi_constants_t &the_table,
-   const DTranslationTable *ttab,
-   const int in_rocid, const int in_slot, const int in_channel) const {
 
-   char str[256];
-
-   DTranslationTable::csc_t daq_index = { in_rocid, in_slot, in_channel };
-   DTranslationTable::DChannelInfo channel_info = ttab->GetDetectorIndex(daq_index);
-
-   if ( (channel_info.cdc.ring <= 0) || (channel_info.cdc.ring > Nrings)) {
-   sprintf(str, "Bad ring # requested in DCDCHit_factory::GetConstant()!"
-   " requested=%d , should be %ud", channel_info.cdc.ring, Nrings);
-   std::cerr << str << std::endl;
-   throw JException(str);
-   }
-   if ( (channel_info.cdc.straw <= 0) || 
-   (channel_info.cdc.straw > Nstraws[channel_info.cdc.ring]))
-   {
-   sprintf(str, "Bad straw # requested in DCDCHit_factory::GetConstant()!"
-   " requested=%d , should be %ud",
-   channel_info.cdc.ring, Nstraws[channel_info.cdc.straw]);
-   std::cerr << str << std::endl;
-   throw JException(str);
-   }
-
-   return the_table[channel_info.cdc.ring-1][channel_info.cdc.straw-1];
-   }
-   */

--- a/src/libraries/CDC/DCDCHit_factory_Calib.h
+++ b/src/libraries/CDC/DCDCHit_factory_Calib.h
@@ -31,9 +31,6 @@ class DCDCHit_factory_Calib:public jana::JFactory<DCDCHit>{
   ~DCDCHit_factory_Calib(){};
   const char* Tag(void){return "Calib";}
 
-  // timing cut limits
-  double LowTCut;
-  double HighTCut;
   // overall scale factors.
   double a_scale;
   double t_scale;


### PR DESCRIPTION
…shold cut to CDC hit amplitudes

and parameter to enable/disamble the pruning cut.
Also modified the pruning cut to not cut away the signal that went to saturation.

three switches are added to the CDC hit factories to
a) CDCHit:RemoveCorrelationHits to turn on/off the removal of correlation hits (default is on)
b) CDCHit:Dissable_TimingCuts to dissable the timing cuts
c)CDC:CDC_HIT_THRESHOLD allows for an additional amplitude cut in ADC counts (default is zero)

-PCDCHit:RemoveCorrelationHits=0 will stop removing correlation hits
-PCDCHit:Dissable_TimingCuts=1 will disable timing cut
-PCDC:CDC_HIT_THRESHOLD=140 will remove all CDC hits with peak amplitude smaller than 140 ADC counts