### PR TITLE
fix logic in useWeight boolean

### DIFF
--- a/src/libraries/AMPTOOLS_DATAIO/ROOTDataReader.cc
+++ b/src/libraries/AMPTOOLS_DATAIO/ROOTDataReader.cc
@@ -47,10 +47,12 @@ ROOTDataReader::ROOTDataReader( const vector< string >& args ):
 	m_inTree->SetBranchAddress( "Px_Beam", &m_pxBeam );
 	m_inTree->SetBranchAddress( "Py_Beam", &m_pyBeam );
 	m_inTree->SetBranchAddress( "Pz_Beam", &m_pzBeam );
-	if(m_inTree->GetBranch("Weight") != NULL)
+
+	if(m_inTree->GetBranch("Weight") != NULL) {
+
+	  m_useWeight = true;
 	  m_inTree->SetBranchAddress( "Weight", &m_weight );
-	else
-	  m_useWeight=false;
+	}
 }
 
 ROOTDataReader::~ROOTDataReader()


### PR DESCRIPTION
fix what appears to be a long-standing bug in feeding weighted events into AmpTools via the GlueX ROOTDataReader