### PR TITLE
add command line parameters to change the CDC timing cuts on the fly

### DIFF
--- a/src/libraries/CDC/DCDCHit_factory.cc
+++ b/src/libraries/CDC/DCDCHit_factory.cc
@@ -70,8 +70,8 @@ jerror_t DCDCHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
     jout << "Error loading /CDC/timing_cut ! set defaul values -60. and 900." << endl;
   } else {
     LowTCut = cdc_timing_cuts[0];
-      HighTCut = cdc_timing_cuts[1];
-      jout<<"CDC Timing Cuts: "<<LowTCut<<" ... "<<HighTCut<<endl;
+    HighTCut = cdc_timing_cuts[1];
+    //jout<<"CDC Timing Cuts: "<<LowTCut<<" ... "<<HighTCut<<endl;
   }
   
   gPARMS->SetDefaultParameter("CDCHit:LowTCut", LowTCut,"Minimum acceptable CDC hit time (ns)");

--- a/src/libraries/CDC/DCDCHit_factory.cc
+++ b/src/libraries/CDC/DCDCHit_factory.cc
@@ -20,6 +20,10 @@ static double DIGI_THRESHOLD = -1.0e8;
 //------------------
 jerror_t DCDCHit_factory::init(void)
 {
+
+  LowTCut = -10000.;
+  HighTCut = 10000.;
+
   Disable_CDC_TimingCuts = 0; // this can be changed by a parameter in brun()
   // Note: That has to be done in brun() because the parameters are read from ccdb at every call to brun()
   gPARMS->SetDefaultParameter("CDCHit:Disable_TimingCuts", Disable_CDC_TimingCuts,
@@ -42,7 +46,7 @@ jerror_t DCDCHit_factory::init(void)
   CorrelatedHitPeak = 3.5;
   gPARMS->SetDefaultParameter("CDCHit:CorrelatedHitPeak", CorrelatedHitPeak,
                               "Location of peak time around which we cut correlated times in units of 8ns bins");
-  
+
   // Setting this flag makes it so that JANA does not delete the objects in _data.
   // This factory will manage this memory.
   SetFactoryFlag(NOT_OBJECT_OWNER);
@@ -59,15 +63,21 @@ jerror_t DCDCHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
   /// Read in calibration constants
   
   vector<double> cdc_timing_cuts;
+  
   if (eventLoop->GetCalib("/CDC/timing_cut", cdc_timing_cuts)){
     LowTCut = -60.;
     HighTCut = 900.;
     jout << "Error loading /CDC/timing_cut ! set defaul values -60. and 900." << endl;
   } else {
     LowTCut = cdc_timing_cuts[0];
-    HighTCut = cdc_timing_cuts[1];
-    //jout<<"CDC Timing Cuts: "<<LowTCut<<" ... "<<HighTCut<<endl;
+      HighTCut = cdc_timing_cuts[1];
+      jout<<"CDC Timing Cuts: "<<LowTCut<<" ... "<<HighTCut<<endl;
   }
+  
+  gPARMS->SetDefaultParameter("CDCHit:LowTCut", LowTCut,"Minimum acceptable CDC hit time (ns)");
+  gPARMS->SetDefaultParameter("CDCHit:HighTCut", HighTCut, "Maximum acceptable CDC hit time (ns)");
+  
+  //jout<<LowTCut<<" / "<<HighTCut<<endl;
 
   if (Disable_CDC_TimingCuts) {
     
@@ -77,7 +87,6 @@ jerror_t DCDCHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
     
   }
   
-
   eventLoop->Get(ttab);
   
   return NOERROR;


### PR DESCRIPTION

add 2 lines of code in brun() to have the option of modifying the CDC hit timing cuts on the command line 