### PR TITLE
Recover missing hypotheses

### DIFF
--- a/src/libraries/TRACKING/DReferenceTrajectory.cc
+++ b/src/libraries/TRACKING/DReferenceTrajectory.cc
@@ -246,6 +246,16 @@ void DReferenceTrajectory::FastSwim(const DVector3 &pos, const DVector3 &mom,
 				    DVector3 &last_pos,DVector3 &last_mom,
 				    double q,double smax,
 				    const DCoordinateSystem *wire){
+  const DVector3 wire_origin=wire->origin;
+  const DVector3 wire_dir=wire->udir;
+  FastSwim(pos,mom,last_pos,last_mom,q,wire_origin,wire_dir,smax);
+}
+void DReferenceTrajectory::FastSwim(const DVector3 &pos, const DVector3 &mom,
+				    DVector3 &last_pos,DVector3 &last_mom,
+				    double q,
+				    const DVector3 &origin,
+				    const DVector3 &dir,double smax){
+
   DVector3 mypos(pos);
   DVector3 mymom(mom);
 
@@ -258,7 +268,7 @@ void DReferenceTrajectory::FastSwim(const DVector3 &pos, const DVector3 &mom,
     old_doca=doca;
 
     // Adjust step size to take smaller steps in regions of high momentum loss
-    if(mass>0. && step_size<0.0 && geom){	
+    if(geom){	
       double KrhoZ_overA=0.0;
       double rhoZ_overA=0.0;
       double LogI=0.0;
@@ -271,29 +281,31 @@ void DReferenceTrajectory::FastSwim(const DVector3 &pos, const DVector3 &mom,
 		
 	if(my_step_size>MAX_STEP_SIZE)my_step_size=MAX_STEP_SIZE; // maximum step size in cm
 	if(my_step_size<MIN_STEP_SIZE)my_step_size=MIN_STEP_SIZE; // minimum step size in cm
-
+	
+	if (ploss_direction==kBackward) my_step_size*=-1.;
 	stepper.SetStepSize(my_step_size);
       }
     }
     // Swim to next
     double ds=stepper.Step(NULL);
-    s+=ds;
-
+    s+=fabs(ds);
     stepper.GetPosMom(mypos,mymom);
-    if (mass>0 && dP_dx<0.){
-      double ptot=mymom.Mag();
-      if (ploss_direction==kForward) ptot+=dP_dx*ds;
-      else ptot-=dP_dx*ds;
-      mymom.SetMag(ptot);
-      stepper.SetStartingParams(q, &mypos, &mymom);
-    }
+
+    // Take into account energy loss
+    double ptot=mymom.Mag();
+    //    if (ploss_direction==kForward) ptot+=dP_dx*ds;
+    //else ptot-=dP_dx*ds; 
+    ptot+=dP_dx*ds;
+
+    mymom.SetMag(ptot);
+    stepper.SetStartingParams(q, &mypos, &mymom);
     
-    // Break if we have passed the wire
-    DVector3 wirepos=wire->origin;
-    if (fabs(wire->udir.z())>0.){ // for CDC wires
-      wirepos+=((mypos.z()-wire->origin.z())/wire->udir.z())*wire->udir;
+    // Break if we have passed the line to which we are trying to find the doca
+    DVector3 linepos=origin;
+    if (fabs(dir.z())>0.){
+      linepos+=((mypos.z()-origin.z())/dir.z())*dir;
     }
-    doca=(wirepos-mypos).Mag();
+    doca=(linepos-mypos).Mag();
     if (doca>old_doca) break;
 
     // Store the position and momentum for this step

--- a/src/libraries/TRACKING/DReferenceTrajectory.cc
+++ b/src/libraries/TRACKING/DReferenceTrajectory.cc
@@ -262,7 +262,7 @@ void DReferenceTrajectory::FastSwim(const DVector3 &pos, const DVector3 &mom,
   // Initialize the stepper
   DMagneticFieldStepper stepper(bfield, q, &pos, &mom);
   double s=0,doca=1000.,old_doca=1000.,dP_dx=0.;
-  double mass=GetMass();
+  //  double mass=GetMass();
   while (s<smax){
     // Save old value of doca
     old_doca=doca;
@@ -446,7 +446,7 @@ void DReferenceTrajectory::FastSwim(const DVector3 &pos, const DVector3 &mom, do
       DVector3 pos, mom;
       stepper.GetPosMom(pos, mom);
       double ptot = mom.Mag() - dP; // correct for energy loss
-      if (ptot<0) {Nswim_steps++; break;}
+      if (ptot<0.005) {Nswim_steps++; break;}
       mom.SetMag(ptot);
       stepper.SetStartingParams(q, &pos, &mom);
     }
@@ -718,10 +718,10 @@ void DReferenceTrajectory::Swim(const DVector3 &pos, const DVector3 &mom, double
 			  cout<<"N: " << Nswim_steps <<" x " << pos.x() <<" y " <<pos.y() <<" z " << pos.z() <<" r " << pos.Perp()<< " s " << s  << " p " << ptot << endl;
 			}
 			*/
-			if(ptot<0.0)ranged_out=true;
+			if(ptot<0.005)ranged_out=true;
 			if(dP<0.0 && ploss_direction==kForward)ranged_out=true;
 			if(dP>0.0 && ploss_direction==kBackward)ranged_out=true;
-			if(mom.Mag()==0.0)ranged_out=true;
+			//if(mom.Mag()==0.0)ranged_out=true;
 			if(ranged_out){
 				Nswim_steps++; // This will at least allow for very low momentum particles to have 1 swim step
 				break;

--- a/src/libraries/TRACKING/DReferenceTrajectory.h
+++ b/src/libraries/TRACKING/DReferenceTrajectory.h
@@ -109,6 +109,11 @@ class DReferenceTrajectory{
 			      DVector3 &last_pos, DVector3 &last_mom,
 			      double q,double smax=2000.0,
 			      const DCoordinateSystem *wire=NULL);
+		void FastSwim(const DVector3 &pos, const DVector3 &mom, 
+			      DVector3 &last_pos, DVector3 &last_mom,double q,
+			      const DVector3 &origin,const DVector3 &dir,
+			      double smax=2000.0
+			      );
 
 		int InsertSteps(const swim_step_t *start_step, double delta_s, double step_size=0.02); 
 		jerror_t GetIntersectionWithPlane(const DVector3 &origin, const DVector3 &norm, DVector3 &pos, double *s=NULL,double *t=NULL,double *var_t=NULL,DetectorSystem_t detector=SYS_NULL) const;	

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -1088,7 +1088,6 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
     if (fitter->GetChisq()<0) status=DTrackFitter::kFitFailed;
 
     if (status==DTrackFitter::kFitSuccess){
-      _DBG_ << "Refit worked!!!" << endl;
       timebased_track->chisq = fitter->GetChisq();
       timebased_track->Ndof = fitter->GetNdof();
       timebased_track->pulls = std::move(fitter->GetPulls());  
@@ -1184,7 +1183,6 @@ bool DTrackTimeBased_factory::InsertMissingHypotheses(JEventLoop *loop){
       int num_hyp=myhypotheses.size();
       if ((q<0 && num_hyp!=mNumHypMinus)||(q>0 && num_hyp!=mNumHypPlus)
 	  || flipped_charge){
-	_DBG_<< "Adding hypotheses" << endl;
 	AddMissingTrackHypotheses(mass_bits,tracks_to_add,myhypotheses,q,
 				  flipped_charge,loop);
       }
@@ -1216,7 +1214,6 @@ bool DTrackTimeBased_factory::InsertMissingHypotheses(JEventLoop *loop){
   int num_hyp=myhypotheses.size();
   if ((q<0 && num_hyp!=mNumHypMinus)||(q>0 && num_hyp!=mNumHypPlus)
       || flipped_charge){
-    _DBG_<< "Adding hypotheses" << endl;
     AddMissingTrackHypotheses(mass_bits,tracks_to_add,myhypotheses,q,
 			      flipped_charge,loop);
   }

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -408,7 +408,7 @@ jerror_t DTrackTimeBased_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
   FilterDuplicates();
 
   // Fill in track data for missing hypotheses 
-  InsertMissingHypotheses();
+  InsertMissingHypotheses(loop);
 
   // Set MC Hit-matching information
   for(size_t loc_i = 0; loc_i < _data.size(); ++loc_i)
@@ -1028,7 +1028,10 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
 void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>&tracks_to_add,
 				      const DTrackTimeBased *src_track,
 							double my_mass,
-							double q){
+							double q,
+							JEventLoop *loop){
+ 
+  
   // Create a new time-based track object
   DTrackTimeBased *timebased_track = new DTrackTimeBased();
   *static_cast<DTrackingData*>(timebased_track) = *static_cast<const DTrackingData*>(src_track);
@@ -1044,26 +1047,105 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
   timebased_track->FOM=src_track->FOM;
   timebased_track->cdc_hit_usage=src_track->cdc_hit_usage;
   timebased_track->fdc_hit_usage=src_track->fdc_hit_usage;
-  
   // Add list of start times
   timebased_track->start_times.assign(src_track->start_times.begin(),  
 				      src_track->start_times.end());
-
-  // Get the hits used in the fit and add them as associated objects 
-  vector<const DCDCTrackHit *>cdchits;
-  src_track->GetT(cdchits);
-  vector<const DFDCPseudo *>fdchits;
-  src_track->GetT(fdchits);
-  for(unsigned int m=0; m<fdchits.size(); m++)
-    timebased_track->AddAssociatedObject(fdchits[m]); 
-  for(unsigned int m=0; m<cdchits.size(); m++)
-    timebased_track->AddAssociatedObject(cdchits[m]);
-  
   // Add DTrack object as associate object
   vector<const DTrackWireBased*>wire_based_track;
   src_track->GetT(wire_based_track);
   timebased_track->AddAssociatedObject(wire_based_track[0]);
 
+  // (Partially) compensate for the difference in energy loss between the 
+  // source track and a particle of mass my_mass 
+  DVector3 position,momentum;
+  if (timebased_track->extrapolations.at(SYS_CDC).size()>0){
+    unsigned int index=timebased_track->extrapolations.at(SYS_CDC).size()-1;
+    position=timebased_track->extrapolations[SYS_CDC][index].position;
+    momentum=timebased_track->extrapolations[SYS_CDC][index].momentum;
+  }
+  else if (timebased_track->extrapolations.at(SYS_FDC).size()>0){
+    unsigned int index=timebased_track->extrapolations.at(SYS_FDC).size()-1;
+    position=timebased_track->extrapolations[SYS_FDC][index].position;
+    momentum=timebased_track->extrapolations[SYS_FDC][index].momentum;
+  }
+
+  DTrackFitter::fit_status_t status=DTrackFitter::kFitNotDone;
+  if (momentum.Mag()>0.){
+    CorrectForELoss(position,momentum,q,my_mass);  
+    timebased_track->setMomentum(momentum);
+    timebased_track->setPosition(position);
+
+    // Redo the fit with the new position and momentum as initial guesses
+    fitter->Reset();
+    fitter->SetFitType(DTrackFitter::kTimeBased);    
+    status = fitter->FindHitsAndFitTrack(*timebased_track,
+					 timebased_track->extrapolations,loop, 
+					 my_mass,timebased_track->Ndof+5,
+					 timebased_track->t0(),
+					 timebased_track->t0_detector());
+    // if the fit returns chisq=-1, something went terribly wrong.  Do not 
+    // update the parameters for the track...
+    if (fitter->GetChisq()<0) status=DTrackFitter::kFitFailed;
+
+    if (status==DTrackFitter::kFitSuccess){
+      _DBG_ << "Refit worked!!!" << endl;
+      timebased_track->chisq = fitter->GetChisq();
+      timebased_track->Ndof = fitter->GetNdof();
+      timebased_track->pulls = std::move(fitter->GetPulls());  
+      timebased_track->extrapolations=std::move(fitter->GetExtrapolations());
+      timebased_track->IsSmoothed = fitter->GetIsSmoothed();  
+      *static_cast<DTrackingData*>(timebased_track) = fitter->GetFitParameters();
+
+      // Add hits used as associated objects
+      const vector<const DCDCTrackHit*> &cdchits = fitter->GetCDCFitHits();
+      const vector<const DFDCPseudo*> &fdchits = fitter->GetFDCFitHits();
+      
+      unsigned int num_fdc_potential=fitter->GetNumPotentialFDCHits();
+      unsigned int num_cdc_potential=fitter->GetNumPotentialCDCHits();
+
+      DTrackTimeBased::hit_usage_t temp;
+      temp.inner_layer=0;
+      temp.outer_layer=0;
+      temp.total_hits=num_cdc_potential;
+      if (cdchits.size()>0){
+	temp.inner_layer=cdchits[0]->wire->ring;
+	temp.outer_layer=cdchits[cdchits.size()-1]->wire->ring;
+      }
+      timebased_track->cdc_hit_usage=temp;
+
+      // Reset the structure
+      temp.inner_layer=0;
+      temp.outer_layer=0;
+      temp.total_hits=num_fdc_potential; 
+      if (fdchits.size()>0){
+	temp.inner_layer=fdchits[0]->wire->layer;
+	temp.outer_layer=fdchits[fdchits.size()-1]->wire->layer;
+      }
+      timebased_track->fdc_hit_usage=temp;
+      
+      for(unsigned int m=0; m<cdchits.size(); m++)
+	timebased_track->AddAssociatedObject(cdchits[m]);
+      for(unsigned int m=0; m<fdchits.size(); m++)
+	timebased_track->AddAssociatedObject(fdchits[m]);
+      
+      // Compute the figure-of-merit based on tracking
+      timebased_track->FOM = TMath::Prob(timebased_track->chisq, timebased_track->Ndof);
+      
+    }
+  }
+
+  if (status!=DTrackFitter::kFitSuccess){
+    // Get the hits used in the fit and add them as associated objects 
+    vector<const DCDCTrackHit *>cdchits;
+    src_track->GetT(cdchits);
+    vector<const DFDCPseudo *>fdchits;
+    src_track->GetT(fdchits);
+    for(unsigned int m=0; m<fdchits.size(); m++)
+      timebased_track->AddAssociatedObject(fdchits[m]); 
+    for(unsigned int m=0; m<cdchits.size(); m++)
+      timebased_track->AddAssociatedObject(cdchits[m]);
+  }
+ 
   // dEdx
   double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp;
   double locdx_CDC,locdx_CDC_amp;
@@ -1085,49 +1167,26 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
 
 // If the fit failed for certain hypotheses, fill in the gaps using data from
 // successful fits for each candidate.
-bool DTrackTimeBased_factory::InsertMissingHypotheses(void){
+bool DTrackTimeBased_factory::InsertMissingHypotheses(JEventLoop *loop){
   if (_data.size()==0) return false;
   
   // Make sure the tracks are ordered by candidate id
   sort(_data.begin(),_data.end(),DTrackTimeBased_cmp);
-  
+ 
   JObject::oid_t old_id=_data[0]->candidateid;
-  bool got_pi=false,got_k=false,got_prot=false;
+  unsigned int mass_bits=0;
   double q=_data[0]->charge();
   bool flipped_charge=false;
   vector<DTrackTimeBased*>myhypotheses;
   vector<DTrackTimeBased*>tracks_to_add;
   for (size_t i=0;i<_data.size();i++){
-    double mass=_data[i]->mass();
-      
     if (_data[i]->candidateid!=old_id){
       int num_hyp=myhypotheses.size();
       if ((q<0 && num_hyp!=mNumHypMinus)||(q>0 && num_hyp!=mNumHypPlus)
 	  || flipped_charge){
-	if (q>0 && got_prot==false){
-	  AddMissingTrackHypothesis(tracks_to_add,
-				      myhypotheses[myhypotheses.size()-1],
-				    ParticleMass(Proton),q); 
-	}
-	if (got_pi==false){
-	  AddMissingTrackHypothesis(tracks_to_add,myhypotheses[0],
-				    ParticleMass(PiPlus),q);
-	  if (flipped_charge) 
-	    myhypotheses.push_back(tracks_to_add[tracks_to_add.size()-1]);
-	}
-	if (got_k==false){
-	  AddMissingTrackHypothesis(tracks_to_add,myhypotheses[0],
-				    ParticleMass(KPlus),q);
-	  if (flipped_charge) 
-	    myhypotheses.push_back(tracks_to_add[tracks_to_add.size()-1]);
-	}
-	if (flipped_charge){
-	  for (size_t j=0;j<myhypotheses.size();j++){
-	    AddMissingTrackHypothesis(tracks_to_add,myhypotheses[j],
-				      myhypotheses[j]->mass(),
-				      -1.*myhypotheses[j]->charge());
-	  }
-	}
+	_DBG_<< "Adding hypotheses" << endl;
+	AddMissingTrackHypotheses(mass_bits,tracks_to_add,myhypotheses,q,
+				  flipped_charge,loop);
       }
       
       // Clear the myhypotheses vector for the next track
@@ -1135,23 +1194,17 @@ bool DTrackTimeBased_factory::InsertMissingHypotheses(void){
       // Reset flags and charge 
       q=_data[i]->charge();	
       flipped_charge=false;
-      got_pi=false,got_k=false,got_prot=false;
-      
-      // Check for particular masses
-      if (mass<0.2) got_pi=true;
-      else if (mass<0.6) got_k=true;
-      else if (q>0) got_prot=true;
+      // Set the bit for this mass hypothesis
+      mass_bits = 1<<_data[i]->PID();
       
       // Add the data to the myhypotheses vector
       myhypotheses.push_back(_data[i]);
     }
     else{
       myhypotheses.push_back(_data[i]);
-      
-      // Check for particular masses
-      if (mass<0.2) got_pi=true;
-	else if (mass<0.6) got_k=true;
-	else if (q>0) got_prot=true;
+
+      // Set the bit for this mass hypothesis
+      mass_bits |= 1<< _data[i]->PID();
       
       // Check if the sign of the charge has flipped
       if (_data[i]->charge()!=q) flipped_charge=true;
@@ -1163,30 +1216,9 @@ bool DTrackTimeBased_factory::InsertMissingHypotheses(void){
   int num_hyp=myhypotheses.size();
   if ((q<0 && num_hyp!=mNumHypMinus)||(q>0 && num_hyp!=mNumHypPlus)
       || flipped_charge){
-    if (q>0 && got_prot==false){
-      AddMissingTrackHypothesis(tracks_to_add,
-				myhypotheses[myhypotheses.size()-1],
-				ParticleMass(Proton),q);	
-    }
-    if (got_pi==false){
-      AddMissingTrackHypothesis(tracks_to_add,myhypotheses[0],
-				ParticleMass(PiPlus),q);
-      if (flipped_charge) 
-	myhypotheses.push_back(tracks_to_add[tracks_to_add.size()-1]);
-    }
-    if (got_k==false){
-      AddMissingTrackHypothesis(tracks_to_add,myhypotheses[0],
-				ParticleMass(KPlus),q);
-      if (flipped_charge) 
-	myhypotheses.push_back(tracks_to_add[tracks_to_add.size()-1]);
-    }
-    if (flipped_charge){
-      for (size_t j=0;j<myhypotheses.size();j++){
-	AddMissingTrackHypothesis(tracks_to_add,myhypotheses[j],
-				  myhypotheses[j]->mass(),
-				  -1.*myhypotheses[j]->charge());
-      }
-    }
+    _DBG_<< "Adding hypotheses" << endl;
+    AddMissingTrackHypotheses(mass_bits,tracks_to_add,myhypotheses,q,
+			      flipped_charge,loop);
   }
     
   // Add the new list of tracks to the output list
@@ -1201,3 +1233,85 @@ bool DTrackTimeBased_factory::InsertMissingHypotheses(void){
 
   return true;
 }
+
+// Use the FastSwim method in DReferenceTrajectory to propagate back to the 
+// POCA to the beam line, adding a bit of energy at each step that would have 
+// been lost had the particle emerged from the target.
+void DTrackTimeBased_factory::CorrectForELoss(DVector3 &position,DVector3 &momentum,double q,double my_mass){  
+  DReferenceTrajectory::swim_step_t dummy_step;
+  DReferenceTrajectory rt(fitter->GetDMagneticFieldMap(),q,&dummy_step);
+  rt.SetDGeometry(geom);
+  rt.SetMass(my_mass);
+  rt.SetPLossDirection(DReferenceTrajectory::kBackward);
+  DVector3 last_pos,last_mom;
+  DVector3 origin(0.,0.,65.);
+  DVector3 dir(0.,0.,1.);
+  rt.FastSwim(position,momentum,last_pos,last_mom,q,origin,dir,300.);   
+  position=last_pos;
+  momentum=last_mom;   
+}
+
+// Fill in all missing hypotheses for a given track candidate
+void DTrackTimeBased_factory::AddMissingTrackHypotheses(unsigned int mass_bits,
+							vector<DTrackTimeBased*>&tracks_to_add,
+							vector<DTrackTimeBased *>&myhypotheses,
+							double q,
+							bool flipped_charge,
+							JEventLoop *loop){ 
+  Particle_t negative_particles[3]={KMinus,PiMinus,Electron};
+  Particle_t positive_particles[3]={KPlus,PiPlus,Positron};
+
+  unsigned int last_index=myhypotheses.size()-1;
+  if (q>0){
+    if (flipped_charge){
+      if ((mass_bits & (1<<AntiProton))==0){
+	AddMissingTrackHypothesis(tracks_to_add,myhypotheses[last_index],
+				  ParticleMass(Proton),-1.,loop);  
+      } 	
+      for (int i=0;i<3;i++){
+	if ((mass_bits & (1<<negative_particles[i]))==0){
+	  AddMissingTrackHypothesis(tracks_to_add,myhypotheses[0],
+				    ParticleMass(negative_particles[i]),
+				    -1.,loop);  
+	} 
+      }
+    }
+    if ((mass_bits & (1<<Proton))==0){
+      AddMissingTrackHypothesis(tracks_to_add,myhypotheses[last_index],
+				ParticleMass(Proton),+1.,loop);  
+    } 
+    for (int i=0;i<3;i++){
+      if ((mass_bits & (1<<positive_particles[i]))==0){
+	AddMissingTrackHypothesis(tracks_to_add,myhypotheses[0],
+				  ParticleMass(positive_particles[i]),
+				  +1.,loop);  
+      } 
+    }    
+  }
+  else{
+    if ((mass_bits & (1<<AntiProton))==0){
+      AddMissingTrackHypothesis(tracks_to_add,myhypotheses[last_index],
+				ParticleMass(Proton),-1.,loop);  
+    } 	
+    for (int i=0;i<3;i++){
+      if ((mass_bits & (1<<negative_particles[i]))==0){
+	AddMissingTrackHypothesis(tracks_to_add,myhypotheses[0],
+				  ParticleMass(negative_particles[i]),
+				  -1.,loop);  
+      } 
+    }
+    if (flipped_charge){
+      if ((mass_bits & (1<<Proton))==0){
+	AddMissingTrackHypothesis(tracks_to_add,myhypotheses[last_index],
+				  ParticleMass(Proton),+1.,loop);  
+      } 
+      for (int i=0;i<3;i++){
+	if ((mass_bits & (1<<positive_particles[i]))==0){
+	  AddMissingTrackHypothesis(tracks_to_add,myhypotheses[0],
+				    ParticleMass(positive_particles[i]),
+				    +1.,loop);  
+	} 
+      }	
+    }
+  }
+} 

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.h
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.h
@@ -82,8 +82,14 @@ class DTrackTimeBased_factory:public jana::JFactory<DTrackTimeBased>{
 
   void AddMissingTrackHypothesis(vector<DTrackTimeBased*>&tracks_to_add,
 				 const DTrackTimeBased *src_track,
-				 double my_mass,double q);
-  bool InsertMissingHypotheses(void);
+				 double my_mass,double q,
+				 JEventLoop *loop);
+  bool InsertMissingHypotheses(JEventLoop *loop);
+  void CorrectForELoss(DVector3 &position,DVector3 &momentum,double q,double my_mass);
+  void AddMissingTrackHypotheses(unsigned int mass_bits,
+				 vector<DTrackTimeBased*>&tracks_to_add,
+				 vector<DTrackTimeBased *>&hypotheses,
+				 double q,bool flipped_charge,JEventLoop *loop);
 
   // Geometry
   const DGeometry *geom;

--- a/src/libraries/TRACKING/DTrackWireBased_factory.h
+++ b/src/libraries/TRACKING/DTrackWireBased_factory.h
@@ -83,7 +83,7 @@ class DTrackWireBased_factory:public jana::JFactory<DTrackWireBased>{
 		void AddMissingTrackHypotheses(unsigned int mass_bits,
 					       vector<DTrackWireBased*>&tracks_to_add,
 					       vector<DTrackWireBased *>&hypotheses,
-					       double q,bool flipped_charge);
+					       double q);
 
  
 		const DGeometry *geom;

--- a/src/libraries/TRACKING/DTrackWireBased_factory.h
+++ b/src/libraries/TRACKING/DTrackWireBased_factory.h
@@ -67,12 +67,20 @@ class DTrackWireBased_factory:public jana::JFactory<DTrackWireBased>{
 		unsigned int num_used_rts;
 		vector<int> mass_hypotheses_positive;
 		vector<int> mass_hypotheses_negative;
-		size_t MAX_DReferenceTrajectoryPoolSize;
+		size_t MAX_DReferenceTrajectoryPoolSize; 
+		int mNumHypPlus,mNumHypMinus;
 
 		void FilterDuplicates(void);
 		void DoFit(unsigned int c_id,const DTrackCandidate *candidate,
 			   DReferenceTrajectory *rt,jana::JEventLoop *loop, 
-			   double mass); 
+			   double mass);
+		void AddMissingTrackHypothesis(vector<DTrackWireBased*>&tracks_to_add,
+					       const DTrackWireBased *src_track,
+					       double my_mass,double q);
+		bool InsertMissingHypotheses(void);
+		void CorrectForELoss(DVector3 &position,DVector3 &momentum,
+				     double q, double mass);
+ 
 		const DGeometry *geom;
 
 		bool DEBUG_HISTS;

--- a/src/libraries/TRACKING/DTrackWireBased_factory.h
+++ b/src/libraries/TRACKING/DTrackWireBased_factory.h
@@ -79,7 +79,12 @@ class DTrackWireBased_factory:public jana::JFactory<DTrackWireBased>{
 					       double my_mass,double q);
 		bool InsertMissingHypotheses(void);
 		void CorrectForELoss(DVector3 &position,DVector3 &momentum,
-				     double q, double mass);
+				     double q, double mass); 
+		void AddMissingTrackHypotheses(unsigned int mass_bits,
+					       vector<DTrackWireBased*>&tracks_to_add,
+					       vector<DTrackWireBased *>&hypotheses,
+					       double q,bool flipped_charge);
+
  
 		const DGeometry *geom;
 


### PR DESCRIPTION
Fills in missing hypotheses at  the wire-based stage in addition to the time-based stage of track fitting.  If a hypothesis is filled in at the time-based stage, attempts a new fit with a new guess for the track parameters after correcting for energy loss.