### PR TITLE
put in check that DIRC geometry exists, and if it doesn't, put in a v…

### DIFF
--- a/src/libraries/TRACKING/DTrackFitter.h
+++ b/src/libraries/TRACKING/DTrackFitter.h
@@ -145,6 +145,7 @@ class DTrackFitter:public jana::JObject{
 		  extrapolations[SYS_FDC].clear();
 		  extrapolations[SYS_CDC].clear();
 		  extrapolations[SYS_START].clear();
+		  extrapolations[SYS_DIRC].clear();
 		};
 		
 		// Fit parameter accessor methods

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -286,7 +286,7 @@ DTrackFitterKalmanSIMD::DTrackFitterKalmanSIMD(JEventLoop *loop):DTrackFitter(lo
    
    // Outer detector geometry parameters
    geom->GetFCALZ(dFCALz); 
-   geom->GetDIRCZ(dDIRCz);
+   if (geom->GetDIRCZ(dDIRCz)==false) dDIRCz=1000.;
    vector<double>tof_face;
    geom->Get("//section/composition/posXYZ[@volume='ForwardTOF']/@X_Y_Z",
 	      tof_face);


### PR DESCRIPTION
…alue for the z-position that would not lead to any extrapolation entries for the DIRC.  Also make sure that the DIRC extrapolation vector is cleared when ClearExtrapolations is called.