### PR TITLE
Made timing cuts accessible via gPARMS

### DIFF
--- a/src/libraries/CDC/DCDCHit_factory.cc
+++ b/src/libraries/CDC/DCDCHit_factory.cc
@@ -42,13 +42,13 @@ jerror_t DCDCHit_factory::init(void)
   gPARMS->SetDefaultParameter("CDCHit:CorrelatedHitPeak", CorrelatedHitPeak,
                               "Location of peak time around which we cut correlated times in units of 8ns bins");
 
-  LowTCut = 0.;   // to be overridden in brun if gPARMS absent
-  gPARMS->SetDefaultParameter("CDCHit:LowTCut", LowTCut,
+  LowTCut_gparms = -20000.0;  // only used if above this value  
+  gPARMS->SetDefaultParameter("CDCHit:LowTCut", LowTCut_gparms,
                               "Minimum acceptable CDC hit time (ns)");
 
-  HighTCut = 0.;   // to be overridden in brun if gPARMS absent
-  gPARMS->SetDefaultParameter("CDCHit:HighTCut", HighTCut,
-                              "Minimum acceptable CDC hit time (ns)");
+  HighTCut_gparms = 20000.0;  // only used if below this value  
+  gPARMS->SetDefaultParameter("CDCHit:HighTCut", HighTCut_gparms,
+                              "Maximum acceptable CDC hit time (ns)");
 
   
   // Setting this flag makes it so that JANA does not delete the objects in _data.
@@ -68,26 +68,40 @@ jerror_t DCDCHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
   
   vector<double> cdc_timing_cuts;
 
+  if (eventLoop->GetCalib("/CDC/timing_cut", cdc_timing_cuts)){
+    LowTCut = -60.;
+    HighTCut = 900.;
+    jout << "Error loading /CDC/timing_cut ! set default values -60. and 900." << endl;
+  } else {
+    LowTCut = cdc_timing_cuts[0];
+    HighTCut = cdc_timing_cuts[1];
+    //jout<<"CDC Timing Cuts: "<<LowTCut<<" ... "<<HighTCut<<endl;
+  }
+
+
   if (Disable_CDC_TimingCuts) {
     
     LowTCut = -10000.;
     HighTCut = 10000.;
     jout << "Disable CDC Hit Timing Cuts!" << endl;
     
-  } else if ((LowTCut == 0.) && (HighTCut == 0.)) {   // gPARMS not used
+  } 
 
-    if (eventLoop->GetCalib("/CDC/timing_cut", cdc_timing_cuts)){
-      LowTCut = -60.;
-      HighTCut = 900.;
-      jout << "Error loading /CDC/timing_cut ! set default values -60. and 900." << endl;
-    } else {
-      LowTCut = cdc_timing_cuts[0];
-      HighTCut = cdc_timing_cuts[1];
-    //jout<<"CDC Timing Cuts: "<<LowTCut<<" ... "<<HighTCut<<endl;
-    }
-  } else {  //gPARMS used
-    jout<<"Override CDC Timing Cuts: "<<LowTCut<<" ... "<<HighTCut<<endl;
+  int overridecut = 0;
+
+  if (LowTCut_gparms > (double)-20000.0) {
+    LowTCut = LowTCut_gparms;
+    overridecut = 1;
   }
+
+
+  if (HighTCut_gparms < (double)20000.0) {
+    HighTCut = HighTCut_gparms;
+    overridecut = 1;
+  }
+
+  if (overridecut) jout<<"Override CDC Timing Cuts: "<<LowTCut<<" ... "<<HighTCut<<endl;
+
 
 
   eventLoop->Get(ttab);

--- a/src/libraries/CDC/DCDCHit_factory.h
+++ b/src/libraries/CDC/DCDCHit_factory.h
@@ -42,9 +42,13 @@ class DCDCHit_factory: public jana::JFactory<DCDCHit>{
   double CorrelatedHitPeak;
   int Disable_CDC_TimingCuts;
 
-  // timing cut limits
+  // timing cut limits 
   double LowTCut;
   double HighTCut;
+
+  // timing cut limits overrides in cmd line
+  double LowTCut_gparms;
+  double HighTCut_gparms;
   
  private:
   jerror_t init(void);						///< Called once at program start.


### PR DESCRIPTION
Added gPARMS so that the LowTCut and HighTCut which Beni added earlier can be accessed through the command line to override the values in CCDB.  

JANA flags these as possible typos.  CDCHit:DisableTimingCuts has the same issue.