### PR TITLE
modify TOF Hit factory to not discard hits with pulse peak zero

### DIFF
--- a/src/libraries/TOF/DTOFHit_factory.h
+++ b/src/libraries/TOF/DTOFHit_factory.h
@@ -20,6 +20,7 @@ using namespace std;
 #include "DTOFGeometry.h"
 #include "TTAB/DTranslationTable.h"
 #include "TTAB/DTTabUtilities.h"
+#include <DAQ/Df250PulseData.h>
 using namespace jana;
 
 


### PR DESCRIPTION
but rather take the integral value and scale them to amplituded.
also in case the peak value is reported zero use the pedestal as
given by the ccdb pedestal table rather than the event pedestal that
is most likely corrupted due to the signal at the begining of the
readout window.