### PR TITLE
Cd cd edx from amplitude

### DIFF
--- a/src/libraries/CDC/DCDCHit_factory_Calib.h
+++ b/src/libraries/CDC/DCDCHit_factory_Calib.h
@@ -32,7 +32,7 @@ class DCDCHit_factory_Calib:public jana::JFactory<DCDCHit>{
   const char* Tag(void){return "Calib";}
 
   // overall scale factors.
-  double a_scale;
+  double a_scale, amp_a_scale;
   double t_scale;
   double t_base;
   

--- a/src/libraries/CDC/DCDCTrackHit.h
+++ b/src/libraries/CDC/DCDCTrackHit.h
@@ -38,7 +38,8 @@ class DCDCTrackHit:public JObject{
       bool is_stereo; // true if this is stereo wire
       float tdrift;				// Drift time of hit in ns
       float dist;					// Measured DOCA in cm
-      float dE; // Energy deposition in GeV
+      float dE; // Energy deposition in GeV, using integral
+      float dE_amp; // same, but using amplitude
 
       void toStrings(vector<pair<string,string> > &items)const{
          AddString(items, "ring", "%d", wire->ring);
@@ -49,6 +50,7 @@ class DCDCTrackHit:public JObject{
          AddString(items, "tdrift(ns)", "%3.1f", tdrift);
          AddString(items, "dist(cm)", "%1.3f", dist);
          AddString(items, "dE(GeV)","%3.1g",dE);
+         AddString(items, "dE_amp(GeV)","%3.1g",dE_amp);
       }
 
 };

--- a/src/libraries/CDC/DCDCTrackHit_factory.cc
+++ b/src/libraries/CDC/DCDCTrackHit_factory.cc
@@ -140,7 +140,7 @@ jerror_t DCDCTrackHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 		double electron_charge=1.6022e-4; /* fC */
 		double dEscale=w_eff/(gas_gain*electron_charge);
 		hit->dE=cdchit->q*dEscale;
-		hit->dE_amp=cdchit->amp*dEscale*28.8; // using Naomi's scale factor
+		hit->dE_amp=cdchit->amp*dEscale; // using Naomi's scale factor
 		
 		// Calculate drift distance assuming no tof to wire for now.
 		// The tracking package will replace this once an estimate

--- a/src/libraries/CDC/DCDCTrackHit_factory.cc
+++ b/src/libraries/CDC/DCDCTrackHit_factory.cc
@@ -138,7 +138,9 @@ jerror_t DCDCTrackHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 		double w_eff=29.5e-9;
 		double gas_gain=1e5;
 		double electron_charge=1.6022e-4; /* fC */
-		hit->dE=cdchit->q*w_eff/(gas_gain*electron_charge);
+		double dEscale=w_eff/(gas_gain*electron_charge);
+		hit->dE=cdchit->q*dEscale;
+		hit->dE_amp=cdchit->amp*dEscale*28.8; // using Naomi's scale factor
 		
 		// Calculate drift distance assuming no tof to wire for now.
 		// The tracking package will replace this once an estimate

--- a/src/libraries/FDC/DFDCPseudo.h
+++ b/src/libraries/FDC/DFDCPseudo.h
@@ -93,7 +93,8 @@ class DFDCPseudo : public JObject {
       double time; ///< time corresponding to this pseudopoint.
       int status; ///< status word for pseudopoint
       double covxx,covxy,covyy; ///< Covariance terms for (x,y) 
-      double dE; ///< 
+      double dE; ///< energy deposition, from integral 
+      double dE_amp; /// < energy deposition, from pulse height
       double q; ///< anode charge deduced from cathode strips
       int itrack;
       DVector2 xy; ///< rough x,y coordinates in lab coordinate system

--- a/src/libraries/FDC/DFDCPseudo_factory.cc
+++ b/src/libraries/FDC/DFDCPseudo_factory.cc
@@ -560,6 +560,7 @@ void DFDCPseudo_factory::makePseudo(vector<const DFDCHit*>& x,
                     double q_from_pulse_height=5.0e-4*(upeaks[i].q_from_pulse_height
                           +vpeaks[j].q_from_pulse_height);
                     if (q_from_pulse_height<CHARGE_THRESHOLD) continue;
+		    double dE_amp=charge_to_energy*q_from_pulse_height;
 
                     if (DEBUG_HISTS){
                        qv_vs_qu->Fill(upeaks[i].q,vpeaks[j].q);
@@ -596,6 +597,7 @@ void DFDCPseudo_factory::makePseudo(vector<const DFDCHit*>& x,
                     newPseu->AddAssociatedObject(u[upeaks[i].cluster]);
 
                     newPseu->dE = dE;
+		    newPseu->dE_amp = dE_amp;
                     newPseu->q = q_from_pulse_height;
 
                     // It can occur (although rarely) that newPseu->wire is NULL

--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -1240,8 +1240,8 @@ jerror_t DEventSourceHDDM::Extract_DCDCHit(JEventLoop* locEventLoop, hddm_s::HDD
             }
 	    else{  
 	      // for generated events (not folded-in background events) for which we
-	      // have no digi hits we simply scale q using Naomi's factor of 28.8
-	      hit->amp=hit->q/28.8;
+	      // have no digi hits return q
+	      hit->amp=hit->q;
 	    }
             hit->QF     = 0;
             if(iter->getCdcHitQFs().size() > 0) {

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -1053,7 +1053,17 @@ jerror_t DEventSourceREST::Extract_DTrackTimeBased(hddm_r::HDDM *record,
          tra->ddEdx_FDC = diter->getDEdxFDC();
          tra->ddEdx_CDC = diter->getDEdxCDC();
          tra->ddx_FDC = diter->getDxFDC();
-         tra->ddx_CDC = diter->getDxCDC();
+         tra->ddx_CDC = diter->getDxCDC();  
+	 const hddm_r::CDCAmpdEdxList &el2 = diter->getCDCAmpdEdxs();
+	 hddm_r::CDCAmpdEdxList::iterator diter2 = el2.begin();
+	 if (diter2 != el2.end()){
+	   tra->ddx_CDC_amp= diter2->getDxCDCAmp();
+	   tra->ddEdx_CDC_amp = diter2->getDEdxCDCAmp();
+	 }
+	 else{
+	   tra->ddx_CDC_amp=tra->ddx_CDC;
+	   tra->ddEdx_CDC_amp=tra->ddEdx_CDC;
+	 }
       }
       else {
          tra->dNumHitsUsedFordEdx_FDC = 0;
@@ -1061,7 +1071,9 @@ jerror_t DEventSourceREST::Extract_DTrackTimeBased(hddm_r::HDDM *record,
          tra->ddEdx_FDC = 0.0;
          tra->ddEdx_CDC = 0.0;
          tra->ddx_FDC = 0.0;
-         tra->ddx_CDC = 0.0;
+         tra->ddx_CDC = 0.0; 
+	 tra->ddEdx_CDC_amp = 0.0;
+         tra->ddx_CDC_amp = 0.0;
       }
 
       data.push_back(tra);

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -364,6 +364,10 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 			elo().setDxCDC(tracks[i]->ddx_CDC);
 			elo().setDEdxFDC(tracks[i]->ddEdx_FDC);
 			elo().setDEdxCDC(tracks[i]->ddEdx_CDC);
+			hddm_r::CDCAmpdEdxList elo2 = elo().addCDCAmpdEdxs(1);
+			elo2().setDxCDCAmp(tracks[i]->ddx_CDC_amp);
+			elo2().setDEdxCDCAmp(tracks[i]->ddEdx_CDC_amp);
+
 		}
 	}
 

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -60,7 +60,9 @@
       <dEdxDC minOccurs="0"
               NsampleFDC="int" dxFDC="float" dEdxFDC="float"
               NsampleCDC="int" dxCDC="float" dEdxCDC="float"
-              lunit="cm" dEdx_unit="GeV/cm"/>
+              lunit="cm" dEdx_unit="GeV/cm">
+	<CDCAmpdEdx dxCDCAmp="float" dEdxCDCAmp="float" minOccurs="0"/>
+      </dEdxDC>
     </chargedTrack>
     <startHit maxOccurs="unbounded" minOccurs="0" jtag="string"
               sector="int" t="float" dE="float"

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -34,7 +34,10 @@ DParticleID::DParticleID(JEventLoop *loop)
 	C_EFFECTIVE = 15.0;
 	ATTEN_LENGTH = 150.0;
 	OUT_OF_TIME_CUT = 35.0; // Changed 200 -> 35 ns, March 2016
-    gPARMS->SetDefaultParameter("PID:OUT_OF_TIME_CUT",OUT_OF_TIME_CUT);
+    gPARMS->SetDefaultParameter("PID:OUT_OF_TIME_CUT",OUT_OF_TIME_CUT);	
+    CDC_TIME_CUT_FOR_DEDX = 1000.0; 
+    gPARMS->SetDefaultParameter("PID:CDC_TIME_CUT_FOR_DEDX",CDC_TIME_CUT_FOR_DEDX);
+
 
   DApplication* dapp = dynamic_cast<DApplication*>(loop->GetJApplication());
   if(!dapp){
@@ -322,14 +325,17 @@ jerror_t DParticleID::GroupTracks(vector<const DTrackTimeBased *> &tracks,
 // Compute the energy losses and the path lengths in the chambers for each hit 
 // on the track. Returns a list of dE and dx pairs with the momentum at the 
 // hit.
-jerror_t DParticleID::GetDCdEdxHits(const DTrackTimeBased *track, vector<dedx_t>& dEdxHits_CDC, vector<dedx_t>& dEdxHits_FDC) const{
+jerror_t DParticleID::GetDCdEdxHits(const DTrackTimeBased *track, vector<dedx_t>& dEdxHits_CDC,vector<dedx_t>& dEdxHits_FDC) const{
  
 
   // Position and momentum
   DVector3 pos,mom;
+  // flight time and t0 for the event
+  double tflight=0.;
+  double t0=track->t0();
   
   //dE and dx pairs
-  pair<double,double>de_and_dx;
+  dedx_t de_and_dx(0.,0.,0.,0.);
 
   //Get the list of cdc hits used in the fit
   vector<const DCDCTrackHit*>cdchits;
@@ -349,16 +355,24 @@ jerror_t DParticleID::GetDCdEdxHits(const DTrackTimeBased *track, vector<dedx_t>
 	  *cdchits[i]->wire->udir;
 	double doca2=(wirepos-cdc_extrapolations[j].position).Mag2();
 	if (doca2>doca2_old){
-	  mom=cdc_extrapolations[j-1].momentum;
-	  pos=cdc_extrapolations[j-1].position;
+	  unsigned int index=j-1;
+	  mom=cdc_extrapolations[index].momentum;
+	  pos=cdc_extrapolations[index].position;
+	  tflight=cdc_extrapolations[index].t;
 	  break;
 	}
 	doca2_old=doca2;
       }
+            
+      // Cut late drift time hits where the energy deposition is degraded
+      double dt=cdchits[i]->tdrift-tflight-t0;
+      if (dt>CDC_TIME_CUT_FOR_DEDX) continue;
+
       // Create the dE,dx pair from the position and momentum using a helical approximation for the path 
       // in the straw and keep track of the momentum in the active region of the detector
-      if (CalcdEdxHit(mom,pos,cdchits[i],de_and_dx)==NOERROR)
-	dEdxHits_CDC.push_back(dedx_t(de_and_dx.first, de_and_dx.second, mom.Mag()));
+      if (CalcdEdxHit(mom,pos,cdchits[i],de_and_dx)==NOERROR){
+	dEdxHits_CDC.push_back(de_and_dx);
+      }
     }
   }
   
@@ -381,7 +395,8 @@ jerror_t DParticleID::GetDCdEdxHits(const DTrackTimeBased *track, vector<dedx_t>
       }
    
       double gas_thickness = 1.0; // cm
-      dEdxHits_FDC.push_back(dedx_t(fdchits[i]->dE, gas_thickness/cos(mom.Theta()), mom.Mag()));
+      dEdxHits_FDC.push_back(dedx_t(fdchits[i]->dE,fdchits[i]->dE_amp,
+				    gas_thickness/cos(mom.Theta()), mom.Mag()));
     }
   }
 
@@ -392,36 +407,43 @@ jerror_t DParticleID::GetDCdEdxHits(const DTrackTimeBased *track, vector<dedx_t>
   return NOERROR;
 }
 
-jerror_t DParticleID::CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const
+jerror_t DParticleID::CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdEdx_CDC_amp,double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const
 {
-	vector<dedx_t> locdEdxHits_CDC, locdEdxHits_FDC;
-	jerror_t locReturnStatus = GetDCdEdxHits(locTrackTimeBased, locdEdxHits_CDC, locdEdxHits_FDC);
+  vector<dedx_t> locdEdxHits_CDC, locdEdxHits_CDC_amp,locdEdxHits_FDC;
+  jerror_t locReturnStatus = GetDCdEdxHits(locTrackTimeBased, locdEdxHits_CDC, locdEdxHits_FDC);
 	if(locReturnStatus != NOERROR)
 	{
 		locdEdx_FDC = numeric_limits<double>::quiet_NaN();
 		locdx_FDC = numeric_limits<double>::quiet_NaN();
 		locNumHitsUsedFordEdx_FDC = 0;
 		locdEdx_CDC = numeric_limits<double>::quiet_NaN();
+		locdEdx_CDC_amp = numeric_limits<double>::quiet_NaN();
 		locdx_CDC = numeric_limits<double>::quiet_NaN();
 		locNumHitsUsedFordEdx_CDC = 0;
 		return locReturnStatus;
 	}
-	return CalcDCdEdx(locTrackTimeBased, locdEdxHits_CDC, locdEdxHits_FDC, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdx_CDC, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
+	return CalcDCdEdx(locTrackTimeBased, locdEdxHits_CDC,locdEdxHits_FDC, 
+			  locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp,
+			  locdx_CDC, locNumHitsUsedFordEdx_FDC, 
+			  locNumHitsUsedFordEdx_CDC);
 }
 
-jerror_t DParticleID::CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, const vector<dedx_t>& locdEdxHits_CDC, const vector<dedx_t>& locdEdxHits_FDC, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const
+jerror_t DParticleID::CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, const vector<dedx_t>& locdEdxHits_CDC, const vector<dedx_t>& locdEdxHits_FDC, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double &locdEdx_CDC_amp,double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const
 {
 	locdx_CDC = 0.0;
 	locdEdx_CDC = 0.0;
+	locdEdx_CDC_amp = 0.0;
 	locNumHitsUsedFordEdx_CDC = locdEdxHits_CDC.size()*4/5;
 	if(locNumHitsUsedFordEdx_CDC > 0)
 	{
-		for(unsigned int loc_i = 0; loc_i < locNumHitsUsedFordEdx_CDC; ++loc_i)
-		{
-			locdEdx_CDC += locdEdxHits_CDC[loc_i].dE; //weight is ~ #e- (scattering sites): dx!
-			locdx_CDC += locdEdxHits_CDC[loc_i].dx;
-		}
-		locdEdx_CDC /= locdx_CDC;
+	  for(unsigned int loc_i = 0; loc_i < locNumHitsUsedFordEdx_CDC; ++loc_i)
+	    {
+	      locdEdx_CDC += locdEdxHits_CDC[loc_i].dE; //weight is ~ #e- (scattering sites): dx!
+	      locdEdx_CDC_amp+=locdEdxHits_CDC[loc_i].dE_amp;
+	      locdx_CDC += locdEdxHits_CDC[loc_i].dx;
+	    }
+	  locdEdx_CDC /= locdx_CDC;
+	  locdEdx_CDC_amp/=locdx_CDC;
 	}
 
 	locdx_FDC = 0.0;
@@ -445,14 +467,18 @@ jerror_t DParticleID::CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, const
 jerror_t DParticleID::CalcdEdxHit(const DVector3 &mom,
 				  const DVector3 &pos,
 				  const DCDCTrackHit *hit,
-				  pair <double,double> &dedx) const{
+				  dedx_t &dedx) const{
   if (hit==NULL || hit->wire==NULL) return RESOURCE_UNAVAILABLE;
  
   double dx=CalcdXHit(mom,pos,hit->wire);
   if (dx>0.){
     // arc length and energy deposition
-    dedx.second=dx;
-    dedx.first=hit->dE; //GeV
+    dedx.dx=dx;
+    dedx.dE=hit->dE; //GeV
+    dedx.dE_amp=hit->dE_amp;
+    dedx.p=mom.Mag();
+    dedx.dEdx=hit->dE/dx;
+    dedx.dEdx_amp=hit->dE_amp/dx;
 
     return NOERROR;
   }

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -71,8 +71,8 @@ class DParticleID:public jana::JObject
 		virtual jerror_t CalcDCdEdxChiSq(DChargedTrackHypothesis *locChargedTrackHypothesis) const = 0;
 
 		jerror_t GetDCdEdxHits(const DTrackTimeBased *track, vector<dedx_t>& dEdxHits_CDC,vector<dedx_t>& dEdxHits_FDC) const;
-		jerror_t CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdEdx_CDC_amp, double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const;
-		jerror_t CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, const vector<dedx_t>& locdEdxHits_CDC, const vector<dedx_t>& locdEdxHits_FDC, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdEdx_CDC_amp,double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const;
+		jerror_t CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdEdx_CDC_amp, double& locdx_CDC, double& locdx_CDC_amp, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const;
+		jerror_t CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, const vector<dedx_t>& locdEdxHits_CDC, const vector<dedx_t>& locdEdxHits_FDC, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdEdx_CDC_amp,double& locdx_CDC, double& locdx_CDC_amp, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const;
 
 		jerror_t CalcdEdxHit(const DVector3 &mom, const DVector3 &pos, const DCDCTrackHit *hit, dedx_t &dedx) const;
 		double CalcdXHit(const DVector3 &mom,const DVector3 &pos,

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -59,20 +59,22 @@ class DParticleID:public jana::JObject
 		class dedx_t
 		{
 			public:
-				dedx_t(double dE,double dx, double p):dE(dE),dx(dx),p(p){dEdx = dE/dx;}
+		dedx_t(double dE,double dE_amp,double dx, double p):dE(dE),dE_amp(dE_amp),dx(dx),p(p){dEdx = dE/dx; dEdx_amp=dE_amp/dx;}
 				double dE; // energy loss in layer
+				double dE_amp;
 				double dx; // path length in layer
 				double dEdx; // ratio dE/dx
+				double dEdx_amp;
 				double p;  // momentum at this dE/dx measurement
 		};
 
 		virtual jerror_t CalcDCdEdxChiSq(DChargedTrackHypothesis *locChargedTrackHypothesis) const = 0;
 
-		jerror_t GetDCdEdxHits(const DTrackTimeBased *track, vector<dedx_t>& dEdxHits_CDC, vector<dedx_t>& dEdxHits_FDC) const;
-		jerror_t CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const;
-		jerror_t CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, const vector<dedx_t>& locdEdxHits_CDC, const vector<dedx_t>& locdEdxHits_FDC, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const;
+		jerror_t GetDCdEdxHits(const DTrackTimeBased *track, vector<dedx_t>& dEdxHits_CDC,vector<dedx_t>& dEdxHits_FDC) const;
+		jerror_t CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdEdx_CDC_amp, double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const;
+		jerror_t CalcDCdEdx(const DTrackTimeBased *locTrackTimeBased, const vector<dedx_t>& locdEdxHits_CDC, const vector<dedx_t>& locdEdxHits_FDC, double& locdEdx_FDC, double& locdx_FDC, double& locdEdx_CDC, double& locdEdx_CDC_amp,double& locdx_CDC, unsigned int& locNumHitsUsedFordEdx_FDC, unsigned int& locNumHitsUsedFordEdx_CDC) const;
 
-		jerror_t CalcdEdxHit(const DVector3 &mom, const DVector3 &pos, const DCDCTrackHit *hit, pair <double,double> &dedx) const;
+		jerror_t CalcdEdxHit(const DVector3 &mom, const DVector3 &pos, const DCDCTrackHit *hit, dedx_t &dedx) const;
 		double CalcdXHit(const DVector3 &mom,const DVector3 &pos,
 				 const DCoordinateSystem *wire) const;
 		jerror_t GroupTracks(vector<const DTrackTimeBased *> &tracks, vector<vector<const DTrackTimeBased*> >&grouped_tracks) const;
@@ -276,6 +278,8 @@ class DParticleID:public jana::JObject
 		double TOF_ATTEN_LENGTH;
 		double TOF_E_THRESHOLD;
 		double ONESIDED_PADDLE_MIDPOINT_MAG; //+/- this number for North/South
+		// time cut for cdc hits
+		double CDC_TIME_CUT_FOR_DEDX;
 
 		double dTargetZCenter;
 

--- a/src/libraries/TRACKING/DTrackTimeBased.h
+++ b/src/libraries/TRACKING/DTrackTimeBased.h
@@ -57,7 +57,7 @@ class DTrackTimeBased:public DTrackingData{
 		double ddx_FDC;
 		unsigned int dNumHitsUsedFordEdx_FDC;
 		double ddEdx_CDC,ddEdx_CDC_amp;
-		double ddx_CDC;
+		double ddx_CDC,ddx_CDC_amp;
 		unsigned int dNumHitsUsedFordEdx_CDC;
 
 		// Hit CDC Rings & FDC Planes

--- a/src/libraries/TRACKING/DTrackTimeBased.h
+++ b/src/libraries/TRACKING/DTrackTimeBased.h
@@ -56,7 +56,7 @@ class DTrackTimeBased:public DTrackingData{
 		double ddEdx_FDC;
 		double ddx_FDC;
 		unsigned int dNumHitsUsedFordEdx_FDC;
-		double ddEdx_CDC;
+		double ddEdx_CDC,ddEdx_CDC_amp;
 		double ddx_CDC;
 		unsigned int dNumHitsUsedFordEdx_CDC;
 
@@ -72,7 +72,7 @@ class DTrackTimeBased:public DTrackingData{
 		void toStrings(vector<pair<string,string> > &items)const{
 			DKinematicData::toStrings(items);
 			AddString(items, "candidate","%d",candidateid);
-			AddString(items, "wirebased","%d",trackid);
+			//AddString(items, "wirebased","%d",trackid);
 			AddString(items, "chisq", "%f", chisq);
 			AddString(items, "Ndof", "%d", Ndof);
 			AddString(items, "FOM", "%f",(float)FOM);

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -905,14 +905,15 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
 	timebased_track->AddAssociatedObject(mycdchits[m]);
 
       // dEdx
-      double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdx_CDC;
+      double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp,locdx_CDC;
       unsigned int locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC;
-      pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdx_CDC, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
+      pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp, locdx_CDC, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
   
       timebased_track->ddEdx_FDC = locdEdx_FDC;
       timebased_track->ddx_FDC = locdx_FDC;
       timebased_track->dNumHitsUsedFordEdx_FDC = locNumHitsUsedFordEdx_FDC;
-      timebased_track->ddEdx_CDC = locdEdx_CDC;
+      timebased_track->ddEdx_CDC = locdEdx_CDC; 
+      timebased_track->ddEdx_CDC_amp = locdEdx_CDC_amp;
       timebased_track->ddx_CDC = locdx_CDC;
       timebased_track->dNumHitsUsedFordEdx_CDC = locNumHitsUsedFordEdx_CDC;
       
@@ -986,14 +987,15 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
 	timebased_track->AddAssociatedObject(fdchits[m]);
       
       // dEdx
-      double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdx_CDC;
+      double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp, locdx_CDC;
       unsigned int locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC;
-      pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdx_CDC, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
+      pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp,locdx_CDC, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
       
       timebased_track->ddEdx_FDC = locdEdx_FDC;
       timebased_track->ddx_FDC = locdx_FDC;
       timebased_track->dNumHitsUsedFordEdx_FDC = locNumHitsUsedFordEdx_FDC;
       timebased_track->ddEdx_CDC = locdEdx_CDC;
+      timebased_track->ddEdx_CDC_amp= locdEdx_CDC_amp;
       timebased_track->ddx_CDC = locdx_CDC;
       timebased_track->dNumHitsUsedFordEdx_CDC = locNumHitsUsedFordEdx_CDC;
       
@@ -1059,14 +1061,15 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
   timebased_track->AddAssociatedObject(wire_based_track[0]);
 
   // dEdx
-  double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdx_CDC;
+  double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp, locdx_CDC;
   unsigned int locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC;
-  pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdx_CDC, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
+  pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp,locdx_CDC, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
   
   timebased_track->ddEdx_FDC = locdEdx_FDC;
   timebased_track->ddx_FDC = locdx_FDC;
   timebased_track->dNumHitsUsedFordEdx_FDC = locNumHitsUsedFordEdx_FDC;
   timebased_track->ddEdx_CDC = locdEdx_CDC;
+  timebased_track->ddEdx_CDC_amp = locdEdx_CDC_amp;
   timebased_track->ddx_CDC = locdx_CDC;
   timebased_track->dNumHitsUsedFordEdx_CDC = locNumHitsUsedFordEdx_CDC;
    

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -905,16 +905,18 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
 	timebased_track->AddAssociatedObject(mycdchits[m]);
 
       // dEdx
-      double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp,locdx_CDC;
+      double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp;
+      double locdx_CDC_amp,locdx_CDC;
       unsigned int locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC;
-      pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp, locdx_CDC, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
+      pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp, locdx_CDC, locdx_CDC_amp,locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
   
       timebased_track->ddEdx_FDC = locdEdx_FDC;
       timebased_track->ddx_FDC = locdx_FDC;
       timebased_track->dNumHitsUsedFordEdx_FDC = locNumHitsUsedFordEdx_FDC;
       timebased_track->ddEdx_CDC = locdEdx_CDC; 
       timebased_track->ddEdx_CDC_amp = locdEdx_CDC_amp;
-      timebased_track->ddx_CDC = locdx_CDC;
+      timebased_track->ddx_CDC = locdx_CDC; 
+      timebased_track->ddx_CDC_amp = locdx_CDC_amp;
       timebased_track->dNumHitsUsedFordEdx_CDC = locNumHitsUsedFordEdx_CDC;
       
       timebased_track->AddAssociatedObject(track);
@@ -987,9 +989,10 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
 	timebased_track->AddAssociatedObject(fdchits[m]);
       
       // dEdx
-      double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp, locdx_CDC;
+      double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp;
+      double locdx_CDC,locdx_CDC_amp;
       unsigned int locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC;
-      pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp,locdx_CDC, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
+      pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp,locdx_CDC,locdx_CDC_amp, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
       
       timebased_track->ddEdx_FDC = locdEdx_FDC;
       timebased_track->ddx_FDC = locdx_FDC;
@@ -997,6 +1000,7 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
       timebased_track->ddEdx_CDC = locdEdx_CDC;
       timebased_track->ddEdx_CDC_amp= locdEdx_CDC_amp;
       timebased_track->ddx_CDC = locdx_CDC;
+      timebased_track->ddx_CDC_amp= locdx_CDC_amp;
       timebased_track->dNumHitsUsedFordEdx_CDC = locNumHitsUsedFordEdx_CDC;
       
       // Add DTrack object as associate object
@@ -1061,9 +1065,10 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
   timebased_track->AddAssociatedObject(wire_based_track[0]);
 
   // dEdx
-  double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp, locdx_CDC;
+  double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp;
+  double locdx_CDC,locdx_CDC_amp;
   unsigned int locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC;
-  pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp,locdx_CDC, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
+  pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp,locdx_CDC,locdx_CDC_amp, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
   
   timebased_track->ddEdx_FDC = locdEdx_FDC;
   timebased_track->ddx_FDC = locdx_FDC;
@@ -1071,6 +1076,7 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
   timebased_track->ddEdx_CDC = locdEdx_CDC;
   timebased_track->ddEdx_CDC_amp = locdEdx_CDC_amp;
   timebased_track->ddx_CDC = locdx_CDC;
+  timebased_track->ddx_CDC_amp = locdx_CDC_amp;
   timebased_track->dNumHitsUsedFordEdx_CDC = locNumHitsUsedFordEdx_CDC;
    
   tracks_to_add.push_back(timebased_track);


### PR DESCRIPTION
Added code to compute dEdx for CDC from amplitude in addition to integral. Also added a command-line parameter (-PPID:CDC_TIME_CUT_FOR_DEDX) to allow cutting on the maximum allowable drift time for using dE measurements.