### PR TITLE
fix reading of number of hit FCAL blocks from REST

### DIFF
--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -816,7 +816,12 @@ jerror_t DEventSourceREST::Extract_DFCALShower(hddm_r::HDDM *record,
 	          shower->setE1E9(locFcalShowerPropertiesIterator->getE1E9());
 	          shower->setE9E25(locFcalShowerPropertiesIterator->getE9E25());
       }
-      
+
+      const hddm_r::FcalShowerNBlocksList& locFcalShowerNBlocksList = iter->getFcalShowerNBlockses();
+      hddm_r::FcalShowerNBlocksList::iterator locFcalShowerNBlocksIterator = locFcalShowerNBlocksList.begin();
+      if(locFcalShowerNBlocksIterator != locFcalShowerNBlocksList.end()) {
+	shower->setNumBlocks(locFcalShowerNBlocksIterator->getNumBlocks());
+      }      
       data.push_back(shower);
    }
 


### PR DESCRIPTION
Add block of code to fetch and set the number of hit FCAL blocks when reading from a REST file.