### PR TITLE
Updated B3pi plugins to new rxn format

### DIFF
--- a/src/plugins/Analysis/B3pi_eff_missgamma/DReaction_factory_B3pi_eff_missgamma.cc
+++ b/src/plugins/Analysis/B3pi_eff_missgamma/DReaction_factory_B3pi_eff_missgamma.cc
@@ -48,7 +48,7 @@ jerror_t DReaction_factory_B3pi_eff_missgamma::evnt(JEventLoop* locEventLoop, ui
         std::deque<Particle_t> off_proton;
         off_proton.push_back(Proton);
 
-
+/*
         // g, p -> omega, p                                                                   
         locReactionStep = new DReactionStep();
         locReactionStep->Set_InitialParticleID(Gamma);
@@ -78,6 +78,29 @@ jerror_t DReaction_factory_B3pi_eff_missgamma::evnt(JEventLoop* locEventLoop, ui
         //locReactionStep->Set_KinFitConstrainInitMassFlag(false);                            
         locReaction->Add_ReactionStep(locReactionStep);
         dReactionStepPool.push_back(locReactionStep);
+*/
+        vector<Particle_t> step0_final;
+        step0_final.push_back(omega);
+        step0_final.push_back(Proton);
+        vector<Particle_t> step1_final;
+        step1_final.push_back(PiPlus);
+        step1_final.push_back(PiMinus);
+        step1_final.push_back(Pi0);
+        vector<Particle_t> step2_final;
+        step2_final.push_back(Gamma);
+
+        locReactionStep = new DReactionStep(Gamma,Proton,step0_final);
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep);
+
+        locReactionStep = new DReactionStep(omega,step1_final);
+        //locReactionStep = new DReactionStep(omega,step1_final);       
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep);
+
+        locReactionStep = new DReactionStep(Pi0,step2_final,Gamma);
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep);
 
 
 
@@ -96,7 +119,8 @@ jerror_t DReaction_factory_B3pi_eff_missgamma::evnt(JEventLoop* locEventLoop, ui
         locReaction->Set_EventStoreSkims("q+, q-"); //boolean-AND of skims
 
         // Highly Recommended: When generating particle combinations, reject all beam photons that match to a different RF bunch
-        locReaction->Set_MaxPhotonRFDeltaT(3.5*dBeamBunchPeriod); //should be minimum cut value
+       //Dep  locReaction->Set_MaxPhotonRFDeltaT(3.5*dBeamBunchPeriod); //should be minimum cut value
+       locReaction->Set_NumPlusMinusRFBunches(2); //should be minimum cut value
 
         // Highly Recommended: Cut on number of extra "good" tracks. "Good" tracks are ones that survive the "PreSelect" (or user custom) factory.
                 // Important: Keep cut large: Can have many ghost and accidental tracks that look "good"
@@ -109,14 +133,14 @@ jerror_t DReaction_factory_B3pi_eff_missgamma::evnt(JEventLoop* locEventLoop, ui
 
         // Highly Recommended: Very loose invariant mass cuts, applied during DParticleComboBlueprint construction
         // Example: pi0 -> g, g cut
-        locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
 
-
-        locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, -0.06, 0.06));
 
         /**************************************************** B3pi Analysis Actions ****************************************************/
 
 //        locReaction->Add_AnalysisAction(new DCutAction_MissingMassSquared(locReaction, false, -0.06, 0.06));
+
+        //Dep locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, -0.06, 0.06));
+        locReaction->Add_AnalysisAction(new DCutAction_MissingMassSquared(locReaction, false, -0.06, 0.06));
 
         //Cris's PID
         // HISTOGRAM PID

--- a/src/plugins/Analysis/B3pi_eff_misspim/DReaction_factory_B3pi_eff_misspim.cc
+++ b/src/plugins/Analysis/B3pi_eff_misspim/DReaction_factory_B3pi_eff_misspim.cc
@@ -46,7 +46,7 @@ jerror_t DReaction_factory_B3pi_eff_misspim::evnt(JEventLoop* locEventLoop, uint
         std::deque<Particle_t> off_proton;
         off_proton.push_back(Proton);
 
-
+/*
         // g, p -> omega, p                                                                   
         locReactionStep = new DReactionStep();
         locReactionStep->Set_InitialParticleID(Gamma);
@@ -75,6 +75,29 @@ jerror_t DReaction_factory_B3pi_eff_misspim::evnt(JEventLoop* locEventLoop, uint
         //locReactionStep->Set_KinFitConstrainInitMassFlag(false);                            
         locReaction->Add_ReactionStep(locReactionStep);
         dReactionStepPool.push_back(locReactionStep);
+*/
+        vector<Particle_t> step0_final;
+        step0_final.push_back(omega);
+        step0_final.push_back(Proton);
+        vector<Particle_t> step1_final;
+        step1_final.push_back(PiPlus);
+        step1_final.push_back(Pi0);
+        vector<Particle_t> step2_final;
+        step2_final.push_back(Gamma);
+        step2_final.push_back(Gamma);
+
+        locReactionStep = new DReactionStep(Gamma,Proton,step0_final);
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep);
+
+        locReactionStep = new DReactionStep(omega,step1_final,PiMinus);
+        //locReactionStep = new DReactionStep(omega,step1_final);       
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep);
+
+        locReactionStep = new DReactionStep(Pi0,step2_final);
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep);
 
 
 
@@ -93,7 +116,8 @@ jerror_t DReaction_factory_B3pi_eff_misspim::evnt(JEventLoop* locEventLoop, uint
         locReaction->Set_EventStoreSkims("q+"); //boolean-AND of skims
 
         // Highly Recommended: When generating particle combinations, reject all beam photons that match to a different RF bunch
-        locReaction->Set_MaxPhotonRFDeltaT(3.5*dBeamBunchPeriod); //should be minimum cut value
+        //dep locReaction->Set_MaxPhotonRFDeltaT(3.5*dBeamBunchPeriod); //should be minimum cut value
+        locReaction->Set_NumPlusMinusRFBunches(2); //should be minimum cut value
 
         // Highly Recommended: Cut on number of extra "good" tracks. "Good" tracks are ones that survive the "PreSelect" (or user custom) factory.
                 // Important: Keep cut large: Can have many ghost and accidental tracks that look "good"
@@ -106,10 +130,11 @@ jerror_t DReaction_factory_B3pi_eff_misspim::evnt(JEventLoop* locEventLoop, uint
 
         // Highly Recommended: Very loose invariant mass cuts, applied during DParticleComboBlueprint construction
         // Example: pi0 -> g, g cut
-        locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+        //dep locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+	locReaction->Add_AnalysisAction(new DCutAction_InvariantMass(locReaction, Pi0, false, 0.05, 0.22));
 
-
-        locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, -0.4, 0.4));
+        //dep locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, -0.4, 0.4));
+        locReaction->Add_AnalysisAction(new DCutAction_MissingMassSquared(locReaction, false, -0.4, 0.4));
 
         /**************************************************** B3pi Analysis Actions ****************************************************/
 

--- a/src/plugins/Analysis/B3pi_eff_misspip/DReaction_factory_B3pi_eff_misspip.cc
+++ b/src/plugins/Analysis/B3pi_eff_misspip/DReaction_factory_B3pi_eff_misspip.cc
@@ -45,7 +45,7 @@ jerror_t DReaction_factory_B3pi_eff_misspip::evnt(JEventLoop* locEventLoop, uint
 
         std::deque<Particle_t> off_proton;
         off_proton.push_back(Proton);
-
+/*
         // g, p -> omega, p                                                                   
         locReactionStep = new DReactionStep();
         locReactionStep->Set_InitialParticleID(Gamma);
@@ -71,9 +71,33 @@ jerror_t DReaction_factory_B3pi_eff_misspip::evnt(JEventLoop* locEventLoop, uint
         locReactionStep->Set_InitialParticleID(Pi0);
         locReactionStep->Add_FinalParticleID(Gamma);
         locReactionStep->Add_FinalParticleID(Gamma);
-        //locReactionStep->Set_KinFitConstrainInitMassFlag(false);                            
+        //locReactionStep->Set_KinFitConstrainInitMassFlag(true);                            
         locReaction->Add_ReactionStep(locReactionStep);
         dReactionStepPool.push_back(locReactionStep);
+
+*/
+	vector<Particle_t> step0_final;
+	step0_final.push_back(omega);
+	step0_final.push_back(Proton);
+	vector<Particle_t> step1_final;
+	step1_final.push_back(PiMinus);
+	step1_final.push_back(Pi0);
+	vector<Particle_t> step2_final;
+	step2_final.push_back(Gamma);
+	step2_final.push_back(Gamma);
+
+	locReactionStep = new DReactionStep(Gamma,Proton,step0_final);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep);
+
+	locReactionStep = new DReactionStep(omega,step1_final,PiPlus);	
+	//locReactionStep = new DReactionStep(omega,step1_final);	
+	locReaction->Add_ReactionStep(locReactionStep);	
+	dReactionStepPool.push_back(locReactionStep);
+
+	locReactionStep = new DReactionStep(Pi0,step2_final);
+	locReaction->Add_ReactionStep(locReactionStep);	
+	dReactionStepPool.push_back(locReactionStep);
 
 
         /**************************************************** pippimpi0_withmiss Control Settings ****************************************************/
@@ -99,11 +123,11 @@ jerror_t DReaction_factory_B3pi_eff_misspip::evnt(JEventLoop* locEventLoop, uint
         locReaction->Set_EventStoreSkims("q+, q-"); //boolean-AND of skims
 
         // Highly Recommended: When generating particle combinations, reject all beam photons that match to a different RF bunch
-        locReaction->Set_MaxPhotonRFDeltaT(3.5*dBeamBunchPeriod); //should be minimum cut value
+        locReaction->Set_NumPlusMinusRFBunches(2); //should be minimum cut value
 
         // Highly Recommended: Cut on number of extra "good" tracks. "Good" tracks are ones that survive the "PreSelect" (or user custom) factory.
                 // Important: Keep cut large: Can have many ghost and accidental tracks that look "good"
-        locReaction->Set_MaxExtraGoodTracks(5);
+//        locReaction->Set_MaxExtraGoodTracks(5);
         // Highly Recommended: Enable ROOT TTree output for this DReaction
         // string is file name (must end in ".root"!!): doen't need to be unique, feel free to change
         locReaction->Enable_TTreeOutput("tree_pippimpi0_eff_misspip.root", true); //true/false: do/don't save unused hypotheses
@@ -112,10 +136,11 @@ jerror_t DReaction_factory_B3pi_eff_misspip::evnt(JEventLoop* locEventLoop, uint
 
         // Highly Recommended: Very loose invariant mass cuts, applied during DParticleComboBlueprint construction
         // Example: pi0 -> g, g cut
-        locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+        //locReaction->Add_AnalysisAction(new DCutAction_InvariantMass(locReaction, Pi0, false, 0.05, 0.22));
+        locReaction->Add_AnalysisAction(new DCutAction_InvariantMass(locReaction, Pi0, false, 0.05, 0.22));
 
 
-        locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, -0.4,0.4));
+        locReaction->Add_AnalysisAction(new DCutAction_MissingMassSquared(locReaction, false, -0.4,0.4));
 
         /**************************************************** B3pi Analysis Actions ****************************************************/
 
@@ -125,7 +150,7 @@ jerror_t DReaction_factory_B3pi_eff_misspip::evnt(JEventLoop* locEventLoop, uint
         // HISTOGRAM PID
         locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
 
-        locReaction->Add_AnalysisAction(new DCutAction_BeamEnergy(locReaction,false,3.0,12.0));
+        locReaction->Add_AnalysisAction(new DCutAction_BeamEnergy(locReaction,false,8.4,9.05));
 
         // PID                                                                                                                                                 
         locReaction->Add_AnalysisAction(new DHistogramAction_PID(locReaction));
@@ -168,6 +193,8 @@ jerror_t DReaction_factory_B3pi_eff_misspip::evnt(JEventLoop* locEventLoop, uint
         //false: fill histograms with measured particle data                                                                                                                                        
 
         _data.push_back(locReaction); //Register the DReaction with the factory                                                                                        
+
+	//printf("Preaction Built\n");
 
 
 	return NOERROR;

--- a/src/plugins/Analysis/B3pi_eff_missprot/DReaction_factory_B3pi_eff_missprot.cc
+++ b/src/plugins/Analysis/B3pi_eff_missprot/DReaction_factory_B3pi_eff_missprot.cc
@@ -47,7 +47,7 @@ jerror_t DReaction_factory_B3pi_eff_missprot::evnt(JEventLoop* locEventLoop, uin
         std::deque<Particle_t> off_proton;
         off_proton.push_back(Proton);
 
-
+/*
         // g, p -> omega, p                                                                   
         locReactionStep = new DReactionStep();
         locReactionStep->Set_InitialParticleID(Gamma);
@@ -76,6 +76,29 @@ jerror_t DReaction_factory_B3pi_eff_missprot::evnt(JEventLoop* locEventLoop, uin
         //locReactionStep->Set_KinFitConstrainInitMassFlag(false);                            
         locReaction->Add_ReactionStep(locReactionStep);
         dReactionStepPool.push_back(locReactionStep);
+*/
+        vector<Particle_t> step0_final;
+        step0_final.push_back(omega);
+        vector<Particle_t> step1_final;
+        step1_final.push_back(PiMinus);
+        step1_final.push_back(Proton);
+        step1_final.push_back(Pi0);
+        vector<Particle_t> step2_final;
+        step2_final.push_back(Gamma);
+        step2_final.push_back(Gamma);
+
+        locReactionStep = new DReactionStep(Gamma,Proton,step0_final,Proton);
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep);
+
+        locReactionStep = new DReactionStep(omega,step1_final);
+        //locReactionStep = new DReactionStep(omega,step1_final);       
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep);
+
+        locReactionStep = new DReactionStep(Pi0,step2_final);
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep);
 
 
 
@@ -94,7 +117,7 @@ jerror_t DReaction_factory_B3pi_eff_missprot::evnt(JEventLoop* locEventLoop, uin
         locReaction->Set_EventStoreSkims("q+, q-"); //boolean-AND of skims
 
         // Highly Recommended: When generating particle combinations, reject all beam photons that match to a different RF bunch
-        locReaction->Set_MaxPhotonRFDeltaT(3.5*dBeamBunchPeriod); //should be minimum cut value
+        locReaction->Set_NumPlusMinusRFBunches(2); //should be minimum cut value
 
         // Highly Recommended: Cut on number of extra "good" tracks. "Good" tracks are ones that survive the "PreSelect" (or user custom) factory.
                 // Important: Keep cut large: Can have many ghost and accidental tracks that look "good"
@@ -106,11 +129,10 @@ jerror_t DReaction_factory_B3pi_eff_missprot::evnt(JEventLoop* locEventLoop, uin
         /************************************************** pippimpi0_withmiss Pre-Combo Custom Cuts *************************************************/
 
         // Highly Recommended: Very loose invariant mass cuts, applied during DParticleComboBlueprint construction
-        // Example: pi0 -> g, g cut
-        locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+        // Example: pi0 -> g, g cut:wq
+        //dep locReaction->Set_InvariantMassCut(Pi0, 0.05, 0.22);
+        locReaction->Add_AnalysisAction(new DCutAction_InvariantMass(locReaction, Pi0, false, 0.05, 0.22));
 
-
-        //locReaction->Add_ComboPreSelectionAction(new DCutAction_MissingMassSquared(locReaction, false, -1.02, 1.02));
 
         /**************************************************** B3pi Analysis Actions ****************************************************/
 


### PR DESCRIPTION
Apparently required to prevent kinfit from crashing on missing charged track.