### PR TITLE
Fix indexing problem in calculation of d (only needed for hdview2).

### DIFF
--- a/src/libraries/CDC/DCDCTrackHit_factory.cc
+++ b/src/libraries/CDC/DCDCTrackHit_factory.cc
@@ -153,7 +153,7 @@ jerror_t DCDCTrackHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 		if(tcorr < cdc_drift_table_min){
 			index = 0;
 		}else if (tcorr >= cdc_drift_table_max){
-			index = cdc_drift_table.size()-1;
+		  index = cdc_drift_table.size()-2;
 		}else{
 			index=locate(cdc_drift_table,tcorr);
 		}


### PR DESCRIPTION
Minor fix to make sure that we don't go beyond the end of the cdc drift table.   This fix is only relevant for hdview2.