### PR TITLE
Tpol hddm

### DIFF
--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -424,6 +424,14 @@ jerror_t DEventSourceHDDM::GetObjects(JEvent &event, JFactory_base *factory)
       return Extract_DCereHit(record, 
                      dynamic_cast<JFactory<DCereHit>*>(factory), tag);
 
+   //if (dataClassName == "DTPOLTruthHit")
+   //   return Extract_DTPOLTruthHit(record,
+   //                  dynamic_cast<JFactory<DTPOLTruthHit>*>(factory), tag);
+
+   if (dataClassName == "DTPOLHit")
+      return Extract_DTPOLHit(record,
+                     dynamic_cast<JFactory<DTPOLHit>*>(factory), tag);
+
    return OBJECT_NOT_AVAILABLE;
 }
 
@@ -2565,6 +2573,87 @@ jerror_t DEventSourceHDDM::Extract_DPSCTruthHit(hddm_s::HDDM *record,
    return NOERROR;
 }
 
+//------------------
+// Etract_DTPOLHit
+//------------------
+jerror_t DEventSourceHDDM::Extract_DTPOLHit(hddm_s::HDDM *record,
+                                   JFactory<DTPOLHit>* factory, string tag)
+{
+   if (factory == NULL)
+      return OBJECT_NOT_AVAILABLE;
+   if (tag != "")
+      return OBJECT_NOT_AVAILABLE;
+
+   vector<DTPOLHit*> data;
+
+   if (tag == "")
+   {
+      const hddm_s::TpolHitList &hits = record->getTpolHits();
+      hddm_s::TpolHitList::iterator iter;
+      for (iter = hits.begin(); iter != hits.end(); ++iter)
+      {
+         DTPOLHit *hit = new DTPOLHit;
+         hit->sector = iter->getSector();
+         hit->ring = iter->getRing();
+         hit->dE = iter->getDE();
+         hit->t = iter->getT();
+
+         data.push_back(hit);
+      }
+   }
+   else if (tag == "Truth")
+   {
+      const hddm_s::TpolTruthHitList &truthHits = record->getTpolTruthHits();
+      hddm_s::TpolTruthHitList::iterator iter;
+      for (iter = truthHits.begin(); iter != truthHits.end(); ++iter)
+      {
+         DTPOLHit *hit = new DTPOLHit;
+         hit->sector = iter->getSector();
+         hit->t = iter->getT();
+
+         data.push_back(hit);
+      }
+   }
+
+   factory->CopyTo(data);
+
+   return NOERROR;
+}
+
+//------------------------
+// Extract_DTPOLTruthHit
+//------------------------
+jerror_t DEventSourceHDDM::Extract_DTPOLTruthHit(hddm_s::HDDM *record,                                                                      JFactory<DTPOLTruthHit>* factory, string tag)
+{
+   if (factory == NULL)
+      return OBJECT_NOT_AVAILABLE;
+   if (tag != "")
+      return OBJECT_NOT_AVAILABLE;
+
+   vector<DTPOLTruthHit*> data;
+
+   const hddm_s::TpolTruthPointList &points = record->getTpolTruthPoints();
+   hddm_s::TpolTruthPointList::iterator iter;
+   for (iter = points.begin(); iter != points.end(); ++iter)
+   {
+      DTPOLTruthHit *hit = new DTPOLTruthHit;
+      hit->dEdx = iter->getDEdx();
+      hit->primary = iter->getPrimary();
+      hit->track = iter->getTrack();
+      hit->ptype = iter->getPtype();
+      hit->r = iter->getR();
+      hit->phi = iter->getPhi();
+      hit->t = iter->getT();
+      const hddm_s::TrackIDList &ids = iter->getTrackIDs();
+      hit->itrack = (ids.size())? ids.begin()->getItrack() : 0;
+
+      data.push_back(hit);
+   }
+
+   factory->CopyTo(data);
+
+   return NOERROR;
+}
 
 Particle_t DEventSourceHDDM::IDTrack(float locCharge, float locMass) const
 {

--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -424,13 +424,13 @@ jerror_t DEventSourceHDDM::GetObjects(JEvent &event, JFactory_base *factory)
       return Extract_DCereHit(record, 
                      dynamic_cast<JFactory<DCereHit>*>(factory), tag);
 
-   //if (dataClassName == "DTPOLTruthHit")
-   //   return Extract_DTPOLTruthHit(record,
-   //                  dynamic_cast<JFactory<DTPOLTruthHit>*>(factory), tag);
-
    if (dataClassName == "DTPOLHit")
       return Extract_DTPOLHit(record,
                      dynamic_cast<JFactory<DTPOLHit>*>(factory), tag);
+
+   if (dataClassName == "DTPOLTruthHit")
+      return Extract_DTPOLTruthHit(record,
+                     dynamic_cast<JFactory<DTPOLTruthHit>*>(factory), tag);
 
    return OBJECT_NOT_AVAILABLE;
 }

--- a/src/libraries/HDDM/DEventSourceHDDM.h
+++ b/src/libraries/HDDM/DEventSourceHDDM.h
@@ -72,6 +72,8 @@ using namespace std;
 #include "FMWPC/DFMWPCTruthHit.h"
 #include "FMWPC/DFMWPCHit.h"
 #include "PAIR_SPECTROMETER/DPSGeometry.h"
+#include "TPOL/DTPOLHit.h"
+#include "TPOL/DTPOLTruthHit.h"
 #include "DResourcePool.h"
 
 class DEventSourceHDDM:public JEventSource
@@ -136,7 +138,10 @@ class DEventSourceHDDM:public JEventSource
       jerror_t Extract_DPSCTruthHit(hddm_s::HDDM *record,JFactory<DPSCTruthHit>* factory, 
 			       string tag);
       jerror_t Extract_DFMWPCTruthHit(hddm_s::HDDM *record,  JFactory<DFMWPCTruthHit> *factory, string tag);
-      jerror_t Extract_DFMWPCHit(  hddm_s::HDDM *record,  JFactory<DFMWPCHit     > *factory, string tag);
+      jerror_t Extract_DFMWPCHit(hddm_s::HDDM *record,  JFactory<DFMWPCHit> *factory, string tag);
+
+      jerror_t Extract_DTPOLHit(hddm_s::HDDM *record, JFactory<DTPOLHit>* factory, string tag);
+      jerror_t Extract_DTPOLTruthHit(hddm_s::HDDM *record, JFactory<DTPOLTruthHit>* factory, string tag);
 
       Particle_t IDTrack(float locCharge, float locMass) const;
 

--- a/src/programs/Simulation/mcsmear/TPOLSmearer.cc
+++ b/src/programs/Simulation/mcsmear/TPOLSmearer.cc
@@ -6,8 +6,9 @@
 tpol_config_t::tpol_config_t(JEventLoop *loop) 
 {
 	// default values
-	TPOL_SIGMA_NS = 15.0;  // ns
-	TPOL_SIGMA_MEV = 0.03; // MeV
+	TPOL_SIGMA_NS = 4.4;  // ns
+	TPOL_SIGMA1_MEV = 0.03; // MeV
+        TPOL_SIGMA2_MEV = 0.03; // MeV
 	TPOL_THRESHOLD_MEV = 0.05; // MeV
 }
 
@@ -30,7 +31,7 @@ void TPOLSmearer::SmearEvent(hddm_s::HDDM *record)
          double dE_MeV = titer->getDE() * 1e3;
          if(config->SMEAR_HITS) {
 			 t_ns += gDRandom.SampleGaussian(tpol_config->TPOL_SIGMA_NS);
-			 dE_MeV += gDRandom.SampleGaussian(tpol_config->TPOL_SIGMA_MEV);
+			 dE_MeV += (gDRandom.SampleGaussian(tpol_config->TPOL_SIGMA1_MEV) + gDRandom.SampleGaussian(tpol_config->TPOL_SIGMA2_MEV));
 		 }
          // apply the threshold
          if (dE_MeV > tpol_config->TPOL_THRESHOLD_MEV) {

--- a/src/programs/Simulation/mcsmear/TPOLSmearer.h
+++ b/src/programs/Simulation/mcsmear/TPOLSmearer.h
@@ -12,7 +12,8 @@ class tpol_config_t
 	tpol_config_t(JEventLoop *loop);
 
 	double TPOL_SIGMA_NS;
-	double TPOL_SIGMA_MEV;
+	double TPOL_SIGMA1_MEV;
+        double TPOL_SIGMA2_MEV;
 	double TPOL_THRESHOLD_MEV;
 
 };


### PR DESCRIPTION
Update DEventSourceHDDM to include TPOL truth hit and hit objects for purposes of reading and writing to HDDM files. Added some changes to mcsmear for smearing TPOL data. More changes to mcsmear may be necessary for matching TPOL data to MC.