### PR TITLE
open up dE/dx cuts for pions and kaons in the CDC ...

### DIFF
--- a/src/libraries/ANALYSIS/DSourceComboer.cc
+++ b/src/libraries/ANALYSIS/DSourceComboer.cc
@@ -140,25 +140,19 @@ void DSourceComboer::Define_DefaultCuts(void)
 	ddEdxCuts_TF1FunctionStrings[PiPlus][SYS_CDC].first = "[0]"; //low bound
 	ddEdxCuts_TF1Params[PiPlus][SYS_CDC].first = {-9.9E9};
 	ddEdxCuts_TF1FunctionStrings[PiPlus][SYS_CDC].second = "exp(-1.0*[0]*x + [1]) + [2]"; //high bound
-	ddEdxCuts_TF1Params[PiPlus][SYS_CDC].second = {-0.1, 0.5, 1.2};
+	ddEdxCuts_TF1Params[PiPlus][SYS_CDC].second = {7.0, 3.0, 6.2};
 
 	//CDC K+
 	ddEdxCuts_TF1FunctionStrings[KPlus][SYS_CDC].first = "[0]"; //low bound
 	ddEdxCuts_TF1Params[KPlus][SYS_CDC].first = {-9.9E9};
 	ddEdxCuts_TF1FunctionStrings[KPlus][SYS_CDC].second = "exp(-1.0*[0]*x + [1]) + [2]"; //high bound
-	ddEdxCuts_TF1Params[KPlus][SYS_CDC].second = {2.0, 0.8, 3.0};
+	ddEdxCuts_TF1Params[KPlus][SYS_CDC].second = {7.0, 3.0, 6.2};
 
 	//CDC e-
 	ddEdxCuts_TF1FunctionStrings[Electron][SYS_CDC].first = "[0]"; //low bound
 	ddEdxCuts_TF1Params[Electron][SYS_CDC].first = {-9.9E9};
 	ddEdxCuts_TF1FunctionStrings[Electron][SYS_CDC].second = "[0]"; //high bound
 	ddEdxCuts_TF1Params[Electron][SYS_CDC].second = {5.5};
-
-	//FDC e-
-	ddEdxCuts_TF1FunctionStrings[Electron][SYS_FDC].first = "[0]"; //low bound
-	ddEdxCuts_TF1Params[Electron][SYS_FDC].first = {-9.9E9};
-	ddEdxCuts_TF1FunctionStrings[Electron][SYS_FDC].second = "[0]"; //high bound
-	ddEdxCuts_TF1Params[Electron][SYS_FDC].second = {3.5};
 
 	//pbar
 	ddEdxCuts_TF1FunctionStrings.emplace(AntiProton, ddEdxCuts_TF1FunctionStrings[Proton]);


### PR DESCRIPTION
... to allow for values from amplitude, removed dE/dx cut for electrons in FDC since it is not calibrated