### PR TITLE
Safe-guard against int wrap-around

### DIFF
--- a/src/libraries/ANALYSIS/DSourceComboer.cc
+++ b/src/libraries/ANALYSIS/DSourceComboer.cc
@@ -1690,6 +1690,9 @@ void DSourceComboer::Combo_WithBeam(const vector<const DReaction*>& locReactions
 	}
 
 	//Select beam particles
+	if (abs(locRFBunch) > 2000000000)
+	  return; // proximity to INT_MAX can cause infinite loops, certainly no valid beam particle
+
 	auto locBeamParticles = dSourceComboTimeHandler->Get_BeamParticlesByRFBunch(locRFBunch, dMaxRFBunchCuts[locReactionVertexInfo]);
 	if(dDebugLevel > 0)
 		cout << "rf bunch, max #rf bunches, #beams = " << locRFBunch << ", " << dMaxRFBunchCuts[locReactionVertexInfo] << ", " << locBeamParticles.size() << endl;


### PR DESCRIPTION
If the RF bunch is close to the maximum of a 32 bit integer, the analysis library could get stuck in an infinite loop. This is a simple safe guard. In parallel, the BCal code was modified by a different commit to prevent crazy RF times from the start.