### PR TITLE
hdview2 root6.12

### DIFF
--- a/src/programs/Analysis/hdview2/hdv_mainframe.h
+++ b/src/programs/Analysis/hdview2/hdv_mainframe.h
@@ -28,6 +28,7 @@
 #include <TGLabel.h>
 #include <TTimer.h>
 
+class hdv_mainframe;
 class trk_mainframe;
 class hdv_optionsframe;
 class hdv_debugerframe;

--- a/src/programs/Analysis/hdview2/trk_mainframe.h
+++ b/src/programs/Analysis/hdview2/trk_mainframe.h
@@ -37,10 +37,20 @@
 #include <TLatex.h>
 
 
-class hdv_mainframe;
 #if !(defined(__CINT__) || defined(__CLING__))
 
 #include "hdv_mainframe.h"
+
+#else
+
+// This ugliness is due to rootcling incorrectly flagging the
+// foward declaration of hdv_mainframe as an error. Since only
+// pointers to the class with no internals being referenced here,
+// a forward declaration should be allowed. This empty class
+// definition is just to appease rootcling but should not be
+// seen by the actual C++ compiler.
+class hdv_mainframe{};
+
 #endif
 
 


### PR DESCRIPTION
This fixes the hdview2 compile error seen with more recent versions of ROOT. The error was seen with v6.12.04, but I think I also saw it with version 6.10.