### PR TITLE
Change default CDC dE/dx used to amplitude-based dE/dx

### DIFF
--- a/src/libraries/ANALYSIS/DCutActions.cc
+++ b/src/libraries/ANALYSIS/DCutActions.cc
@@ -930,7 +930,7 @@ bool DCutAction_dEdx::Cut_dEdx(const DChargedTrackHypothesis* locChargedTrackHyp
 		return true;
 
 	auto locP = locTrackTimeBased->momentum().Mag();
-	auto locdEdx = locTrackTimeBased->ddEdx_CDC*1.0E6;
+	auto locdEdx = locTrackTimeBased->ddEdx_CDC_amp*1.0E6;
 
 	return ((locdEdx >= locCutPair.first->Eval(locP)) && (locdEdx <= locCutPair.second->Eval(locP)));
 }

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -620,6 +620,7 @@ void DEventWriterROOT::Create_Branches_ChargedHypotheses(DTreeBranchRegister& lo
 	locBranchRegister.Register_FundamentalArray<UInt_t>(Build_BranchName(locParticleBranchName, "NDF_DCdEdx"), locArraySizeString, dInitNumTrackArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_DCdEdx"), locArraySizeString, dInitNumTrackArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "dEdx_CDC"), locArraySizeString, dInitNumTrackArraySize);
+	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "dEdx_CDC_integral"), locArraySizeString, dInitNumTrackArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "dEdx_FDC"), locArraySizeString, dInitNumTrackArraySize);
 
 	//TIMING INFO
@@ -1494,7 +1495,8 @@ void DEventWriterROOT::Fill_ChargedHypo(DTreeFillData* locTreeFillData, unsigned
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Tracking"), locTrackTimeBased->chisq, locArrayIndex);
 	locTreeFillData->Fill_Array<UInt_t>(Build_BranchName(locParticleBranchName, "NDF_DCdEdx"), locChargedTrackHypothesis->Get_NDF_DCdEdx(), locArrayIndex);
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_DCdEdx"), locChargedTrackHypothesis->Get_ChiSq_DCdEdx(), locArrayIndex);
-	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "dEdx_CDC"), locTrackTimeBased->ddEdx_CDC, locArrayIndex);
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "dEdx_CDC"), locTrackTimeBased->ddEdx_CDC_amp, locArrayIndex);
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "dEdx_CDC_integral"), locTrackTimeBased->ddEdx_CDC, locArrayIndex);
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "dEdx_FDC"), locTrackTimeBased->ddEdx_FDC, locArrayIndex);
 
 	//HIT ENERGY

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -1765,9 +1765,12 @@ void DHistogramAction_DetectorPID::Initialize(JEventLoop* locEventLoop)
 			//CDC
 			CreateAndChangeTo_Directory("CDC", "CDC");
 
-			locHistName = string("dEdXVsP_") + locParticleName;
-			locHistTitle = locParticleROOTName + string(";p (GeV/c);CDC dE/dx (keV/cm)");
+			locHistName = string("dEdXVsP_Int_") + locParticleName;
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);CDC dE/dx [Integral-based] (keV/cm)");
 			dHistMap_dEdXVsP[SYS_CDC][locCharge] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DdEdxBins, dMindEdX, dMaxdEdX);
+			locHistName = string("dEdXVsP_Amp_") + locParticleName;
+			locHistTitle = locParticleROOTName + string(";p (GeV/c);CDC dE/dx [Amplitude-based] (keV/cm)");
+			dHistMap_dEdXVsP[SYS_CDC_AMP][locCharge] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DdEdxBins, dMindEdX, dMaxdEdX);
 
 			gDirectory->cd("..");
 
@@ -1891,9 +1894,13 @@ void DHistogramAction_DetectorPID::Initialize(JEventLoop* locEventLoop)
 			//CDC
 			CreateAndChangeTo_Directory("CDC", "CDC");
 
-			locHistName = string("DeltadEdXVsP_") + locParticleName;
-			locHistTitle = locParticleROOTName + string(" Candidates;p (GeV/c);CDC #Delta(dE/dX) (keV/cm)");
+			locHistName = string("DeltadEdXVsP_Int_") + locParticleName;
+			locHistTitle = locParticleROOTName + string(" Candidates;p (GeV/c);CDC #Delta(dE/dX) [Integral-based] (keV/cm)");
 			dHistMap_DeltadEdXVsP[SYS_CDC][locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DDeltadEdxBins, dMinDeltadEdx, dMaxDeltadEdx);
+
+			locHistName = string("DeltadEdXVsP_Amp_") + locParticleName;
+			locHistTitle = locParticleROOTName + string(" Candidates;p (GeV/c);CDC #Delta(dE/dX) [Amplitude-based] (keV/cm)");
+			dHistMap_DeltadEdXVsP[SYS_CDC_AMP][locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DDeltadEdxBins, dMinDeltadEdx, dMaxDeltadEdx);
 
 /*
 			//Uncomment when ready!
@@ -2093,10 +2100,16 @@ bool DHistogramAction_DetectorPID::Perform_Action(JEventLoop* locEventLoop, cons
 			if(locTrackTimeBased->dNumHitsUsedFordEdx_CDC > 0)
 			{
 				dHistMap_dEdXVsP[SYS_CDC][locCharge]->Fill(locP, locTrackTimeBased->ddEdx_CDC*1.0E6);
+				dHistMap_dEdXVsP[SYS_CDC_AMP][locCharge]->Fill(locP, locTrackTimeBased->ddEdx_CDC_amp*1.0E6);
 				if(dHistMap_DeltadEdXVsP[SYS_CDC].find(locPID) != dHistMap_DeltadEdXVsP[SYS_CDC].end())
 				{
 					double locProbabledEdx = locParticleID->GetMostProbabledEdx_DC(locP, locChargedTrackHypothesis->mass(), locTrackTimeBased->ddx_CDC, true);
 					dHistMap_DeltadEdXVsP[SYS_CDC][locPID]->Fill(locP, (locTrackTimeBased->ddEdx_CDC - locProbabledEdx)*1.0E6);
+				}
+				if(dHistMap_DeltadEdXVsP[SYS_CDC_AMP].find(locPID) != dHistMap_DeltadEdXVsP[SYS_CDC_AMP].end())
+				{
+					double locProbabledEdx = locParticleID->GetMostProbabledEdx_DC(locP, locChargedTrackHypothesis->mass(), locTrackTimeBased->ddx_CDC_amp, true);
+					dHistMap_DeltadEdXVsP[SYS_CDC_AMP][locPID]->Fill(locP, (locTrackTimeBased->ddEdx_CDC_amp - locProbabledEdx)*1.0E6);
 				}
 			}
 			if(locTrackTimeBased->dNumHitsUsedFordEdx_FDC > 0)

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.h
@@ -389,6 +389,9 @@ class DHistogramAction_DetectorPID : public DAnalysisAction
 		{
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
 			dFinalStatePIDs.push_back(PiMinus);  dFinalStatePIDs.push_back(KMinus);
+
+			// used for indexing into maps
+			SYS_CDC_AMP = static_cast<DetectorSystem_t>(SYS_CDC + SYS_FDC);
 		}
 
 		DHistogramAction_DetectorPID(string locActionUniqueString) :
@@ -401,6 +404,9 @@ class DHistogramAction_DetectorPID : public DAnalysisAction
 		{
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
 			dFinalStatePIDs.push_back(PiMinus);  dFinalStatePIDs.push_back(KMinus);
+
+			// used for indexing into maps
+			SYS_CDC_AMP = static_cast<DetectorSystem_t>(SYS_CDC + SYS_FDC);
 		}
 
 		DHistogramAction_DetectorPID(void) :
@@ -413,6 +419,9 @@ class DHistogramAction_DetectorPID : public DAnalysisAction
 		{
 			dFinalStatePIDs.push_back(PiPlus);  dFinalStatePIDs.push_back(KPlus);  dFinalStatePIDs.push_back(Proton);
 			dFinalStatePIDs.push_back(PiMinus);  dFinalStatePIDs.push_back(KMinus);
+
+			// used for indexing into maps
+			SYS_CDC_AMP = static_cast<DetectorSystem_t>(SYS_CDC + SYS_FDC);
 		}
 
 		void Initialize(JEventLoop* locEventLoop);
@@ -426,6 +435,7 @@ class DHistogramAction_DetectorPID : public DAnalysisAction
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo = NULL);
 
+		DetectorSystem_t SYS_CDC_AMP;
 		vector<Particle_t> dFinalStatePIDs;
 
 		//int is charge: -1, 0, 1

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -229,21 +229,37 @@ void DHistogramAction_PID::Initialize(JEventLoop* locEventLoop)
 				//CDC
 				CreateAndChangeTo_Directory("CDC", "CDC");
 
-				locHistName = "dEdXVsP";
-				locHistTitle = locParticleROOTName + string(" Candidates;p (GeV/c);CDC dE/dx (keV/cm)");
+				locHistName = "dEdXVsP_Int";
+				locHistTitle = locParticleROOTName + string(" Candidates;p (GeV/c);CDC dE/dx [Integral-based] (keV/cm)");
 				dHistMap_dEdXVsP[locPID][SYS_CDC] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DdEdxBins, dMindEdX, dMaxdEdX);
 
-				locHistName = "DeltadEdXVsP";
-				locHistTitle = locParticleROOTName + string(" Candidates;p (GeV/c);CDC #Delta(dE/dX) (keV/cm)");
+				locHistName = "dEdXVsP_Amp";
+				locHistTitle = locParticleROOTName + string(" Candidates;p (GeV/c);CDC dE/dx [Amplitude-based] (keV/cm)");
+				dHistMap_dEdXVsP[locPID][SYS_CDC_AMP] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DdEdxBins, dMindEdX, dMaxdEdX);
+
+				locHistName = "DeltadEdXVsP_Int";
+				locHistTitle = locParticleROOTName + string(" Candidates;p (GeV/c);CDC #Delta(dE/dX) [Integral-based] (keV/cm)");
 				dHistMap_DeltadEdXVsP[locPID][SYS_CDC] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DDeltadEdxBins, dMinDeltadEdx, dMaxDeltadEdx);
 
-				locHistName = string("dEdXPullVsP_") + locParticleName;
-				locHistTitle = locParticleROOTName + string(";p (GeV/c);CDC #Delta(dE/dX)/#sigma_{#Delta(dE/dX)}");
+				locHistName = "DeltadEdXVsP_Amp";
+				locHistTitle = locParticleROOTName + string(" Candidates;p (GeV/c);CDC #Delta(dE/dX) [Amplitude-based] (keV/cm)");
+				dHistMap_DeltadEdXVsP[locPID][SYS_CDC_AMP] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DDeltadEdxBins, dMinDeltadEdx, dMaxDeltadEdx);
+
+				locHistName = string("dEdXPullVsP_Int_") + locParticleName;
+				locHistTitle = locParticleROOTName + string(";p (GeV/c);CDC #Delta(dE/dX)/#sigma_{#Delta(dE/dX)} [Integral-based]");
 				dHistMap_dEdXPullVsP[locPID][SYS_CDC] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DPullBins, dMinPull, dMaxPull);
 
-				locHistName = string("dEdXFOMVsP_") + locParticleName;
-				locHistTitle = locParticleROOTName + string(";p (GeV/c);CDC dE/dx PID Confidence Level");
+				locHistName = string("dEdXPullVsP_Amp_") + locParticleName;
+				locHistTitle = locParticleROOTName + string(";p (GeV/c);CDC #Delta(dE/dX)/#sigma_{#Delta(dE/dX)} [Amplitude-based]");
+				dHistMap_dEdXPullVsP[locPID][SYS_CDC_AMP] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DPullBins, dMinPull, dMaxPull);
+
+				locHistName = string("dEdXFOMVsP_Int_") + locParticleName;
+				locHistTitle = locParticleROOTName + string(";p (GeV/c);CDC dE/dx [Integral-based] PID Confidence Level");
 				dHistMap_dEdXFOMVsP[locPID][SYS_CDC] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DFOMBins, 0.0, 1.0);
+
+				locHistName = string("dEdXFOMVsP_Amp_") + locParticleName;
+				locHistTitle = locParticleROOTName + string(";p (GeV/c);CDC dE/dx [Amplitude-based] PID Confidence Level");
+				dHistMap_dEdXFOMVsP[locPID][SYS_CDC_AMP] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DPBins, dMinP, dMaxP, dNum2DFOMBins, 0.0, 1.0);
 
 				gDirectory->cd("..");
 
@@ -428,16 +444,27 @@ void DHistogramAction_PID::Fill_ChargedHists(const DChargedTrackHypothesis* locC
 		if(locTrackTimeBased->dNumHitsUsedFordEdx_CDC > 0)
 		{
 			dHistMap_dEdXVsP[locPID][SYS_CDC]->Fill(locP, locTrackTimeBased->ddEdx_CDC*1.0E6);
+			dHistMap_dEdXVsP[locPID][SYS_CDC_AMP]->Fill(locP, locTrackTimeBased->ddEdx_CDC_amp*1.0E6);
+
 			double locProbabledEdx = dParticleID->GetMostProbabledEdx_DC(locP, locChargedTrackHypothesis->mass(), locTrackTimeBased->ddx_CDC, true);
 			double locDeltadEdx = locTrackTimeBased->ddEdx_CDC - locProbabledEdx;
 			dHistMap_DeltadEdXVsP[locPID][SYS_CDC]->Fill(locP, 1.0E6*locDeltadEdx);
+			double locDeltadEdx_amp = locTrackTimeBased->ddEdx_CDC_amp - locProbabledEdx;
+			dHistMap_DeltadEdXVsP[locPID][SYS_CDC_AMP]->Fill(locP, 1.0E6*locDeltadEdx_amp);
+
 			double locMeandx = locTrackTimeBased->ddx_CDC/locTrackTimeBased->dNumHitsUsedFordEdx_CDC;
 			double locSigmadEdx = dParticleID->GetdEdxSigma_DC(locTrackTimeBased->dNumHitsUsedFordEdx_CDC, locP, locChargedTrackHypothesis->mass(), locMeandx, true);
 			double locdEdXPull = locDeltadEdx/locSigmadEdx;
 			dHistMap_dEdXPullVsP[locPID][SYS_CDC]->Fill(locP, locDeltadEdx/locSigmadEdx);
+			double locdEdXPull_amp = locDeltadEdx_amp/locSigmadEdx;
+			dHistMap_dEdXPullVsP[locPID][SYS_CDC_AMP]->Fill(locP, locDeltadEdx_amp/locSigmadEdx);
+
 			double locdEdXChiSq = locdEdXPull*locdEdXPull;
 			double locdEdXFOM = TMath::Prob(locdEdXChiSq, locTrackTimeBased->dNumHitsUsedFordEdx_CDC);
 			dHistMap_dEdXFOMVsP[locPID][SYS_CDC]->Fill(locP, locdEdXFOM);
+			double locdEdXChiSq_amp = locdEdXPull_amp*locdEdXPull_amp;
+			double locdEdXFOM_amp = TMath::Prob(locdEdXChiSq_amp, locTrackTimeBased->dNumHitsUsedFordEdx_CDC);
+			dHistMap_dEdXFOMVsP[locPID][SYS_CDC_AMP]->Fill(locP, locdEdXFOM_amp);
 		}
 
 		//FDC dE/dx

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -89,6 +89,9 @@ class DHistogramAction_PID : public DAnalysisAction
 			dThrownPIDs.push_back(PiPlus);  dThrownPIDs.push_back(KPlus);  dThrownPIDs.push_back(Proton);
 			dThrownPIDs.push_back(PiMinus);  dThrownPIDs.push_back(KMinus);
 
+			// used for indexing into maps
+			SYS_CDC_AMP = static_cast<DetectorSystem_t>(SYS_CDC + SYS_FDC);
+
 			dParticleID = NULL;
 			dAnalysisUtilities = NULL;
 		}
@@ -112,6 +115,8 @@ class DHistogramAction_PID : public DAnalysisAction
 
 		void Fill_ChargedHists(const DChargedTrackHypothesis* locChargedTrackHypothesis, const DMCThrownMatching* locMCThrownMatching, const DEventRFBunch* locEventRFBunch);
 		void Fill_NeutralHists(const DNeutralParticleHypothesis* locNeutralParticleHypothesis, const DMCThrownMatching* locMCThrownMatching, const DEventRFBunch* locEventRFBunch);
+
+		DetectorSystem_t SYS_CDC_AMP;
 
 		const DParticleID* dParticleID;
 		const DAnalysisUtilities* dAnalysisUtilities;

--- a/src/libraries/ANALYSIS/DSourceComboer.cc
+++ b/src/libraries/ANALYSIS/DSourceComboer.cc
@@ -1253,7 +1253,7 @@ bool DSourceComboer::Cut_dEdxAndEOverP(const DChargedTrackHypothesis* locCharged
 //cout << "PID, p, dedx, #hits = " << locPID << ", " << locP << ", " << locTrackTimeBased->ddEdx_CDC*1.0E6 << ", " << locTrackTimeBased->dNumHitsUsedFordEdx_CDC << endl;
 	if(locTrackTimeBased->dNumHitsUsedFordEdx_CDC > 0)
 	{
-		auto locdEdx = locTrackTimeBased->ddEdx_CDC*1.0E6;
+		auto locdEdx = locTrackTimeBased->ddEdx_CDC_amp*1.0E6;
 		if(!Cut_dEdx(locPID, SYS_CDC, locP, locdEdx))
 			locPassedCutFlag = false;
 	}

--- a/src/libraries/TRACKING/DTrackTimeBased.h
+++ b/src/libraries/TRACKING/DTrackTimeBased.h
@@ -22,7 +22,7 @@ class DTrackTimeBased:public DTrackingData{
 	public:
 		JOBJECT_PUBLIC(DTrackTimeBased);
 		
-		double dEdx(void) const{return ((dNumHitsUsedFordEdx_CDC >= dNumHitsUsedFordEdx_FDC) ? ddEdx_CDC : ddEdx_FDC);}
+		double dEdx(void) const{return ((dNumHitsUsedFordEdx_CDC >= dNumHitsUsedFordEdx_FDC) ? ddEdx_CDC_amp : ddEdx_FDC);}
 		typedef struct{
 		  unsigned int inner_layer;
 		  unsigned int outer_layer;

--- a/src/plugins/Analysis/fcal_charged/DEventProcessor_fcal_charged.cc
+++ b/src/plugins/Analysis/fcal_charged/DEventProcessor_fcal_charged.cc
@@ -386,7 +386,7 @@ jerror_t DEventProcessor_fcal_charged::evnt(jana::JEventLoop* locEventLoop, int 
 	    double trkmass = locTrackTimeBased[0]->mass();
 
 	    double radius = sqrt(trkpos.X()*trkpos.X() + trkpos.Y()*trkpos.Y());  // distance of track from beamline
-	    dEdx = (locTrackTimeBased[0]->dNumHitsUsedFordEdx_CDC >= locTrackTimeBased[0]->dNumHitsUsedFordEdx_FDC) ? locTrackTimeBased[0]->ddEdx_CDC : locTrackTimeBased[0]->ddEdx_FDC;
+	    dEdx = (locTrackTimeBased[0]->dNumHitsUsedFordEdx_CDC >= locTrackTimeBased[0]->dNumHitsUsedFordEdx_FDC) ? locTrackTimeBased[0]->ddEdx_CDC_amp : locTrackTimeBased[0]->ddEdx_FDC;
 	    dEdx *= 1e6; // convert to keV
 	    if(!(trkmass < 0.15 && FOM>0.01 && radius>20)) {
 	      continue;   // select tracks of interest

--- a/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.cc
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.cc
@@ -408,7 +408,7 @@ jerror_t JEventProcessor_BCAL_TDC_Timing::evnt(JEventLoop *loop, uint64_t eventn
       if (timeBasedTrack->Ndof < 10) continue; // CDC: 5 params in fit, 10 dof => [15 hits]; FDC [10 hits]
 
       // Use CDC dEdx to help reject protons
-      double dEdx=1e6*timeBasedTrack->ddEdx_CDC;
+      double dEdx=1e6*timeBasedTrack->ddEdx_CDC_amp;
       double P_track=timeBasedTrack->momentum().Mag();
       bool dEdx_pion = 0;
       if (dEdx<2.5) dEdx_pion = 1;

--- a/src/plugins/monitoring/CDC_Efficiency/JEventProcessor_CDC_Efficiency.cc
+++ b/src/plugins/monitoring/CDC_Efficiency/JEventProcessor_CDC_Efficiency.cc
@@ -267,7 +267,7 @@ jerror_t JEventProcessor_CDC_Efficiency::evnt(JEventLoop *loop, uint64_t eventnu
 
       //The cuts used for track quality
       if(!dIsNoFieldFlag){ // Quality cuts for Field on runs.
-         if(thisTimeBasedTrack->ddEdx_CDC > 1E-3) {
+         if(thisTimeBasedTrack->ddEdx_CDC_amp > 1E-3) {
             //cout << "Cut on dEdX" << endl;
             continue; // Trying to cut out "proton" candidates
          }


### PR DESCRIPTION
This change is primarily in the Analysis library. 

Also:
- Write out both ampliude- and integral-based CDC dE/dx to ROOT files
- Add monitoring histograms for both types of CDC dE/dx